### PR TITLE
feat(control-center): add clients domain attention read model

### DIFF
--- a/control-center/domains/clients/.env.example
+++ b/control-center/domains/clients/.env.example
@@ -1,0 +1,10 @@
+# In-process store is the persistence bar for this wave. No secrets required.
+CONTROL_CENTER_CLIENTS_STORE=memory
+
+# Display timezone for operator presentation only. Internal timestamps stay UTC.
+CONTROL_CENTER_DISPLAY_TZ=America/Sao_Paulo
+
+# Reserved for convergence with control-center/persistence.
+# This package will not open a database connection in this wave.
+# Never commit the value. Never put the URL in logs or client bundles.
+# DATABASE_URL=

--- a/control-center/domains/clients/.gitignore
+++ b/control-center/domains/clients/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+*.log
+coverage/

--- a/control-center/domains/clients/README.md
+++ b/control-center/domains/clients/README.md
@@ -1,0 +1,110 @@
+# Control Center — clients domain
+
+Read model for **account health / delivery commitments**, not a CRM.
+
+Warmbly remains the commercial/CRM authority (contacts, leads, pipeline,
+email). Governance remains the strategic/canonical authority. This package
+aggregates delivery state so a homepage can answer:
+
+> Qual cliente precisa de mim agora e por quê?
+
+It does not own client master data, does not send commercial messages, and
+does not charge, refund, checkout, or mutate Asaas/providers.
+
+## Decisions
+
+- Not a parallel CRM. Identity is a stable `client_slug` plus a
+  non-sensitive `display_name`. No extra PII, government IDs, secrets, or
+  payment instruments.
+- Every aggregated fact carries `source`, `observed_at` (UTC),
+  `freshness_status`, and `confidence` when applicable. Missing provenance
+  is rejected at ingest.
+- Sources this wave: `manual`, `governance`, `adapter:<port>` (future
+  connector). Derived fields use `derived:<algorithm>` and are never
+  accepted as ingest input.
+- Commitments require `owner`, `due_at`, `evidence_ref`, `status`.
+- Health is a deterministic, explainable, rule-based score. No ML.
+- Queries are scoped. `client:<slug>` never dumps other clients.
+- Persistence this wave is an in-process store with the same operations a
+  later Postgres adapter must match. This package does not import
+  `control-center/persistence` or `control-center/contracts` (siblings are
+  absent on `main`).
+- Money, if ever attached by a future adapter, is integer `amount_cents` +
+  ISO-4217 `currency`. This domain does not store receivables.
+
+## Run
+
+Requires Node >= 20.
+
+```bash
+cd control-center/domains/clients
+npm install
+npm test
+npm run consumer
+npm run typecheck
+```
+
+`npm test` drives the shipped ingest, health-score, and query operations
+with PII-free fixtures. `npm run consumer` is a separate process that loads
+the same fixtures through the public API and prints the homepage payload.
+
+## Env vars
+
+See `.env.example`. None are required for tests or the consumer.
+
+| Variable | Purpose |
+| --- | --- |
+| `CONTROL_CENTER_CLIENTS_STORE` | `memory` (only supported value this wave) |
+| `CONTROL_CENTER_DISPLAY_TZ` | presentation timezone; internal timestamps stay UTC |
+| `DATABASE_URL` | reserved for convergence; unused here; never commit |
+
+No identity, password, or API token is read by this package.
+
+## Local contract / adapter
+
+While sibling workstreams are not on `main`, this package owns a local copy:
+
+- `src/contract.ts` — ClientStatus, Provenance, Commitment, Blocker,
+  Deliverable, Risk, AttentionItem
+- `src/store.ts` — `ClientStatusRepository` + `InMemoryClientStore`
+- `src/ops.ts` — `createClientOps()` facade
+
+`ClientFactsPort` is the future adapter interface (`adapter:<port>` source).
+Do not implement Warmbly/Asaas/GitHub pulls here.
+
+### Convergence mapping
+
+Canonical `control-center/contracts` (not imported) uses a `SourceRef`
+object and uppercase freshness. Mapping at the later convergence campaign:
+
+| This package | Contracts (expected) |
+| --- | --- |
+| `source: "manual"` | `{ system: "manual", kind: "human-entry", locator: "manual" }` |
+| `source: "governance"` | `{ system: "governance", kind: "canonical", locator: "governance" }` |
+| `source: "adapter:<port>"` | `{ system: "<port>", kind: "adapter", locator: "adapter:<port>" }` |
+| `fresh` / `stale` / `unknown` / `error` | `FRESH` / `STALE` / `UNKNOWN` / `ERROR` |
+| `client_slug`, `display_name`, `scope`, `id`, `schema_version` | same names |
+| health, commitments, next_action, due_dates, blockers, deliverables, risk | extend the thin contracts `ClientStatus` stub |
+
+## Query contract for later consumers
+
+Homepage (exceptions + “the 3 things that matter now”) should call
+`queryAttention()` / `toHomepageAttention()` — not own client rows.
+
+```ts
+createClientOps({ now }).queryAttention({ scope?: "client:<slug>" | "clients" })
+// → { client_slug, display_name, why, next_action, health_score, reasons, urgency }[]
+```
+
+MCP `confenge.get_client_context` should call `getClient(slug)` or
+`queryAttention({ scope: "client:<slug>" })`. A scoped read must not
+return another client.
+
+Persistence should implement `ClientStatusRepository` (`upsert`,
+`getBySlug`, `list`) on PostgreSQL with the same provenance columns.
+
+## Out of scope this wave
+
+Homepage UI, MCP server, Context API, Postgres migrations, Warmbly
+connector, Asaas, commercial send, and any write outside
+`control-center/domains/clients/`.

--- a/control-center/domains/clients/package-lock.json
+++ b/control-center/domains/clients/package-lock.json
@@ -1,0 +1,581 @@
+{
+  "name": "@confenge/control-center-clients",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-clients",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/control-center/domains/clients/package.json
+++ b/control-center/domains/clients/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@confenge/control-center-clients",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Confenge Control Center — client delivery/account-health read model. Not a CRM.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
+    "test": "tsx --test --test-concurrency=1 tests/client-status.test.ts tests/health.test.ts",
+    "consumer": "tsx scripts/consumer.ts"
+  },
+  "dependencies": {
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/domains/clients/scripts/consumer.ts
+++ b/control-center/domains/clients/scripts/consumer.ts
@@ -1,0 +1,53 @@
+/**
+ * Fresh consumer of the shipped package (not the unit test file).
+ * Loads the same fixtures and asks: which client needs me now, and why?
+ */
+import {
+  createClientOps,
+  serializeCanonical,
+  toHomepageAttention,
+} from "../src/index.js";
+import { FIXED_NOW, HEALTHY_SLUG, NEEDY_SLUG, fixturePayloads } from "../tests/fixtures.js";
+
+const ops = createClientOps({ now: FIXED_NOW });
+for (const payload of fixturePayloads()) {
+  ops.ingest(payload);
+}
+
+const attention = ops.queryAttention();
+const needy = attention.find((item) => item.client_slug === NEEDY_SLUG);
+if (!needy) {
+  console.error("FAIL: expected norte-engenharia in attention");
+  process.exit(1);
+}
+if (needy.why.length === 0) {
+  console.error("FAIL: why is empty");
+  process.exit(1);
+}
+if (!needy.why.some((line) => /vencido|bloqueio|risco/i.test(line))) {
+  console.error("FAIL: why does not cite overdue/blocker/risk");
+  process.exit(1);
+}
+if (!needy.next_action || needy.next_action.summary.trim().length === 0) {
+  console.error("FAIL: next_action missing");
+  process.exit(1);
+}
+if (attention.some((item) => item.client_slug === HEALTHY_SLUG)) {
+  console.error("FAIL: healthy client listed in attention");
+  process.exit(1);
+}
+
+const homepage = toHomepageAttention(needy);
+const headline = `${homepage.display_name} precisa de atenção agora porque ${homepage.why.join("; ")}. Próxima ação: ${homepage.next_action_summary}`;
+
+const output = {
+  ok: true,
+  client_slug: homepage.client_slug,
+  display_name: homepage.display_name,
+  why: homepage.why,
+  next_action_summary: homepage.next_action_summary,
+  headline,
+  attention: attention.map((item) => toHomepageAttention(item)),
+};
+
+process.stdout.write(`${serializeCanonical(output)}\n`);

--- a/control-center/domains/clients/src/clock.ts
+++ b/control-center/domains/clients/src/clock.ts
@@ -1,0 +1,47 @@
+import { UTC_DATETIME_PATTERN } from "./contract.js";
+import { ClientOpsError } from "./errors.js";
+
+const UTC_RE = new RegExp(UTC_DATETIME_PATTERN);
+
+export type Clock = () => Date;
+
+export function frozenClock(at: Date): Clock {
+  const ms = at.getTime();
+  return () => new Date(ms);
+}
+
+export function systemClock(): Clock {
+  return () => new Date();
+}
+
+export function toUtcIso(date: Date): string {
+  return date.toISOString();
+}
+
+export function isUtcDateTime(value: string): boolean {
+  return UTC_RE.test(value);
+}
+
+export function parseUtc(iso: string): Date {
+  if (!isUtcDateTime(iso)) {
+    throw new ClientOpsError(
+      "invalid_input",
+      `timestamp must be UTC RFC3339 ending in Z, got ${iso}`,
+    );
+  }
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) {
+    throw new ClientOpsError("invalid_input", `unparseable timestamp: ${iso}`);
+  }
+  return new Date(ms);
+}
+
+export function resolveClock(now?: Date | Clock): Clock {
+  if (typeof now === "function") {
+    return now;
+  }
+  if (now instanceof Date) {
+    return frozenClock(now);
+  }
+  return systemClock();
+}

