### PR TITLE
feat(control-center): read-only Warmbly commercial connector

### DIFF
--- a/control-center/connectors/warmbly/.gitignore
+++ b/control-center/connectors/warmbly/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+coverage/
+*.log
+.env
+.env.*
+!env.example

--- a/control-center/connectors/warmbly/README.md
+++ b/control-center/connectors/warmbly/README.md
@@ -1,0 +1,104 @@
+# Warmbly connector (Control Center)
+
+Read-only adapter that turns Warmbly's commercial runtime into a `CommercialSnapshot` plus `observations` so the cockpit can answer **o que exige atenção comercial** without owning the CRM pipeline.
+
+Canonical CRM remains Warmbly. This workstream does not persist leads/deals/stages as Control Center source of truth.
+
+## Decisions
+
+- Governance is strategic/canonical; Warmbly is operational commercial/CRM authority.
+- HTTP is fail-closed: timeouts, exponential backoff, circuit breaker, method allowlist.
+- Allowed methods: `GET`/`HEAD` of discovered commercial reads; `POST` only for Warmbly's existing `/search` and `/summary` on contacts, deals, and tasks (read queries that must not change stub/upstream state).
+- Forbidden: `PATCH`/`PUT`/`DELETE`, creating contacts/deals/tasks, campaign start/stop/send, Confenge import/enroll/bootstrap/dispatch, unibox reply/compose, any Asaas/financial mutation.
+- Every aggregated item carries `source`, `observed_at` (UTC), `freshness_status`, and `confidence` when the upstream payload supplies it.
+- Deal money is integer **cents** + `currency`. Warmbly `value` is treated as major units (1500.50 BRL → 150050 cents).
+- No `GET /leads` exists on Warmbly. Contacts search + Confenge inbound (when enabled) are the lead surface. The gap is documented in `required_upstream_contract.json`.
+- `/v1/confenge/*` (except `GET /v1/confenge/status`) is feature-flagged. A 404 produces `freshness_status` UNKNOWN/ERROR and a `required_upstream_contract` row — never a Warmbly write.
+- Local snapshot contract lives here until convergence with `control-center/contracts/`.
+
+## Mapped Warmbly routes
+
+See `required_upstream_contract.json` for the full table. Collect calls:
+
+| Method | Path | Why |
+| --- | --- | --- |
+| GET | `/health` | liveness / version stamp (`API-Version` header) |
+| GET | `/v1/crm/pipelines` | stage names for stalled-deal context; **not** stored as a board |
+| GET | `/v1/crm/deals` | commercial states + timestamps + values |
+| POST | `/v1/crm/deals/summary` | open-value aggregate (read) |
+| GET | `/v1/crm/tasks` | next actions |
+| POST | `/v1/crm/tasks/search` | overdue filter GET list lacks (read) |
+| POST | `/v1/contacts/search` | contacts / lead surface (no GET list) |
+| GET | `/v1/campaigns` | campaign exception signals |
+| GET | `/v1/campaigns-overview` | active/paused counts |
+| GET | `/v1/unibox/overview` | unread / awaiting-reply signals |
+| GET | `/v1/confenge/status` | feature flag + readiness |
+| GET | `/v1/confenge/ops/health` | health/version when Confenge is on |
+| GET | `/v1/confenge/attention` | Warmbly-native needs-attention |
+| GET | `/v1/confenge/today` | executable human work |
+| GET | `/v1/confenge/inbound` | inbound leads needing a human |
+
+Auth: `Authorization: Bearer <token>` and `API-Version: v1`. Tokens are prefixed `wmbly_`.
+
+## Env vars (names only)
+
+Copy `env.example`. Never commit values, put secrets in git, logs, URLs, analytics, or a client bundle.
+
+| Name | Purpose |
+| --- | --- |
+| `WARMBLY_BASE_URL` | Warmbly API origin (no trailing slash) |
+| `WARMBLY_API_TOKEN` | Bearer credential (preferred) |
+| `WARMBLY_API_KEY` | Alias for the same credential |
+| `WARMBLY_OBSERVED_AT` | Optional RFC3339 UTC clock for reproducible collect |
+
+## How to run
+
+```bash
+cd control-center/connectors/warmbly
+npm install
+npm test
+npm run typecheck
+```
+
+Collect entry (the function `collect` / CLI `npm run collect`):
+
+```bash
+# Fixture-only (no HTTP)
+npm run collect -- --fixture fixtures/commercial-runtime.json --now 2026-08-20T15:00:00.000Z
+
+# In-process Warmbly-shaped stub (no live Warmbly)
+npm run collect -- --stub --now 2026-08-20T15:00:00.000Z
+
+# Against a local stub/server you already started
+WARMBLY_BASE_URL=http://127.0.0.1:PORT WARMBLY_API_TOKEN=wmbly_… npm run collect
+```
+
+JSON snapshot goes to stdout. Structured logs go to stderr and are redacted.
+
+## Attention derivation (no pipeline replica)
+
+The snapshot's `attention` list is the cockpit slice, not a kanban:
+
+- overdue CRM tasks
+- next actions (due in 24h or high/urgent open tasks)
+- stalled open deals (no movement ≥ 14 days)
+- campaign guardrail / exceptional status
+- unibox unread / awaiting-reply / draft-review counts
+- Confenge needs-attention, today actions, inbound-now (when those reads exist)
+
+Completed tasks, recently-updated open deals, healthy active campaigns, and handled inbound leads are **not** attention. The snapshot has no `deals` / `pipelines` / `tasks` arrays.
+
+## Expected later integration
+
+This adapter is designed to land unchanged during the convergence campaign:
+
+- **`control-center/contracts/`** — replace the local `CommercialSnapshot` / `SourceObservation` / `RequiredUpstreamContract` types with the canonical schemas (`schema: control-center.commercial-snapshot.v1`). Field names here (`source`, `observed_at`, `freshness_status`, `confidence`, `amount_cents`) are the intended join keys.
+- **Persistence ingest** (`control-center` PostgreSQL) — consume `collect()` output as observations + attention facts. Do **not** upsert a replica pipeline from `GET /v1/crm/deals` or `/pipelines`.
+- **Context service / MCP** — agents should query attention by scope, not dump this snapshot wholesale.
+- **Cockpit homepage** — render `attention` (the few things that need a human now), not KPI walls.
+
+Until those packages exist on the same branch, depend on this folder only.
+
+## Tests
+
+Synthetic Warmbly-shaped fixtures in `fixtures/`. Unit/contract tests drive `collectFromWarmblyPayload` and `collect()` (the shipped path) plus the HTTP client against a local stub. Live Warmbly and Asaas are never called.

--- a/control-center/connectors/warmbly/env.example
+++ b/control-center/connectors/warmbly/env.example
@@ -1,0 +1,13 @@
+# Warmbly commercial-read connector (Control Center). Names only — never commit values.
+# Copy to a local .env that is gitignored, or export in the process environment.
+
+# Base URL of the Warmbly API (no trailing slash). Example: https://warmbly.example.com
+WARMBLY_BASE_URL=
+
+# API credential. Warmbly API keys are Bearer tokens with prefix wmbly_.
+# Either name is accepted; WARMBLY_API_TOKEN is preferred.
+WARMBLY_API_TOKEN=
+WARMBLY_API_KEY=
+
+# Optional. RFC3339 UTC clock used by collect (tests/repro). Default: now.
+WARMBLY_OBSERVED_AT=

--- a/control-center/connectors/warmbly/fixtures/commercial-runtime.json
+++ b/control-center/connectors/warmbly/fixtures/commercial-runtime.json
@@ -1,0 +1,287 @@
+{
+  "health": { "status": "ok" },
+  "api_version": "v1",
+  "pipelines": [
+    {
+      "id": "11111111-1111-4111-8111-111111111111",
+      "name": "Comercial",
+      "position": 0,
+      "stages": [
+        {
+          "id": "11111111-1111-4111-8111-111111111112",
+          "pipeline_id": "11111111-1111-4111-8111-111111111111",
+          "name": "Qualificação",
+          "position": 0,
+          "deal_count": 1
+        },
+        {
+          "id": "11111111-1111-4111-8111-111111111113",
+          "pipeline_id": "11111111-1111-4111-8111-111111111111",
+          "name": "Proposta",
+          "position": 1,
+          "deal_count": 1
+        }
+      ],
+      "created_at": "2026-01-10T12:00:00.000Z",
+      "updated_at": "2026-08-01T12:00:00.000Z"
+    }
+  ],
+  "deals": {
+    "data": [
+      {
+        "id": "deal-healthy-1",
+        "pipeline_id": "11111111-1111-4111-8111-111111111111",
+        "stage_id": "11111111-1111-4111-8111-111111111112",
+        "contact_id": "contact-lead-1",
+        "name": "Diagnóstico — Construtora Beta",
+        "value": 1500.5,
+        "currency": "BRL",
+        "status": "open",
+        "created_at": "2026-08-18T12:00:00.000Z",
+        "updated_at": "2026-08-20T10:00:00.000Z"
+      },
+      {
+        "id": "deal-stalled-1",
+        "pipeline_id": "11111111-1111-4111-8111-111111111111",
+        "stage_id": "11111111-1111-4111-8111-111111111113",
+        "contact_id": "contact-quiet-1",
+        "name": "Diagnóstico — Escritório Gama",
+        "value": 2000,
+        "currency": "BRL",
+        "status": "open",
+        "created_at": "2026-06-01T12:00:00.000Z",
+        "updated_at": "2026-07-01T12:00:00.000Z"
+      },
+      {
+        "id": "deal-won-1",
+        "pipeline_id": "11111111-1111-4111-8111-111111111111",
+        "stage_id": "11111111-1111-4111-8111-111111111113",
+        "name": "Diagnóstico — Cliente Fechado",
+        "value": 990,
+        "currency": "BRL",
+        "status": "won",
+        "won_at": "2026-08-10T12:00:00.000Z",
+        "created_at": "2026-07-15T12:00:00.000Z",
+        "updated_at": "2026-08-10T12:00:00.000Z"
+      }
+    ],
+    "pagination": { "total": 3, "has_more": false }
+  },
+  "deals_summary": {
+    "total": 3,
+    "open_count": 2,
+    "open_value": 3500.5,
+    "won_count": 1,
+    "won_value": 990,
+    "lost_count": 0,
+    "lost_value": 0,
+    "currency": "BRL",
+    "mixed_currency": false
+  },
+  "tasks": {
+    "data": [
+      {
+        "id": "task-overdue-1",
+        "contact_id": "contact-lead-1",
+        "deal_id": "deal-stalled-1",
+        "title": "Ligar para Gama — follow-up da proposta",
+        "due_date": "2026-08-19T12:00:00.000Z",
+        "priority": "urgent",
+        "type": "Call",
+        "status": "pending",
+        "created_at": "2026-08-17T12:00:00.000Z",
+        "updated_at": "2026-08-17T12:00:00.000Z"
+      },
+      {
+        "id": "task-next-1",
+        "contact_id": "contact-lead-1",
+        "title": "Enviar resumo do diagnóstico para Beta",
+        "due_date": "2026-08-20T16:00:00.000Z",
+        "priority": "high",
+        "type": "Email",
+        "status": "pending",
+        "created_at": "2026-08-20T09:00:00.000Z",
+        "updated_at": "2026-08-20T09:00:00.000Z"
+      },
+      {
+        "id": "task-done-1",
+        "title": "Arquivar nota de reunião já concluída",
+        "due_date": "2026-08-18T12:00:00.000Z",
+        "priority": "low",
+        "type": "Meeting",
+        "status": "completed",
+        "completed_at": "2026-08-18T15:00:00.000Z",
+        "created_at": "2026-08-16T12:00:00.000Z",
+        "updated_at": "2026-08-18T15:00:00.000Z"
+      }
+    ],
+    "pagination": { "total": 3, "has_more": false }
+  },
+  "tasks_search": {
+    "data": [
+      {
+        "id": "task-overdue-1",
+        "contact_id": "contact-lead-1",
+        "deal_id": "deal-stalled-1",
+        "title": "Ligar para Gama — follow-up da proposta",
+        "due_date": "2026-08-19T12:00:00.000Z",
+        "priority": "urgent",
+        "type": "Call",
+        "status": "pending",
+        "created_at": "2026-08-17T12:00:00.000Z",
+        "updated_at": "2026-08-17T12:00:00.000Z"
+      }
+    ],
+    "pagination": { "total": 1, "has_more": false }
+  },
+  "tasks_summary": {
+    "total": 3,
+    "pending_count": 2,
+    "in_progress_count": 0,
+    "completed_count": 1,
+    "cancelled_count": 0,
+    "overdue_count": 1,
+    "high_priority_count": 2
+  },
+  "contacts": {
+    "data": [
+      {
+        "id": "contact-quiet-1",
+        "first_name": "Ana",
+        "last_name": "Quiet",
+        "email": "ana.quiet@example.test",
+        "company": "Escritório Gama",
+        "subscribed": true,
+        "created_at": "2026-06-01T12:00:00.000Z",
+        "updated_at": "2026-08-01T12:00:00.000Z"
+      },
+      {
+        "id": "contact-lead-1",
+        "first_name": "Bruno",
+        "last_name": "Lead",
+        "email": "bruno.lead@example.test",
+        "company": "Construtora Beta",
+        "subscribed": true,
+        "campaign_lead": { "status": "replied", "last_activity_at": "2026-08-20T09:30:00.000Z" },
+        "created_at": "2026-08-10T12:00:00.000Z",
+        "updated_at": "2026-08-20T09:30:00.000Z"
+      }
+    ],
+    "pagination": { "total": 2, "has_more": false }
+  },
+  "campaigns": {
+    "data": [
+      {
+        "id": "camp-active-1",
+        "name": "Outbound engenharia — ativo",
+        "status": "active",
+        "created_at": "2026-08-01T12:00:00.000Z",
+        "updated_at": "2026-08-20T08:00:00.000Z"
+      },
+      {
+        "id": "camp-tripped-1",
+        "name": "Outbound piloto — pausado por guardrail",
+        "status": "paused",
+        "guardrail_tripped_at": "2026-08-19T18:00:00.000Z",
+        "guardrail_reason": "bounce_rate_max",
+        "created_at": "2026-08-01T12:00:00.000Z",
+        "updated_at": "2026-08-19T18:00:00.000Z"
+      }
+    ],
+    "pagination": { "total": 2, "has_more": false }
+  },
+  "campaigns_overview": {
+    "total": 2,
+    "active": 1,
+    "paused": 1,
+    "draft": 0,
+    "completed": 0
+  },
+  "unibox_overview": {
+    "total": 12,
+    "unread": 3,
+    "today": 4,
+    "week": 12,
+    "snoozed": 0,
+    "awaiting_reply": 1,
+    "awaiting_agent_draft": 0,
+    "scheduled_pending": 0,
+    "generated_at": "2026-08-20T14:55:00.000Z"
+  },
+  "confenge_status": {
+    "enabled": true,
+    "auto_send_enabled": false,
+    "kill_switch": false,
+    "sending_allowed": true,
+    "feed_configured": true
+  },
+  "confenge_ops_health": {
+    "data": {
+      "computed_at": "2026-08-20T14:50:00.000Z",
+      "lead_persisted": false,
+      "health_matrix": { "status": "READY" },
+      "alerts": [],
+      "slos": []
+    }
+  },
+  "confenge_attention": {
+    "data": [
+      {
+        "account_id": "acc-needs-1",
+        "company_name": "Construtora Alpha",
+        "contact_name": "Carla Reply",
+        "commercial_state": "POSITIVE_INTEREST",
+        "queue_state": "REPLIED",
+        "suggested_action": "Responder o interesse positivo hoje",
+        "confidence": 0.8,
+        "intent": "positive_interest",
+        "updated_at": "2026-08-20T14:00:00.000Z"
+      }
+    ]
+  },
+  "confenge_today": {
+    "data": {
+      "summary": { "total": 1, "calls": 1, "emails_to_review": 0 },
+      "actions": [
+        {
+          "action_id": "action-call-1",
+          "company": "Construtora Alpha",
+          "person": "Carla Reply",
+          "why_now": "Resposta positiva aguardando retorno humano",
+          "recommended_action": "Ligar agora",
+          "next_action_at": "2026-08-20T14:30:00.000Z",
+          "lane": "call_queue",
+          "state": "actionable",
+          "actionable": true,
+          "confidence": "HIGH"
+        }
+      ]
+    }
+  },
+  "confenge_inbound": {
+    "data": [
+      {
+        "lead_id": "inbound-new-1",
+        "company": "Obra Delta",
+        "person": "Diego Inbound",
+        "status": "NEW",
+        "why_now": "Lead inbound sem dono há 40 minutos",
+        "recommended_action": "Assumir e ligar",
+        "confidence": "HIGH",
+        "freshness": "FRESH",
+        "lead_age_seconds": 2400
+      },
+      {
+        "lead_id": "inbound-done-1",
+        "company": "Obra já tratada",
+        "person": "Eva Done",
+        "status": "DONE",
+        "why_now": "Já atendido",
+        "recommended_action": "none",
+        "confidence": "HIGH",
+        "freshness": "FRESH",
+        "lead_age_seconds": 86400
+      }
+    ]
+  }
+}