--- a/control-center/domains/clients/src/contract.ts
+++ b/control-center/domains/clients/src/contract.ts
@@ -1,0 +1,253 @@
+/**
+ * Local ClientStatus / provenance contract for this workstream.
+ *
+ * Canonical types will live in `control-center/contracts` after convergence.
+ * This file is a copy of the fields this domain owns plus the shared
+ * provenance envelope. Do not import the sibling tree from here.
+ *
+ * Convergence mapping (documented, not imported):
+ * - `source` string here → contracts `Provenance.source` SourceRef
+ *   (`manual` → { system: "manual", kind: "human-entry", locator: "manual" },
+ *    `governance` → { system: "governance", kind: "canonical", locator: "governance" },
+ *    `adapter:<port>` → { system: <port>, kind: "adapter", locator: "adapter:<port>" }).
+ * - `freshness_status` lowercase here → contracts uppercase
+ *   (fresh→FRESH, stale→STALE, unknown→UNKNOWN, error→ERROR).
+ * - `client_slug` / `display_name` / `scope` (`client:<slug>`) / `id`
+ *   (`cc:client-status:<slug>`) / `schema_version` match contracts.
+ * - Rich delivery fields (health, commitments, next_action, due_dates,
+ *   blockers, deliverables, risk) are owned by this domain; the contracts
+ *   stub of ClientStatus is thinner and must be extended at convergence.
+ * - Money, if ever attached, is `{ amount_cents, currency }` — never floats.
+ */
+
+export const SCHEMA_VERSION = "control-center.client-status.v1" as const;
+
+export const UTC_DATETIME_PATTERN =
+  "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$";
+
+export const CLIENT_SLUG_PATTERN = "^[a-z0-9]+(?:-[a-z0-9]+)*$";
+
+export const FACT_ID_PATTERN = "^[a-z0-9]+(?:-[a-z0-9]+)*$";
+
+export const OWNER_PATTERN = "^[a-z][a-z0-9_-]{0,63}$";
+
+export const EVIDENCE_REF_PATTERN = "^[a-z0-9][a-z0-9:._/~-]{0,255}$";
+
+export const CURRENCY_PATTERN = "^[A-Z]{3}$";
+
+export const INGEST_SOURCE_PATTERN =
+  "^(manual|governance|adapter:[a-z][a-z0-9-]{0,63})$";
+
+export const ANY_SOURCE_PATTERN =
+  "^(manual|governance|adapter:[a-z][a-z0-9-]{0,63}|derived:[a-z][a-z0-9-]{0,63})$";
+
+export const FRESHNESS_STATUSES = ["fresh", "stale", "unknown", "error"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const COMMITMENT_STATUSES = [
+  "open",
+  "due",
+  "overdue",
+  "done",
+  "cancelled",
+] as const;
+export type CommitmentStatus = (typeof COMMITMENT_STATUSES)[number];
+
+export const BLOCKER_STATUSES = ["open", "resolved"] as const;
+export type BlockerStatus = (typeof BLOCKER_STATUSES)[number];
+
+export const DELIVERABLE_STATUSES = [
+  "pending",
+  "in_progress",
+  "delivered",
+  "blocked",
+] as const;
+export type DeliverableStatus = (typeof DELIVERABLE_STATUSES)[number];
+
+export const RISK_STATUSES = ["open", "mitigated", "closed"] as const;
+export type RiskStatus = (typeof RISK_STATUSES)[number];
+
+export const RISK_SEVERITIES = ["low", "medium", "high", "critical"] as const;
+export type RiskSeverity = (typeof RISK_SEVERITIES)[number];
+
+export const HEALTH_BANDS = ["healthy", "watch", "attention", "critical"] as const;
+export type HealthBand = (typeof HEALTH_BANDS)[number];
+
+export const CLIENT_LIFECYCLES = [
+  "lead",
+  "active",
+  "paused",
+  "churn_risk",
+  "churned",
+  "unknown",
+] as const;
+export type ClientLifecycle = (typeof CLIENT_LIFECYCLES)[number];
+
+export const HEALTH_REASON_CODES = [
+  "overdue_commitment",
+  "due_soon_commitment",
+  "open_blocker",
+  "open_risk",
+  "blocked_deliverable",
+] as const;
+export type HealthReasonCode = (typeof HEALTH_REASON_CODES)[number];
+
+export const SOURCE_MANUAL = "manual";
+export const SOURCE_GOVERNANCE = "governance";
+export const SOURCE_DERIVED_HEALTH = "derived:health-score";
+export const SOURCE_DERIVED_NEXT_ACTION = "derived:next-action";
+export const SOURCE_DERIVED_DUE_DATES = "derived:due-dates";
+
+/** Every aggregated fact carries this envelope. `confidence` is optional. */
+export interface Provenance {
+  source: string;
+  observed_at: string;
+  freshness_status: FreshnessStatus;
+  confidence?: number;
+}
+
+/** Integer cents + ISO-4217 currency. Never floats, never formatted strings. */
+export interface Money {
+  amount_cents: number;
+  currency: string;
+}
+
+export interface Commitment {
+  id: string;
+  title: string;
+  owner: string;
+  due_at: string;
+  evidence_ref: string;
+  status: CommitmentStatus;
+  provenance: Provenance;
+}
+
+export interface Blocker {
+  id: string;
+  title: string;
+  owner: string | null;
+  evidence_ref: string | null;
+  status: BlockerStatus;
+  provenance: Provenance;
+}
+
+export interface Deliverable {
+  id: string;
+  title: string;
+  status: DeliverableStatus;
+  due_at: string | null;
+  evidence_ref: string | null;
+  provenance: Provenance;
+}
+
+export interface Risk {
+  id: string;
+  title: string;
+  severity: RiskSeverity;
+  status: RiskStatus;
+  evidence_ref: string | null;
+  provenance: Provenance;
+}
+
+export interface NextAction {
+  summary: string;
+  due_at: string | null;
+  owner: string | null;
+  provenance: Provenance;
+}
+
+export interface HealthReason {
+  code: HealthReasonCode;
+  delta: number;
+  message: string;
+  related_id: string | null;
+}
+
+export interface AccountHealth {
+  score: number;
+  band: HealthBand;
+  reasons: HealthReason[];
+  provenance: Provenance;
+}
+
+export interface DueDate {
+  kind: "commitment" | "deliverable";
+  ref: string;
+  label: string;
+  at: string;
+  provenance: Provenance;
+}
+
+/**
+ * Delivery/account-health read model. Not a CRM contact/lead/pipeline record.
+ * Identity is a stable slug + non-sensitive display name only.
+ */
+export interface ClientStatus {
+  schema_version: typeof SCHEMA_VERSION;
+  id: string;
+  scope: string;
+  client_slug: string;
+  display_name: string;
+  lifecycle: ClientLifecycle;
+  health: AccountHealth;
+  commitments: Commitment[];
+  next_action: NextAction | null;
+  due_dates: DueDate[];
+  blockers: Blocker[];
+  deliverables: Deliverable[];
+  risk: Risk[];
+  provenance: Provenance;
+}
+
+export interface AttentionItem {
+  client_slug: string;
+  display_name: string;
+  scope: string;
+  why: string[];
+  next_action: NextAction | null;
+  health_score: number;
+  health_band: HealthBand;
+  reasons: HealthReason[];
+  urgency: number;
+}
+
+export interface HomepageAttention {
+  client_slug: string;
+  display_name: string;
+  why: string[];
+  next_action_summary: string;
+}
+
+export interface DueCommitmentItem {
+  client_slug: string;
+  display_name: string;
+  commitment: Commitment;
+  overdue: boolean;
+}
+
+export interface OpenBlockerItem {
+  client_slug: string;
+  display_name: string;
+  blocker: Blocker;
+}
+
+/**
+ * Future adapter port. Collectors in other workstreams implement this.
+ * This package does not call Warmbly/Asaas/GitHub.
+ */
+export interface ClientFactsPort {
+  readonly portName: string;
+  collect(scope: string): Promise<unknown[]>;
+}
+
+export function clientStatusId(slug: string): string {
+  return `cc:client-status:${slug}`;
+}
+
+export function clientScope(slug: string): string {
+  return `client:${slug}`;
+}
+
+export function adapterSource(port: string): string {
+  return `adapter:${port}`;
+}

--- a/control-center/domains/clients/src/errors.ts
+++ b/control-center/domains/clients/src/errors.ts
@@ -1,0 +1,22 @@
+export const CLIENT_OPS_ERROR_CODES = [
+  "missing_provenance",
+  "sensitive_field",
+  "invalid_input",
+  "invalid_scope",
+] as const;
+
+export type ClientOpsErrorCode = (typeof CLIENT_OPS_ERROR_CODES)[number];
+
+export class ClientOpsError extends Error {
+  readonly code: ClientOpsErrorCode;
+
+  constructor(code: ClientOpsErrorCode, message: string) {
+    super(message);
+    this.name = "ClientOpsError";
+    this.code = code;
+  }
+}
+
+export function isClientOpsError(value: unknown): value is ClientOpsError {
+  return value instanceof ClientOpsError;
+}

--- a/control-center/domains/clients/src/health.ts
+++ b/control-center/domains/clients/src/health.ts
@@ -1,0 +1,223 @@
+import {
+  SOURCE_DERIVED_HEALTH,
+  type AccountHealth,
+  type Blocker,
+  type ClientLifecycle,
+  type Commitment,
+  type CommitmentStatus,
+  type Deliverable,
+  type HealthBand,
+  type HealthReason,
+  type Risk,
+  type RiskSeverity,
+} from "./contract.js";
+import { toUtcIso } from "./clock.js";
+
+export const DUE_SOON_HOURS = 48;
+
+export const HEALTH_DELTAS = {
+  overdue_commitment: 20,
+  due_soon_commitment: 8,
+  open_blocker: 15,
+  blocked_deliverable: 10,
+  risk: {
+    low: 3,
+    medium: 8,
+    high: 15,
+    critical: 25,
+  },
+} as const;
+
+const CLOSED_COMMITMENT = new Set<CommitmentStatus>(["done", "cancelled"]);
+
+export type CommitmentClass = "closed" | "overdue" | "due_soon" | "upcoming";
+
+export function classifyCommitment(commitment: Commitment, now: Date): CommitmentClass {
+  if (CLOSED_COMMITMENT.has(commitment.status)) {
+    return "closed";
+  }
+  const dueMs = Date.parse(commitment.due_at);
+  const nowMs = now.getTime();
+  if (dueMs < nowMs) {
+    return "overdue";
+  }
+  if (dueMs - nowMs <= DUE_SOON_HOURS * 60 * 60 * 1000) {
+    return "due_soon";
+  }
+  return "upcoming";
+}
+
+export function isOpenBlocker(blocker: Blocker): boolean {
+  return blocker.status === "open";
+}
+
+export function isOpenRisk(risk: Risk): boolean {
+  return risk.status === "open";
+}
+
+export function isBlockedDeliverable(deliverable: Deliverable): boolean {
+  return deliverable.status === "blocked";
+}
+
+export function isMaterialRisk(risk: Risk): boolean {
+  return isOpenRisk(risk) && risk.severity !== "low";
+}
+
+/**
+ * Deterministic, explainable, rule-based account health. No ML.
+ * Same inputs + clock always produce the same score and reason set.
+ */
+export function scoreAccountHealth(
+  input: {
+    commitments: readonly Commitment[];
+    blockers: readonly Blocker[];
+    risk: readonly Risk[];
+    deliverables: readonly Deliverable[];
+  },
+  now: Date,
+): AccountHealth {
+  let score = 100;
+  const reasons: HealthReason[] = [];
+
+  const commitments = sortById(input.commitments);
+  const blockers = sortById(input.blockers);
+  const risks = sortById(input.risk);
+  const deliverables = sortById(input.deliverables);
+
+  for (const commitment of commitments) {
+    const klass = classifyCommitment(commitment, now);
+    if (klass === "overdue") {
+      score -= HEALTH_DELTAS.overdue_commitment;
+      reasons.push({
+        code: "overdue_commitment",
+        delta: HEALTH_DELTAS.overdue_commitment,
+        message: `Compromisso vencido: ${commitment.title}`,
+        related_id: commitment.id,
+      });
+    } else if (klass === "due_soon") {
+      score -= HEALTH_DELTAS.due_soon_commitment;
+      reasons.push({
+        code: "due_soon_commitment",
+        delta: HEALTH_DELTAS.due_soon_commitment,
+        message: `Compromisso vencendo: ${commitment.title}`,
+        related_id: commitment.id,
+      });
+    }
+  }
+
+  for (const blocker of blockers) {
+    if (!isOpenBlocker(blocker)) {
+      continue;
+    }
+    score -= HEALTH_DELTAS.open_blocker;
+    reasons.push({
+      code: "open_blocker",
+      delta: HEALTH_DELTAS.open_blocker,
+      message: `Bloqueio aberto: ${blocker.title}`,
+      related_id: blocker.id,
+    });
+  }
+
+  for (const risk of risks) {
+    if (!isOpenRisk(risk)) {
+      continue;
+    }
+    const delta = HEALTH_DELTAS.risk[risk.severity];
+    score -= delta;
+    reasons.push({
+      code: "open_risk",
+      delta,
+      message: `Risco aberto (${risk.severity}): ${risk.title}`,
+      related_id: risk.id,
+    });
+  }
+
+  for (const deliverable of deliverables) {
+    if (!isBlockedDeliverable(deliverable)) {
+      continue;
+    }
+    score -= HEALTH_DELTAS.blocked_deliverable;
+    reasons.push({
+      code: "blocked_deliverable",
+      delta: HEALTH_DELTAS.blocked_deliverable,
+      message: `Entrega bloqueada: ${deliverable.title}`,
+      related_id: deliverable.id,
+    });
+  }
+
+  reasons.sort(compareReasons);
+  const clamped = clampScore(score);
+
+  return {
+    score: clamped,
+    band: bandFor(clamped),
+    reasons,
+    provenance: {
+      source: SOURCE_DERIVED_HEALTH,
+      observed_at: toUtcIso(now),
+      freshness_status: "fresh",
+    },
+  };
+}
+
+export function bandFor(score: number): HealthBand {
+  if (score >= 80) {
+    return "healthy";
+  }
+  if (score >= 60) {
+    return "watch";
+  }
+  if (score >= 40) {
+    return "attention";
+  }
+  return "critical";
+}
+
+export function lifecycleFromHealth(
+  health: AccountHealth,
+  risks: readonly Risk[],
+): ClientLifecycle {
+  const openCritical = risks.some((risk) => isOpenRisk(risk) && risk.severity === "critical");
+  if (openCritical || health.band === "critical") {
+    return "churn_risk";
+  }
+  return "active";
+}
+
+export function compareReasons(a: HealthReason, b: HealthReason): number {
+  if (a.code !== b.code) {
+    return a.code.localeCompare(b.code);
+  }
+  return (a.related_id ?? "").localeCompare(b.related_id ?? "");
+}
+
+function clampScore(score: number): number {
+  if (score < 0) {
+    return 0;
+  }
+  if (score > 100) {
+    return 100;
+  }
+  return score;
+}
+
+function sortById<T extends { id: string }>(items: readonly T[]): T[] {
+  return [...items].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function riskWeight(severity: RiskSeverity): number {
+  switch (severity) {
+    case "critical":
+      return 80;
+    case "high":
+      return 40;
+    case "medium":
+      return 15;
+    case "low":
+      return 5;
+    default: {
+      const _exhaustive: never = severity;
+      return _exhaustive;
+    }
+  }
+}

--- a/control-center/domains/clients/src/index.ts
+++ b/control-center/domains/clients/src/index.ts
@@ -1,0 +1,98 @@
+export { createClientOps } from "./ops.js";
+export type { ClientOps, CreateClientOpsOptions, QueryArgs } from "./ops.js";
+
+export { ingestClientStatus, buildClientStatus, deriveNextAction } from "./ingest.js";
+export type { IngestOptions } from "./ingest.js";
+export type { IngestDraft } from "./validate.js";
+
+export {
+  scoreAccountHealth,
+  classifyCommitment,
+  isOpenBlocker,
+  isOpenRisk,
+  isBlockedDeliverable,
+  isMaterialRisk,
+  HEALTH_DELTAS,
+  DUE_SOON_HOURS,
+  bandFor,
+  lifecycleFromHealth,
+} from "./health.js";
+
+export {
+  queryAttention,
+  queryDueCommitments,
+  queryOpenBlockers,
+  toHomepageAttention,
+  requiresAttention,
+  DEFAULT_DUE_HORIZON_HOURS,
+} from "./queries.js";
+export type { QueryInput } from "./queries.js";
+
+export { InMemoryClientStore } from "./store.js";
+export type { ClientStatusRepository } from "./store.js";
+
+export { parseScope, formatClientScope, matchesScope } from "./scope.js";
+export type { ParsedScope } from "./scope.js";
+
+export {
+  serializeCanonical,
+  serializeClientStatus,
+  serializeAttention,
+  canonicalize,
+} from "./serialize.js";
+
+export { ClientOpsError, isClientOpsError, CLIENT_OPS_ERROR_CODES } from "./errors.js";
+export type { ClientOpsErrorCode } from "./errors.js";
+
+export { parseIngestInput } from "./validate.js";
+export { findSensitiveHits, collectKeys, FORBIDDEN_KEY_REGEX } from "./sensitive.js";
+export { frozenClock, systemClock, toUtcIso, isUtcDateTime, parseUtc } from "./clock.js";
+
+export {
+  SCHEMA_VERSION,
+  FRESHNESS_STATUSES,
+  COMMITMENT_STATUSES,
+  BLOCKER_STATUSES,
+  DELIVERABLE_STATUSES,
+  RISK_STATUSES,
+  RISK_SEVERITIES,
+  HEALTH_BANDS,
+  CLIENT_LIFECYCLES,
+  HEALTH_REASON_CODES,
+  SOURCE_MANUAL,
+  SOURCE_GOVERNANCE,
+  SOURCE_DERIVED_HEALTH,
+  SOURCE_DERIVED_NEXT_ACTION,
+  SOURCE_DERIVED_DUE_DATES,
+  clientStatusId,
+  clientScope,
+  adapterSource,
+} from "./contract.js";
+
+export type {
+  Provenance,
+  Money,
+  Commitment,
+  Blocker,
+  Deliverable,
+  Risk,
+  NextAction,
+  HealthReason,
+  AccountHealth,
+  DueDate,
+  ClientStatus,
+  AttentionItem,
+  HomepageAttention,
+  DueCommitmentItem,
+  OpenBlockerItem,
+  ClientFactsPort,
+  FreshnessStatus,
+  CommitmentStatus,
+  BlockerStatus,
+  DeliverableStatus,
+  RiskStatus,
+  RiskSeverity,
+  HealthBand,
+  ClientLifecycle,
+  HealthReasonCode,
+} from "./contract.js";

--- a/control-center/domains/clients/src/ingest.ts
+++ b/control-center/domains/clients/src/ingest.ts
@@ -1,0 +1,188 @@
+import {
+  SOURCE_DERIVED_DUE_DATES,
+  SOURCE_DERIVED_NEXT_ACTION,
+  clientScope,
+  clientStatusId,
+  type Blocker,
+  type ClientStatus,
+  type Commitment,
+  type Deliverable,
+  type DueDate,
+  type NextAction,
+  type Risk,
+} from "./contract.js";
+import { toUtcIso } from "./clock.js";
+import {
+  classifyCommitment,
+  isMaterialRisk,
+  isOpenBlocker,
+  lifecycleFromHealth,
+  scoreAccountHealth,
+} from "./health.js";
+import type { ClientStatusRepository } from "./store.js";
+import { parseIngestInput, type IngestDraft } from "./validate.js";
+
+export interface IngestOptions {
+  now: Date;
+  store: ClientStatusRepository;
+}
+
+/**
+ * Validate + build + upsert. Older envelope `observed_at` does not overwrite
+ * a newer stored snapshot (collector idempotency).
+ */
+export function ingestClientStatus(raw: unknown, options: IngestOptions): ClientStatus {
+  const draft = parseIngestInput(raw);
+  const built = buildClientStatus(draft, options.now);
+  const existing = options.store.getBySlug(built.client_slug);
+  if (
+    existing !== undefined &&
+    Date.parse(draft.provenance.observed_at) < Date.parse(existing.provenance.observed_at)
+  ) {
+    return existing;
+  }
+  options.store.upsert(built);
+  return built;
+}
+
+export function buildClientStatus(draft: IngestDraft, now: Date): ClientStatus {
+  const commitments = sortById(draft.commitments);
+  const blockers = sortById(draft.blockers);
+  const deliverables = sortById(draft.deliverables);
+  const risk = sortBySeverityThenId(draft.risk);
+
+  const health = scoreAccountHealth({ commitments, blockers, risk, deliverables }, now);
+  const nextAction = draft.next_action ?? deriveNextAction({ commitments, blockers, risk }, now);
+  const dueDates = buildDueDates(commitments, deliverables);
+
+  return {
+    schema_version: "control-center.client-status.v1",
+    id: clientStatusId(draft.client_slug),
+    scope: clientScope(draft.client_slug),
+    client_slug: draft.client_slug,
+    display_name: draft.display_name,
+    lifecycle: lifecycleFromHealth(health, risk),
+    health,
+    commitments,
+    next_action: nextAction,
+    due_dates: dueDates,
+    blockers,
+    deliverables,
+    risk,
+    provenance: draft.provenance,
+  };
+}
+
+export function deriveNextAction(
+  input: {
+    commitments: readonly Commitment[];
+    blockers: readonly Blocker[];
+    risk: readonly Risk[];
+  },
+  now: Date,
+): NextAction | null {
+  const observedAt = toUtcIso(now);
+  const derived = {
+    source: SOURCE_DERIVED_NEXT_ACTION,
+    observed_at: observedAt,
+    freshness_status: "fresh" as const,
+  };
+
+  const openBlocker = [...input.blockers].filter(isOpenBlocker).sort((a, b) => a.id.localeCompare(b.id))[0];
+  if (openBlocker) {
+    return {
+      summary: `Destravar bloqueio: ${openBlocker.title}`,
+      due_at: null,
+      owner: openBlocker.owner,
+      provenance: derived,
+    };
+  }
+
+  const overdue = [...input.commitments]
+    .filter((item) => classifyCommitment(item, now) === "overdue")
+    .sort((a, b) => a.due_at.localeCompare(b.due_at) || a.id.localeCompare(b.id))[0];
+  if (overdue) {
+    return {
+      summary: `Cumprir compromisso vencido: ${overdue.title}`,
+      due_at: overdue.due_at,
+      owner: overdue.owner,
+      provenance: derived,
+    };
+  }
+
+  const dueSoon = [...input.commitments]
+    .filter((item) => classifyCommitment(item, now) === "due_soon")
+    .sort((a, b) => a.due_at.localeCompare(b.due_at) || a.id.localeCompare(b.id))[0];
+  if (dueSoon) {
+    return {
+      summary: `Antecipar compromisso: ${dueSoon.title}`,
+      due_at: dueSoon.due_at,
+      owner: dueSoon.owner,
+      provenance: derived,
+    };
+  }
+
+  const material = [...input.risk]
+    .filter(isMaterialRisk)
+    .sort((a, b) => a.id.localeCompare(b.id))[0];
+  if (material) {
+    return {
+      summary: `Mitigar risco: ${material.title}`,
+      due_at: null,
+      owner: null,
+      provenance: derived,
+    };
+  }
+
+  return null;
+}
+
+function buildDueDates(commitments: Commitment[], deliverables: Deliverable[]): DueDate[] {
+  const rows: DueDate[] = [];
+  for (const commitment of commitments) {
+    rows.push({
+      kind: "commitment",
+      ref: commitment.id,
+      label: commitment.title,
+      at: commitment.due_at,
+      provenance: {
+        source: SOURCE_DERIVED_DUE_DATES,
+        observed_at: commitment.provenance.observed_at,
+        freshness_status: commitment.provenance.freshness_status,
+        ...(commitment.provenance.confidence !== undefined
+          ? { confidence: commitment.provenance.confidence }
+          : {}),
+      },
+    });
+  }
+  for (const deliverable of deliverables) {
+    if (deliverable.due_at === null) {
+      continue;
+    }
+    rows.push({
+      kind: "deliverable",
+      ref: deliverable.id,
+      label: deliverable.title,
+      at: deliverable.due_at,
+      provenance: {
+        source: SOURCE_DERIVED_DUE_DATES,
+        observed_at: deliverable.provenance.observed_at,
+        freshness_status: deliverable.provenance.freshness_status,
+        ...(deliverable.provenance.confidence !== undefined
+          ? { confidence: deliverable.provenance.confidence }
+          : {}),
+      },
+    });
+  }
+  rows.sort((a, b) => a.at.localeCompare(b.at) || a.ref.localeCompare(b.ref));
+  return rows;
+}
+
+function sortById<T extends { id: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function sortBySeverityThenId(items: Risk[]): Risk[] {
+  const rank = { critical: 0, high: 1, medium: 2, low: 3 };
+  return [...items].sort((a, b) => rank[a.severity] - rank[b.severity] || a.id.localeCompare(b.id));
+}

--- a/control-center/domains/clients/src/ops.ts
+++ b/control-center/domains/clients/src/ops.ts
@@ -1,0 +1,77 @@
+import type {
+  AttentionItem,
+  ClientStatus,
+  DueCommitmentItem,
+  OpenBlockerItem,
+} from "./contract.js";
+import { resolveClock, type Clock } from "./clock.js";
+import { ingestClientStatus } from "./ingest.js";
+import {
+  DEFAULT_DUE_HORIZON_HOURS,
+  queryAttention,
+  queryDueCommitments,
+  queryOpenBlockers,
+} from "./queries.js";
+import { parseScope } from "./scope.js";
+import { InMemoryClientStore, type ClientStatusRepository } from "./store.js";
+
+export interface CreateClientOpsOptions {
+  now?: Date | Clock;
+  store?: ClientStatusRepository;
+}
+
+export interface QueryArgs {
+  scope?: string;
+  horizonHours?: number;
+}
+
+export interface ClientOps {
+  ingest(raw: unknown): ClientStatus;
+  queryAttention(args?: QueryArgs): AttentionItem[];
+  queryDueCommitments(args?: QueryArgs): DueCommitmentItem[];
+  queryOpenBlockers(args?: QueryArgs): OpenBlockerItem[];
+  getClient(clientSlug: string): ClientStatus | undefined;
+  list(scope?: string): ClientStatus[];
+}
+
+/**
+ * In-process client-ops facade. Homepage and MCP should call these queries
+ * (not own client data) after convergence.
+ */
+export function createClientOps(options: CreateClientOpsOptions = {}): ClientOps {
+  const clock = resolveClock(options.now);
+  const store = options.store ?? new InMemoryClientStore();
+
+  return {
+    ingest(raw: unknown): ClientStatus {
+      return ingestClientStatus(raw, { now: clock(), store });
+    },
+    queryAttention(args: QueryArgs = {}): AttentionItem[] {
+      return queryAttention({ now: clock(), records: store.list(), scope: args.scope });
+    },
+    queryDueCommitments(args: QueryArgs = {}): DueCommitmentItem[] {
+      return queryDueCommitments({
+        now: clock(),
+        records: store.list(),
+        scope: args.scope,
+        horizonHours: args.horizonHours ?? DEFAULT_DUE_HORIZON_HOURS,
+      });
+    },
+    queryOpenBlockers(args: QueryArgs = {}): OpenBlockerItem[] {
+      return queryOpenBlockers({ now: clock(), records: store.list(), scope: args.scope });
+    },
+    getClient(clientSlug: string): ClientStatus | undefined {
+      parseScope(`client:${clientSlug}`);
+      return store.getBySlug(clientSlug);
+    },
+    list(scope?: string): ClientStatus[] {
+      const parsed = parseScope(scope);
+      return store.list().filter((item) => {
+        if (parsed.kind === "all") {
+          return true;
+        }
+        return item.client_slug === parsed.clientSlug;
+      });
+    },
+  };
+}

--- a/control-center/domains/clients/src/queries.ts
+++ b/control-center/domains/clients/src/queries.ts
@@ -1,0 +1,156 @@
+import type {
+  AttentionItem,
+  ClientStatus,
+  DueCommitmentItem,
+  HomepageAttention,
+  OpenBlockerItem,
+} from "./contract.js";
+import {
+  classifyCommitment,
+  isMaterialRisk,
+  isOpenBlocker,
+  riskWeight,
+} from "./health.js";
+import { matchesScope, parseScope } from "./scope.js";
+import { assertQueryHorizonHours } from "./validate.js";
+
+export const DEFAULT_DUE_HORIZON_HOURS = 7 * 24;
+
+export interface QueryInput {
+  now: Date;
+  records: readonly ClientStatus[];
+  scope?: string;
+  horizonHours?: number;
+}
+
+/**
+ * Clients that need the operator now, each with why + next action.
+ * Homepage contract: "qual cliente precisa de mim agora e por quê?"
+ */
+export function queryAttention(input: QueryInput): AttentionItem[] {
+  const scope = parseScope(input.scope);
+  const items: AttentionItem[] = [];
+  for (const record of input.records) {
+    if (!matchesScope(record.client_slug, scope)) {
+      continue;
+    }
+    if (!requiresAttention(record, input.now)) {
+      continue;
+    }
+    const why = record.health.reasons.map((reason) => reason.message);
+    items.push({
+      client_slug: record.client_slug,
+      display_name: record.display_name,
+      scope: record.scope,
+      why,
+      next_action: record.next_action,
+      health_score: record.health.score,
+      health_band: record.health.band,
+      reasons: record.health.reasons,
+      urgency: urgencyOf(record, input.now),
+    });
+  }
+  items.sort((a, b) => b.urgency - a.urgency || a.client_slug.localeCompare(b.client_slug));
+  return items;
+}
+
+export function queryDueCommitments(input: QueryInput): DueCommitmentItem[] {
+  const scope = parseScope(input.scope);
+  const horizonHours = input.horizonHours ?? DEFAULT_DUE_HORIZON_HOURS;
+  assertQueryHorizonHours(horizonHours);
+  const horizonMs = input.now.getTime() + horizonHours * 60 * 60 * 1000;
+  const items: DueCommitmentItem[] = [];
+  for (const record of input.records) {
+    if (!matchesScope(record.client_slug, scope)) {
+      continue;
+    }
+    for (const commitment of record.commitments) {
+      const klass = classifyCommitment(commitment, input.now);
+      if (klass === "closed") {
+        continue;
+      }
+      const dueMs = Date.parse(commitment.due_at);
+      if (dueMs > horizonMs) {
+        continue;
+      }
+      items.push({
+        client_slug: record.client_slug,
+        display_name: record.display_name,
+        commitment,
+        overdue: klass === "overdue",
+      });
+    }
+  }
+  items.sort(
+    (a, b) =>
+      a.commitment.due_at.localeCompare(b.commitment.due_at) ||
+      a.client_slug.localeCompare(b.client_slug) ||
+      a.commitment.id.localeCompare(b.commitment.id),
+  );
+  return items;
+}
+
+export function queryOpenBlockers(input: QueryInput): OpenBlockerItem[] {
+  const scope = parseScope(input.scope);
+  const items: OpenBlockerItem[] = [];
+  for (const record of input.records) {
+    if (!matchesScope(record.client_slug, scope)) {
+      continue;
+    }
+    for (const blocker of record.blockers) {
+      if (!isOpenBlocker(blocker)) {
+        continue;
+      }
+      items.push({
+        client_slug: record.client_slug,
+        display_name: record.display_name,
+        blocker,
+      });
+    }
+  }
+  items.sort(
+    (a, b) => a.client_slug.localeCompare(b.client_slug) || a.blocker.id.localeCompare(b.blocker.id),
+  );
+  return items;
+}
+
+export function toHomepageAttention(item: AttentionItem): HomepageAttention {
+  return {
+    client_slug: item.client_slug,
+    display_name: item.display_name,
+    why: item.why,
+    next_action_summary: item.next_action?.summary ?? "",
+  };
+}
+
+export function requiresAttention(record: ClientStatus, now: Date): boolean {
+  const overdue = record.commitments.some((item) => classifyCommitment(item, now) === "overdue");
+  const dueSoon = record.commitments.some((item) => classifyCommitment(item, now) === "due_soon");
+  const openBlocker = record.blockers.some(isOpenBlocker);
+  const materialRisk = record.risk.some(isMaterialRisk);
+  const bandNeeds = record.health.band === "attention" || record.health.band === "critical";
+  return overdue || dueSoon || openBlocker || materialRisk || bandNeeds;
+}
+
+function urgencyOf(record: ClientStatus, now: Date): number {
+  let urgency = 100 - record.health.score;
+  for (const commitment of record.commitments) {
+    const klass = classifyCommitment(commitment, now);
+    if (klass === "overdue") {
+      urgency += 100;
+    } else if (klass === "due_soon") {
+      urgency += 25;
+    }
+  }
+  for (const blocker of record.blockers) {
+    if (isOpenBlocker(blocker)) {
+      urgency += 50;
+    }
+  }
+  for (const risk of record.risk) {
+    if (risk.status === "open") {
+      urgency += riskWeight(risk.severity);
+    }
+  }
+  return urgency;
+}

--- a/control-center/domains/clients/src/scope.ts
+++ b/control-center/domains/clients/src/scope.ts
@@ -1,0 +1,47 @@
+import { CLIENT_SLUG_PATTERN } from "./contract.js";
+import { ClientOpsError } from "./errors.js";
+
+const CLIENT_SLUG_RE = new RegExp(CLIENT_SLUG_PATTERN);
+
+export type ParsedScope =
+  | { kind: "all" }
+  | { kind: "client"; clientSlug: string };
+
+const ALL_SCOPES = new Set(["all", "clients", "company"]);
+
+/**
+ * Query scope. `client:<slug>` never dumps other clients.
+ * `clients` / `company` / `all` / omitted mean every client in this store
+ * (this domain's universe — not whole-company memory).
+ */
+export function parseScope(input: string | undefined): ParsedScope {
+  if (input === undefined || input.trim() === "") {
+    return { kind: "all" };
+  }
+  const trimmed = input.trim();
+  if (ALL_SCOPES.has(trimmed)) {
+    return { kind: "all" };
+  }
+  if (trimmed.startsWith("client:")) {
+    const slug = trimmed.slice("client:".length);
+    if (!CLIENT_SLUG_RE.test(slug)) {
+      throw new ClientOpsError("invalid_scope", `invalid client scope: ${input}`);
+    }
+    return { kind: "client", clientSlug: slug };
+  }
+  throw new ClientOpsError("invalid_scope", `invalid scope: ${input}`);
+}
+
+export function formatClientScope(slug: string): string {
+  if (!CLIENT_SLUG_RE.test(slug)) {
+    throw new ClientOpsError("invalid_scope", `invalid client slug: ${slug}`);
+  }
+  return `client:${slug}`;
+}
+
+export function matchesScope(clientSlug: string, scope: ParsedScope): boolean {
+  if (scope.kind === "all") {
+    return true;
+  }
+  return scope.clientSlug === clientSlug;
+}

--- a/control-center/domains/clients/src/sensitive.ts
+++ b/control-center/domains/clients/src/sensitive.ts
@@ -1,0 +1,72 @@
+/**
+ * Fail-closed denylist for secrets, government IDs, payment instruments,
+ * and extra PII. Allowed identity is slug + non-sensitive display name.
+ */
+
+export const FORBIDDEN_KEY_REGEX =
+  /^(secret|token|password|authorization|api[_-]?key|cookie|credential|private[_-]?key|cpf|cnpj|rg|ssn|pan|card[_-]?number|cvv|credit[_-]?card|email|e-mail|phone|telefone|endereco|address|account[_-]?number)$/i;
+
+const CPF_LIKE = /\b\d{3}\.\d{3}\.\d{3}-\d{2}\b/;
+const PAN_LIKE = /\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b/;
+
+export interface SensitiveHit {
+  path: string;
+  reason: "key" | "value";
+}
+
+export function findSensitiveHits(value: unknown, path = "$"): SensitiveHit[] {
+  const hits: SensitiveHit[] = [];
+  walk(value, path, hits);
+  return hits;
+}
+
+function walk(value: unknown, path: string, hits: SensitiveHit[]): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      walk(value[i], `${path}[${i}]`, hits);
+    }
+    return;
+  }
+  if (typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      const childPath = `${path}.${key}`;
+      if (FORBIDDEN_KEY_REGEX.test(key)) {
+        hits.push({ path: childPath, reason: "key" });
+      }
+      walk(child, childPath, hits);
+    }
+    return;
+  }
+  if (typeof value === "string") {
+    if (CPF_LIKE.test(value) || PAN_LIKE.test(value)) {
+      hits.push({ path, reason: "value" });
+    }
+  }
+}
+
+export function collectKeys(value: unknown): string[] {
+  const keys = new Set<string>();
+  collect(value, keys);
+  return [...keys].sort();
+}
+
+function collect(value: unknown, keys: Set<string>): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collect(item, keys);
+    }
+    return;
+  }
+  if (typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      keys.add(key);
+      collect(child, keys);
+    }
+  }
+}

--- a/control-center/domains/clients/src/serialize.ts
+++ b/control-center/domains/clients/src/serialize.ts
@@ -1,0 +1,35 @@
+/**
+ * Canonical JSON for equality of two consumer runs.
+ * Object keys are sorted; array order is preserved (builders sort first).
+ */
+export function canonicalize(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value ?? null;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value)
+      .filter(([, child]) => child !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of entries) {
+      out[key] = canonicalize(child);
+    }
+    return out;
+  }
+  return value;
+}
+
+export function serializeCanonical(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function serializeClientStatus(value: unknown): string {
+  return serializeCanonical(value);
+}
+
+export function serializeAttention(value: unknown): string {
+  return serializeCanonical(value);
+}

--- a/control-center/domains/clients/src/store.ts
+++ b/control-center/domains/clients/src/store.ts
@@ -1,0 +1,44 @@
+import type { ClientStatus } from "./contract.js";
+import { matchesScope, parseScope, type ParsedScope } from "./scope.js";
+
+/**
+ * Persistence port. Postgres in `control-center/persistence` should implement
+ * the same operations at convergence. This wave uses an in-process Map.
+ */
+export interface ClientStatusRepository {
+  upsert(status: ClientStatus): void;
+  getBySlug(clientSlug: string): ClientStatus | undefined;
+  list(): ClientStatus[];
+}
+
+export class InMemoryClientStore implements ClientStatusRepository {
+  private readonly records = new Map<string, ClientStatus>();
+
+  upsert(status: ClientStatus): void {
+    this.records.set(status.client_slug, clone(status));
+  }
+
+  getBySlug(clientSlug: string): ClientStatus | undefined {
+    const found = this.records.get(clientSlug);
+    return found === undefined ? undefined : clone(found);
+  }
+
+  list(): ClientStatus[] {
+    return [...this.records.values()]
+      .sort((a, b) => a.client_slug.localeCompare(b.client_slug))
+      .map((item) => clone(item));
+  }
+
+  listScoped(scope: ParsedScope | string | undefined): ClientStatus[] {
+    const parsed = typeof scope === "string" || scope === undefined ? parseScope(scope) : scope;
+    return this.list().filter((item) => matchesScope(item.client_slug, parsed));
+  }
+
+  clear(): void {
+    this.records.clear();
+  }
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/control-center/domains/clients/src/validate.ts
+++ b/control-center/domains/clients/src/validate.ts
@@ -1,0 +1,333 @@
+import { z, type ZodIssue } from "zod";
+import {
+  ANY_SOURCE_PATTERN,
+  BLOCKER_STATUSES,
+  CLIENT_SLUG_PATTERN,
+  COMMITMENT_STATUSES,
+  CURRENCY_PATTERN,
+  DELIVERABLE_STATUSES,
+  EVIDENCE_REF_PATTERN,
+  FACT_ID_PATTERN,
+  FRESHNESS_STATUSES,
+  INGEST_SOURCE_PATTERN,
+  OWNER_PATTERN,
+  RISK_SEVERITIES,
+  RISK_STATUSES,
+  UTC_DATETIME_PATTERN,
+  type Blocker,
+  type Commitment,
+  type Deliverable,
+  type NextAction,
+  type Provenance,
+  type Risk,
+} from "./contract.js";
+import { ClientOpsError } from "./errors.js";
+import { findSensitiveHits } from "./sensitive.js";
+
+const utc = z.string().regex(new RegExp(UTC_DATETIME_PATTERN), "must be UTC RFC3339 ending in Z");
+const slug = z.string().regex(new RegExp(CLIENT_SLUG_PATTERN), "must be a kebab-case slug");
+const factId = z.string().regex(new RegExp(FACT_ID_PATTERN), "must be a kebab-case id");
+const owner = z.string().regex(new RegExp(OWNER_PATTERN), "must be a role-like owner id, not an email");
+const evidence = z
+  .string()
+  .regex(new RegExp(EVIDENCE_REF_PATTERN), "must be an opaque evidence ref")
+  .refine((value) => !/password=|token=|secret=/i.test(value), "evidence_ref must not carry secrets");
+const ingestSource = z
+  .string()
+  .regex(new RegExp(INGEST_SOURCE_PATTERN), "source must be manual, governance, or adapter:<port>");
+const anySource = z.string().regex(new RegExp(ANY_SOURCE_PATTERN));
+
+const provenanceSchema = z
+  .object({
+    source: ingestSource,
+    observed_at: utc,
+    freshness_status: z.enum(FRESHNESS_STATUSES),
+    confidence: z.number().min(0).max(1).optional(),
+  })
+  .strict();
+
+const title = z.string().trim().min(1).max(200);
+
+const commitmentSchema = z
+  .object({
+    id: factId,
+    title,
+    owner,
+    due_at: utc,
+    evidence_ref: evidence,
+    status: z.enum(COMMITMENT_STATUSES),
+    provenance: provenanceSchema,
+  })
+  .strict();
+
+const blockerSchema = z
+  .object({
+    id: factId,
+    title,
+    owner: owner.nullable().optional(),
+    evidence_ref: evidence.nullable().optional(),
+    status: z.enum(BLOCKER_STATUSES),
+    provenance: provenanceSchema,
+  })
+  .strict();
+
+const deliverableSchema = z
+  .object({
+    id: factId,
+    title,
+    status: z.enum(DELIVERABLE_STATUSES),
+    due_at: utc.nullable().optional(),
+    evidence_ref: evidence.nullable().optional(),
+    provenance: provenanceSchema,
+  })
+  .strict();
+
+const riskSchema = z
+  .object({
+    id: factId,
+    title,
+    severity: z.enum(RISK_SEVERITIES),
+    status: z.enum(RISK_STATUSES),
+    evidence_ref: evidence.nullable().optional(),
+    provenance: provenanceSchema,
+  })
+  .strict();
+
+const nextActionSchema = z
+  .object({
+    summary: z.string().trim().min(1).max(300),
+    due_at: utc.nullable().optional(),
+    owner: owner.nullable().optional(),
+    provenance: provenanceSchema,
+  })
+  .strict();
+
+const moneySchema = z
+  .object({
+    amount_cents: z.number().int(),
+    currency: z.string().regex(new RegExp(CURRENCY_PATTERN)),
+  })
+  .strict();
+
+const ingestSchema = z
+  .object({
+    client_slug: slug,
+    display_name: z
+      .string()
+      .trim()
+      .min(1)
+      .max(120)
+      .refine((value) => !value.includes("@"), "display_name must not look like an email"),
+    source: ingestSource,
+    observed_at: utc,
+    freshness_status: z.enum(FRESHNESS_STATUSES),
+    confidence: z.number().min(0).max(1).optional(),
+    commitments: z.array(commitmentSchema).default([]),
+    blockers: z.array(blockerSchema).default([]),
+    deliverables: z.array(deliverableSchema).default([]),
+    risk: z.array(riskSchema).default([]),
+    next_action: nextActionSchema.nullable().optional(),
+    // Accepted only so a later finance adapter can attach integer cents.
+    // This domain does not persist receivables on the read model.
+    value: moneySchema.optional(),
+  })
+  .strict();
+
+export interface IngestDraft {
+  client_slug: string;
+  display_name: string;
+  provenance: Provenance;
+  commitments: Commitment[];
+  blockers: Blocker[];
+  deliverables: Deliverable[];
+  risk: Risk[];
+  next_action: NextAction | null;
+}
+
+export function parseIngestInput(raw: unknown): IngestDraft {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ClientOpsError("invalid_input", "ingest payload must be an object");
+  }
+
+  const sensitive = findSensitiveHits(raw);
+  if (sensitive.length > 0) {
+    const first = sensitive[0];
+    throw new ClientOpsError(
+      "sensitive_field",
+      `refusing sensitive field at ${first?.path ?? "$"}`,
+    );
+  }
+
+  const parsed = ingestSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw mapZodError(parsed.error);
+  }
+
+  const data = parsed.data;
+  assertUniqueIds(
+    data.commitments.map((item) => item.id),
+    "commitment",
+  );
+  assertUniqueIds(
+    data.blockers.map((item) => item.id),
+    "blocker",
+  );
+  assertUniqueIds(
+    data.deliverables.map((item) => item.id),
+    "deliverable",
+  );
+  assertUniqueIds(
+    data.risk.map((item) => item.id),
+    "risk",
+  );
+
+  const envelope: Provenance = {
+    source: data.source,
+    observed_at: data.observed_at,
+    freshness_status: data.freshness_status,
+    ...(data.confidence !== undefined ? { confidence: data.confidence } : {}),
+  };
+
+  return {
+    client_slug: data.client_slug,
+    display_name: data.display_name,
+    provenance: envelope,
+    commitments: data.commitments.map(normalizeCommitment),
+    blockers: data.blockers.map(normalizeBlocker),
+    deliverables: data.deliverables.map(normalizeDeliverable),
+    risk: data.risk.map(normalizeRisk),
+    next_action: data.next_action ? normalizeNextAction(data.next_action) : null,
+  };
+}
+
+function normalizeCommitment(item: z.infer<typeof commitmentSchema>): Commitment {
+  return {
+    id: item.id,
+    title: item.title,
+    owner: item.owner,
+    due_at: item.due_at,
+    evidence_ref: item.evidence_ref,
+    status: item.status,
+    provenance: normalizeProvenance(item.provenance),
+  };
+}
+
+function normalizeBlocker(item: z.infer<typeof blockerSchema>): Blocker {
+  return {
+    id: item.id,
+    title: item.title,
+    owner: item.owner ?? null,
+    evidence_ref: item.evidence_ref ?? null,
+    status: item.status,
+    provenance: normalizeProvenance(item.provenance),
+  };
+}
+
+function normalizeDeliverable(item: z.infer<typeof deliverableSchema>): Deliverable {
+  return {
+    id: item.id,
+    title: item.title,
+    status: item.status,
+    due_at: item.due_at ?? null,
+    evidence_ref: item.evidence_ref ?? null,
+    provenance: normalizeProvenance(item.provenance),
+  };
+}
+
+function normalizeRisk(item: z.infer<typeof riskSchema>): Risk {
+  return {
+    id: item.id,
+    title: item.title,
+    severity: item.severity,
+    status: item.status,
+    evidence_ref: item.evidence_ref ?? null,
+    provenance: normalizeProvenance(item.provenance),
+  };
+}
+
+function normalizeNextAction(item: z.infer<typeof nextActionSchema>): NextAction {
+  return {
+    summary: item.summary,
+    due_at: item.due_at ?? null,
+    owner: item.owner ?? null,
+    provenance: normalizeProvenance(item.provenance),
+  };
+}
+
+function normalizeProvenance(item: z.infer<typeof provenanceSchema>): Provenance {
+  return {
+    source: item.source,
+    observed_at: item.observed_at,
+    freshness_status: item.freshness_status,
+    ...(item.confidence !== undefined ? { confidence: item.confidence } : {}),
+  };
+}
+
+function assertUniqueIds(ids: string[], kind: string): void {
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (seen.has(id)) {
+      throw new ClientOpsError("invalid_input", `duplicate ${kind} id: ${id}`);
+    }
+    seen.add(id);
+  }
+}
+
+function mapZodError(error: z.ZodError): ClientOpsError {
+  const issue = error.issues[0];
+  if (!issue) {
+    return new ClientOpsError("invalid_input", "invalid ingest payload");
+  }
+  if (isMissingProvenance(issue)) {
+    return new ClientOpsError(
+      "missing_provenance",
+      `missing provenance at ${formatPath(issue.path)}: ${issue.message}`,
+    );
+  }
+  return new ClientOpsError(
+    "invalid_input",
+    `invalid input at ${formatPath(issue.path)}: ${issue.message}`,
+  );
+}
+
+function isMissingProvenance(issue: ZodIssue): boolean {
+  const path = issue.path.map(String);
+  const last = path[path.length - 1];
+  const provenanceFields = new Set(["source", "observed_at", "freshness_status", "provenance"]);
+  if (last !== undefined && provenanceFields.has(last) && isAbsent(issue)) {
+    return true;
+  }
+  if (path.includes("provenance") && isAbsent(issue)) {
+    return true;
+  }
+  return false;
+}
+
+function isAbsent(issue: ZodIssue): boolean {
+  return (
+    issue.code === "invalid_type" &&
+    "received" in issue &&
+    (issue.received === "undefined" || issue.received === "null")
+  );
+}
+
+function formatPath(path: PropertyKey[]): string {
+  if (path.length === 0) {
+    return "$";
+  }
+  return path.map(String).join(".");
+}
+
+/** Runtime guard used by query inputs. */
+export function assertQueryHorizonHours(value: number): void {
+  if (!Number.isInteger(value) || value < 0 || value > 24 * 90) {
+    throw new ClientOpsError("invalid_input", "horizonHours must be an integer between 0 and 2160");
+  }
+}
+
+export function assertAnySource(source: string): void {
+  const result = anySource.safeParse(source);
+  if (!result.success) {
+    throw new ClientOpsError("invalid_input", `invalid source: ${source}`);
+  }
+}