--- a/control-center/connectors/warmbly/fixtures/missing-endpoint.json
+++ b/control-center/connectors/warmbly/fixtures/missing-endpoint.json
@@ -1,0 +1,111 @@
+{
+  "health": { "status": "ok" },
+  "api_version": "v1",
+  "pipelines": [],
+  "deals": {
+    "data": [
+      {
+        "id": "deal-healthy-1",
+        "name": "Diagnóstico — Construtora Beta",
+        "value": 1500.5,
+        "currency": "BRL",
+        "status": "open",
+        "created_at": "2026-08-18T12:00:00.000Z",
+        "updated_at": "2026-08-20T10:00:00.000Z"
+      }
+    ],
+    "pagination": { "total": 1, "has_more": false }
+  },
+  "deals_summary": {
+    "total": 1,
+    "open_count": 1,
+    "open_value": 1500.5,
+    "currency": "BRL",
+    "mixed_currency": false
+  },
+  "tasks": {
+    "data": [
+      {
+        "id": "task-overdue-1",
+        "title": "Ligar para Gama — follow-up da proposta",
+        "due_date": "2026-08-19T12:00:00.000Z",
+        "priority": "urgent",
+        "status": "pending",
+        "created_at": "2026-08-17T12:00:00.000Z",
+        "updated_at": "2026-08-17T12:00:00.000Z"
+      },
+      {
+        "id": "task-done-1",
+        "title": "Arquivar nota de reunião já concluída",
+        "due_date": "2026-08-18T12:00:00.000Z",
+        "priority": "low",
+        "status": "completed",
+        "completed_at": "2026-08-18T15:00:00.000Z",
+        "created_at": "2026-08-16T12:00:00.000Z",
+        "updated_at": "2026-08-18T15:00:00.000Z"
+      }
+    ],
+    "pagination": { "total": 2, "has_more": false }
+  },
+  "contacts": {
+    "data": [
+      {
+        "id": "contact-quiet-1",
+        "first_name": "Ana",
+        "last_name": "Quiet",
+        "company": "Escritório Gama",
+        "subscribed": true,
+        "created_at": "2026-06-01T12:00:00.000Z",
+        "updated_at": "2026-08-01T12:00:00.000Z"
+      }
+    ],
+    "pagination": { "total": 1, "has_more": false }
+  },
+  "campaigns": {
+    "data": [
+      {
+        "id": "camp-active-1",
+        "name": "Outbound engenharia — ativo",
+        "status": "active",
+        "created_at": "2026-08-01T12:00:00.000Z",
+        "updated_at": "2026-08-20T08:00:00.000Z"
+      }
+    ],
+    "pagination": { "total": 1, "has_more": false }
+  },
+  "campaigns_overview": { "total": 1, "active": 1, "paused": 0, "draft": 0, "completed": 0 },
+  "unibox_overview": {
+    "total": 2,
+    "unread": 0,
+    "awaiting_reply": 0,
+    "awaiting_agent_draft": 0,
+    "generated_at": "2026-08-20T14:55:00.000Z"
+  },
+  "confenge_status": { "enabled": false },
+  "unavailable": [
+    {
+      "method": "GET",
+      "path": "/v1/confenge/attention",
+      "status": 404,
+      "reason": "CONFENGE outreach is not enabled on this server"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/confenge/today",
+      "status": 404,
+      "reason": "CONFENGE outreach is not enabled on this server"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/confenge/inbound",
+      "status": 404,
+      "reason": "CONFENGE outreach is not enabled on this server"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/confenge/ops/health",
+      "status": 404,
+      "reason": "CONFENGE outreach is not enabled on this server"
+    }
+  ]
+}

--- a/control-center/connectors/warmbly/package-lock.json
+++ b/control-center/connectors/warmbly/package-lock.json
@@ -1,0 +1,572 @@
+{
+  "name": "@confenge/control-center-warmbly-connector",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-warmbly-connector",
+      "version": "0.1.0",
+      "bin": {
+        "warmbly-collect": "src/cli.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/control-center/connectors/warmbly/package.json
+++ b/control-center/connectors/warmbly/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@confenge/control-center-warmbly-connector",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Read-only Warmbly adapter that yields CommercialSnapshot + observations for the Confenge Control Center cockpit.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "warmbly-collect": "./src/cli.ts"
+  },
+  "scripts": {
+    "test": "tsx --test tests/*.test.ts",
+    "collect": "tsx src/cli.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/connectors/warmbly/required_upstream_contract.json
+++ b/control-center/connectors/warmbly/required_upstream_contract.json
@@ -1,0 +1,64 @@
+{
+  "connector": "control-center/connectors/warmbly",
+  "discovered_from": "Warmbly fork internal/api/routes.go (read-only)",
+  "api_prefix": "/v1",
+  "api_version_header": "API-Version: v1",
+  "auth": "Authorization: Bearer <WARMBLY_API_TOKEN> (keys prefixed wmbly_)",
+  "mapped_reads": [
+    { "method": "GET", "path": "/health", "notes": "unauthenticated; {status}" },
+    { "method": "GET", "path": "/v1/crm/pipelines", "notes": "JSON array of pipelines+stages; not persisted as Control Center pipeline" },
+    { "method": "GET", "path": "/v1/crm/deals", "notes": "prefer GET list; query pipeline_id, stage_id, status, limit, cursor" },
+    { "method": "POST", "path": "/v1/crm/deals/search", "notes": "read query; empty body matches all org deals" },
+    { "method": "POST", "path": "/v1/crm/deals/summary", "notes": "read aggregate over the same filter body" },
+    { "method": "GET", "path": "/v1/crm/tasks", "notes": "prefer GET list; query status, contact_id, deal_id, limit, cursor" },
+    { "method": "POST", "path": "/v1/crm/tasks/search", "notes": "read query; overdue=true is the overdue filter GET list lacks" },
+    { "method": "POST", "path": "/v1/crm/tasks/summary", "notes": "read aggregate" },
+    { "method": "POST", "path": "/v1/contacts/search", "notes": "no GET /contacts list; empty JSON body is a valid read" },
+    { "method": "GET", "path": "/v1/contacts/:id", "notes": "detail; collect uses search, not per-id crawl" },
+    { "method": "GET", "path": "/v1/campaigns", "notes": "GET list (query q, cursor, folder, status, limit)" },
+    { "method": "GET", "path": "/v1/campaigns-overview", "notes": "status-bucket counts" },
+    { "method": "GET", "path": "/v1/unibox/overview", "notes": "unread / awaiting_reply / drafts" },
+    { "method": "GET", "path": "/v1/confenge/status", "notes": "always readable; enabled=false when feature-flagged off" },
+    { "method": "GET", "path": "/v1/confenge/ops/health", "notes": "feature-flagged; 404 when Confenge org is off" },
+    { "method": "GET", "path": "/v1/confenge/attention", "notes": "feature-flagged needs-attention accounts" },
+    { "method": "GET", "path": "/v1/confenge/today", "notes": "feature-flagged executable human work" },
+    { "method": "GET", "path": "/v1/confenge/inbound", "notes": "feature-flagged inbound-now queue (lead surface)" }
+  ],
+  "forbidden_in_this_connector": [
+    "PATCH/PUT/DELETE any path",
+    "POST /v1/campaigns, /start, /stop, /test-email, enroll, import, dispatch",
+    "POST /v1/confenge/import, /sync, /crm/bootstrap, /campaign/bootstrap, /inbound/:id/outcome, send/enroll/approve",
+    "POST /v1/unibox/reply, /compose, /snooze",
+    "POST /v1/crm/deals (create), POST /v1/crm/tasks (create), POST /v1/contacts (create)",
+    "Any Asaas / checkout / refund / financial mutation"
+  ],
+  "gaps": [
+    {
+      "id": "GET /v1/leads",
+      "method": "GET",
+      "path": "/v1/leads",
+      "reason": "Warmbly has no GET /leads. Connector maps POST /v1/contacts/search plus GET /v1/confenge/inbound as the lead surface.",
+      "min_request": {
+        "method": "GET",
+        "path": "/v1/leads",
+        "query": { "limit": "100" },
+        "headers": ["Authorization", "API-Version"]
+      },
+      "min_response": {
+        "status": 200,
+        "body": {
+          "data": [
+            {
+              "id": "uuid",
+              "company": "string",
+              "status": "string",
+              "created_at": "RFC3339 UTC",
+              "updated_at": "RFC3339 UTC"
+            }
+          ],
+          "pagination": { "total": 0, "has_more": false }
+        }
+      }
+    }
+  ]
+}

--- a/control-center/connectors/warmbly/src/cli.ts
+++ b/control-center/connectors/warmbly/src/cli.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { collect, collectFromWarmblyPayload } from "./collect.ts";
+import type { WarmblyPayload } from "./contracts/warmbly-payload.ts";
+import { WarmblyClient } from "./http/client.ts";
+import { createStderrLogger } from "./http/redaction.ts";
+import { startFixtureStub } from "./stub-server.ts";
+
+function argValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx === -1) {
+    return undefined;
+  }
+  return args[idx + 1];
+}
+
+function parseNow(raw: string | undefined): Date | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`invalid --now: ${raw}`);
+  }
+  return d;
+}
+
+async function loadPayload(path: string): Promise<WarmblyPayload> {
+  const text = await readFile(path, "utf8");
+  return JSON.parse(text) as WarmblyPayload;
+}
+
+async function main(argv: string[]): Promise<void> {
+  const args = argv.slice(2);
+  const fixture = argValue(args, "--fixture");
+  const stubFixture = argValue(args, "--stub-fixture") ?? (args.includes("--stub") ? undefined : undefined);
+  const now = parseNow(argValue(args, "--now") ?? process.env.WARMBLY_OBSERVED_AT);
+  const logger = createStderrLogger();
+
+  if (fixture) {
+    const payload = await loadPayload(resolve(fixture));
+    const snapshot = collectFromWarmblyPayload(payload, { now });
+    process.stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
+    return;
+  }
+
+  const inlineStub = args.includes("--stub") || Boolean(stubFixture);
+  if (inlineStub) {
+    const fixturePath =
+      stubFixture ??
+      resolve(fileURLToPath(new URL("../fixtures/commercial-runtime.json", import.meta.url)));
+    const payload = await loadPayload(fixturePath);
+    const hide = args.includes("--hide-confenge")
+      ? [
+          "/v1/confenge/attention",
+          "/v1/confenge/today",
+          "/v1/confenge/inbound",
+          "/v1/confenge/ops/health",
+        ]
+      : [];
+    const token = process.env.WARMBLY_API_TOKEN ?? process.env.WARMBLY_API_KEY ?? "wmbly_stub_local_token";
+    const stub = await startFixtureStub({ payload, hide, token });
+    try {
+      const snapshot = await collect({
+        now,
+        client: new WarmblyClient({
+          baseUrl: stub.url,
+          token,
+          timeoutMs: 3_000,
+          maxRetries: 0,
+          logger,
+        }),
+      });
+      process.stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
+    } finally {
+      await stub.close();
+    }
+    return;
+  }
+
+  const baseUrl = process.env.WARMBLY_BASE_URL;
+  const token = process.env.WARMBLY_API_TOKEN ?? process.env.WARMBLY_API_KEY;
+  if (!baseUrl || !token) {
+    throw new Error(
+      "Set WARMBLY_BASE_URL and WARMBLY_API_TOKEN, or pass --fixture / --stub. See README.md.",
+    );
+  }
+  const snapshot = await collect({
+    now,
+    client: new WarmblyClient({
+      baseUrl,
+      token,
+      logger,
+    }),
+  });
+  process.stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
+}
+
+main(process.argv).catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : "cli failed";
+  process.stderr.write(`${JSON.stringify({ level: "error", msg: "warmbly.cli.fail", error: message })}\n`);
+  process.exitCode = 1;
+});