--- a/control-center/domains/clients/tests/client-status.test.ts
+++ b/control-center/domains/clients/tests/client-status.test.ts
@@ -1,0 +1,292 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  ClientOpsError,
+  FRESHNESS_STATUSES,
+  collectKeys,
+  createClientOps,
+  findSensitiveHits,
+  isUtcDateTime,
+  serializeClientStatus,
+  toHomepageAttention,
+  type ClientStatus,
+  type Provenance,
+} from "../src/index.js";
+import {
+  FIXED_NOW,
+  HEALTHY_SLUG,
+  NEEDY_SLUG,
+  RESOLVED_SLUG,
+  WEEK_DUE_SLUG,
+  fixturePayloads,
+  lesteObrasPayload,
+  norteEngenhariaPayload,
+  oesteProjetoPayload,
+  sulConsultoriaPayload,
+} from "./fixtures.js";
+
+function loadOps() {
+  const ops = createClientOps({ now: FIXED_NOW });
+  for (const payload of fixturePayloads()) {
+    ops.ingest(payload);
+  }
+  return ops;
+}
+
+function assertProvenance(provenance: Provenance, label: string): void {
+  assert.equal(typeof provenance.source, "string", `${label}.source`);
+  assert.ok(provenance.source.length > 0, `${label}.source nonempty`);
+  assert.ok(isUtcDateTime(provenance.observed_at), `${label}.observed_at UTC`);
+  assert.ok(
+    (FRESHNESS_STATUSES as readonly string[]).includes(provenance.freshness_status),
+    `${label}.freshness_status`,
+  );
+  if (provenance.confidence !== undefined) {
+    assert.ok(provenance.confidence >= 0 && provenance.confidence <= 1, `${label}.confidence`);
+  }
+}
+
+function assertEveryFactHasProvenance(status: ClientStatus): void {
+  assertProvenance(status.provenance, "envelope");
+  assertProvenance(status.health.provenance, "health");
+  if (status.next_action) {
+    assertProvenance(status.next_action.provenance, "next_action");
+  }
+  for (const item of status.commitments) {
+    assertProvenance(item.provenance, `commitment:${item.id}`);
+  }
+  for (const item of status.blockers) {
+    assertProvenance(item.provenance, `blocker:${item.id}`);
+  }
+  for (const item of status.deliverables) {
+    assertProvenance(item.provenance, `deliverable:${item.id}`);
+  }
+  for (const item of status.risk) {
+    assertProvenance(item.provenance, `risk:${item.id}`);
+  }
+  for (const item of status.due_dates) {
+    assertProvenance(item.provenance, `due_date:${item.ref}`);
+  }
+}
+
+describe("ClientStatus ingest/build", () => {
+  test("builds a mixed-source read model with health, commitments, next action, due dates, blockers, deliverables, risk", () => {
+    const ops = loadOps();
+    const norte = ops.getClient(NEEDY_SLUG);
+    assert.ok(norte, "norte-engenharia must exist");
+    assert.equal(norte.client_slug, NEEDY_SLUG);
+    assert.equal(norte.display_name, "Norte Engenharia");
+    assert.equal(norte.schema_version, "control-center.client-status.v1");
+    assert.equal(norte.scope, `client:${NEEDY_SLUG}`);
+    assert.equal(norte.id, `cc:client-status:${NEEDY_SLUG}`);
+    assert.ok(norte.health);
+    assert.equal(typeof norte.health.score, "number");
+    assert.ok(norte.commitments.length >= 1);
+    assert.ok(norte.next_action);
+    assert.ok(norte.due_dates.length >= 1);
+    assert.ok(norte.blockers.length >= 1);
+    assert.ok(norte.deliverables.length >= 1);
+    assert.ok(norte.risk.length >= 1);
+    assertEveryFactHasProvenance(norte);
+
+    const commitment = norte.commitments.find((item) => item.id === "c-relatorio-mensal");
+    assert.ok(commitment);
+    assert.equal(commitment.provenance.source, "governance");
+    const blocker = norte.blockers.find((item) => item.id === "b-acesso-homolog");
+    assert.ok(blocker);
+    assert.equal(blocker.provenance.source, "manual");
+    const risk = norte.risk.find((item) => item.id === "r-escopo");
+    assert.ok(risk);
+    assert.equal(risk.provenance.source, "adapter:delivery");
+    assert.equal(risk.provenance.confidence, 0.7);
+    assert.equal(norte.provenance.source, "manual");
+  });
+
+  test("commitment round-trips owner, due_at, evidence_ref, status", () => {
+    const ops = loadOps();
+    const norte = ops.getClient(NEEDY_SLUG);
+    assert.ok(norte);
+    const commitment = norte.commitments.find((item) => item.id === "c-relatorio-mensal");
+    assert.ok(commitment);
+    assert.equal(commitment.owner, "founder");
+    assert.equal(commitment.due_at, "2026-08-18T12:00:00.000Z");
+    assert.equal(commitment.evidence_ref, "governance:decision/relatorio-mensal-2026-08");
+    assert.equal(commitment.status, "open");
+  });
+
+  test("rejects ingest without envelope provenance fields", () => {
+    const ops = createClientOps({ now: FIXED_NOW });
+    const missingObserved = norteEngenhariaPayload();
+    delete missingObserved.observed_at;
+    assert.throws(
+      () => ops.ingest(missingObserved),
+      (err: unknown) => err instanceof ClientOpsError && err.code === "missing_provenance",
+    );
+
+    const missingSource = norteEngenhariaPayload();
+    delete missingSource.source;
+    assert.throws(
+      () => ops.ingest(missingSource),
+      (err: unknown) => err instanceof ClientOpsError && err.code === "missing_provenance",
+    );
+
+    const missingFreshness = norteEngenhariaPayload();
+    delete missingFreshness.freshness_status;
+    assert.throws(
+      () => ops.ingest(missingFreshness),
+      (err: unknown) => err instanceof ClientOpsError && err.code === "missing_provenance",
+    );
+  });
+
+  test("rejects a commitment without provenance", () => {
+    const ops = createClientOps({ now: FIXED_NOW });
+    const payload = norteEngenhariaPayload();
+    const commitments = payload.commitments as Array<Record<string, unknown>>;
+    const first = commitments[0];
+    assert.ok(first);
+    delete first.provenance;
+    assert.throws(
+      () => ops.ingest(payload),
+      (err: unknown) => err instanceof ClientOpsError && err.code === "missing_provenance",
+    );
+  });
+
+  test("rejects sensitive extra fields", () => {
+    const ops = createClientOps({ now: FIXED_NOW });
+    const withCpf = { ...norteEngenhariaPayload(), cpf: "123.456.789-00" };
+    assert.throws(
+      () => ops.ingest(withCpf),
+      (err: unknown) => err instanceof ClientOpsError && err.code === "sensitive_field",
+    );
+    const withPassword = { ...norteEngenhariaPayload(), password: "not-a-real-secret" };
+    assert.throws(
+      () => ops.ingest(withPassword),
+      (err: unknown) => err instanceof ClientOpsError && err.code === "sensitive_field",
+    );
+  });
+
+  test("ingest is idempotent for the same snapshot", () => {
+    const ops = createClientOps({ now: FIXED_NOW });
+    const first = ops.ingest(norteEngenhariaPayload());
+    const second = ops.ingest(norteEngenhariaPayload());
+    assert.equal(serializeClientStatus(first), serializeClientStatus(second));
+  });
+});
+
+describe("queries", () => {
+  test("attention names the client that needs the operator now, with why and next action", () => {
+    const ops = loadOps();
+    const attention = ops.queryAttention();
+    const needy = attention.find((item) => item.client_slug === NEEDY_SLUG);
+    assert.ok(needy, "norte-engenharia must require attention");
+    assert.ok(needy.why.length > 0, "why must be non-empty");
+    assert.ok(needy.why.some((line) => /vencido/i.test(line)));
+    assert.ok(needy.why.some((line) => /bloqueio/i.test(line)));
+    assert.ok(needy.why.some((line) => /risco/i.test(line)));
+    assert.ok(needy.next_action);
+    assert.ok(needy.next_action.summary.trim().length > 0);
+    assert.match(needy.next_action.summary, /homolog/i);
+
+    const homepage = toHomepageAttention(needy);
+    assert.equal(homepage.client_slug, NEEDY_SLUG);
+    assert.equal(homepage.display_name, "Norte Engenharia");
+    assert.ok(homepage.why.length > 0);
+    assert.ok(homepage.next_action_summary.length > 0);
+
+    const healthy = attention.find((item) => item.client_slug === HEALTHY_SLUG);
+    assert.equal(healthy, undefined, "healthy client must not appear in attention");
+    const resolved = attention.find((item) => item.client_slug === RESOLVED_SLUG);
+    assert.equal(resolved, undefined);
+  });
+
+  test("due-commitments lists overdue/due items and omits far-future and done", () => {
+    const ops = loadOps();
+    const due = ops.queryDueCommitments();
+    const ids = due.map((item) => item.commitment.id);
+    assert.ok(ids.includes("c-relatorio-mensal"), "overdue commitment must be listed");
+    assert.ok(ids.includes("c-parecer-tecnico"), "commitment due this week must be listed");
+    assert.ok(!ids.includes("c-revisao-trimestral"), "far-future commitment must be omitted");
+    assert.ok(!ids.includes("c-kickoff"), "done commitment must be omitted");
+    const overdue = due.find((item) => item.commitment.id === "c-relatorio-mensal");
+    assert.equal(overdue?.overdue, true);
+    const week = due.find((item) => item.commitment.id === "c-parecer-tecnico");
+    assert.equal(week?.overdue, false);
+  });
+
+  test("blockers query lists open blockers and omits resolved", () => {
+    const ops = loadOps();
+    const blockers = ops.queryOpenBlockers();
+    const ids = blockers.map((item) => item.blocker.id);
+    assert.ok(ids.includes("b-acesso-homolog"));
+    assert.ok(!ids.includes("b-vpn-antiga"));
+    assert.equal(
+      blockers.find((item) => item.client_slug === RESOLVED_SLUG),
+      undefined,
+    );
+  });
+
+  test("scoped read for one client does not return another client's records", () => {
+    const ops = loadOps();
+    const scope = `client:${NEEDY_SLUG}`;
+    const attention = ops.queryAttention({ scope });
+    assert.ok(attention.every((item) => item.client_slug === NEEDY_SLUG));
+    assert.equal(
+      attention.find((item) => item.client_slug === HEALTHY_SLUG),
+      undefined,
+    );
+
+    const due = ops.queryDueCommitments({ scope });
+    assert.ok(due.every((item) => item.client_slug === NEEDY_SLUG));
+    assert.equal(
+      due.find((item) => item.client_slug === WEEK_DUE_SLUG),
+      undefined,
+    );
+
+    const blockers = ops.queryOpenBlockers({ scope });
+    assert.ok(blockers.every((item) => item.client_slug === NEEDY_SLUG));
+
+    const listed = ops.list(scope);
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0]?.client_slug, NEEDY_SLUG);
+
+    const healthyScope = ops.queryAttention({ scope: `client:${HEALTHY_SLUG}` });
+    assert.equal(healthyScope.length, 0);
+
+    const healthyRecord = ops.getClient(HEALTHY_SLUG);
+    assert.ok(healthyRecord);
+    assert.equal(healthyRecord.client_slug, HEALTHY_SLUG);
+    const serializedHealthy = serializeClientStatus(healthyRecord);
+    assert.equal(serializedHealthy.includes(NEEDY_SLUG), false);
+  });
+
+  test("serialized ClientStatus has no password/secret/CPF/PAN-like fields", () => {
+    const ops = loadOps();
+    for (const record of ops.list()) {
+      const json = serializeClientStatus(record);
+      const parsed: unknown = JSON.parse(json);
+      const keys = collectKeys(parsed);
+      for (const key of keys) {
+        assert.doesNotMatch(
+          key,
+          /password|secret|token|cpf|cnpj|pan|cvv|ssn|authorization|api[_-]?key/i,
+        );
+      }
+      assert.equal(findSensitiveHits(parsed).length, 0, record.client_slug);
+      assert.doesNotMatch(json, /\d{3}\.\d{3}\.\d{3}-\d{2}/);
+      assert.doesNotMatch(json, /\d{4}[-\s]\d{4}[-\s]\d{4}[-\s]\d{4}/);
+    }
+  });
+});
+
+describe("fixtures stay PII-free", () => {
+  test("synthetic fixtures do not include extra identity fields", () => {
+    for (const payload of [
+      norteEngenhariaPayload(),
+      sulConsultoriaPayload(),
+      lesteObrasPayload(),
+      oesteProjetoPayload(),
+    ]) {
+      assert.equal(findSensitiveHits(payload).length, 0);
+    }
+  });
+});

--- a/control-center/domains/clients/tests/fixtures.ts
+++ b/control-center/domains/clients/tests/fixtures.ts
@@ -1,0 +1,260 @@
+export const FIXED_NOW = new Date("2026-08-20T15:00:00.000Z");
+
+export const NEEDY_SLUG = "norte-engenharia";
+export const HEALTHY_SLUG = "sul-consultoria";
+export const RESOLVED_SLUG = "leste-obras";
+export const WEEK_DUE_SLUG = "oeste-projeto";
+
+const MANUAL = {
+  source: "manual",
+  observed_at: "2026-08-20T14:00:00.000Z",
+  freshness_status: "fresh",
+  confidence: 1,
+} as const;
+
+const GOVERNANCE = {
+  source: "governance",
+  observed_at: "2026-08-19T10:00:00.000Z",
+  freshness_status: "fresh",
+  confidence: 1,
+} as const;
+
+const ADAPTER = {
+  source: "adapter:delivery",
+  observed_at: "2026-08-20T09:00:00.000Z",
+  freshness_status: "stale",
+  confidence: 0.7,
+} as const;
+
+/** Mixed-source client that needs the operator now. */
+export function norteEngenhariaPayload(): Record<string, unknown> {
+  return {
+    client_slug: NEEDY_SLUG,
+    display_name: "Norte Engenharia",
+    source: MANUAL.source,
+    observed_at: MANUAL.observed_at,
+    freshness_status: MANUAL.freshness_status,
+    confidence: MANUAL.confidence,
+    commitments: [
+      {
+        id: "c-relatorio-mensal",
+        title: "Entrega do relatório mensal de obra",
+        owner: "founder",
+        due_at: "2026-08-18T12:00:00.000Z",
+        evidence_ref: "governance:decision/relatorio-mensal-2026-08",
+        status: "open",
+        provenance: { ...GOVERNANCE },
+      },
+    ],
+    blockers: [
+      {
+        id: "b-acesso-homolog",
+        title: "Acesso ao ambiente de homologação pendente",
+        owner: "founder",
+        evidence_ref: "manual:note/homolog-access",
+        status: "open",
+        provenance: {
+          source: "manual",
+          observed_at: "2026-08-20T12:00:00.000Z",
+          freshness_status: "fresh",
+          confidence: 1,
+        },
+      },
+    ],
+    deliverables: [
+      {
+        id: "d-relatorio",
+        title: "Relatório mensal de obra",
+        status: "blocked",
+        due_at: "2026-08-18T12:00:00.000Z",
+        evidence_ref: "governance:deliverable/relatorio-mensal",
+        provenance: { ...GOVERNANCE },
+      },
+    ],
+    risk: [
+      {
+        id: "r-escopo",
+        title: "Escopo da fase 2 ainda não fechado",
+        severity: "medium",
+        status: "open",
+        evidence_ref: "adapter:delivery/risk-escopo",
+        provenance: { ...ADAPTER },
+      },
+    ],
+    next_action: {
+      summary: "Destravar acesso de homologação e reconfirmar prazo da entrega",
+      due_at: "2026-08-20T18:00:00.000Z",
+      owner: "founder",
+      provenance: { ...MANUAL },
+    },
+  };
+}
+
+/** Healthy in-scope client: far-future commitment, no blocker, no risk. */
+export function sulConsultoriaPayload(): Record<string, unknown> {
+  return {
+    client_slug: HEALTHY_SLUG,
+    display_name: "Sul Consultoria",
+    source: "manual",
+    observed_at: "2026-08-20T13:00:00.000Z",
+    freshness_status: "fresh",
+    confidence: 1,
+    commitments: [
+      {
+        id: "c-revisao-trimestral",
+        title: "Revisão trimestral de entregas",
+        owner: "founder",
+        due_at: "2026-12-01T12:00:00.000Z",
+        evidence_ref: "manual:note/revisao-trimestral",
+        status: "open",
+        provenance: {
+          source: "manual",
+          observed_at: "2026-08-20T13:00:00.000Z",
+          freshness_status: "fresh",
+          confidence: 1,
+        },
+      },
+    ],
+    blockers: [],
+    deliverables: [
+      {
+        id: "d-pacote-q4",
+        title: "Pacote de entregas Q4",
+        status: "in_progress",
+        due_at: "2026-12-01T12:00:00.000Z",
+        evidence_ref: "manual:note/pacote-q4",
+        provenance: {
+          source: "manual",
+          observed_at: "2026-08-20T13:00:00.000Z",
+          freshness_status: "fresh",
+          confidence: 1,
+        },
+      },
+    ],
+    risk: [],
+    next_action: {
+      summary: "Acompanhar cronograma trimestral",
+      due_at: "2026-11-15T12:00:00.000Z",
+      owner: "founder",
+      provenance: {
+        source: "manual",
+        observed_at: "2026-08-20T13:00:00.000Z",
+        freshness_status: "fresh",
+        confidence: 1,
+      },
+    },
+  };
+}
+
+/** Resolved blocker + done commitment: must not surface as attention/due/blocker. */
+export function lesteObrasPayload(): Record<string, unknown> {
+  return {
+    client_slug: RESOLVED_SLUG,
+    display_name: "Leste Obras",
+    source: "governance",
+    observed_at: "2026-08-19T16:00:00.000Z",
+    freshness_status: "fresh",
+    confidence: 1,
+    commitments: [
+      {
+        id: "c-kickoff",
+        title: "Kickoff da obra leste",
+        owner: "founder",
+        due_at: "2026-08-01T12:00:00.000Z",
+        evidence_ref: "governance:decision/kickoff-leste",
+        status: "done",
+        provenance: {
+          source: "governance",
+          observed_at: "2026-08-02T12:00:00.000Z",
+          freshness_status: "fresh",
+          confidence: 1,
+        },
+      },
+    ],
+    blockers: [
+      {
+        id: "b-vpn-antiga",
+        title: "VPN antiga indisponível",
+        owner: "founder",
+        evidence_ref: "manual:note/vpn-antiga",
+        status: "resolved",
+        provenance: {
+          source: "manual",
+          observed_at: "2026-08-10T12:00:00.000Z",
+          freshness_status: "fresh",
+          confidence: 1,
+        },
+      },
+    ],
+    deliverables: [
+      {
+        id: "d-kickoff-ata",
+        title: "Ata de kickoff",
+        status: "delivered",
+        due_at: "2026-08-01T12:00:00.000Z",
+        evidence_ref: "governance:deliverable/kickoff-ata",
+        provenance: {
+          source: "governance",
+          observed_at: "2026-08-02T12:00:00.000Z",
+          freshness_status: "fresh",
+          confidence: 1,
+        },
+      },
+    ],
+    risk: [
+      {
+        id: "r-atraso-kickoff",
+        title: "Atraso de kickoff",
+        severity: "high",
+        status: "closed",
+        evidence_ref: "governance:risk/atraso-kickoff",
+        provenance: {
+          source: "governance",
+          observed_at: "2026-08-02T12:00:00.000Z",
+          freshness_status: "fresh",
+          confidence: 1,
+        },
+      },
+    ],
+  };
+}
+
+/** Commitment due inside 7 days but not overdue / not within 48h. */
+export function oesteProjetoPayload(): Record<string, unknown> {
+  return {
+    client_slug: WEEK_DUE_SLUG,
+    display_name: "Oeste Projeto",
+    source: "adapter:delivery",
+    observed_at: "2026-08-20T11:00:00.000Z",
+    freshness_status: "fresh",
+    confidence: 0.8,
+    commitments: [
+      {
+        id: "c-parecer-tecnico",
+        title: "Parecer técnico da etapa 3",
+        owner: "delivery",
+        due_at: "2026-08-25T12:00:00.000Z",
+        evidence_ref: "adapter:delivery/parecer-etapa-3",
+        status: "open",
+        provenance: {
+          source: "adapter:delivery",
+          observed_at: "2026-08-20T11:00:00.000Z",
+          freshness_status: "fresh",
+          confidence: 0.8,
+        },
+      },
+    ],
+    blockers: [],
+    deliverables: [],
+    risk: [],
+  };
+}
+
+export function fixturePayloads(): unknown[] {
+  return [
+    norteEngenhariaPayload(),
+    sulConsultoriaPayload(),
+    lesteObrasPayload(),
+    oesteProjetoPayload(),
+  ];
+}