--- a/control-center/connectors/warmbly/src/collect.ts
+++ b/control-center/connectors/warmbly/src/collect.ts
@@ -1,0 +1,47 @@
+import { fetchWarmblyPayload } from "./collector/fetch.ts";
+import type { CommercialSnapshot } from "./contracts/snapshot.ts";
+import type { WarmblyPayload } from "./contracts/warmbly-payload.ts";
+import { WarmblyClient, type WarmblyClientOptions } from "./http/client.ts";
+import {
+  attentionSlice,
+  collectFromWarmblyPayload,
+  type NormalizeOptions,
+} from "./mapper/normalize.ts";
+
+export type CollectOptions = NormalizeOptions & {
+  client?: WarmblyClient;
+  clientOptions?: WarmblyClientOptions;
+};
+
+/**
+ * Shipped collect entry: fetch Warmbly commercial reads (or accept a fixture
+ * payload) and normalize into CommercialSnapshot + observations.
+ *
+ * Tests should call this function (or collectFromWarmblyPayload) — not a
+ * reimplementation of mapping.
+ */
+export async function collect(opts: CollectOptions = {}): Promise<CommercialSnapshot> {
+  if (!opts.client && !opts.clientOptions) {
+    throw new Error("collect requires a WarmblyClient or clientOptions");
+  }
+  const client = opts.client ?? new WarmblyClient(opts.clientOptions as WarmblyClientOptions);
+  const { payload, api_version } = await fetchWarmblyPayload(client);
+  if (api_version && !payload.api_version) {
+    payload.api_version = api_version;
+  }
+  return collectFromWarmblyPayload(payload, { now: opts.now });
+}
+
+export function collectFromFixture(
+  payload: WarmblyPayload,
+  opts: NormalizeOptions = {},
+): CommercialSnapshot {
+  return collectFromWarmblyPayload(payload, opts);
+}
+
+export {
+  attentionSlice,
+  collectFromWarmblyPayload,
+  WarmblyClient,
+};
+export type { CommercialSnapshot, WarmblyPayload };

--- a/control-center/connectors/warmbly/src/collector/fetch.ts
+++ b/control-center/connectors/warmbly/src/collector/fetch.ts
@@ -1,0 +1,145 @@
+import type { EndpointFailure, WarmblyPayload } from "../contracts/warmbly-payload.ts";
+import {
+  CircuitOpenError,
+  MethodNotAllowedError,
+  TimeoutError,
+  type WarmblyClient,
+} from "../http/client.ts";
+import { COLLECT_ROUTES } from "./routes.ts";
+
+export type FetchResult = {
+  payload: WarmblyPayload;
+  api_version?: string;
+};
+
+function asPayloadValue(json: unknown): unknown {
+  return json;
+}
+
+export async function fetchWarmblyPayload(client: WarmblyClient): Promise<FetchResult> {
+  const payload: WarmblyPayload = { unavailable: [] };
+  let apiVersion: string | undefined;
+
+  for (const route of COLLECT_ROUTES) {
+    try {
+      const res = await client.request({
+        method: route.method,
+        path: route.path,
+        body: route.body,
+      });
+      if (res.api_version) {
+        apiVersion = res.api_version;
+      }
+      if (res.status === 404 || res.status === 501) {
+        const failure: EndpointFailure = {
+          method: route.method,
+          path: route.path.split("?")[0] ?? route.path,
+          status: res.status,
+          reason: `Warmbly returned ${res.status} for ${route.method} ${route.path}`,
+        };
+        payload.unavailable = [...(payload.unavailable ?? []), failure];
+        continue;
+      }
+      if (!res.ok) {
+        const failure: EndpointFailure = {
+          method: route.method,
+          path: route.path.split("?")[0] ?? route.path,
+          status: res.status,
+          reason: `Warmbly returned ${res.status} for ${route.method} ${route.path}`,
+        };
+        payload.unavailable = [...(payload.unavailable ?? []), failure];
+        continue;
+      }
+      assignRoute(payload, route.key, asPayloadValue(res.json));
+    } catch (err) {
+      if (err instanceof MethodNotAllowedError) {
+        throw err;
+      }
+      const status =
+        err instanceof TimeoutError ? 598 : err instanceof CircuitOpenError ? 599 : 500;
+      const failure: EndpointFailure = {
+        method: route.method,
+        path: route.path.split("?")[0] ?? route.path,
+        status,
+        reason: err instanceof Error ? err.message : "fetch failed",
+      };
+      payload.unavailable = [...(payload.unavailable ?? []), failure];
+      if (err instanceof CircuitOpenError) {
+        break;
+      }
+    }
+  }
+
+  if (apiVersion) {
+    payload.api_version = apiVersion;
+  }
+  return { payload, api_version: apiVersion };
+}
+
+function assignRoute(payload: WarmblyPayload, key: CollectRouteKey, json: unknown): void {
+  switch (key) {
+    case "health":
+      payload.health = asRecord(json) as WarmblyPayload["health"];
+      break;
+    case "pipelines":
+      payload.pipelines = json as WarmblyPayload["pipelines"];
+      break;
+    case "deals":
+      payload.deals = json as WarmblyPayload["deals"];
+      break;
+    case "deals_summary":
+      payload.deals_summary = unwrapMaybeData(json) as WarmblyPayload["deals_summary"];
+      break;
+    case "tasks":
+      payload.tasks = json as WarmblyPayload["tasks"];
+      break;
+    case "tasks_search":
+      payload.tasks_search = json as WarmblyPayload["tasks_search"];
+      break;
+    case "contacts":
+      payload.contacts = json as WarmblyPayload["contacts"];
+      break;
+    case "campaigns":
+      payload.campaigns = json as WarmblyPayload["campaigns"];
+      break;
+    case "campaigns_overview":
+      payload.campaigns_overview = json as WarmblyPayload["campaigns_overview"];
+      break;
+    case "unibox_overview":
+      payload.unibox_overview = json as WarmblyPayload["unibox_overview"];
+      break;
+    case "confenge_status":
+      payload.confenge_status = json as WarmblyPayload["confenge_status"];
+      break;
+    case "confenge_ops_health":
+      payload.confenge_ops_health = json as WarmblyPayload["confenge_ops_health"];
+      break;
+    case "confenge_attention":
+      payload.confenge_attention = json as WarmblyPayload["confenge_attention"];
+      break;
+    case "confenge_today":
+      payload.confenge_today = json as WarmblyPayload["confenge_today"];
+      break;
+    case "confenge_inbound":
+      payload.confenge_inbound = json as WarmblyPayload["confenge_inbound"];
+      break;
+    default:
+      break;
+  }
+}
+
+type CollectRouteKey = (typeof COLLECT_ROUTES)[number]["key"];
+
+function asRecord(json: unknown): Record<string, unknown> {
+  if (json && typeof json === "object" && !Array.isArray(json)) {
+    return json as Record<string, unknown>;
+  }
+  return {};
+}
+
+function unwrapMaybeData(json: unknown): unknown {
+  if (json && typeof json === "object" && "data" in json) {
+    return (json as { data: unknown }).data;
+  }
+  return json;
+}

--- a/control-center/connectors/warmbly/src/collector/routes.ts
+++ b/control-center/connectors/warmbly/src/collector/routes.ts
@@ -1,0 +1,51 @@
+/**
+ * Mapped Warmbly commercial-read routes (discovered from the fork, not invented).
+ *
+ * Prefer GET list when it exists. Contacts have no GET list — POST /search
+ * is the documented read. Deal/task POST /search and /summary are read queries.
+ */
+
+export type CollectRoute = {
+  key: keyof import("../contracts/warmbly-payload.ts").WarmblyPayload;
+  method: "GET" | "POST";
+  path: string;
+  body?: Record<string, unknown>;
+  required: boolean;
+};
+
+export const COLLECT_ROUTES: CollectRoute[] = [
+  { key: "health", method: "GET", path: "/health", required: true },
+  { key: "pipelines", method: "GET", path: "/v1/crm/pipelines", required: true },
+  { key: "deals", method: "GET", path: "/v1/crm/deals?limit=100", required: true },
+  {
+    key: "deals_summary",
+    method: "POST",
+    path: "/v1/crm/deals/summary",
+    body: {},
+    required: false,
+  },
+  { key: "tasks", method: "GET", path: "/v1/crm/tasks?limit=100", required: true },
+  {
+    key: "tasks_search",
+    method: "POST",
+    path: "/v1/crm/tasks/search",
+    body: { overdue: true, statuses: ["pending", "in_progress"] },
+    required: false,
+  },
+  { key: "contacts", method: "POST", path: "/v1/contacts/search", body: {}, required: true },
+  { key: "campaigns", method: "GET", path: "/v1/campaigns?limit=100", required: true },
+  { key: "campaigns_overview", method: "GET", path: "/v1/campaigns-overview", required: false },
+  { key: "unibox_overview", method: "GET", path: "/v1/unibox/overview", required: false },
+  { key: "confenge_status", method: "GET", path: "/v1/confenge/status", required: false },
+  { key: "confenge_ops_health", method: "GET", path: "/v1/confenge/ops/health", required: false },
+  {
+    key: "confenge_attention",
+    method: "GET",
+    path: "/v1/confenge/attention?filter=needs_attention&limit=50",
+    required: false,
+  },
+  { key: "confenge_today", method: "GET", path: "/v1/confenge/today", required: false },
+  { key: "confenge_inbound", method: "GET", path: "/v1/confenge/inbound", required: false },
+];
+
+export const MAPPED_READ_ROUTES = COLLECT_ROUTES.map((r) => `${r.method} ${r.path.split("?")[0]}`);

--- a/control-center/connectors/warmbly/src/contracts/required-upstream.ts
+++ b/control-center/connectors/warmbly/src/contracts/required-upstream.ts
@@ -1,0 +1,167 @@
+import type { RequiredUpstreamContract } from "./snapshot.ts";
+
+const AUTH_HEADERS = ["Authorization", "API-Version"];
+
+/** Always-documented gap: Warmbly has no GET /leads. */
+export const LEADS_LIST_CONTRACT: RequiredUpstreamContract = {
+  id: "GET /v1/leads",
+  method: "GET",
+  path: "/v1/leads",
+  reason:
+    "Warmbly has no GET /leads. The connector maps POST /v1/contacts/search plus GET /v1/confenge/inbound (and accounts, when enabled) as the lead surface. A dedicated leads list is not required while those reads stay available.",
+  min_request: {
+    method: "GET",
+    path: "/v1/leads",
+    query: { limit: "100" },
+    headers: AUTH_HEADERS,
+  },
+  min_response: {
+    status: 200,
+    body: {
+      data: [
+        {
+          id: "uuid",
+          company: "string",
+          status: "string",
+          created_at: "RFC3339 UTC",
+          updated_at: "RFC3339 UTC",
+        },
+      ],
+      pagination: { total: 0, has_more: false },
+    },
+  },
+};
+
+export function contractForUnavailable(path: string, method: string): RequiredUpstreamContract {
+  const normalized = path.split("?")[0] ?? path;
+  if (normalized === "/v1/confenge/attention") {
+    return {
+      id: "GET /v1/confenge/attention",
+      method: "GET",
+      path: "/v1/confenge/attention",
+      reason:
+        "Feature-flagged Confenge attention list was not readable. Cockpit still derives commercial attention from CRM tasks/deals, unibox, and campaigns; this read is needed to surface Warmbly-native needs-attention accounts.",
+      min_request: {
+        method: "GET",
+        path: "/v1/confenge/attention",
+        query: { filter: "needs_attention", limit: "50" },
+        headers: AUTH_HEADERS,
+      },
+      min_response: {
+        status: 200,
+        body: {
+          data: [
+            {
+              account_id: "uuid",
+              company_name: "string",
+              commercial_state: "string",
+              queue_state: "REPLIED",
+              confidence: 0.8,
+              updated_at: "RFC3339 UTC",
+            },
+          ],
+        },
+      },
+    };
+  }
+  if (normalized === "/v1/confenge/today") {
+    return {
+      id: "GET /v1/confenge/today",
+      method: "GET",
+      path: "/v1/confenge/today",
+      reason:
+        "Feature-flagged Confenge today view was not readable. Next-action attention still comes from CRM tasks when present.",
+      min_request: {
+        method: "GET",
+        path: "/v1/confenge/today",
+        headers: AUTH_HEADERS,
+      },
+      min_response: {
+        status: 200,
+        body: {
+          data: {
+            summary: { total: 0 },
+            actions: [
+              {
+                action_id: "uuid",
+                company: "string",
+                recommended_action: "string",
+                next_action_at: "RFC3339 UTC",
+                actionable: true,
+              },
+            ],
+          },
+        },
+      },
+    };
+  }
+  if (normalized === "/v1/confenge/inbound") {
+    return {
+      id: "GET /v1/confenge/inbound",
+      method: "GET",
+      path: "/v1/confenge/inbound",
+      reason:
+        "Feature-flagged inbound-now queue was not readable. Contacts search remains the substitute lead surface.",
+      min_request: {
+        method: "GET",
+        path: "/v1/confenge/inbound",
+        headers: AUTH_HEADERS,
+      },
+      min_response: {
+        status: 200,
+        body: {
+          data: [
+            {
+              lead_id: "string",
+              company: "string",
+              status: "NEW",
+              why_now: "string",
+              recommended_action: "string",
+              confidence: "HIGH",
+            },
+          ],
+        },
+      },
+    };
+  }
+  if (normalized === "/v1/confenge/ops/health") {
+    return {
+      id: "GET /v1/confenge/ops/health",
+      method: "GET",
+      path: "/v1/confenge/ops/health",
+      reason:
+        "Confenge ops health is feature-flagged. GET /health and GET /v1/confenge/status remain the always-on health/version probes.",
+      min_request: {
+        method: "GET",
+        path: "/v1/confenge/ops/health",
+        headers: AUTH_HEADERS,
+      },
+      min_response: {
+        status: 200,
+        body: {
+          data: {
+            computed_at: "RFC3339 UTC",
+            health_matrix: { status: "READY" },
+            alerts: [],
+            slos: [],
+          },
+        },
+      },
+    };
+  }
+  return {
+    id: `${method} ${normalized}`,
+    method: method === "POST" || method === "HEAD" ? method : "GET",
+    path: normalized,
+    reason: `Warmbly did not expose a safely readable ${method} ${normalized}. The connector fail-closed this surface instead of inventing or mutating upstream.`,
+    min_request: {
+      method,
+      path: normalized,
+      headers: AUTH_HEADERS,
+    },
+    min_response: {
+      status: 200,
+      body: { data: [] },
+    },
+  };
+}