--- a/control-center/domains/clients/tests/health.test.ts
+++ b/control-center/domains/clients/tests/health.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  HEALTH_DELTAS,
+  createClientOps,
+  scoreAccountHealth,
+  serializeCanonical,
+} from "../src/index.js";
+import { FIXED_NOW, norteEngenhariaPayload, sulConsultoriaPayload } from "./fixtures.js";
+
+describe("explainable health score", () => {
+  test("same inputs produce the same score and reason set; reasons cite overdue, blocker, risk", () => {
+    const ops = createClientOps({ now: FIXED_NOW });
+    const norte = ops.ingest(norteEngenhariaPayload());
+
+    const first = scoreAccountHealth(
+      {
+        commitments: norte.commitments,
+        blockers: norte.blockers,
+        risk: norte.risk,
+        deliverables: norte.deliverables,
+      },
+      FIXED_NOW,
+    );
+    const second = scoreAccountHealth(
+      {
+        commitments: norte.commitments,
+        blockers: norte.blockers,
+        risk: norte.risk,
+        deliverables: norte.deliverables,
+      },
+      FIXED_NOW,
+    );
+
+    assert.equal(serializeCanonical(first), serializeCanonical(second));
+    assert.equal(first.score, norte.health.score);
+    assert.equal(serializeCanonical(first.reasons), serializeCanonical(norte.health.reasons));
+
+    const overdue = first.reasons.find((reason) => reason.code === "overdue_commitment");
+    assert.ok(overdue);
+    assert.equal(overdue.related_id, "c-relatorio-mensal");
+    assert.match(overdue.message, /vencido/i);
+    assert.equal(overdue.delta, HEALTH_DELTAS.overdue_commitment);
+
+    const blocker = first.reasons.find((reason) => reason.code === "open_blocker");
+    assert.ok(blocker);
+    assert.equal(blocker.related_id, "b-acesso-homolog");
+    assert.match(blocker.message, /bloqueio/i);
+    assert.equal(blocker.delta, HEALTH_DELTAS.open_blocker);
+
+    const risk = first.reasons.find((reason) => reason.code === "open_risk");
+    assert.ok(risk);
+    assert.equal(risk.related_id, "r-escopo");
+    assert.match(risk.message, /risco/i);
+    assert.equal(risk.delta, HEALTH_DELTAS.risk.medium);
+
+    const blocked = first.reasons.find((reason) => reason.code === "blocked_deliverable");
+    assert.ok(blocked);
+    assert.equal(blocked.related_id, "d-relatorio");
+
+    const blob = serializeCanonical(first);
+    assert.doesNotMatch(blob, /ml|machine[- ]?learning|model-score|opaque/i);
+    assert.equal(first.provenance.source, "derived:health-score");
+
+    const expected =
+      100 -
+      HEALTH_DELTAS.overdue_commitment -
+      HEALTH_DELTAS.open_blocker -
+      HEALTH_DELTAS.risk.medium -
+      HEALTH_DELTAS.blocked_deliverable;
+    assert.equal(first.score, expected);
+  });
+
+  test("healthy client with no due/blocker/risk scores 100 with empty reasons", () => {
+    const ops = createClientOps({ now: FIXED_NOW });
+    const sul = ops.ingest(sulConsultoriaPayload());
+    const health = scoreAccountHealth(
+      {
+        commitments: sul.commitments,
+        blockers: sul.blockers,
+        risk: sul.risk,
+        deliverables: sul.deliverables,
+      },
+      FIXED_NOW,
+    );
+    assert.equal(health.score, 100);
+    assert.equal(health.band, "healthy");
+    assert.equal(health.reasons.length, 0);
+    assert.equal(sul.client_slug, "sul-consultoria");
+  });
+});