--- a/control-center/connectors/warmbly/src/contracts/snapshot.ts
+++ b/control-center/connectors/warmbly/src/contracts/snapshot.ts
@@ -1,0 +1,118 @@
+/**
+ * Local CommercialSnapshot / SourceObservation contract.
+ *
+ * Canonical schemas live in control-center/contracts/ (owned by a parallel
+ * workstream). This file is the adapter-local shape used until convergence.
+ * Do not import that package from here.
+ */
+
+export const COMMERCIAL_SNAPSHOT_SCHEMA =
+  "control-center.commercial-snapshot.v1" as const;
+
+export const SNAPSHOT_SOURCE = "warmbly" as const;
+
+export type FreshnessStatus = "FRESH" | "STALE" | "UNKNOWN" | "ERROR";
+
+export type Money = {
+  amount_cents: number;
+  currency: string;
+};
+
+export type Provenance = {
+  source: typeof SNAPSHOT_SOURCE;
+  observed_at: string;
+  freshness_status: FreshnessStatus;
+  confidence?: number;
+};
+
+export type AttentionKind =
+  | "overdue_task"
+  | "next_action"
+  | "stalled_deal"
+  | "exception_state"
+  | "inbox_signal"
+  | "campaign_signal"
+  | "inbound_lead"
+  | "confenge_attention";
+
+export type AttentionSeverity = "high" | "medium" | "low";
+
+export type EntityRef = {
+  type: string;
+  id: string;
+};
+
+export type CommercialAttentionItem = {
+  id: string;
+  kind: AttentionKind;
+  title: string;
+  why: string;
+  severity: AttentionSeverity;
+  entity_ref?: EntityRef;
+  due_at?: string;
+  commercial_state?: string;
+  provenance: Provenance;
+};
+
+export type SourceObservation = {
+  id: string;
+  surface: string;
+  kind: "fetch" | "gap" | "health";
+  provenance: Provenance;
+  http_method?: string;
+  http_path?: string;
+  http_status?: number;
+  note?: string;
+};
+
+export type RequiredUpstreamContract = {
+  id: string;
+  method: "GET" | "POST" | "HEAD";
+  path: string;
+  reason: string;
+  min_request: {
+    method: string;
+    path: string;
+    query?: Record<string, string>;
+    headers: string[];
+    body?: Record<string, unknown>;
+  };
+  min_response: {
+    status: number;
+    body: Record<string, unknown>;
+  };
+};
+
+export type CommercialCounts = {
+  contacts: number;
+  deals_open: number;
+  deals_stalled: number;
+  tasks_open: number;
+  tasks_overdue: number;
+  campaigns_active: number;
+  inbox_unread: number;
+  inbox_awaiting_reply: number;
+  inbound_now: number;
+  confenge_attention: number;
+  attention: number;
+};
+
+export type ConnectorHealth = {
+  status: string;
+  api_version?: string;
+  confenge_enabled?: boolean;
+  version?: string;
+};
+
+export type CommercialSnapshot = {
+  schema: typeof COMMERCIAL_SNAPSHOT_SCHEMA;
+  source: typeof SNAPSHOT_SOURCE;
+  observed_at: string;
+  freshness_status: FreshnessStatus;
+  health: ConnectorHealth;
+  counts: CommercialCounts;
+  deal_value_open?: Money;
+  attention: CommercialAttentionItem[];
+  observations: SourceObservation[];
+  required_upstream_contract: RequiredUpstreamContract[];
+};

--- a/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
+++ b/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
@@ -1,0 +1,255 @@
+/** Warmbly-shaped runtime payload (synthetic fixtures or live HTTP bodies). */
+
+export type WarmblyPagination = {
+  total?: number | null;
+  next_cursor?: string | null;
+  has_more?: boolean;
+};
+
+export type WarmblyPipelineStage = {
+  id: string;
+  pipeline_id?: string;
+  name: string;
+  color?: string;
+  position?: number;
+  deal_count?: number;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type WarmblyPipeline = {
+  id: string;
+  name: string;
+  position?: number;
+  stages?: WarmblyPipelineStage[];
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type WarmblyDeal = {
+  id: string;
+  pipeline_id?: string;
+  stage_id?: string;
+  contact_id?: string | null;
+  name: string;
+  value?: number | null;
+  currency?: string;
+  status: string;
+  expected_close_date?: string | null;
+  won_at?: string | null;
+  lost_at?: string | null;
+  lost_reason?: string | null;
+  assigned_to?: string | null;
+  campaign_id?: string | null;
+  created_at: string;
+  updated_at: string;
+  stage?: WarmblyPipelineStage;
+};
+
+export type WarmblyDealsSummary = {
+  total?: number;
+  open_count?: number;
+  open_value?: number;
+  won_count?: number;
+  won_value?: number;
+  lost_count?: number;
+  lost_value?: number;
+  currency?: string;
+  mixed_currency?: boolean;
+};
+
+export type WarmblyTask = {
+  id: string;
+  contact_id?: string | null;
+  deal_id?: string | null;
+  assigned_to?: string | null;
+  title: string;
+  description?: string | null;
+  due_date?: string | null;
+  priority?: string;
+  type?: string;
+  status: string;
+  completed_at?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type WarmblyTasksSummary = {
+  total?: number;
+  pending_count?: number;
+  in_progress_count?: number;
+  completed_count?: number;
+  cancelled_count?: number;
+  overdue_count?: number;
+  high_priority_count?: number;
+};
+
+export type WarmblyContact = {
+  id: string;
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+  company?: string;
+  phone?: string;
+  subscribed?: boolean;
+  verification_status?: string;
+  campaign_lead?: {
+    status: string;
+    last_activity_at?: string | null;
+  } | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type WarmblyCampaign = {
+  id: string;
+  name: string;
+  status: string;
+  guardrail_tripped_at?: string | null;
+  guardrail_reason?: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type WarmblyCampaignsOverview = {
+  total?: number;
+  active?: number;
+  paused?: number;
+  draft?: number;
+  completed?: number;
+};
+
+export type WarmblyUniboxOverview = {
+  total?: number;
+  unread?: number;
+  today?: number;
+  week?: number;
+  snoozed?: number;
+  awaiting_reply?: number;
+  awaiting_agent_draft?: number;
+  scheduled_pending?: number;
+  generated_at?: string;
+};
+
+export type WarmblyConfengeStatus = {
+  enabled?: boolean;
+  auto_send_enabled?: boolean;
+  kill_switch?: boolean;
+  sending_allowed?: boolean;
+  feed_configured?: boolean;
+  ops_health?: { status?: string };
+  readiness?: { status?: string };
+};
+
+export type WarmblyOpsHealth = {
+  computed_at?: string;
+  lead_persisted?: boolean;
+  alerts?: Array<{ id?: string; status?: string }>;
+  slos?: Array<{ id?: string; status?: string }>;
+  health_matrix?: { status?: string };
+  matrix?: { status?: string };
+};
+
+export type WarmblyAttentionItem = {
+  account_id: string;
+  company_name: string;
+  contact_name?: string;
+  commercial_state?: string;
+  queue_state?: string;
+  suggested_action?: string;
+  confidence?: number;
+  intent?: string;
+  updated_at: string;
+  do_not_contact?: boolean;
+  blocked?: boolean;
+};
+
+export type WarmblyActionCard = {
+  action_id: string;
+  company?: string;
+  person?: string;
+  why_now?: string;
+  recommended_action?: string;
+  next_action_at?: string;
+  lane?: string;
+  state?: string;
+  actionable?: boolean;
+  confidence?: string;
+};
+
+export type WarmblyTodayView = {
+  summary?: { total?: number; calls?: number; emails_to_review?: number };
+  actions?: WarmblyActionCard[];
+};
+
+export type WarmblyInboundItem = {
+  lead_id: string;
+  company?: string;
+  person?: string;
+  status?: string;
+  why_now?: string;
+  recommended_action?: string;
+  next_action?: string;
+  freshness?: string;
+  confidence?: string;
+  lead_age_seconds?: number;
+  account_id?: string;
+};
+
+export type WarmblyList<T> = {
+  data: T[];
+  pagination?: WarmblyPagination;
+};
+
+export type EndpointFailure = {
+  method: string;
+  path: string;
+  status: number;
+  reason: string;
+};
+
+export type WarmblyHealth = {
+  status?: string;
+  version?: string;
+};
+
+export type WarmblyPayload = {
+  health?: WarmblyHealth;
+  api_version?: string;
+  pipelines?: WarmblyPipeline[] | WarmblyList<WarmblyPipeline>;
+  deals?: WarmblyDeal[] | WarmblyList<WarmblyDeal>;
+  deals_summary?: WarmblyDealsSummary;
+  tasks?: WarmblyTask[] | WarmblyList<WarmblyTask>;
+  tasks_search?: WarmblyTask[] | WarmblyList<WarmblyTask>;
+  tasks_summary?: WarmblyTasksSummary;
+  contacts?: WarmblyContact[] | WarmblyList<WarmblyContact>;
+  campaigns?: WarmblyCampaign[] | WarmblyList<WarmblyCampaign>;
+  campaigns_overview?: WarmblyCampaignsOverview;
+  unibox_overview?: WarmblyUniboxOverview;
+  confenge_status?: WarmblyConfengeStatus;
+  confenge_ops_health?: WarmblyOpsHealth | { data: WarmblyOpsHealth };
+  confenge_attention?: WarmblyAttentionItem[] | WarmblyList<WarmblyAttentionItem>;
+  confenge_today?: WarmblyTodayView | { data: WarmblyTodayView };
+  confenge_inbound?: WarmblyInboundItem[] | WarmblyList<WarmblyInboundItem>;
+  unavailable?: EndpointFailure[];
+};
+
+export function unwrapList<T>(value: T[] | WarmblyList<T> | undefined): T[] {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return Array.isArray(value.data) ? value.data : [];
+}
+
+export function unwrapData<T>(value: T | { data: T } | undefined): T | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "object" && value !== null && "data" in value) {
+    return (value as { data: T }).data;
+  }
+  return value;
+}

--- a/control-center/connectors/warmbly/src/http/allowlist.ts
+++ b/control-center/connectors/warmbly/src/http/allowlist.ts
@@ -1,0 +1,165 @@
+/**
+ * Fail-closed method/path allowlist.
+ *
+ * GET/HEAD of known commercial read surfaces, plus Warmbly's existing POST
+ * /search and /summary on contacts/deals/tasks (read queries; they must not
+ * change upstream state). Every other POST, and all PATCH/PUT/DELETE, is
+ * denied even if a caller asks.
+ */
+
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const GET_EXACT = new Set<string>([
+  "/health",
+  "/v1/crm/pipelines",
+  "/v1/crm/deals",
+  "/v1/crm/tasks",
+  "/v1/crm/task-types",
+  "/v1/campaigns",
+  "/v1/campaigns-overview",
+  "/v1/unibox/overview",
+  "/v1/unibox/count",
+  "/v1/confenge/status",
+  "/v1/confenge/ops/health",
+  "/v1/confenge/attention",
+  "/v1/confenge/today",
+  "/v1/confenge/inbound",
+  "/v1/confenge/summary",
+  "/v1/confenge/accounts",
+  "/v1/confenge/working-overview",
+  "/v1/confenge/dispatch/status",
+]);
+
+export const POST_READ_EXACT = new Set<string>([
+  "/v1/contacts/search",
+  "/v1/crm/deals/search",
+  "/v1/crm/deals/summary",
+  "/v1/crm/tasks/search",
+  "/v1/crm/tasks/summary",
+]);
+
+const MUTATING_POST_PREFIXES = [
+  "/v1/campaigns/",
+  "/v1/contacts",
+  "/v1/confenge/",
+  "/v1/unibox/",
+  "/v1/crm/deals",
+  "/v1/crm/tasks",
+  "/v1/crm/pipelines",
+];
+
+export function pathnameOf(urlOrPath: string): string {
+  try {
+    if (urlOrPath.startsWith("http://") || urlOrPath.startsWith("https://")) {
+      return new URL(urlOrPath).pathname;
+    }
+  } catch {
+    // fall through
+  }
+  const cut = urlOrPath.split("?")[0] ?? urlOrPath;
+  return cut.startsWith("/") ? cut : `/${cut}`;
+}
+
+function isUuidSegment(seg: string): boolean {
+  return UUID.test(seg);
+}
+
+function isAllowedGetPath(pathname: string): boolean {
+  if (GET_EXACT.has(pathname)) {
+    return true;
+  }
+  const parts = pathname.split("/").filter((p) => p.length > 0);
+  if (parts[0] !== "v1") {
+    return false;
+  }
+  if (parts[1] === "contacts" && parts.length === 3 && isUuidSegment(parts[2] ?? "")) {
+    return true;
+  }
+  if (
+    parts[1] === "crm" &&
+    (parts[2] === "deals" || parts[2] === "tasks" || parts[2] === "pipelines") &&
+    parts.length === 4 &&
+    isUuidSegment(parts[3] ?? "")
+  ) {
+    return true;
+  }
+  if (parts[1] === "campaigns" && parts.length === 3 && isUuidSegment(parts[2] ?? "")) {
+    return true;
+  }
+  if (
+    parts[1] === "confenge" &&
+    parts[2] === "attention" &&
+    parts.length === 4 &&
+    isUuidSegment(parts[3] ?? "")
+  ) {
+    return true;
+  }
+  if (
+    parts[1] === "confenge" &&
+    parts[2] === "accounts" &&
+    parts.length === 4 &&
+    isUuidSegment(parts[3] ?? "")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export type DeniedRequest = {
+  allowed: false;
+  method: string;
+  path: string;
+  reason: string;
+};
+
+export type AllowedRequest = {
+  allowed: true;
+  method: "GET" | "HEAD" | "POST";
+  path: string;
+};
+
+export function classifyRequest(
+  method: string,
+  urlOrPath: string,
+): AllowedRequest | DeniedRequest {
+  const path = pathnameOf(urlOrPath);
+  const m = method.toUpperCase();
+  if (m === "GET" || m === "HEAD") {
+    if (isAllowedGetPath(path)) {
+      return { allowed: true, method: m, path };
+    }
+    return {
+      allowed: false,
+      method: m,
+      path,
+      reason: `GET/HEAD path is not on the Warmbly commercial read allowlist: ${path}`,
+    };
+  }
+  if (m === "POST") {
+    if (POST_READ_EXACT.has(path)) {
+      return { allowed: true, method: "POST", path };
+    }
+    const mutating = MUTATING_POST_PREFIXES.some(
+      (prefix) => path === prefix || path.startsWith(prefix),
+    );
+    return {
+      allowed: false,
+      method: m,
+      path,
+      reason: mutating
+        ? `Mutating POST is forbidden on the Warmbly connector: ${path}`
+        : `POST path is not a documented read-search/summary: ${path}`,
+    };
+  }
+  return {
+    allowed: false,
+    method: m,
+    path,
+    reason: `${m} is forbidden (connector is read-only; only GET/HEAD and documented search/summary POST)`,
+  };
+}
+
+export function isAllowedRead(method: string, urlOrPath: string): boolean {
+  return classifyRequest(method, urlOrPath).allowed;
+}

--- a/control-center/connectors/warmbly/src/http/circuit-breaker.ts
+++ b/control-center/connectors/warmbly/src/http/circuit-breaker.ts
@@ -1,0 +1,61 @@
+export type CircuitState = "closed" | "open" | "half_open";
+
+export type CircuitBreakerOptions = {
+  failureThreshold: number;
+  resetMs: number;
+  now?: () => number;
+};
+
+export class CircuitOpenError extends Error {
+  readonly code = "CIRCUIT_OPEN" as const;
+  constructor(message = "Warmbly circuit breaker is open; fail-closed without upstream call") {
+    super(message);
+    this.name = "CircuitOpenError";
+  }
+}
+
+export class CircuitBreaker {
+  private failures = 0;
+  private state: CircuitState = "closed";
+  private openedAt = 0;
+  private readonly failureThreshold: number;
+  private readonly resetMs: number;
+  private readonly now: () => number;
+
+  constructor(opts: CircuitBreakerOptions) {
+    this.failureThreshold = opts.failureThreshold;
+    this.resetMs = opts.resetMs;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  getState(): CircuitState {
+    this.maybeHalfOpen();
+    return this.state;
+  }
+
+  assertClosed(): void {
+    if (this.getState() === "open") {
+      throw new CircuitOpenError();
+    }
+  }
+
+  recordSuccess(): void {
+    this.failures = 0;
+    this.state = "closed";
+    this.openedAt = 0;
+  }
+
+  recordFailure(): void {
+    this.failures += 1;
+    if (this.state === "half_open" || this.failures >= this.failureThreshold) {
+      this.state = "open";
+      this.openedAt = this.now();
+    }
+  }
+
+  private maybeHalfOpen(): void {
+    if (this.state === "open" && this.now() - this.openedAt >= this.resetMs) {
+      this.state = "half_open";
+    }
+  }
+}

--- a/control-center/connectors/warmbly/src/http/client.ts
+++ b/control-center/connectors/warmbly/src/http/client.ts
@@ -1,0 +1,271 @@
+import { classifyRequest } from "./allowlist.ts";
+import { CircuitBreaker, CircuitOpenError } from "./circuit-breaker.ts";
+import {
+  createStderrLogger,
+  redactHeaders,
+  redactSecrets,
+  type Logger,
+} from "./redaction.ts";
+
+export class MethodNotAllowedError extends Error {
+  readonly code = "METHOD_NOT_ALLOWED" as const;
+  readonly method: string;
+  readonly path: string;
+  constructor(method: string, path: string, reason: string) {
+    super(reason);
+    this.name = "MethodNotAllowedError";
+    this.method = method;
+    this.path = path;
+  }
+}
+
+export class TimeoutError extends Error {
+  readonly code = "TIMEOUT" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+export class UpstreamError extends Error {
+  readonly code = "UPSTREAM" as const;
+  readonly status: number;
+  constructor(status: number, path: string) {
+    super(`Warmbly upstream ${status} on ${path}`);
+    this.name = "UpstreamError";
+    this.status = status;
+  }
+}
+
+export type WarmblyClientOptions = {
+  baseUrl: string;
+  token: string;
+  timeoutMs?: number;
+  maxRetries?: number;
+  backoffMs?: number;
+  failureThreshold?: number;
+  resetMs?: number;
+  fetchImpl?: typeof fetch;
+  logger?: Logger;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+};
+
+export type WarmblyRequest = {
+  method: "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE";
+  path: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+};
+
+export type WarmblyResponse = {
+  ok: boolean;
+  status: number;
+  path: string;
+  method: string;
+  api_version?: string;
+  json: unknown;
+  fromCache: false;
+};
+
+function joinUrl(base: string, path: string): string {
+  const trimmed = base.replace(/\/+$/, "");
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${trimmed}${p}`;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class WarmblyClient {
+  readonly baseUrl: string;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+  private readonly maxRetries: number;
+  private readonly backoffMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger: Logger;
+  private readonly sleep: (ms: number) => Promise<void>;
+  readonly breaker: CircuitBreaker;
+  hitCount = 0;
+
+  constructor(opts: WarmblyClientOptions) {
+    if (!opts.baseUrl) {
+      throw new Error("WARMBLY_BASE_URL is required");
+    }
+    if (!opts.token) {
+      throw new Error("WARMBLY_API_TOKEN is required");
+    }
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.token = opts.token;
+    this.timeoutMs = opts.timeoutMs ?? 8_000;
+    this.maxRetries = opts.maxRetries ?? 2;
+    this.backoffMs = opts.backoffMs ?? 100;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.logger = opts.logger ?? createStderrLogger();
+    this.sleep = opts.sleep ?? defaultSleep;
+    this.breaker = new CircuitBreaker({
+      failureThreshold: opts.failureThreshold ?? 3,
+      resetMs: opts.resetMs ?? 30_000,
+      now: opts.now,
+    });
+  }
+
+  async request(req: WarmblyRequest): Promise<WarmblyResponse> {
+    const classified = classifyRequest(req.method, req.path);
+    if (!classified.allowed) {
+      this.logger({
+        level: "error",
+        msg: "warmbly.request.denied",
+        method: req.method,
+        path: classified.path,
+        reason: classified.reason,
+      });
+      throw new MethodNotAllowedError(req.method, classified.path, classified.reason);
+    }
+
+    this.breaker.assertClosed();
+
+    const url = joinUrl(this.baseUrl, req.path);
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      Authorization: `Bearer ${this.token}`,
+      "API-Version": "v1",
+      ...req.headers,
+    };
+    if (classified.method === "POST") {
+      headers["Content-Type"] = "application/json";
+    }
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt += 1) {
+      try {
+        this.breaker.assertClosed();
+        const response = await this.once(classified.method, url, headers, req.body);
+        if (response.status >= 500 || response.status === 429) {
+          throw new UpstreamError(response.status, classified.path);
+        }
+        this.breaker.recordSuccess();
+        this.logger({
+          level: "info",
+          msg: "warmbly.request.ok",
+          method: classified.method,
+          path: classified.path,
+          status: response.status,
+          attempt,
+        });
+        return response;
+      } catch (err) {
+        lastError = err;
+        if (err instanceof CircuitOpenError || err instanceof MethodNotAllowedError) {
+          throw err;
+        }
+        const retryable = isRetryable(err);
+        this.logger({
+          level: "warn",
+          msg: "warmbly.request.fail",
+          method: classified.method,
+          path: classified.path,
+          attempt,
+          retryable,
+          error: err instanceof Error ? err.name : "error",
+        });
+        if (!retryable || attempt === this.maxRetries) {
+          this.breaker.recordFailure();
+          throw err;
+        }
+        const delay = this.backoffMs * 2 ** attempt;
+        await this.sleep(delay);
+      }
+    }
+    this.breaker.recordFailure();
+    throw lastError instanceof Error ? lastError : new Error("warmbly request failed");
+  }
+
+  private async once(
+    method: "GET" | "HEAD" | "POST",
+    url: string,
+    headers: Record<string, string>,
+    body: unknown,
+  ): Promise<WarmblyResponse> {
+    this.hitCount += 1;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const init: RequestInit = {
+        method,
+        headers,
+        signal: controller.signal,
+      };
+      if (method === "POST") {
+        init.body = JSON.stringify(body ?? {});
+      }
+      const res = await this.fetchImpl(url, init);
+      const apiVersion = res.headers.get("API-Version") ?? undefined;
+      let json: unknown = null;
+      if (method !== "HEAD") {
+        const text = await res.text();
+        if (text.length > 0) {
+          try {
+            json = JSON.parse(text) as unknown;
+          } catch {
+            json = { raw: redactSecrets(text.slice(0, 200)) };
+          }
+        }
+      }
+      return {
+        ok: res.ok,
+        status: res.status,
+        path: pathnameFromUrl(url),
+        method,
+        api_version: apiVersion,
+        json,
+        fromCache: false,
+      };
+    } catch (err) {
+      if (isAbortError(err)) {
+        throw new TimeoutError(
+          `Warmbly request timed out after ${this.timeoutMs}ms: ${redactSecrets(url)}`,
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  describeAuthForLogs(): Record<string, string> {
+    return redactHeaders({ Authorization: `Bearer ${this.token}` });
+  }
+}
+
+function pathnameFromUrl(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    (err instanceof Error && err.name === "AbortError") ||
+    (typeof err === "object" && err !== null && "name" in err && (err as { name: string }).name === "AbortError")
+  );
+}
+
+function isRetryable(err: unknown): boolean {
+  if (err instanceof TimeoutError) {
+    return false;
+  }
+  if (err instanceof CircuitOpenError) {
+    return false;
+  }
+  if (err instanceof UpstreamError) {
+    return err.status >= 500 || err.status === 429;
+  }
+  return true;
+}
+
+export { CircuitOpenError };

--- a/control-center/connectors/warmbly/src/http/redaction.ts
+++ b/control-center/connectors/warmbly/src/http/redaction.ts
@@ -1,0 +1,91 @@
+const SECRET_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authorization",
+  "x-api-key",
+  "x-warmbly-key",
+]);
+
+const SECRET_KEY_NAMES = new Set([
+  "authorization",
+  "api_key",
+  "apikey",
+  "api-key",
+  "token",
+  "access_token",
+  "refresh_token",
+  "password",
+  "secret",
+  "warMBLY_API_TOKEN".toLowerCase(),
+  "warmbly_api_token",
+  "warmbly_api_key",
+  "bearer",
+]);
+
+const SECRET_PATTERN =
+  /(?:wmbly_[A-Za-z0-9+/=_-]{8,}|Bearer\s+[A-Za-z0-9._+/=-]{8,})/gi;
+
+export function redactSecrets(value: string): string {
+  return value.replace(SECRET_PATTERN, "[REDACTED]");
+}
+
+export function redactHeaders(
+  headers: Record<string, string> | Headers | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!headers) {
+    return out;
+  }
+  const entries =
+    headers instanceof Headers
+      ? Array.from(headers.entries())
+      : Object.entries(headers);
+  for (const [key, raw] of entries) {
+    if (SECRET_HEADER_NAMES.has(key.toLowerCase())) {
+      out[key] = "[REDACTED]";
+    } else {
+      out[key] = redactSecrets(String(raw));
+    }
+  }
+  return out;
+}
+
+export function redactUnknown(value: unknown): unknown {
+  if (typeof value === "string") {
+    return redactSecrets(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(redactUnknown);
+  }
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (SECRET_KEY_NAMES.has(k.toLowerCase())) {
+        out[k] = "[REDACTED]";
+      } else {
+        out[k] = redactUnknown(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+export type StructuredLog = {
+  level: "info" | "warn" | "error";
+  msg: string;
+  [key: string]: unknown;
+};
+
+export type Logger = (entry: StructuredLog) => void;
+
+export function createStderrLogger(): Logger {
+  return (entry) => {
+    const safe = redactUnknown(entry);
+    process.stderr.write(`${JSON.stringify(safe)}\n`);
+  };
+}
+
+export function serializeLog(entry: StructuredLog): string {
+  return JSON.stringify(redactUnknown(entry));
+}

--- a/control-center/connectors/warmbly/src/index.ts
+++ b/control-center/connectors/warmbly/src/index.ts
@@ -1,0 +1,29 @@
+export {
+  attentionSlice,
+  collect,
+  collectFromFixture,
+  collectFromWarmblyPayload,
+  WarmblyClient,
+} from "./collect.ts";
+export type { CollectOptions } from "./collect.ts";
+export {
+  COMMERCIAL_SNAPSHOT_SCHEMA,
+  SNAPSHOT_SOURCE,
+} from "./contracts/snapshot.ts";
+export type {
+  CommercialAttentionItem,
+  CommercialSnapshot,
+  FreshnessStatus,
+  Money,
+  Provenance,
+  RequiredUpstreamContract,
+  SourceObservation,
+} from "./contracts/snapshot.ts";
+export type { WarmblyPayload } from "./contracts/warmbly-payload.ts";
+export { classifyRequest, isAllowedRead } from "./http/allowlist.ts";
+export {
+  CircuitOpenError,
+  MethodNotAllowedError,
+  TimeoutError,
+} from "./http/client.ts";
+export { COLLECT_ROUTES, MAPPED_READ_ROUTES } from "./collector/routes.ts";

--- a/control-center/connectors/warmbly/src/mapper/attention.ts
+++ b/control-center/connectors/warmbly/src/mapper/attention.ts
@@ -1,0 +1,347 @@
+import type {
+  AttentionKind,
+  AttentionSeverity,
+  CommercialAttentionItem,
+  FreshnessStatus,
+} from "../contracts/snapshot.ts";
+import type {
+  WarmblyActionCard,
+  WarmblyAttentionItem,
+  WarmblyCampaign,
+  WarmblyDeal,
+  WarmblyInboundItem,
+  WarmblyTask,
+  WarmblyUniboxOverview,
+} from "../contracts/warmbly-payload.ts";
+import { mapConfidence, parseUtc, provenance } from "./freshness.ts";
+
+const STALL_MS = 14 * 24 * 60 * 60 * 1000;
+const NEXT_ACTION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const TERMINAL_TASK = new Set(["completed", "cancelled"]);
+const HIGH_PRIORITY = new Set(["high", "urgent"]);
+const INBOUND_DONE = new Set([
+  "done",
+  "completed",
+  "handled",
+  "closed",
+  "won",
+  "lost",
+  "dnc",
+  "do_not_contact",
+]);
+
+export type AttentionContext = {
+  now: Date;
+  freshness: FreshnessStatus;
+};
+
+function item(
+  kind: AttentionKind,
+  entityType: string,
+  entityId: string,
+  title: string,
+  why: string,
+  severity: AttentionSeverity,
+  ctx: AttentionContext,
+  extra?: {
+    due_at?: string;
+    commercial_state?: string;
+    confidence?: number;
+  },
+): CommercialAttentionItem {
+  const row: CommercialAttentionItem = {
+    id: `warmbly:${entityType}:${entityId}:${kind}`,
+    kind,
+    title,
+    why,
+    severity,
+    entity_ref: { type: entityType, id: entityId },
+    provenance: provenance(ctx.now, ctx.freshness, extra?.confidence),
+  };
+  if (extra?.due_at) {
+    row.due_at = extra.due_at;
+  }
+  if (extra?.commercial_state) {
+    row.commercial_state = extra.commercial_state;
+  }
+  return row;
+}
+
+export function attentionFromTasks(tasks: WarmblyTask[], ctx: AttentionContext): CommercialAttentionItem[] {
+  const out: CommercialAttentionItem[] = [];
+  for (const task of tasks) {
+    const status = (task.status ?? "").toLowerCase();
+    if (TERMINAL_TASK.has(status)) {
+      continue;
+    }
+    const due = parseUtc(task.due_date);
+    const overdue = Boolean(due && due.getTime() < ctx.now.getTime());
+    if (overdue && task.due_date) {
+      out.push(
+        item(
+          "overdue_task",
+          "task",
+          task.id,
+          task.title,
+          `CRM task is overdue (due ${task.due_date})`,
+          task.priority && HIGH_PRIORITY.has(task.priority.toLowerCase()) ? "high" : "high",
+          ctx,
+          { due_at: task.due_date, commercial_state: status },
+        ),
+      );
+      continue;
+    }
+    const dueSoon = Boolean(
+      due && due.getTime() - ctx.now.getTime() <= NEXT_ACTION_WINDOW_MS && due.getTime() >= ctx.now.getTime(),
+    );
+    const hot = HIGH_PRIORITY.has((task.priority ?? "").toLowerCase());
+    if (dueSoon || hot) {
+      out.push(
+        item(
+          "next_action",
+          "task",
+          task.id,
+          task.title,
+          dueSoon
+            ? `Next CRM action is due ${task.due_date}`
+            : `Open ${task.priority ?? "high"}-priority CRM task`,
+          hot ? "high" : "medium",
+          ctx,
+          { due_at: task.due_date ?? undefined, commercial_state: status },
+        ),
+      );
+    }
+  }
+  return out;
+}
+
+export function attentionFromDeals(deals: WarmblyDeal[], ctx: AttentionContext): CommercialAttentionItem[] {
+  const out: CommercialAttentionItem[] = [];
+  for (const deal of deals) {
+    const status = (deal.status ?? "").toLowerCase();
+    if (status !== "open") {
+      continue;
+    }
+    const updated = parseUtc(deal.updated_at);
+    if (!updated) {
+      continue;
+    }
+    if (ctx.now.getTime() - updated.getTime() >= STALL_MS) {
+      out.push(
+        item(
+          "stalled_deal",
+          "deal",
+          deal.id,
+          deal.name,
+          `Open deal has not moved since ${deal.updated_at}`,
+          "medium",
+          ctx,
+          { commercial_state: status },
+        ),
+      );
+    }
+  }
+  return out;
+}
+
+export function attentionFromCampaigns(
+  campaigns: WarmblyCampaign[],
+  ctx: AttentionContext,
+): CommercialAttentionItem[] {
+  const out: CommercialAttentionItem[] = [];
+  for (const campaign of campaigns) {
+    const tripped = Boolean(campaign.guardrail_tripped_at);
+    const status = (campaign.status ?? "").toLowerCase();
+    const exceptional =
+      tripped ||
+      status.includes("guardrail") ||
+      status === "error" ||
+      status === "failed";
+    if (!exceptional) {
+      continue;
+    }
+    out.push(
+      item(
+        "campaign_signal",
+        "campaign",
+        campaign.id,
+        campaign.name,
+        campaign.guardrail_reason
+          ? `Campaign needs a human: ${campaign.guardrail_reason}`
+          : `Campaign in exceptional state ${campaign.status}`,
+        "high",
+        ctx,
+        { commercial_state: campaign.status },
+      ),
+    );
+  }
+  return out;
+}
+
+export function attentionFromUnibox(
+  overview: WarmblyUniboxOverview | undefined,
+  ctx: AttentionContext,
+): CommercialAttentionItem[] {
+  if (!overview) {
+    return [];
+  }
+  const out: CommercialAttentionItem[] = [];
+  if ((overview.unread ?? 0) > 0) {
+    out.push(
+      item(
+        "inbox_signal",
+        "unibox",
+        "unread",
+        `${overview.unread} unread inbox threads`,
+        "Unibox has unread mail that needs a human",
+        overview.unread && overview.unread >= 5 ? "high" : "medium",
+        ctx,
+        { commercial_state: "unread" },
+      ),
+    );
+  }
+  if ((overview.awaiting_reply ?? 0) > 0) {
+    out.push(
+      item(
+        "inbox_signal",
+        "unibox",
+        "awaiting_reply",
+        `${overview.awaiting_reply} threads awaiting reply`,
+        "Unibox has unreplied threads",
+        "high",
+        ctx,
+        { commercial_state: "awaiting_reply" },
+      ),
+    );
+  }
+  if ((overview.awaiting_agent_draft ?? 0) > 0) {
+    out.push(
+      item(
+        "inbox_signal",
+        "unibox",
+        "awaiting_agent_draft",
+        `${overview.awaiting_agent_draft} inbox drafts awaiting review`,
+        "Inbox-agent drafts need a human decision",
+        "medium",
+        ctx,
+        { commercial_state: "awaiting_agent_draft" },
+      ),
+    );
+  }
+  return out;
+}
+
+export function attentionFromConfenge(
+  items: WarmblyAttentionItem[],
+  ctx: AttentionContext,
+): CommercialAttentionItem[] {
+  return items.map((row) =>
+    item(
+      "confenge_attention",
+      "account",
+      row.account_id,
+      row.company_name,
+      row.suggested_action ||
+        `Warmbly account in ${row.commercial_state || row.queue_state || "needs_attention"}`,
+      "high",
+      ctx,
+      {
+        commercial_state: row.commercial_state || row.queue_state,
+        confidence: mapConfidence(row.confidence),
+      },
+    ),
+  );
+}
+
+export function attentionFromToday(
+  cards: WarmblyActionCard[],
+  ctx: AttentionContext,
+): CommercialAttentionItem[] {
+  const out: CommercialAttentionItem[] = [];
+  for (const card of cards) {
+    if (card.actionable === false) {
+      continue;
+    }
+    const due = parseUtc(card.next_action_at);
+    const dueNow = !due || due.getTime() <= ctx.now.getTime() + NEXT_ACTION_WINDOW_MS;
+    if (!dueNow) {
+      continue;
+    }
+    out.push(
+      item(
+        "next_action",
+        "action",
+        card.action_id,
+        card.company ? `${card.company}: ${card.recommended_action ?? "next action"}` : (card.recommended_action ?? "Next commercial action"),
+        card.why_now || "Confenge today-view action requires a human",
+        "high",
+        ctx,
+        {
+          due_at: card.next_action_at,
+          commercial_state: card.state,
+          confidence: mapConfidence(card.confidence),
+        },
+      ),
+    );
+  }
+  return out;
+}
+
+export function attentionFromInbound(
+  items: WarmblyInboundItem[],
+  ctx: AttentionContext,
+): CommercialAttentionItem[] {
+  const out: CommercialAttentionItem[] = [];
+  for (const lead of items) {
+    const status = (lead.status ?? "new").toLowerCase();
+    if (INBOUND_DONE.has(status)) {
+      continue;
+    }
+    out.push(
+      item(
+        "inbound_lead",
+        "inbound_lead",
+        lead.lead_id,
+        lead.company || lead.person || lead.lead_id,
+        lead.why_now || lead.recommended_action || "Inbound lead needs a human",
+        "high",
+        ctx,
+        {
+          commercial_state: lead.status,
+          confidence: mapConfidence(lead.confidence),
+        },
+      ),
+    );
+  }
+  return out;
+}
+
+const SEVERITY_RANK: Record<AttentionSeverity, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+export function sortAttention(items: CommercialAttentionItem[]): CommercialAttentionItem[] {
+  return [...items].sort((a, b) => {
+    const s = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (s !== 0) {
+      return s;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function dedupeAttention(items: CommercialAttentionItem[]): CommercialAttentionItem[] {
+  const seen = new Set<string>();
+  const out: CommercialAttentionItem[] = [];
+  for (const row of items) {
+    if (seen.has(row.id)) {
+      continue;
+    }
+    seen.add(row.id);
+    out.push(row);
+  }
+  return out;
+}

--- a/control-center/connectors/warmbly/src/mapper/freshness.ts
+++ b/control-center/connectors/warmbly/src/mapper/freshness.ts
@@ -1,0 +1,83 @@
+import type { FreshnessStatus, Provenance } from "../contracts/snapshot.ts";
+import { SNAPSHOT_SOURCE } from "../contracts/snapshot.ts";
+
+export function toUtcIso(date: Date): string {
+  return date.toISOString();
+}
+
+export function parseUtc(value: string | undefined | null): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) {
+    return undefined;
+  }
+  return d;
+}
+
+export function provenance(
+  observedAt: Date,
+  freshness: FreshnessStatus,
+  confidence?: number,
+): Provenance {
+  const p: Provenance = {
+    source: SNAPSHOT_SOURCE,
+    observed_at: toUtcIso(observedAt),
+    freshness_status: freshness,
+  };
+  if (confidence !== undefined && Number.isFinite(confidence)) {
+    p.confidence = clampConfidence(confidence);
+  }
+  return p;
+}
+
+export function clampConfidence(value: number): number {
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return value > 1 && value <= 100 ? value / 100 : 1;
+  }
+  return value;
+}
+
+export function mapConfidence(raw: number | string | undefined): number | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  if (typeof raw === "number") {
+    return clampConfidence(raw);
+  }
+  const key = raw.trim().toUpperCase();
+  switch (key) {
+    case "HIGH":
+      return 0.9;
+    case "MEDIUM":
+      return 0.6;
+    case "LOW":
+      return 0.3;
+    case "UNKNOWN":
+      return undefined;
+    default: {
+      const n = Number(raw);
+      return Number.isFinite(n) ? clampConfidence(n) : undefined;
+    }
+  }
+}
+
+export function rollupFreshness(statuses: FreshnessStatus[]): FreshnessStatus {
+  if (statuses.includes("ERROR")) {
+    return "ERROR";
+  }
+  if (statuses.includes("UNKNOWN") && !statuses.includes("FRESH") && !statuses.includes("STALE")) {
+    return "UNKNOWN";
+  }
+  if (statuses.includes("STALE")) {
+    return "STALE";
+  }
+  if (statuses.includes("FRESH")) {
+    return "FRESH";
+  }
+  return "UNKNOWN";
+}

--- a/control-center/connectors/warmbly/src/mapper/money.ts
+++ b/control-center/connectors/warmbly/src/mapper/money.ts
@@ -1,0 +1,36 @@
+import type { Money } from "../contracts/snapshot.ts";
+
+const DEFAULT_CURRENCY = "BRL";
+
+/**
+ * Warmbly deal.value is a major-unit float (e.g. 1500.50 BRL).
+ * Control Center persists integer cents + currency.
+ */
+export function majorUnitsToCents(value: number, currency?: string): Money {
+  if (!Number.isFinite(value)) {
+    throw new Error("deal value is not a finite number");
+  }
+  return {
+    amount_cents: Math.round(value * 100),
+    currency: (currency && currency.trim()) || DEFAULT_CURRENCY,
+  };
+}
+
+export function sumOpenDealValue(
+  deals: Array<{ status: string; value?: number | null; currency?: string }>,
+): Money | undefined {
+  const open = deals.filter((d) => d.status.toLowerCase() === "open" && d.value != null);
+  if (open.length === 0) {
+    return undefined;
+  }
+  const currencies = new Set(open.map((d) => (d.currency && d.currency.trim()) || DEFAULT_CURRENCY));
+  if (currencies.size !== 1) {
+    return undefined;
+  }
+  const currency = [...currencies][0] ?? DEFAULT_CURRENCY;
+  let cents = 0;
+  for (const d of open) {
+    cents += majorUnitsToCents(d.value as number, currency).amount_cents;
+  }
+  return { amount_cents: cents, currency };
+}

--- a/control-center/connectors/warmbly/src/mapper/normalize.ts
+++ b/control-center/connectors/warmbly/src/mapper/normalize.ts
@@ -1,0 +1,330 @@
+import {
+  COMMERCIAL_SNAPSHOT_SCHEMA,
+  SNAPSHOT_SOURCE,
+  type CommercialSnapshot,
+  type FreshnessStatus,
+  type RequiredUpstreamContract,
+  type SourceObservation,
+} from "../contracts/snapshot.ts";
+import {
+  contractForUnavailable,
+  LEADS_LIST_CONTRACT,
+} from "../contracts/required-upstream.ts";
+import {
+  unwrapData,
+  unwrapList,
+  type EndpointFailure,
+  type WarmblyPayload,
+  type WarmblyTask,
+} from "../contracts/warmbly-payload.ts";
+import {
+  attentionFromCampaigns,
+  attentionFromConfenge,
+  attentionFromDeals,
+  attentionFromInbound,
+  attentionFromTasks,
+  attentionFromToday,
+  attentionFromUnibox,
+  dedupeAttention,
+  sortAttention,
+  type AttentionContext,
+} from "./attention.ts";
+import { provenance, rollupFreshness } from "./freshness.ts";
+import { majorUnitsToCents, sumOpenDealValue } from "./money.ts";
+
+export type NormalizeOptions = {
+  now?: Date;
+};
+
+function observation(
+  surface: string,
+  now: Date,
+  freshness: FreshnessStatus,
+  extra?: Partial<SourceObservation>,
+): SourceObservation {
+  return {
+    id: `warmbly:obs:${surface}`,
+    surface,
+    kind: extra?.kind ?? "fetch",
+    provenance: provenance(now, freshness, extra?.provenance?.confidence),
+    http_method: extra?.http_method,
+    http_path: extra?.http_path,
+    http_status: extra?.http_status,
+    note: extra?.note,
+  };
+}
+
+function mergeTasks(payload: WarmblyPayload): WarmblyTask[] {
+  const byId = new Map<string, WarmblyTask>();
+  for (const t of unwrapList(payload.tasks)) {
+    byId.set(t.id, t);
+  }
+  for (const t of unwrapList(payload.tasks_search)) {
+    byId.set(t.id, t);
+  }
+  return [...byId.values()];
+}
+
+export function collectFromWarmblyPayload(
+  payload: WarmblyPayload,
+  opts: NormalizeOptions = {},
+): CommercialSnapshot {
+  const now = opts.now ?? new Date();
+  const observations: SourceObservation[] = [];
+  const contracts: RequiredUpstreamContract[] = [];
+  const freshnessBySurface: FreshnessStatus[] = [];
+
+  const mark = (
+    surface: string,
+    present: boolean,
+    failure: EndpointFailure | undefined,
+    httpPath: string,
+    httpMethod: string,
+  ): FreshnessStatus => {
+    if (failure) {
+      const status: FreshnessStatus =
+        failure.status >= 500 ? "ERROR" : failure.status === 404 ? "UNKNOWN" : "ERROR";
+      freshnessBySurface.push(status);
+      observations.push(
+        observation(surface, now, status, {
+          kind: "gap",
+          http_method: failure.method,
+          http_path: failure.path,
+          http_status: failure.status,
+          note: failure.reason,
+        }),
+      );
+      contracts.push(contractForUnavailable(failure.path, failure.method));
+      return status;
+    }
+    if (!present) {
+      freshnessBySurface.push("UNKNOWN");
+      observations.push(
+        observation(surface, now, "UNKNOWN", {
+          kind: "gap",
+          http_method: httpMethod,
+          http_path: httpPath,
+          note: `${surface} was not present on this payload`,
+        }),
+      );
+      return "UNKNOWN";
+    }
+    freshnessBySurface.push("FRESH");
+    observations.push(
+      observation(surface, now, "FRESH", {
+        kind: surface === "health" ? "health" : "fetch",
+        http_method: httpMethod,
+        http_path: httpPath,
+        http_status: 200,
+      }),
+    );
+    return "FRESH";
+  };
+
+  const unavailable = new Map(
+    (payload.unavailable ?? []).map((u) => [`${u.method.toUpperCase()} ${u.path.split("?")[0]}`, u]),
+  );
+  const fail = (method: string, path: string): EndpointFailure | undefined =>
+    unavailable.get(`${method} ${path}`) ??
+    (payload.unavailable ?? []).find((u) => u.path.split("?")[0] === path);
+
+  const healthFresh = mark("health", Boolean(payload.health), fail("GET", "/health"), "/health", "GET");
+  mark(
+    "pipelines",
+    payload.pipelines !== undefined,
+    fail("GET", "/v1/crm/pipelines"),
+    "/v1/crm/pipelines",
+    "GET",
+  );
+  mark("deals", payload.deals !== undefined, fail("GET", "/v1/crm/deals"), "/v1/crm/deals", "GET");
+  mark(
+    "deals_summary",
+    payload.deals_summary !== undefined,
+    fail("POST", "/v1/crm/deals/summary"),
+    "/v1/crm/deals/summary",
+    "POST",
+  );
+  mark("tasks", payload.tasks !== undefined, fail("GET", "/v1/crm/tasks"), "/v1/crm/tasks", "GET");
+  mark(
+    "tasks_search",
+    payload.tasks_search !== undefined,
+    fail("POST", "/v1/crm/tasks/search"),
+    "/v1/crm/tasks/search",
+    "POST",
+  );
+  mark(
+    "contacts",
+    payload.contacts !== undefined,
+    fail("POST", "/v1/contacts/search"),
+    "/v1/contacts/search",
+    "POST",
+  );
+  mark(
+    "campaigns",
+    payload.campaigns !== undefined,
+    fail("GET", "/v1/campaigns"),
+    "/v1/campaigns",
+    "GET",
+  );
+  mark(
+    "campaigns_overview",
+    payload.campaigns_overview !== undefined,
+    fail("GET", "/v1/campaigns-overview"),
+    "/v1/campaigns-overview",
+    "GET",
+  );
+  mark(
+    "unibox_overview",
+    payload.unibox_overview !== undefined,
+    fail("GET", "/v1/unibox/overview"),
+    "/v1/unibox/overview",
+    "GET",
+  );
+  mark(
+    "confenge_status",
+    payload.confenge_status !== undefined,
+    fail("GET", "/v1/confenge/status"),
+    "/v1/confenge/status",
+    "GET",
+  );
+  const opsFail = fail("GET", "/v1/confenge/ops/health");
+  mark("confenge_ops_health", payload.confenge_ops_health !== undefined, opsFail, "/v1/confenge/ops/health", "GET");
+  mark(
+    "confenge_attention",
+    payload.confenge_attention !== undefined,
+    fail("GET", "/v1/confenge/attention"),
+    "/v1/confenge/attention",
+    "GET",
+  );
+  mark(
+    "confenge_today",
+    payload.confenge_today !== undefined,
+    fail("GET", "/v1/confenge/today"),
+    "/v1/confenge/today",
+    "GET",
+  );
+  mark(
+    "confenge_inbound",
+    payload.confenge_inbound !== undefined,
+    fail("GET", "/v1/confenge/inbound"),
+    "/v1/confenge/inbound",
+    "GET",
+  );
+
+  // Always record the known GET /leads gap (Warmbly does not expose it).
+  observations.push(
+    observation("leads", now, "UNKNOWN", {
+      kind: "gap",
+      http_method: "GET",
+      http_path: "/v1/leads",
+      note: LEADS_LIST_CONTRACT.reason,
+    }),
+  );
+  contracts.push(LEADS_LIST_CONTRACT);
+
+  const deals = unwrapList(payload.deals);
+  const tasks = mergeTasks(payload);
+  const contacts = unwrapList(payload.contacts);
+  const campaigns = unwrapList(payload.campaigns);
+  const pipelines = unwrapList(payload.pipelines);
+  const confengeAttention = unwrapList(payload.confenge_attention);
+  const inbound = unwrapList(payload.confenge_inbound);
+  const today = unwrapData(payload.confenge_today);
+  const unibox = payload.unibox_overview;
+
+  const ctx: AttentionContext = { now, freshness: "FRESH" };
+  const attention = sortAttention(
+    dedupeAttention([
+      ...attentionFromTasks(tasks, ctx),
+      ...attentionFromDeals(deals, ctx),
+      ...attentionFromCampaigns(campaigns, ctx),
+      ...attentionFromUnibox(unibox, ctx),
+      ...attentionFromConfenge(confengeAttention, ctx),
+      ...attentionFromToday(today?.actions ?? [], ctx),
+      ...attentionFromInbound(inbound, ctx),
+    ]),
+  );
+
+  const openDeals = deals.filter((d) => (d.status ?? "").toLowerCase() === "open");
+  const stalled = attention.filter((a) => a.kind === "stalled_deal").length;
+  const overdue = attention.filter((a) => a.kind === "overdue_task").length;
+  const openTasks = tasks.filter((t) => {
+    const s = (t.status ?? "").toLowerCase();
+    return s !== "completed" && s !== "cancelled";
+  }).length;
+
+  let dealValue = sumOpenDealValue(deals);
+  if (!dealValue && payload.deals_summary && payload.deals_summary.mixed_currency !== true) {
+    const currency = payload.deals_summary.currency || "BRL";
+    if (typeof payload.deals_summary.open_value === "number") {
+      dealValue = majorUnitsToCents(payload.deals_summary.open_value, currency);
+    }
+  }
+
+  const snapshotFreshness = rollupFreshness(
+    freshnessBySurface.length > 0 ? freshnessBySurface : [healthFresh],
+  );
+
+  const uniqueContracts = new Map<string, RequiredUpstreamContract>();
+  for (const c of contracts) {
+    uniqueContracts.set(c.id, c);
+  }
+
+  const snapshot: CommercialSnapshot = {
+    schema: COMMERCIAL_SNAPSHOT_SCHEMA,
+    source: SNAPSHOT_SOURCE,
+    observed_at: now.toISOString(),
+    freshness_status: snapshotFreshness,
+    health: {
+      status: payload.health?.status ?? (healthFresh === "FRESH" ? "ok" : "unknown"),
+      api_version: payload.api_version ?? "v1",
+      version: payload.health?.version,
+      confenge_enabled: payload.confenge_status?.enabled,
+    },
+    counts: {
+      contacts: contacts.length,
+      deals_open: openDeals.length,
+      deals_stalled: stalled,
+      tasks_open: openTasks,
+      tasks_overdue: overdue,
+      campaigns_active:
+        payload.campaigns_overview?.active ??
+        campaigns.filter((c) => (c.status ?? "").toLowerCase() === "active").length,
+      inbox_unread: unibox?.unread ?? 0,
+      inbox_awaiting_reply: unibox?.awaiting_reply ?? 0,
+      inbound_now: inbound.filter((l) => {
+        const s = (l.status ?? "new").toLowerCase();
+        return s !== "done" && s !== "handled" && s !== "closed";
+      }).length,
+      confenge_attention: confengeAttention.length,
+      attention: attention.length,
+    },
+    attention,
+    observations,
+    required_upstream_contract: [...uniqueContracts.values()],
+  };
+  if (dealValue) {
+    snapshot.deal_value_open = dealValue;
+  }
+
+  // Pipelines are read for stage names on stalled deals only — never copied
+  // onto the snapshot as a replica board.
+  void pipelines;
+
+  return snapshot;
+}
+
+/** Stable attention slice for idempotency comparisons (ignores observed_at). */
+export function attentionSlice(snapshot: CommercialSnapshot): Array<{
+  id: string;
+  kind: string;
+  title: string;
+  why: string;
+}> {
+  return snapshot.attention.map((a) => ({
+    id: a.id,
+    kind: a.kind,
+    title: a.title,
+    why: a.why,
+  }));
+}

--- a/control-center/connectors/warmbly/src/stub-server.ts
+++ b/control-center/connectors/warmbly/src/stub-server.ts
@@ -1,0 +1,188 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { pathnameOf } from "./http/allowlist.ts";
+import type { WarmblyPayload } from "./contracts/warmbly-payload.ts";
+
+export type RecordedCall = {
+  method: string;
+  path: string;
+  url: string;
+};
+
+export type StubOptions = {
+  payload: WarmblyPayload;
+  hide?: string[];
+  delayMs?: number;
+  failStatus?: number;
+  failAfter?: number;
+  token?: string;
+};
+
+export type FixtureStub = {
+  server: Server;
+  url: string;
+  calls: RecordedCall[];
+  close: () => Promise<void>;
+};
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function json(res: ServerResponse, status: number, body: unknown, apiVersion = "v1"): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("API-Version", apiVersion);
+  res.end(JSON.stringify(body));
+}
+
+function routeBody(payload: WarmblyPayload, pathname: string): unknown | undefined {
+  switch (pathname) {
+    case "/health":
+      return payload.health ?? { status: "ok" };
+    case "/v1/crm/pipelines":
+      return payload.pipelines ?? [];
+    case "/v1/crm/deals":
+      return payload.deals ?? { data: [], pagination: { has_more: false } };
+    case "/v1/crm/deals/summary":
+      return payload.deals_summary ?? { total: 0, open_count: 0, open_value: 0, currency: "BRL" };
+    case "/v1/crm/deals/search":
+      return payload.deals ?? { data: [], pagination: { has_more: false } };
+    case "/v1/crm/tasks":
+      return payload.tasks ?? { data: [], pagination: { has_more: false } };
+    case "/v1/crm/tasks/search":
+      return payload.tasks_search ?? payload.tasks ?? { data: [], pagination: { has_more: false } };
+    case "/v1/crm/tasks/summary":
+      return payload.tasks_summary ?? { total: 0, overdue_count: 0 };
+    case "/v1/contacts/search":
+      return payload.contacts ?? { data: [], pagination: { has_more: false } };
+    case "/v1/campaigns":
+      return payload.campaigns ?? { data: [], pagination: { has_more: false } };
+    case "/v1/campaigns-overview":
+      return payload.campaigns_overview ?? { total: 0, active: 0 };
+    case "/v1/unibox/overview":
+      return payload.unibox_overview ?? { unread: 0, awaiting_reply: 0 };
+    case "/v1/confenge/status":
+      return payload.confenge_status ?? { enabled: false };
+    case "/v1/confenge/ops/health":
+      return payload.confenge_ops_health ?? { data: { computed_at: new Date().toISOString() } };
+    case "/v1/confenge/attention":
+      return payload.confenge_attention ?? { data: [] };
+    case "/v1/confenge/today":
+      return payload.confenge_today ?? { data: { summary: { total: 0 }, actions: [] } };
+    case "/v1/confenge/inbound":
+      return payload.confenge_inbound ?? { data: [] };
+    default:
+      return undefined;
+  }
+}
+
+export async function startFixtureStub(opts: StubOptions): Promise<FixtureStub> {
+  const calls: RecordedCall[] = [];
+  const hide = new Set(opts.hide ?? []);
+  let hits = 0;
+  const stateChanged = { value: false };
+
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const method = (req.method ?? "GET").toUpperCase();
+    const url = req.url ?? "/";
+    const path = pathnameOf(url);
+    calls.push({ method, path, url });
+    hits += 1;
+
+    const finish = (): void => {
+      if (opts.token) {
+        const auth = req.headers.authorization ?? "";
+        if (auth !== `Bearer ${opts.token}`) {
+          json(res, 401, { error: "unauthorized" });
+          return;
+        }
+      }
+      if (method === "PUT" || method === "PATCH" || method === "DELETE") {
+        json(res, 405, { error: "mutated" });
+        return;
+      }
+      if (method === "POST") {
+        void readBody(req).then(() => {
+          if (
+            path === "/v1/contacts/search" ||
+            path === "/v1/crm/deals/search" ||
+            path === "/v1/crm/deals/summary" ||
+            path === "/v1/crm/tasks/search" ||
+            path === "/v1/crm/tasks/summary"
+          ) {
+            serveRead();
+            return;
+          }
+          stateChanged.value = true;
+          json(res, 201, { error: "stub-would-mutate", path });
+        });
+        return;
+      }
+      serveRead();
+    };
+
+    const serveRead = (): void => {
+      if (typeof opts.failStatus === "number" && hits > (opts.failAfter ?? 0)) {
+        json(res, opts.failStatus, { error: "injected" });
+        return;
+      }
+      if (hide.has(path) || hide.has(`${method} ${path}`)) {
+        json(res, 404, { error: "CONFENGE outreach is not enabled on this server" });
+        return;
+      }
+      const body = routeBody(opts.payload, path);
+      if (body === undefined) {
+        json(res, 404, { error: "not found", path });
+        return;
+      }
+      json(res, 200, body);
+    };
+
+    if (opts.delayMs && opts.delayMs > 0) {
+      setTimeout(finish, opts.delayMs);
+    } else {
+      finish();
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    throw new Error("stub server failed to bind");
+  }
+  const url = `http://127.0.0.1:${addr.port}`;
+  return {
+    server,
+    url,
+    calls,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+export function stubMutated(calls: RecordedCall[]): boolean {
+  return calls.some((c) => {
+    if (c.method === "PUT" || c.method === "PATCH" || c.method === "DELETE") {
+      return true;
+    }
+    if (c.method !== "POST") {
+      return false;
+    }
+    return (
+      c.path !== "/v1/contacts/search" &&
+      c.path !== "/v1/crm/deals/search" &&
+      c.path !== "/v1/crm/deals/summary" &&
+      c.path !== "/v1/crm/tasks/search" &&
+      c.path !== "/v1/crm/tasks/summary"
+    );
+  });
+}

--- a/control-center/connectors/warmbly/tests/collect.test.ts
+++ b/control-center/connectors/warmbly/tests/collect.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  attentionSlice,
+  collect,
+  collectFromWarmblyPayload,
+} from "../src/collect.ts";
+import { COMMERCIAL_SNAPSHOT_SCHEMA, SNAPSHOT_SOURCE } from "../src/contracts/snapshot.ts";
+import { WarmblyClient } from "../src/http/client.ts";
+import { startFixtureStub } from "../src/stub-server.ts";
+import { loadFixture, NOW } from "./helpers.ts";
+
+describe("collectFromWarmblyPayload (shipped normalize)", () => {
+  it("maps Warmbly-shaped fixtures into CommercialSnapshot + observations with provenance", () => {
+    const payload = loadFixture("commercial-runtime.json");
+    const snapshot = collectFromWarmblyPayload(payload, { now: NOW });
+
+    assert.equal(snapshot.schema, COMMERCIAL_SNAPSHOT_SCHEMA);
+    assert.equal(snapshot.source, SNAPSHOT_SOURCE);
+    assert.equal(snapshot.observed_at, NOW.toISOString());
+    assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(snapshot.freshness_status));
+    assert.equal(snapshot.health.status, "ok");
+    assert.equal(snapshot.health.api_version, "v1");
+
+    for (const row of snapshot.attention) {
+      assert.equal(row.provenance.source, "warmbly");
+      assert.equal(row.provenance.observed_at, NOW.toISOString());
+      assert.ok(row.provenance.freshness_status);
+    }
+    for (const obs of snapshot.observations) {
+      assert.equal(obs.provenance.source, "warmbly");
+      assert.equal(obs.provenance.observed_at, NOW.toISOString());
+      assert.ok(obs.provenance.freshness_status);
+    }
+
+    const alpha = snapshot.attention.find((a) => a.entity_ref?.id === "acc-needs-1");
+    assert.ok(alpha);
+    assert.equal(alpha.provenance.confidence, 0.8);
+
+    const inbound = snapshot.attention.find((a) => a.entity_ref?.id === "inbound-new-1");
+    assert.ok(inbound);
+    assert.equal(inbound.provenance.confidence, 0.9);
+  });
+
+  it("converts deal values to integer cents + currency and does not replica the pipeline", () => {
+    const snapshot = collectFromWarmblyPayload(loadFixture("commercial-runtime.json"), { now: NOW });
+    assert.ok(snapshot.deal_value_open);
+    assert.equal(Number.isInteger(snapshot.deal_value_open.amount_cents), true);
+    assert.equal(snapshot.deal_value_open.currency, "BRL");
+    assert.equal(snapshot.deal_value_open.amount_cents, Math.round(1500.5 * 100) + Math.round(2000 * 100));
+
+    assert.equal("deals" in snapshot, false);
+    assert.equal("pipelines" in snapshot, false);
+    assert.equal("tasks" in snapshot, false);
+    assert.equal("contacts" in snapshot, false);
+    assert.equal("stages" in snapshot, false);
+    assert.ok(!JSON.stringify(snapshot.attention).includes("Qualificação"));
+  });
+
+  it("derives commercial attention from mixed fixtures without owning the pipeline", () => {
+    const snapshot = collectFromWarmblyPayload(loadFixture("commercial-runtime.json"), { now: NOW });
+    assert.ok(snapshot.attention.length > 0);
+
+    const ids = snapshot.attention.map((a) => a.id);
+    assert.ok(ids.includes("warmbly:task:task-overdue-1:overdue_task"));
+    assert.ok(ids.includes("warmbly:task:task-next-1:next_action"));
+    assert.ok(ids.includes("warmbly:deal:deal-stalled-1:stalled_deal"));
+    assert.ok(ids.includes("warmbly:campaign:camp-tripped-1:campaign_signal"));
+    assert.ok(ids.includes("warmbly:unibox:unread:inbox_signal"));
+    assert.ok(ids.includes("warmbly:unibox:awaiting_reply:inbox_signal"));
+    assert.ok(ids.includes("warmbly:account:acc-needs-1:confenge_attention"));
+    assert.ok(ids.includes("warmbly:inbound_lead:inbound-new-1:inbound_lead"));
+
+    assert.ok(!ids.some((id) => id.includes("task-done-1")));
+    assert.ok(!ids.some((id) => id.includes("deal-healthy-1")));
+    assert.ok(!ids.some((id) => id.includes("deal-won-1")));
+    assert.ok(!ids.some((id) => id.includes("camp-active-1")));
+    assert.ok(!ids.some((id) => id.includes("inbound-done-1")));
+
+    const overdue = snapshot.attention.find((a) => a.id.includes("task-overdue-1"));
+    assert.ok(overdue);
+    assert.match(overdue.title, /Gama/);
+    assert.equal(overdue.kind, "overdue_task");
+  });
+
+  it("is idempotent: second collect of the same fixtures keeps stable ids and no duplicate attention rows", () => {
+    const payload = loadFixture("commercial-runtime.json");
+    const a = collectFromWarmblyPayload(payload, { now: NOW });
+    const b = collectFromWarmblyPayload(payload, { now: NOW });
+    assert.deepEqual(attentionSlice(a), attentionSlice(b));
+    const idSet = new Set(a.attention.map((row) => row.id));
+    assert.equal(idSet.size, a.attention.length);
+  });
+
+  it("fail-closes a missing Confenge endpoint with required_upstream_contract and UNKNOWN/ERROR freshness", () => {
+    const snapshot = collectFromWarmblyPayload(loadFixture("missing-endpoint.json"), { now: NOW });
+    const gap = snapshot.observations.find((o) => o.http_path === "/v1/confenge/attention");
+    assert.ok(gap);
+    assert.ok(gap.provenance.freshness_status === "UNKNOWN" || gap.provenance.freshness_status === "ERROR");
+    const contract = snapshot.required_upstream_contract.find((c) => c.path === "/v1/confenge/attention");
+    assert.ok(contract);
+    assert.equal(contract.method, "GET");
+    assert.ok(contract.min_request.path);
+    assert.ok(contract.min_response.body);
+    assert.ok(snapshot.attention.some((a) => a.id.includes("task-overdue-1")));
+    assert.equal(snapshot.attention.some((a) => a.kind === "confenge_attention"), false);
+  });
+});
+
+describe("collect() against a local Warmbly-shaped stub", () => {
+  it("returns the same non-empty attention slice on two runs", async () => {
+    const payload = loadFixture("commercial-runtime.json");
+    const token = "wmbly_collect_stub_token";
+    const stub = await startFixtureStub({ payload, token });
+    try {
+      const client = () =>
+        new WarmblyClient({
+          baseUrl: stub.url,
+          token,
+          timeoutMs: 2_000,
+          maxRetries: 0,
+          logger: () => undefined,
+        });
+      const run1 = await collect({ client: client(), now: NOW });
+      const run2 = await collect({ client: client(), now: NOW });
+      assert.equal(run1.schema, COMMERCIAL_SNAPSHOT_SCHEMA);
+      assert.ok(run1.attention.length > 0);
+      assert.deepEqual(attentionSlice(run1), attentionSlice(run2));
+      assert.equal(
+        stub.calls.some((c) => c.method === "PATCH" || c.method === "PUT" || c.method === "DELETE"),
+        false,
+      );
+    } finally {
+      await stub.close();
+    }
+  });
+});

--- a/control-center/connectors/warmbly/tests/helpers.ts
+++ b/control-center/connectors/warmbly/tests/helpers.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { WarmblyPayload } from "../src/contracts/warmbly-payload.ts";
+
+export const NOW = new Date("2026-08-20T15:00:00.000Z");
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+export function loadFixture(name: string): WarmblyPayload {
+  const text = readFileSync(join(ROOT, "fixtures", name), "utf8");
+  return JSON.parse(text) as WarmblyPayload;
+}
+
+export function capturingLogger(): {
+  entries: Array<Record<string, unknown>>;
+  logger: (entry: { level: "info" | "warn" | "error"; msg: string; [k: string]: unknown }) => void;
+  blob: () => string;
+} {
+  const entries: Array<Record<string, unknown>> = [];
+  return {
+    entries,
+    logger: (entry) => {
+      entries.push(entry);
+    },
+    blob: () => JSON.stringify(entries),
+  };
+}

--- a/control-center/connectors/warmbly/tests/http-safety.test.ts
+++ b/control-center/connectors/warmbly/tests/http-safety.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { classifyRequest } from "../src/http/allowlist.ts";
+import {
+  CircuitOpenError,
+  MethodNotAllowedError,
+  TimeoutError,
+  WarmblyClient,
+} from "../src/http/client.ts";
+import { serializeLog } from "../src/http/redaction.ts";
+import { startFixtureStub } from "../src/stub-server.ts";
+import { capturingLogger, loadFixture } from "./helpers.ts";
+
+const TOKEN = "wmbly_super_secret_test_token_do_not_log";
+
+describe("HTTP allowlist", () => {
+  it("allows GET commercial reads and documented search/summary POST", () => {
+    assert.equal(classifyRequest("GET", "/health").allowed, true);
+    assert.equal(classifyRequest("GET", "/v1/crm/deals?limit=100").allowed, true);
+    assert.equal(classifyRequest("POST", "/v1/contacts/search").allowed, true);
+    assert.equal(classifyRequest("POST", "/v1/crm/deals/search").allowed, true);
+    assert.equal(classifyRequest("POST", "/v1/crm/deals/summary").allowed, true);
+    assert.equal(classifyRequest("POST", "/v1/crm/tasks/search").allowed, true);
+    assert.equal(classifyRequest("POST", "/v1/crm/tasks/summary").allowed, true);
+  });
+
+  it("denies mutating methods and mutating POST paths", () => {
+    assert.equal(classifyRequest("POST", "/v1/crm/deals").allowed, false);
+    assert.equal(classifyRequest("POST", "/v1/crm/tasks").allowed, false);
+    assert.equal(classifyRequest("POST", "/v1/contacts").allowed, false);
+    assert.equal(classifyRequest("POST", "/v1/campaigns/abc/start").allowed, false);
+    assert.equal(classifyRequest("POST", "/v1/confenge/import").allowed, false);
+    assert.equal(classifyRequest("POST", "/v1/confenge/crm/bootstrap").allowed, false);
+    assert.equal(classifyRequest("POST", "/v1/unibox/reply").allowed, false);
+    assert.equal(classifyRequest("PATCH", "/v1/crm/deals/x").allowed, false);
+    assert.equal(classifyRequest("PUT", "/v1/crm/deals/x").allowed, false);
+    assert.equal(classifyRequest("DELETE", "/v1/crm/tasks/x").allowed, false);
+  });
+});
+
+describe("WarmblyClient against a local stub", () => {
+  it("never issues mutating calls even if a caller asks; stub state is untouched", async () => {
+    const stub = await startFixtureStub({ payload: loadFixture("commercial-runtime.json"), token: TOKEN });
+    const fetchHits: string[] = [];
+    const logger = capturingLogger();
+    try {
+      const client = new WarmblyClient({
+        baseUrl: stub.url,
+        token: TOKEN,
+        maxRetries: 0,
+        logger: logger.logger,
+        fetchImpl: async (input, init) => {
+          fetchHits.push(`${init?.method ?? "GET"} ${String(input)}`);
+          return fetch(input, init);
+        },
+      });
+
+      await assert.rejects(
+        () => client.request({ method: "POST", path: "/v1/crm/deals", body: { name: "nope" } }),
+        MethodNotAllowedError,
+      );
+      await assert.rejects(
+        () => client.request({ method: "PATCH", path: "/v1/crm/deals/deal-healthy-1" }),
+        MethodNotAllowedError,
+      );
+      await assert.rejects(
+        () => client.request({ method: "DELETE", path: "/v1/crm/tasks/task-overdue-1" }),
+        MethodNotAllowedError,
+      );
+      await assert.rejects(
+        () => client.request({ method: "POST", path: "/v1/confenge/import" }),
+        MethodNotAllowedError,
+      );
+      await assert.rejects(
+        () => client.request({ method: "POST", path: "/v1/unibox/reply" }),
+        MethodNotAllowedError,
+      );
+
+      const search = await client.request({ method: "POST", path: "/v1/contacts/search", body: {} });
+      assert.equal(search.status, 200);
+
+      assert.equal(fetchHits.some((h) => h.startsWith("PATCH") || h.startsWith("DELETE") || h.startsWith("PUT")), false);
+      assert.equal(
+        fetchHits.some((h) => h.includes("/v1/crm/deals") && h.startsWith("POST ") && !h.includes("/search") && !h.includes("/summary")),
+        false,
+      );
+      assert.equal(stub.calls.some((c) => c.method === "PATCH" || c.method === "DELETE" || c.method === "PUT"), false);
+      assert.equal(
+        stub.calls.some((c) => c.method === "POST" && c.path === "/v1/crm/deals"),
+        false,
+      );
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("fires timeouts", async () => {
+    const stub = await startFixtureStub({
+      payload: loadFixture("commercial-runtime.json"),
+      token: TOKEN,
+      delayMs: 250,
+    });
+    try {
+      const client = new WarmblyClient({
+        baseUrl: stub.url,
+        token: TOKEN,
+        timeoutMs: 40,
+        maxRetries: 0,
+        logger: () => undefined,
+      });
+      await assert.rejects(() => client.request({ method: "GET", path: "/health" }), TimeoutError);
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("opens the circuit breaker after repeated failures and then fail-closes without hitting the stub", async () => {
+    const stub = await startFixtureStub({
+      payload: loadFixture("commercial-runtime.json"),
+      token: TOKEN,
+      failStatus: 500,
+    });
+    try {
+      const client = new WarmblyClient({
+        baseUrl: stub.url,
+        token: TOKEN,
+        timeoutMs: 1_000,
+        maxRetries: 0,
+        failureThreshold: 2,
+        resetMs: 60_000,
+        logger: () => undefined,
+      });
+      await assert.rejects(() => client.request({ method: "GET", path: "/health" }));
+      await assert.rejects(() => client.request({ method: "GET", path: "/health" }));
+      const hitsAfterFailures = stub.calls.length;
+      assert.ok(hitsAfterFailures >= 2);
+      await assert.rejects(() => client.request({ method: "GET", path: "/health" }), CircuitOpenError);
+      assert.equal(stub.calls.length, hitsAfterFailures);
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("does not leak API keys in structured logs", async () => {
+    const stub = await startFixtureStub({ payload: loadFixture("commercial-runtime.json"), token: TOKEN });
+    const logger = capturingLogger();
+    try {
+      const client = new WarmblyClient({
+        baseUrl: stub.url,
+        token: TOKEN,
+        maxRetries: 0,
+        logger: logger.logger,
+      });
+      await client.request({ method: "GET", path: "/health" });
+      const serialized = serializeLog({
+        level: "info",
+        msg: "probe",
+        authorization: `Bearer ${TOKEN}`,
+        token: TOKEN,
+      });
+      const blob = `${logger.blob()}\n${serialized}\n${JSON.stringify(client.describeAuthForLogs())}`;
+      assert.equal(blob.includes(TOKEN), false);
+      assert.equal(blob.includes("wmbly_super_secret"), false);
+    } finally {
+      await stub.close();
+    }
+  });
+});

--- a/control-center/connectors/warmbly/tsconfig.json
+++ b/control-center/connectors/warmbly/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Read-only Warmbly adapter for the Confenge Control Center cockpit. It maps Warmbly commercial runtime (contacts/leads, deals/pipeline stages, tasks/next actions, campaign + unibox signals, commercial states/timestamps, health/version) into a local `CommercialSnapshot` plus `observations` so the cockpit can answer **o que exige atenção comercial** without owning the CRM pipeline.

Canonical CRM remains Warmbly. This PR does not persist a replica pipeline and does not write Warmbly.

## Path

Owned exclusively: `control-center/connectors/warmbly/` on `cc/06-warmbly-connector`.
Does not touch `commercial/`, `decisions/`, `scripts/`, root README, Governance PR #8, Warmbly, web-cfg, or extra-cli.

## Behavior

- HTTP client is fail-closed: timeouts, backoff, circuit breaker, method allowlist.
- GET/HEAD of discovered commercial reads; POST only for Warmbly `/search` and `/summary` on contacts, deals, and tasks (read queries).
- PATCH/PUT/DELETE and mutating POST (create, send, enroll, import, bootstrap, dispatch, Asaas) are denied even if a caller asks.
- Every aggregated item carries `source`, `observed_at` (UTC), `freshness_status`, and `confidence` when supplied.
- Deal money is integer cents + currency.
- Collect is idempotent on the same upstream payload (stable attention ids, no duplicate rows).
- Missing feature-flagged Confenge reads produce `required_upstream_contract` + UNKNOWN/ERROR observations, not a Warmbly write.
- `GET /v1/leads` does not exist; contacts search + inbound are the lead surface (documented gap).

## Tests

From `control-center/connectors/warmbly`:

```bash
npm install
npm test
npm run collect -- --stub --now 2026-08-20T15:00:00.000Z
```

Local stub only. No live Warmbly/Asaas calls.

## Convergence (later campaign)

- Replace local snapshot types with `control-center/contracts/` `CommercialSnapshot` / `SourceObservation`.
- Persistence ingest should store observations + attention facts, not a deal/pipeline replica.
- Context service / MCP should query attention by scope.

Draft — do not merge automatically.