--- a/control-center/domains/clients/tsconfig.json
+++ b/control-center/domains/clients/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/control-center/domains/clients/tsconfig.test.json
+++ b/control-center/domains/clients/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts"]
+}


### PR DESCRIPTION
Isolated ClientStatus domain under `control-center/domains/clients/` that answers **which client needs the operator now and why**, without creating a parallel CRM.

Warmbly remains the commercial/CRM authority. This package aggregates delivery/account-health state with mandatory provenance (`source`, `observed_at`, `freshness_status`, `confidence` when set).

## What this PR adds
- ClientStatus read model: health, commitments, next action, due dates, blockers, deliverables, risk
- Commitment fields: `owner`, `due_at`, `evidence_ref`, `status`
- Deterministic, explainable, rule-based health score (no ML)
- Queries: attention-now-with-why, due/overdue commitments, open blockers
- Scoped reads (`client:{slug}` never dumps other clients)
- In-process `ClientStatusRepository` adapter (Postgres is a later convergence)
- Local tests + a separate consumer script that prints the homepage payload

## Homepage contract
`queryAttention()` / `toHomepageAttention()` return `client_slug`, `display_name`, `why[]`, and `next_action_summary`. That is the payload a later homepage/MCP `confenge.get_client_context` should consume — this PR does not render UI.

## Out of scope
No writes to `commercial/`, `decisions/`, `scripts/`, root README, Warmbly, Asaas, or sibling `control-center/` trees. No cobrança/checkout/refund/provider mutations. Canonical contracts live in a parallel workstream; this package copies the local envelope and documents the mapping.

## How to verify
```bash
cd control-center/domains/clients
npm install
npm test
npm run consumer
```

Draft only — do not merge as part of this campaign.