### PR TITLE
feat(control-center): add read-only infrastructure health collector

### DIFF
--- a/control-center/connectors/infrastructure/.gitignore
+++ b/control-center/connectors/infrastructure/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/control-center/connectors/infrastructure/ADAPTER.md
+++ b/control-center/connectors/infrastructure/ADAPTER.md
@@ -1,0 +1,77 @@
+# Local adapter (pre-convergence)
+
+Canonical Control Center contracts live in sibling path `control-center/contracts/` and are **not** imported from this collector. This file is the local stand-in so later convergence can wire PostgreSQL ingest without guessing field names.
+
+## SourceObservation
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `observation_id` | string | Stable: `{source}:{target_id}:{check}` |
+| `source` | string | Allowlist `source` (default `infrastructure`) |
+| `observed_at` | string | ISO-8601 UTC (`…Z`) |
+| `freshness_status` | `FRESH` \| `STALE` \| `UNKNOWN` \| `ERROR` | Separate from confidence |
+| `confidence` | number 0–1 | Present on every mapped observation |
+| `scope` | `infrastructure` | Agents must query by scope later |
+| `target_id` | string | Allowlisted target |
+| `check` | `reachability` \| `host_metrics` \| `docker` \| `http` \| `tls` \| `backup` \| `uptime` | |
+| `summary` | string | Human-readable outcome |
+| `payload` | object | Probe evidence (no secrets) |
+
+## ServiceHealth
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `service_id` | string | Allowlisted target id |
+| `display_name` | string | |
+| `source` | string | |
+| `observed_at` | string | UTC |
+| `freshness_status` | same enum | Worst of member checks |
+| `status` | `healthy` \| `degraded` \| `unhealthy` \| `unknown` | Never `healthy` unless freshness is `FRESH` |
+| `checks` | array | Per-check status + freshness + summary |
+| `uptime_seconds` | number? | When the uptime probe observed it |
+| `restart_count` | number? | When the uptime probe observed it |
+| `confidence` | number? | Min of member observations |
+
+## ActionableException
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `exception_id` | string | Stable: `exc:{source}:{target_id}:{check}[:qualifier]` |
+| `source` | string | |
+| `timestamp` | string | UTC; equals `observed_at` |
+| `observed_at` | string | UTC |
+| `target_id` | string | Allowlisted target |
+| `check` | check kind | |
+| `severity` | `critical` \| `warning` | |
+| `title` | string | Names the service/check |
+| `evidence` | string | Non-empty; includes check, target, summary, timestamps |
+| `freshness_status` | enum | |
+
+A service incident (failed/unreachable/unhealthy probe, expired TLS, missing/failed backup, timeout, stale metrics) **must** produce at least one exception with evidence and a timestamp.
+
+## Allowlist
+
+See `config/allowlist.example.json`. No secrets, SSH material, passwords, tokens, or PEM. Hosts/URLs only. Thresholds are operational, not credentials.
+
+## Read-only agent payload (`GET {AGENT}/v1/targets/{id}`)
+
+```json
+{
+  "observed_at": "2026-08-20T15:00:00.000Z",
+  "disk": { "used_pct": 41, "used_bytes": 0, "total_bytes": 0 },
+  "memory": { "used_pct": 52, "available_bytes": 0, "total_bytes": 0 },
+  "load": { "load_1": 0.2, "load_5": 0.2, "load_15": 0.2 },
+  "docker": { "services": [{ "name": "extra-crawler", "health": "healthy", "restart_count": 0, "uptime_seconds": 86400 }] },
+  "backup": { "status": "ok", "last_success_at": "2026-08-20T14:00:00.000Z" },
+  "host": { "uptime_seconds": 604800, "restart_count": 1 }
+}
+```
+
+Missing/unusable agent payload is fail-closed (`UNKNOWN` / exception), never silent green.
+
+## Convergence wiring (later campaign)
+
+- Replace this adapter with canonical `control-center/contracts` `SourceObservation` / `ServiceHealth`.
+- Persist collector output into PostgreSQL `source_observations` + collector runs + exception/attention rows.
+- Do not SSH as root from the web runtime; keep a minimal read-only agent (or HTTP/TLS/TCP probes) outside this app.
+- extra-cli `scripts/health_check.py` remains the origin VPS checker — this collector aggregates/normalizes only.

--- a/control-center/connectors/infrastructure/README.md
+++ b/control-center/connectors/infrastructure/README.md
@@ -1,0 +1,78 @@
+# Control Center — infrastructure health collector
+
+Read-only collector for Netcup / 24×7 service health. It turns allowlisted probes into `SourceObservation`, `ServiceHealth`, and **actionable exceptions**. It is not chat, not Prometheus/Grafana, and it does not replace extra-cli `scripts/health_check.py` or systemd units on the VPS.
+
+Ownership path: `control-center/connectors/infrastructure/` only.
+
+## Decisions
+
+1. **Allowlist only.** Hosts, URLs, and check kinds are explicit. Unknown targets are not probed.
+2. **No root SSH in the app runtime.** Live probes are TCP reachability, HTTP GET, and TLS certificate `notAfter`. Disk/memory/load, Docker health, backup last-success, and uptime come from a **minimal read-only agent** (HTTP JSON) or from recorded fixtures. Secrets and SSH material stay out of git, the database, logs, URLs, analytics, and the client bundle.
+3. **Fail-closed.** Timeout, missing agent payload, unusable timestamps, and stale `observed_at` are never reported as `healthy` + `FRESH`. Sibling probes in the same run still emit.
+4. **Provenance on every aggregate.** `source`, `observed_at` (UTC), `freshness_status` (`FRESH|STALE|UNKNOWN|ERROR`), plus `confidence`.
+5. **Idempotency** is a stable observation identity (`source + target + check`), not deletion of prior runs.
+6. **Local adapter.** Canonical `control-center/contracts/` is a sibling workstream. This tree ships a local field set documented in `ADAPTER.md` so convergence can ingest without this collector writing that path.
+7. extra-cli remains the origin VPS checker (DB/disk/load/mem, systemd, backup mount). This collector normalizes those *kinds* of signals; it does not rewrite extra-cli.
+
+## Run
+
+```bash
+cd control-center/connectors/infrastructure
+npm install
+npm test
+npm run collect -- --fixture fixtures/incident.json
+```
+
+`npm test` typechecks with strict TypeScript and runs `node:test` against the compiled collector.
+
+Replay a fixture through the shipped CLI (same entry the cockpit/agents will wrap later):
+
+```bash
+node dist/src/cli.js --fixture fixtures/incident.json
+```
+
+Live mode (TCP/HTTP/TLS only; no SSH):
+
+```bash
+export CONTROL_CENTER_INFRA_ALLOWLIST_PATH=./config/allowlist.example.json
+# optional read-only agent; omit to fail-closed on host_metrics/docker/backup/uptime
+# export CONTROL_CENTER_INFRA_AGENT_URL=http://127.0.0.1:9100/
+npm run collect -- --live
+```
+
+## Environment
+
+| Variable | Purpose |
+| --- | --- |
+| `CONTROL_CENTER_INFRA_ALLOWLIST_PATH` | Filesystem path to the allowlist JSON (live mode). Names only; file must not contain secrets. |
+| `CONTROL_CENTER_INFRA_AGENT_URL` | Optional base URL of a **read-only** agent (`GET /v1/targets/{id}`). `http(s)` only, no userinfo. |
+
+No SSH private keys, tokens, or database DSNs are read by this collector.
+
+## Checks
+
+| Check | How |
+| --- | --- |
+| Host reachability | TCP connect to allowlisted `host:port` |
+| Disk / memory / load | Agent payload when exposed |
+| Docker / service health | Agent payload `docker.services[].health` |
+| HTTP health | GET allowlisted URL, expected status |
+| TLS expiry | Peer certificate `notAfter` vs collector clock |
+| Backup last-success | Agent `backup.status` + `last_success_at` |
+| Restart count / uptime | Agent `host` fields when present |
+
+## Fixtures
+
+Under `fixtures/`: `healthy`, `incident`, `host-failure`, `tls-expired`, `backup-missing`, `timeout`, `partial-outage`, `stale`. Timeouts hang the injected port; the collector deadline still fires.
+
+## Expected convergence
+
+Later campaign (not this PR):
+
+- Import canonical `SourceObservation` / `ServiceHealth` from `control-center/contracts/` and drop this local adapter.
+- Persist runs into PostgreSQL `source_observations` / collector_runs / attention rows.
+- Homepage consumes exceptions as “the 3 things that matter now”.
+- MCP context by `scope=infrastructure` — never a whole-company dump.
+- Wire a production allowlist of internal health URLs; keep secrets in the host environment, not in this tree.
+
+See `ADAPTER.md` for the exact local field set.

--- a/control-center/connectors/infrastructure/config/allowlist.example.json
+++ b/control-center/connectors/infrastructure/config/allowlist.example.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "collector_id": "infrastructure.netcup",
+  "source": "infrastructure",
+  "default_timeout_ms": 5000,
+  "thresholds": {
+    "stale_after_seconds": 300,
+    "disk_warn_pct": 80,
+    "disk_crit_pct": 90,
+    "mem_warn_pct": 90,
+    "backup_max_age_seconds": 86400,
+    "tls_warn_days": 21,
+    "tls_crit_days": 7
+  },
+  "targets": [
+    {
+      "id": "netcup-vps-1",
+      "display_name": "Netcup VPS",
+      "host": "vps.internal.example",
+      "port": 443,
+      "checks": ["reachability", "host_metrics", "docker", "tls", "backup", "uptime"]
+    },
+    {
+      "id": "extra-contracts",
+      "display_name": "extra-contracts HTTP",
+      "url": "http://127.0.0.1:18080/health",
+      "expect_status": 200,
+      "checks": ["http"]
+    },
+    {
+      "id": "cfg-health",
+      "display_name": "cfg-health HTTP",
+      "url": "http://127.0.0.1:18081/health",
+      "expect_status": 200,
+      "checks": ["http"]
+    }
+  ]
+}

--- a/control-center/connectors/infrastructure/fixtures/backup-missing.json
+++ b/control-center/connectors/infrastructure/fixtures/backup-missing.json
@@ -1,0 +1,46 @@
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "allowlist": {
+    "version": 1,
+    "collector_id": "infrastructure.netcup",
+    "source": "infrastructure",
+    "default_timeout_ms": 50,
+    "thresholds": {
+      "stale_after_seconds": 300,
+      "disk_warn_pct": 80,
+      "disk_crit_pct": 90,
+      "mem_warn_pct": 90,
+      "backup_max_age_seconds": 86400,
+      "tls_warn_days": 21,
+      "tls_crit_days": 7
+    },
+    "targets": [
+      {
+        "id": "netcup-vps-1",
+        "display_name": "Netcup VPS",
+        "host": "vps.internal.example",
+        "port": 443,
+        "checks": ["reachability", "backup"]
+      },
+      {
+        "id": "cfg-health",
+        "display_name": "cfg-health HTTP",
+        "url": "http://127.0.0.1:18081/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      }
+    ]
+  },
+  "reachability": {
+    "netcup-vps-1": { "ok": true, "latency_ms": 8 }
+  },
+  "http": {
+    "cfg-health": { "status": 200, "elapsed_ms": 9 }
+  },
+  "agent": {
+    "netcup-vps-1": {
+      "observed_at": "2026-08-20T15:00:00.000Z",
+      "disk": { "used_pct": 41 }
+    }
+  }
+}

--- a/control-center/connectors/infrastructure/fixtures/healthy.json
+++ b/control-center/connectors/infrastructure/fixtures/healthy.json
@@ -1,0 +1,67 @@
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "allowlist": {
+    "version": 1,
+    "collector_id": "infrastructure.netcup",
+    "source": "infrastructure",
+    "default_timeout_ms": 50,
+    "thresholds": {
+      "stale_after_seconds": 300,
+      "disk_warn_pct": 80,
+      "disk_crit_pct": 90,
+      "mem_warn_pct": 90,
+      "backup_max_age_seconds": 86400,
+      "tls_warn_days": 21,
+      "tls_crit_days": 7
+    },
+    "targets": [
+      {
+        "id": "netcup-vps-1",
+        "display_name": "Netcup VPS",
+        "host": "vps.internal.example",
+        "port": 443,
+        "checks": ["reachability", "host_metrics", "docker", "tls", "backup", "uptime"]
+      },
+      {
+        "id": "extra-contracts",
+        "display_name": "extra-contracts HTTP",
+        "url": "http://127.0.0.1:18080/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      },
+      {
+        "id": "cfg-health",
+        "display_name": "cfg-health HTTP",
+        "url": "http://127.0.0.1:18081/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      }
+    ]
+  },
+  "reachability": {
+    "netcup-vps-1": { "ok": true, "latency_ms": 12 }
+  },
+  "http": {
+    "extra-contracts": { "status": 200, "elapsed_ms": 18 },
+    "cfg-health": { "status": 200, "elapsed_ms": 9 }
+  },
+  "tls": {
+    "netcup-vps-1": { "not_after": "2027-08-20T00:00:00.000Z" }
+  },
+  "agent": {
+    "netcup-vps-1": {
+      "observed_at": "2026-08-20T15:00:00.000Z",
+      "disk": { "used_pct": 41, "used_bytes": 41000000000, "total_bytes": 100000000000 },
+      "memory": { "used_pct": 52, "available_bytes": 4000000000, "total_bytes": 8300000000 },
+      "load": { "load_1": 0.21, "load_5": 0.18, "load_15": 0.15 },
+      "docker": {
+        "services": [
+          { "name": "extra-crawler", "health": "healthy", "restart_count": 0, "uptime_seconds": 86400 },
+          { "name": "extra-health-check", "health": "healthy", "restart_count": 0, "uptime_seconds": 86400 }
+        ]
+      },
+      "backup": { "status": "ok", "last_success_at": "2026-08-20T14:00:00.000Z" },
+      "host": { "uptime_seconds": 604800, "restart_count": 1 }
+    }
+  }
+}

--- a/control-center/connectors/infrastructure/fixtures/host-failure.json
+++ b/control-center/connectors/infrastructure/fixtures/host-failure.json
@@ -1,0 +1,66 @@
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "allowlist": {
+    "version": 1,
+    "collector_id": "infrastructure.netcup",
+    "source": "infrastructure",
+    "default_timeout_ms": 50,
+    "thresholds": {
+      "stale_after_seconds": 300,
+      "disk_warn_pct": 80,
+      "disk_crit_pct": 90,
+      "mem_warn_pct": 90,
+      "backup_max_age_seconds": 86400,
+      "tls_warn_days": 21,
+      "tls_crit_days": 7
+    },
+    "targets": [
+      {
+        "id": "netcup-vps-1",
+        "display_name": "Netcup VPS",
+        "host": "vps.internal.example",
+        "port": 443,
+        "checks": ["reachability", "host_metrics", "docker", "tls", "backup", "uptime"]
+      },
+      {
+        "id": "extra-contracts",
+        "display_name": "extra-contracts HTTP",
+        "url": "http://127.0.0.1:18080/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      },
+      {
+        "id": "cfg-health",
+        "display_name": "cfg-health HTTP",
+        "url": "http://127.0.0.1:18081/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      }
+    ]
+  },
+  "reachability": {
+    "netcup-vps-1": { "ok": false, "error": "connection refused" }
+  },
+  "http": {
+    "extra-contracts": { "status": 200, "elapsed_ms": 18 },
+    "cfg-health": { "status": 200, "elapsed_ms": 9 }
+  },
+  "tls": {
+    "netcup-vps-1": { "not_after": "2027-08-20T00:00:00.000Z" }
+  },
+  "agent": {
+    "netcup-vps-1": {
+      "observed_at": "2026-08-20T15:00:00.000Z",
+      "disk": { "used_pct": 41 },
+      "memory": { "used_pct": 52 },
+      "load": { "load_1": 0.21, "load_5": 0.18, "load_15": 0.15 },
+      "docker": {
+        "services": [
+          { "name": "extra-crawler", "health": "healthy" }
+        ]
+      },
+      "backup": { "status": "ok", "last_success_at": "2026-08-20T14:00:00.000Z" },
+      "host": { "uptime_seconds": 604800, "restart_count": 1 }
+    }
+  }
+}

--- a/control-center/connectors/infrastructure/fixtures/incident.json
+++ b/control-center/connectors/infrastructure/fixtures/incident.json
@@ -1,0 +1,67 @@
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "allowlist": {
+    "version": 1,
+    "collector_id": "infrastructure.netcup",
+    "source": "infrastructure",
+    "default_timeout_ms": 50,
+    "thresholds": {
+      "stale_after_seconds": 300,
+      "disk_warn_pct": 80,
+      "disk_crit_pct": 90,
+      "mem_warn_pct": 90,
+      "backup_max_age_seconds": 86400,
+      "tls_warn_days": 21,
+      "tls_crit_days": 7
+    },
+    "targets": [
+      {
+        "id": "netcup-vps-1",
+        "display_name": "Netcup VPS",
+        "host": "vps.internal.example",
+        "port": 443,
+        "checks": ["reachability", "host_metrics", "docker", "tls", "backup", "uptime"]
+      },
+      {
+        "id": "extra-contracts",
+        "display_name": "extra-contracts HTTP",
+        "url": "http://127.0.0.1:18080/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      },
+      {
+        "id": "cfg-health",
+        "display_name": "cfg-health HTTP",
+        "url": "http://127.0.0.1:18081/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      }
+    ]
+  },
+  "reachability": {
+    "netcup-vps-1": { "ok": true, "latency_ms": 12 }
+  },
+  "http": {
+    "extra-contracts": { "status": 503, "elapsed_ms": 22 },
+    "cfg-health": { "status": 200, "elapsed_ms": 9 }
+  },
+  "tls": {
+    "netcup-vps-1": { "not_after": "2027-08-20T00:00:00.000Z" }
+  },
+  "agent": {
+    "netcup-vps-1": {
+      "observed_at": "2026-08-20T15:00:00.000Z",
+      "disk": { "used_pct": 41, "used_bytes": 41000000000, "total_bytes": 100000000000 },
+      "memory": { "used_pct": 52, "available_bytes": 4000000000, "total_bytes": 8300000000 },
+      "load": { "load_1": 0.21, "load_5": 0.18, "load_15": 0.15 },
+      "docker": {
+        "services": [
+          { "name": "extra-crawler", "health": "unhealthy", "restart_count": 6, "uptime_seconds": 40 },
+          { "name": "extra-health-check", "health": "healthy", "restart_count": 0, "uptime_seconds": 86400 }
+        ]
+      },
+      "backup": { "status": "ok", "last_success_at": "2026-08-20T14:00:00.000Z" },
+      "host": { "uptime_seconds": 604800, "restart_count": 1 }
+    }
+  }
+}

--- a/control-center/connectors/infrastructure/fixtures/partial-outage.json
+++ b/control-center/connectors/infrastructure/fixtures/partial-outage.json
@@ -1,0 +1,48 @@
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "allowlist": {
+    "version": 1,
+    "collector_id": "infrastructure.netcup",
+    "source": "infrastructure",
+    "default_timeout_ms": 50,
+    "thresholds": {
+      "stale_after_seconds": 300,
+      "disk_warn_pct": 80,
+      "disk_crit_pct": 90,
+      "mem_warn_pct": 90,
+      "backup_max_age_seconds": 86400,
+      "tls_warn_days": 21,
+      "tls_crit_days": 7
+    },
+    "targets": [
+      {
+        "id": "netcup-vps-1",
+        "display_name": "Netcup VPS",
+        "host": "vps.internal.example",
+        "port": 443,
+        "checks": ["reachability"]
+      },
+      {
+        "id": "extra-contracts",
+        "display_name": "extra-contracts HTTP",
+        "url": "http://127.0.0.1:18080/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      },
+      {
+        "id": "cfg-health",
+        "display_name": "cfg-health HTTP",
+        "url": "http://127.0.0.1:18081/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      }
+    ]
+  },
+  "reachability": {
+    "netcup-vps-1": { "ok": true, "latency_ms": 11 }
+  },
+  "http": {
+    "extra-contracts": { "status": 503, "elapsed_ms": 30 },
+    "cfg-health": { "status": 200, "elapsed_ms": 8 }
+  }
+}

--- a/control-center/connectors/infrastructure/fixtures/stale.json
+++ b/control-center/connectors/infrastructure/fixtures/stale.json
@@ -1,0 +1,53 @@
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "allowlist": {
+    "version": 1,
+    "collector_id": "infrastructure.netcup",
+    "source": "infrastructure",
+    "default_timeout_ms": 50,
+    "thresholds": {
+      "stale_after_seconds": 300,
+      "disk_warn_pct": 80,
+      "disk_crit_pct": 90,
+      "mem_warn_pct": 90,
+      "backup_max_age_seconds": 86400,
+      "tls_warn_days": 21,
+      "tls_crit_days": 7
+    },
+    "targets": [
+      {
+        "id": "netcup-vps-1",
+        "display_name": "Netcup VPS",
+        "host": "vps.internal.example",
+        "port": 443,
+        "checks": ["reachability", "host_metrics", "docker"]
+      },
+      {
+        "id": "cfg-health",
+        "display_name": "cfg-health HTTP",
+        "url": "http://127.0.0.1:18081/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      }
+    ]
+  },
+  "reachability": {
+    "netcup-vps-1": { "ok": true, "latency_ms": 10 }
+  },
+  "http": {
+    "cfg-health": { "status": 200, "elapsed_ms": 7 }
+  },
+  "agent": {
+    "netcup-vps-1": {
+      "observed_at": "2026-08-20T12:00:00.000Z",
+      "disk": { "used_pct": 41 },
+      "memory": { "used_pct": 52 },
+      "load": { "load_1": 0.2, "load_5": 0.2, "load_15": 0.2 },
+      "docker": {
+        "services": [
+          { "name": "extra-crawler", "health": "healthy" }
+        ]
+      }
+    }
+  }
+}

--- a/control-center/connectors/infrastructure/fixtures/timeout.json
+++ b/control-center/connectors/infrastructure/fixtures/timeout.json
@@ -1,0 +1,56 @@
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "hang": ["extra-contracts:http"],
+  "allowlist": {
+    "version": 1,
+    "collector_id": "infrastructure.netcup",
+    "source": "infrastructure",
+    "default_timeout_ms": 40,
+    "thresholds": {
+      "stale_after_seconds": 300,
+      "disk_warn_pct": 80,
+      "disk_crit_pct": 90,
+      "mem_warn_pct": 90,
+      "backup_max_age_seconds": 86400,
+      "tls_warn_days": 21,
+      "tls_crit_days": 7
+    },
+    "targets": [
+      {
+        "id": "netcup-vps-1",
+        "display_name": "Netcup VPS",
+        "host": "vps.internal.example",
+        "port": 443,
+        "checks": ["reachability", "host_metrics"]
+      },
+      {
+        "id": "extra-contracts",
+        "display_name": "extra-contracts HTTP",
+        "url": "http://127.0.0.1:18080/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      },
+      {
+        "id": "cfg-health",
+        "display_name": "cfg-health HTTP",
+        "url": "http://127.0.0.1:18081/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      }
+    ]
+  },
+  "reachability": {
+    "netcup-vps-1": { "ok": true, "latency_ms": 12 }
+  },
+  "http": {
+    "cfg-health": { "status": 200, "elapsed_ms": 9 }
+  },
+  "agent": {
+    "netcup-vps-1": {
+      "observed_at": "2026-08-20T15:00:00.000Z",
+      "disk": { "used_pct": 41 },
+      "memory": { "used_pct": 52 },
+      "load": { "load_1": 0.21, "load_5": 0.18, "load_15": 0.15 }
+    }
+  }
+}

--- a/control-center/connectors/infrastructure/fixtures/tls-expired.json
+++ b/control-center/connectors/infrastructure/fixtures/tls-expired.json
@@ -1,0 +1,43 @@
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "allowlist": {
+    "version": 1,
+    "collector_id": "infrastructure.netcup",
+    "source": "infrastructure",
+    "default_timeout_ms": 50,
+    "thresholds": {
+      "stale_after_seconds": 300,
+      "disk_warn_pct": 80,
+      "disk_crit_pct": 90,
+      "mem_warn_pct": 90,
+      "backup_max_age_seconds": 86400,
+      "tls_warn_days": 21,
+      "tls_crit_days": 7
+    },
+    "targets": [
+      {
+        "id": "netcup-vps-1",
+        "display_name": "Netcup VPS",
+        "host": "vps.internal.example",
+        "port": 443,
+        "checks": ["reachability", "tls"]
+      },
+      {
+        "id": "cfg-health",
+        "display_name": "cfg-health HTTP",
+        "url": "http://127.0.0.1:18081/health",
+        "expect_status": 200,
+        "checks": ["http"]
+      }
+    ]
+  },
+  "reachability": {
+    "netcup-vps-1": { "ok": true, "latency_ms": 8 }
+  },
+  "http": {
+    "cfg-health": { "status": 200, "elapsed_ms": 9 }
+  },
+  "tls": {
+    "netcup-vps-1": { "not_after": "2026-08-01T00:00:00.000Z" }
+  }
+}

--- a/control-center/connectors/infrastructure/package-lock.json
+++ b/control-center/connectors/infrastructure/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@confenge/cc-infrastructure-collector",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/cc-infrastructure-collector",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/control-center/connectors/infrastructure/package.json
+++ b/control-center/connectors/infrastructure/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@confenge/cc-infrastructure-collector",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Read-only Confenge Control Center collector for Netcup/24x7 infrastructure health.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json --pretty false",
+    "typecheck": "tsc -p tsconfig.json --pretty false --noEmit",
+    "test": "tsc -p tsconfig.json --pretty false && node --test dist/tests/*.test.js",
+    "collect": "tsc -p tsconfig.json --pretty false && node dist/src/cli.js"
+  },
+  "exports": {
+    ".": "./dist/src/index.js"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/connectors/infrastructure/src/agent.ts
+++ b/control-center/connectors/infrastructure/src/agent.ts
@@ -1,0 +1,152 @@
+import type {
+  AgentBackup,
+  AgentDisk,
+  AgentDockerService,
+  AgentHost,
+  AgentLoad,
+  AgentMemory,
+  AgentPayload,
+} from "./types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function asFinite(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseDisk(raw: unknown): AgentDisk | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const usedPct = asFinite(raw.used_pct);
+  if (usedPct === undefined) {
+    return undefined;
+  }
+  const disk: AgentDisk = { used_pct: usedPct };
+  const usedBytes = asFinite(raw.used_bytes);
+  const totalBytes = asFinite(raw.total_bytes);
+  if (usedBytes !== undefined) {
+    Object.assign(disk, { used_bytes: usedBytes });
+  }
+  if (totalBytes !== undefined) {
+    Object.assign(disk, { total_bytes: totalBytes });
+  }
+  return disk;
+}
+
+function parseMemory(raw: unknown): AgentMemory | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const usedPct = asFinite(raw.used_pct);
+  if (usedPct === undefined) {
+    return undefined;
+  }
+  const memory: AgentMemory = { used_pct: usedPct };
+  const available = asFinite(raw.available_bytes);
+  const total = asFinite(raw.total_bytes);
+  if (available !== undefined) {
+    Object.assign(memory, { available_bytes: available });
+  }
+  if (total !== undefined) {
+    Object.assign(memory, { total_bytes: total });
+  }
+  return memory;
+}
+
+function parseLoad(raw: unknown): AgentLoad | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const load1 = asFinite(raw.load_1);
+  const load5 = asFinite(raw.load_5);
+  const load15 = asFinite(raw.load_15);
+  if (load1 === undefined || load5 === undefined || load15 === undefined) {
+    return undefined;
+  }
+  return { load_1: load1, load_5: load5, load_15: load15 };
+}
+
+function parseDocker(raw: unknown): { services: AgentDockerService[] } | undefined {
+  if (!isRecord(raw) || !Array.isArray(raw.services)) {
+    return undefined;
+  }
+  const services: AgentDockerService[] = [];
+  for (const item of raw.services) {
+    if (!isRecord(item) || typeof item.name !== "string" || typeof item.health !== "string") {
+      continue;
+    }
+    const service: AgentDockerService = { name: item.name, health: item.health };
+    const restart = asFinite(item.restart_count);
+    const uptime = asFinite(item.uptime_seconds);
+    if (restart !== undefined) {
+      Object.assign(service, { restart_count: restart });
+    }
+    if (uptime !== undefined) {
+      Object.assign(service, { uptime_seconds: uptime });
+    }
+    services.push(service);
+  }
+  return { services };
+}
+
+function parseBackup(raw: unknown): AgentBackup | undefined {
+  if (!isRecord(raw) || typeof raw.status !== "string") {
+    return undefined;
+  }
+  const backup: AgentBackup = { status: raw.status };
+  if (typeof raw.last_success_at === "string") {
+    Object.assign(backup, { last_success_at: raw.last_success_at });
+  }
+  return backup;
+}
+
+function parseHost(raw: unknown): AgentHost | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const host: AgentHost = {};
+  const uptime = asFinite(raw.uptime_seconds);
+  const restart = asFinite(raw.restart_count);
+  if (uptime !== undefined) {
+    Object.assign(host, { uptime_seconds: uptime });
+  }
+  if (restart !== undefined) {
+    Object.assign(host, { restart_count: restart });
+  }
+  return Object.keys(host).length > 0 ? host : undefined;
+}
+
+export function parseAgentPayload(raw: unknown): AgentPayload | null {
+  if (!isRecord(raw) || typeof raw.observed_at !== "string") {
+    return null;
+  }
+  const payload: AgentPayload = { observed_at: raw.observed_at };
+  const disk = parseDisk(raw.disk);
+  const memory = parseMemory(raw.memory);
+  const load = parseLoad(raw.load);
+  const docker = parseDocker(raw.docker);
+  const backup = parseBackup(raw.backup);
+  const host = parseHost(raw.host);
+  if (disk) {
+    Object.assign(payload, { disk });
+  }
+  if (memory) {
+    Object.assign(payload, { memory });
+  }
+  if (load) {
+    Object.assign(payload, { load });
+  }
+  if (docker) {
+    Object.assign(payload, { docker });
+  }
+  if (backup) {
+    Object.assign(payload, { backup });
+  }
+  if (host) {
+    Object.assign(payload, { host });
+  }
+  return payload;
+}

--- a/control-center/connectors/infrastructure/src/allowlist.ts
+++ b/control-center/connectors/infrastructure/src/allowlist.ts
@@ -1,0 +1,224 @@
+import { CHECK_KINDS, type Allowlist, type AllowlistTarget, type CheckKind } from "./types.js";
+
+const TARGET_ID = /^[a-z0-9][a-z0-9._-]{0,62}$/;
+const COLLECTOR_ID = /^[a-z0-9][a-z0-9._-]{0,80}$/;
+const SECRET_KEY =
+  /^(.*(_|-))?((pass(word)?)|secret|token|api[_-]?key|authorization|private[_-]?key|ssh|credential|pem|identity)((_|-).*)?$/i;
+const FORBIDDEN_VALUE = /BEGIN [A-Z ]*(PRIVATE KEY|CERTIFICATE)|ssh-rsa |ssh-ed25519 /i;
+
+class AllowlistError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AllowlistError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function rejectSecrets(node: unknown, path: string): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => rejectSecrets(item, `${path}[${i}]`));
+    return;
+  }
+  if (!isRecord(node)) {
+    if (typeof node === "string" && FORBIDDEN_VALUE.test(node)) {
+      throw new AllowlistError(`${path} contains material that looks like a secret or key`);
+    }
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (SECRET_KEY.test(key)) {
+      throw new AllowlistError(`${path}.${key} is not allowed (secrets stay out of allowlist/config)`);
+    }
+    rejectSecrets(value, `${path}.${key}`);
+  }
+}
+
+function asPositiveInt(value: unknown, path: string, fallback?: number): number {
+  if (value === undefined && fallback !== undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new AllowlistError(`${path} must be a positive integer`);
+  }
+  return value;
+}
+
+function asPct(value: unknown, path: string, fallback: number): number {
+  const n = value === undefined ? fallback : value;
+  if (typeof n !== "number" || Number.isNaN(n) || n < 1 || n > 100) {
+    throw new AllowlistError(`${path} must be a percentage between 1 and 100`);
+  }
+  return n;
+}
+
+function asCheck(value: unknown, path: string): CheckKind {
+  if (typeof value !== "string" || !CHECK_KINDS.includes(value as CheckKind)) {
+    throw new AllowlistError(`${path} must be one of: ${CHECK_KINDS.join(", ")}`);
+  }
+  return value as CheckKind;
+}
+
+function assertSafeUrl(raw: string, path: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new AllowlistError(`${path} is not a valid URL`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new AllowlistError(`${path} must be http(s)`);
+  }
+  if (url.username || url.password) {
+    throw new AllowlistError(`${path} must not embed credentials`);
+  }
+  for (const key of url.searchParams.keys()) {
+    if (SECRET_KEY.test(key)) {
+      throw new AllowlistError(`${path} query parameter ${key} looks like a secret`);
+    }
+  }
+  return url;
+}
+
+function parseTarget(raw: unknown, index: number): AllowlistTarget {
+  const path = `targets[${index}]`;
+  if (!isRecord(raw)) {
+    throw new AllowlistError(`${path} must be an object`);
+  }
+  if (typeof raw.id !== "string" || !TARGET_ID.test(raw.id)) {
+    throw new AllowlistError(`${path}.id must match ${TARGET_ID}`);
+  }
+  if (typeof raw.display_name !== "string" || raw.display_name.trim().length === 0) {
+    throw new AllowlistError(`${path}.display_name is required`);
+  }
+  if (!Array.isArray(raw.checks) || raw.checks.length === 0) {
+    throw new AllowlistError(`${path}.checks must be a non-empty array`);
+  }
+  const checks = raw.checks.map((check, i) => asCheck(check, `${path}.checks[${i}]`));
+  const unique = new Set(checks);
+  if (unique.size !== checks.length) {
+    throw new AllowlistError(`${path}.checks must not repeat`);
+  }
+
+  const target: AllowlistTarget = {
+    id: raw.id,
+    display_name: raw.display_name.trim(),
+    checks,
+  };
+
+  if (raw.host !== undefined) {
+    if (typeof raw.host !== "string" || raw.host.trim().length === 0) {
+      throw new AllowlistError(`${path}.host must be a hostname`);
+    }
+    if (raw.host.includes("@") || raw.host.includes("/")) {
+      throw new AllowlistError(`${path}.host must not contain credentials or paths`);
+    }
+    Object.assign(target, { host: raw.host.trim() });
+  }
+  if (raw.port !== undefined) {
+    const port = asPositiveInt(raw.port, `${path}.port`);
+    if (port > 65535) {
+      throw new AllowlistError(`${path}.port out of range`);
+    }
+    Object.assign(target, { port });
+  }
+  if (raw.url !== undefined) {
+    if (typeof raw.url !== "string") {
+      throw new AllowlistError(`${path}.url must be a string`);
+    }
+    assertSafeUrl(raw.url, `${path}.url`);
+    Object.assign(target, { url: raw.url });
+  }
+  if (raw.expect_status !== undefined) {
+    const status = asPositiveInt(raw.expect_status, `${path}.expect_status`);
+    if (status < 100 || status > 599) {
+      throw new AllowlistError(`${path}.expect_status must be an HTTP status`);
+    }
+    Object.assign(target, { expect_status: status });
+  }
+  if (raw.timeout_ms !== undefined) {
+    Object.assign(target, { timeout_ms: asPositiveInt(raw.timeout_ms, `${path}.timeout_ms`) });
+  }
+  if (raw.agent_id !== undefined) {
+    if (typeof raw.agent_id !== "string" || !TARGET_ID.test(raw.agent_id)) {
+      throw new AllowlistError(`${path}.agent_id must match ${TARGET_ID}`);
+    }
+    Object.assign(target, { agent_id: raw.agent_id });
+  }
+
+  if (checks.includes("http") && !target.url) {
+    throw new AllowlistError(`${path} http check requires url`);
+  }
+  if ((checks.includes("reachability") || checks.includes("tls")) && !target.host) {
+    throw new AllowlistError(`${path} reachability/tls checks require host`);
+  }
+  return target;
+}
+
+export function parseAllowlist(input: unknown): Allowlist {
+  if (!isRecord(input)) {
+    throw new AllowlistError("allowlist must be an object");
+  }
+  rejectSecrets(input, "allowlist");
+  if (input.version !== 1) {
+    throw new AllowlistError("allowlist.version must be 1");
+  }
+  if (typeof input.collector_id !== "string" || !COLLECTOR_ID.test(input.collector_id)) {
+    throw new AllowlistError("allowlist.collector_id is invalid");
+  }
+  if (typeof input.source !== "string" || input.source.trim().length === 0) {
+    throw new AllowlistError("allowlist.source is required");
+  }
+  if (!Array.isArray(input.targets) || input.targets.length === 0) {
+    throw new AllowlistError("allowlist.targets must be a non-empty array");
+  }
+
+  const thresholdsRaw = isRecord(input.thresholds) ? input.thresholds : {};
+  const thresholds = {
+    stale_after_seconds: asPositiveInt(
+      thresholdsRaw.stale_after_seconds,
+      "thresholds.stale_after_seconds",
+      300,
+    ),
+    disk_warn_pct: asPct(thresholdsRaw.disk_warn_pct, "thresholds.disk_warn_pct", 80),
+    disk_crit_pct: asPct(thresholdsRaw.disk_crit_pct, "thresholds.disk_crit_pct", 90),
+    mem_warn_pct: asPct(thresholdsRaw.mem_warn_pct, "thresholds.mem_warn_pct", 90),
+    backup_max_age_seconds: asPositiveInt(
+      thresholdsRaw.backup_max_age_seconds,
+      "thresholds.backup_max_age_seconds",
+      86_400,
+    ),
+    tls_warn_days: asPositiveInt(thresholdsRaw.tls_warn_days, "thresholds.tls_warn_days", 21),
+    tls_crit_days: asPositiveInt(thresholdsRaw.tls_crit_days, "thresholds.tls_crit_days", 7),
+  };
+  if (thresholds.disk_crit_pct < thresholds.disk_warn_pct) {
+    throw new AllowlistError("thresholds.disk_crit_pct must be >= disk_warn_pct");
+  }
+  if (thresholds.tls_crit_days > thresholds.tls_warn_days) {
+    throw new AllowlistError("thresholds.tls_crit_days must be <= tls_warn_days");
+  }
+
+  const targets = input.targets.map((target, i) => parseTarget(target, i));
+  const ids = new Set<string>();
+  for (const target of targets) {
+    if (ids.has(target.id)) {
+      throw new AllowlistError(`duplicate target id ${target.id}`);
+    }
+    ids.add(target.id);
+  }
+
+  return {
+    version: 1,
+    collector_id: input.collector_id,
+    source: input.source.trim(),
+    default_timeout_ms: asPositiveInt(input.default_timeout_ms, "default_timeout_ms", 5_000),
+    thresholds,
+    targets,
+  };
+}
+
+export function timeoutFor(allowlist: Allowlist, target: AllowlistTarget): number {
+  return target.timeout_ms ?? allowlist.default_timeout_ms;
+}

--- a/control-center/connectors/infrastructure/src/cli.ts
+++ b/control-center/connectors/infrastructure/src/cli.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseAllowlist } from "./allowlist.js";
+import { collect } from "./collect.js";
+import { createFixturePorts, parseFixture } from "./fixture-ports.js";
+import { createLivePorts } from "./live-ports.js";
+import { logEvent } from "./log.js";
+
+export interface CliArgs {
+  readonly fixture?: string;
+  readonly live: boolean;
+  readonly allowlist?: string;
+}
+
+export function parseCliArgs(argv: readonly string[]): CliArgs {
+  let fixture: string | undefined;
+  let allowlist: string | undefined;
+  let live = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--fixture") {
+      fixture = argv[i + 1];
+      i += 1;
+    } else if (arg === "--allowlist") {
+      allowlist = argv[i + 1];
+      i += 1;
+    } else if (arg === "--live") {
+      live = true;
+    } else if (arg === "--help" || arg === "-h") {
+      throw new Error("usage: collect --fixture <path> | --live [--allowlist <path>]");
+    }
+  }
+  const args: CliArgs = { live };
+  if (fixture) {
+    Object.assign(args, { fixture });
+  }
+  if (allowlist) {
+    Object.assign(args, { allowlist });
+  }
+  return args;
+}
+
+function resolvePath(raw: string): string {
+  return isAbsolute(raw) ? raw : resolve(process.cwd(), raw);
+}
+
+export async function collectFromFixtureFile(fixturePath: string): Promise<unknown> {
+  const raw: unknown = JSON.parse(await readFile(resolvePath(fixturePath), "utf8"));
+  const fixture = parseFixture(raw);
+  const allowlist = parseAllowlist(fixture.allowlist);
+  return collect({
+    allowlist,
+    ports: createFixturePorts(fixture, allowlist),
+  });
+}
+
+export async function runCli(argv: readonly string[] = process.argv.slice(2)): Promise<string> {
+  const args = parseCliArgs(argv);
+  if (args.fixture && args.live) {
+    throw new Error("use either --fixture or --live, not both");
+  }
+  if (args.fixture) {
+    const result = await collectFromFixtureFile(args.fixture);
+    return JSON.stringify(result, null, 2);
+  }
+  if (!args.live) {
+    throw new Error("usage: collect --fixture <path> | --live [--allowlist <path>]");
+  }
+  const allowlistPath =
+    args.allowlist ?? process.env.CONTROL_CENTER_INFRA_ALLOWLIST_PATH;
+  if (!allowlistPath) {
+    throw new Error("live mode requires --allowlist or CONTROL_CENTER_INFRA_ALLOWLIST_PATH");
+  }
+  const allowlistRaw: unknown = JSON.parse(await readFile(resolvePath(allowlistPath), "utf8"));
+  const agentBaseUrl = process.env.CONTROL_CENTER_INFRA_AGENT_URL;
+  const result = await collect({
+    allowlist: allowlistRaw,
+    ports: createLivePorts(agentBaseUrl ? { agentBaseUrl } : {}),
+  });
+  return JSON.stringify(result, null, 2);
+}
+
+async function main(): Promise<void> {
+  try {
+    const json = await runCli();
+    process.stdout.write(`${json}\n`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "collect failed";
+    logEvent("infra_collect_error", { error: message });
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+function isMain(): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isMain()) {
+  void main();
+}

--- a/control-center/connectors/infrastructure/src/collect.ts
+++ b/control-center/connectors/infrastructure/src/collect.ts
@@ -1,0 +1,59 @@
+import { parseAllowlist } from "./allowlist.js";
+import { deriveExceptions } from "./exceptions.js";
+import { logEvent } from "./log.js";
+import { assertKnownTargets, mapCollectRecords } from "./map.js";
+import type { ProbePorts } from "./ports.js";
+import { runProbes } from "./probes.js";
+import { ADAPTER_SCHEMA_VERSION, type Allowlist, type CollectResult, type ProbeResult } from "./types.js";
+import { toUtcIso } from "./ids.js";
+
+export interface CollectInput {
+  readonly allowlist: unknown;
+  readonly ports: ProbePorts;
+}
+
+export function mapCollectResult(
+  allowlist: Allowlist,
+  probes: readonly ProbeResult[],
+  now: Date,
+  startedAt: Date = now,
+): CollectResult {
+  assertKnownTargets(allowlist, probes);
+  const { observations, service_health } = mapCollectRecords(allowlist, probes, now);
+  const exceptions = deriveExceptions(allowlist, observations);
+  return {
+    collector_run: {
+      schema_version: ADAPTER_SCHEMA_VERSION,
+      collector_id: allowlist.collector_id,
+      source: allowlist.source,
+      started_at: toUtcIso(startedAt),
+      finished_at: toUtcIso(now),
+      target_count: allowlist.targets.length,
+      observation_count: observations.length,
+      exception_count: exceptions.length,
+    },
+    observations,
+    service_health,
+    exceptions,
+  };
+}
+
+export async function collect(input: CollectInput): Promise<CollectResult> {
+  const allowlist = parseAllowlist(input.allowlist);
+  const startedAt = input.ports.now();
+  logEvent("infra_collect_start", {
+    collector_id: allowlist.collector_id,
+    source: allowlist.source,
+    target_count: allowlist.targets.length,
+  });
+  const probes = await runProbes(allowlist, input.ports);
+  const finishedAt = input.ports.now();
+  const result = mapCollectResult(allowlist, probes, finishedAt, startedAt);
+  logEvent("infra_collect_finish", {
+    collector_id: allowlist.collector_id,
+    observation_count: result.observations.length,
+    exception_count: result.exceptions.length,
+    health_count: result.service_health.length,
+  });
+  return result;
+}

--- a/control-center/connectors/infrastructure/src/exceptions.ts
+++ b/control-center/connectors/infrastructure/src/exceptions.ts
@@ -1,0 +1,135 @@
+import { exceptionId, slug } from "./ids.js";
+import type { ActionableException, Allowlist, SourceObservation } from "./types.js";
+
+function serviceStatusOf(obs: SourceObservation): string {
+  const value = obs.payload.service_status;
+  return typeof value === "string" ? value : "unknown";
+}
+
+function timedOut(obs: SourceObservation): boolean {
+  return obs.payload.probe_status === "timeout" || obs.payload.timed_out === true;
+}
+
+function isIncident(obs: SourceObservation): boolean {
+  const status = serviceStatusOf(obs);
+  if (status === "unhealthy") {
+    return true;
+  }
+  if (obs.freshness_status === "ERROR" || obs.freshness_status === "STALE") {
+    return true;
+  }
+  if (obs.freshness_status === "UNKNOWN" && status !== "healthy") {
+    return true;
+  }
+  return false;
+}
+
+function severityOf(obs: SourceObservation): ActionableException["severity"] {
+  const status = serviceStatusOf(obs);
+  if (status === "degraded" && obs.freshness_status === "FRESH") {
+    return "warning";
+  }
+  if (obs.check === "tls" && status === "degraded") {
+    return "warning";
+  }
+  return "critical";
+}
+
+function titleOf(obs: SourceObservation, displayName: string): string {
+  const status = serviceStatusOf(obs);
+  if (timedOut(obs)) {
+    return `Timed out ${obs.check} probe for ${displayName}`;
+  }
+  if (obs.freshness_status === "STALE") {
+    return `Stale ${obs.check} metrics for ${displayName}`;
+  }
+  if (obs.check === "tls") {
+    return `TLS incident on ${displayName}`;
+  }
+  if (obs.check === "backup") {
+    return `Backup last-success incident on ${displayName}`;
+  }
+  if (obs.check === "docker") {
+    return `Docker/service health incident on ${displayName}`;
+  }
+  if (obs.check === "http") {
+    return `HTTP health incident on ${displayName}`;
+  }
+  if (obs.check === "reachability") {
+    return `Host unreachable: ${displayName}`;
+  }
+  return `Infrastructure ${status} on ${displayName} (${obs.check})`;
+}
+
+function evidenceOf(obs: SourceObservation, displayName: string): string {
+  const bits = [
+    `check=${obs.check}`,
+    `allowlisted_target=${obs.target_id}`,
+    `display_name=${displayName}`,
+    `probe_status=${String(obs.payload.probe_status ?? "unknown")}`,
+    `service_status=${serviceStatusOf(obs)}`,
+    `freshness_status=${obs.freshness_status}`,
+    `observed_at=${obs.observed_at}`,
+    `summary=${obs.summary}`,
+  ];
+  if (obs.check === "http" && typeof obs.payload.url === "string") {
+    bits.push(`url=${obs.payload.url}`);
+  }
+  if (obs.check === "http" && typeof obs.payload.status === "number") {
+    bits.push(`http_status=${obs.payload.status}`);
+  }
+  if (obs.check === "tls" && typeof obs.payload.not_after === "string") {
+    bits.push(`tls_not_after=${obs.payload.not_after}`);
+  }
+  if (obs.check === "backup") {
+    bits.push(`backup_status=${String(obs.payload.status ?? "missing")}`);
+    bits.push(`last_success_at=${String(obs.payload.last_success_at ?? "missing")}`);
+  }
+  if (obs.check === "docker" && Array.isArray(obs.payload.services)) {
+    bits.push(`services=${JSON.stringify(obs.payload.services)}`);
+  }
+  return bits.join("; ");
+}
+
+function qualifier(obs: SourceObservation): string {
+  if (obs.check === "docker" && Array.isArray(obs.payload.services)) {
+    const names = obs.payload.services
+      .filter((item) => item && typeof item === "object")
+      .map((item) => String((item as Record<string, unknown>).name ?? "service"))
+      .join(",");
+    return slug(names);
+  }
+  return "";
+}
+
+export function deriveExceptions(
+  allowlist: Allowlist,
+  observations: readonly SourceObservation[],
+): ActionableException[] {
+  const names = new Map(allowlist.targets.map((t) => [t.id, t.display_name]));
+  const exceptions: ActionableException[] = [];
+  for (const obs of observations) {
+    if (!isIncident(obs)) {
+      continue;
+    }
+    const displayName = names.get(obs.target_id) ?? obs.target_id;
+    const evidence = evidenceOf(obs, displayName);
+    if (evidence.trim().length === 0) {
+      continue;
+    }
+    exceptions.push({
+      exception_id: exceptionId(allowlist.source, obs.target_id, obs.check, qualifier(obs)),
+      source: allowlist.source,
+      timestamp: obs.observed_at,
+      observed_at: obs.observed_at,
+      target_id: obs.target_id,
+      check: obs.check,
+      severity: severityOf(obs),
+      title: titleOf(obs, displayName),
+      evidence,
+      freshness_status: obs.freshness_status,
+    });
+  }
+  exceptions.sort((a, b) => a.exception_id.localeCompare(b.exception_id));
+  return exceptions;
+}

--- a/control-center/connectors/infrastructure/src/fixture-ports.ts
+++ b/control-center/connectors/infrastructure/src/fixture-ports.ts
@@ -1,0 +1,133 @@
+import { parseAgentPayload } from "./agent.js";
+import { parseAllowlist } from "./allowlist.js";
+import { parseUtcIso } from "./ids.js";
+import type { ProbePorts } from "./ports.js";
+import type { Allowlist, AllowlistTarget, HttpSample, ReachabilitySample, TlsSample } from "./types.js";
+
+export interface FixtureFile {
+  readonly now: string;
+  readonly allowlist: unknown;
+  readonly hang?: readonly string[];
+  readonly reachability?: Readonly<Record<string, ReachabilitySample>>;
+  readonly http?: Readonly<Record<string, HttpSample>>;
+  readonly tls?: Readonly<Record<string, TlsSample>>;
+  readonly agent?: Readonly<Record<string, unknown>>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hangForever(): Promise<never> {
+  return new Promise(() => {
+    /* fixture-driven timeout: collect() timeout wrapper must win */
+  });
+}
+
+function hangKey(targetId: string, check: string): string {
+  return `${targetId}:${check}`;
+}
+
+export function parseFixture(raw: unknown): FixtureFile {
+  if (!isRecord(raw) || typeof raw.now !== "string") {
+    throw new Error("fixture.now is required");
+  }
+  parseUtcIso(raw.now, "fixture.now");
+  if (!("allowlist" in raw)) {
+    throw new Error("fixture.allowlist is required");
+  }
+  const hang = Array.isArray(raw.hang)
+    ? raw.hang.filter((item): item is string => typeof item === "string")
+    : [];
+  const fixture: FixtureFile = {
+    now: raw.now,
+    allowlist: raw.allowlist,
+  };
+  if (hang.length > 0) {
+    Object.assign(fixture, { hang });
+  }
+  if (isRecord(raw.reachability)) {
+    Object.assign(fixture, { reachability: raw.reachability as Record<string, ReachabilitySample> });
+  }
+  if (isRecord(raw.http)) {
+    Object.assign(fixture, { http: raw.http as Record<string, HttpSample> });
+  }
+  if (isRecord(raw.tls)) {
+    Object.assign(fixture, { tls: raw.tls as Record<string, TlsSample> });
+  }
+  if (isRecord(raw.agent)) {
+    Object.assign(fixture, { agent: raw.agent });
+  }
+  return fixture;
+}
+
+function findTarget(
+  allowlist: Allowlist,
+  predicate: (target: AllowlistTarget) => boolean,
+): AllowlistTarget | undefined {
+  return allowlist.targets.find(predicate);
+}
+
+export function createFixturePorts(fixture: FixtureFile, allowlist?: Allowlist): ProbePorts {
+  const now = parseUtcIso(fixture.now, "fixture.now");
+  const resolved = allowlist ?? parseAllowlist(fixture.allowlist);
+  const hangs = new Set(fixture.hang ?? []);
+
+  return {
+    now: () => now,
+    async reachHost(host, port) {
+      const target = findTarget(
+        resolved,
+        (item) => item.host === host && (item.port ?? 443) === port,
+      );
+      if (target && hangs.has(hangKey(target.id, "reachability"))) {
+        return hangForever();
+      }
+      if (target) {
+        return fixture.reachability?.[target.id] ?? { ok: false, error: "fixture reachability missing" };
+      }
+      return { ok: false, error: "host is not allowlisted" };
+    },
+    async httpGet(url) {
+      const target = findTarget(resolved, (item) => item.url === url);
+      if (target && hangs.has(hangKey(target.id, "http"))) {
+        return hangForever();
+      }
+      if (target) {
+        return fixture.http?.[target.id] ?? { status: 0, error: "fixture HTTP sample missing" };
+      }
+      return { status: 0, error: "url is not allowlisted" };
+    },
+    async readTls(host, port) {
+      const target = findTarget(
+        resolved,
+        (item) => item.host === host && (item.port ?? 443) === port,
+      );
+      if (target && hangs.has(hangKey(target.id, "tls"))) {
+        return hangForever();
+      }
+      if (target) {
+        return (
+          fixture.tls?.[target.id] ?? {
+            not_after: "1970-01-01T00:00:00.000Z",
+            error: "fixture TLS sample missing",
+          }
+        );
+      }
+      return { not_after: "1970-01-01T00:00:00.000Z", error: "host is not allowlisted" };
+    },
+    async readAgent(targetId) {
+      const agentChecks = ["host_metrics", "docker", "backup", "uptime"] as const;
+      for (const check of agentChecks) {
+        if (hangs.has(hangKey(targetId, check))) {
+          return hangForever();
+        }
+      }
+      const raw = fixture.agent?.[targetId];
+      if (raw === undefined) {
+        return null;
+      }
+      return parseAgentPayload(raw);
+    },
+  };
+}

--- a/control-center/connectors/infrastructure/src/freshness.ts
+++ b/control-center/connectors/infrastructure/src/freshness.ts
@@ -1,0 +1,100 @@
+import type { FreshnessStatus, ProbeStatus, ServiceStatus } from "./types.js";
+
+export function freshnessFromProbe(args: {
+  probeStatus: ProbeStatus;
+  now: Date;
+  staleAfterSeconds: number;
+  agentObservedAt?: string;
+}): FreshnessStatus {
+  if (args.probeStatus === "timeout" || args.probeStatus === "error") {
+    return "ERROR";
+  }
+  if (args.probeStatus === "missing") {
+    return "UNKNOWN";
+  }
+  if (args.agentObservedAt) {
+    const observedMs = Date.parse(args.agentObservedAt);
+    if (Number.isNaN(observedMs)) {
+      return "UNKNOWN";
+    }
+    const ageSec = (args.now.getTime() - observedMs) / 1000;
+    if (ageSec > args.staleAfterSeconds) {
+      return "STALE";
+    }
+    if (ageSec < -args.staleAfterSeconds) {
+      return "UNKNOWN";
+    }
+  }
+  return "FRESH";
+}
+
+export function worstFreshness(statuses: readonly FreshnessStatus[]): FreshnessStatus {
+  const rank: Record<FreshnessStatus, number> = {
+    ERROR: 4,
+    STALE: 3,
+    UNKNOWN: 2,
+    FRESH: 1,
+  };
+  let worst: FreshnessStatus = "FRESH";
+  for (const status of statuses) {
+    if (rank[status] > rank[worst]) {
+      worst = status;
+    }
+  }
+  return worst;
+}
+
+export function worstServiceStatus(statuses: readonly ServiceStatus[]): ServiceStatus {
+  const rank: Record<ServiceStatus, number> = {
+    unhealthy: 4,
+    degraded: 3,
+    unknown: 2,
+    healthy: 1,
+  };
+  let worst: ServiceStatus = "healthy";
+  for (const status of statuses) {
+    if (rank[status] > rank[worst]) {
+      worst = status;
+    }
+  }
+  return worst;
+}
+
+/** Healthy+FRESH is only legal when freshness is FRESH and status is healthy. */
+export function coalesceServiceStatus(
+  checkStatuses: readonly ServiceStatus[],
+  freshness: FreshnessStatus,
+): ServiceStatus {
+  const worst = worstServiceStatus(checkStatuses);
+  if (freshness !== "FRESH" && worst === "healthy") {
+    return "unknown";
+  }
+  return worst;
+}
+
+export function confidenceFor(freshness: FreshnessStatus, probeStatus: ProbeStatus): number {
+  if (probeStatus === "timeout") {
+    return 0.1;
+  }
+  if (probeStatus === "error" || probeStatus === "missing") {
+    return 0.2;
+  }
+  if (freshness === "STALE") {
+    return 0.4;
+  }
+  if (freshness === "UNKNOWN") {
+    return 0.3;
+  }
+  if (freshness === "ERROR") {
+    return 0.2;
+  }
+  return 0.95;
+}
+
+export function daysUntil(notAfterIso: string, now: Date): number {
+  const notAfter = Date.parse(notAfterIso);
+  if (Number.isNaN(notAfter)) {
+    return Number.NaN;
+  }
+  return (notAfter - now.getTime()) / 86_400_000;
+}

--- a/control-center/connectors/infrastructure/src/ids.ts
+++ b/control-center/connectors/infrastructure/src/ids.ts
@@ -1,0 +1,40 @@
+import type { CheckKind } from "./types.js";
+
+export function observationId(source: string, targetId: string, check: CheckKind): string {
+  return `${source}:${targetId}:${check}`;
+}
+
+export function exceptionId(
+  source: string,
+  targetId: string,
+  check: CheckKind,
+  qualifier = "",
+): string {
+  return qualifier
+    ? `exc:${source}:${targetId}:${check}:${qualifier}`
+    : `exc:${source}:${targetId}:${check}`;
+}
+
+export function toUtcIso(date: Date): string {
+  return date.toISOString();
+}
+
+export function parseUtcIso(value: string, label: string): Date {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?Z$/.test(value)) {
+    throw new Error(`${label} must be an ISO-8601 UTC timestamp ending in Z`);
+  }
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) {
+    throw new Error(`${label} is not a valid timestamp`);
+  }
+  return new Date(ms);
+}
+
+export function slug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}

--- a/control-center/connectors/infrastructure/src/index.ts
+++ b/control-center/connectors/infrastructure/src/index.ts
@@ -1,0 +1,20 @@
+export { parseAllowlist } from "./allowlist.js";
+export { collect, mapCollectResult, type CollectInput } from "./collect.js";
+export { collectFromFixtureFile, parseCliArgs, runCli } from "./cli.js";
+export { deriveExceptions } from "./exceptions.js";
+export { createFixturePorts, parseFixture } from "./fixture-ports.js";
+export { createLivePorts } from "./live-ports.js";
+export { mapCollectRecords, mapObservation, mapServiceHealth } from "./map.js";
+export { runProbes } from "./probes.js";
+export type {
+  ActionableException,
+  AgentPayload,
+  Allowlist,
+  CheckKind,
+  CollectResult,
+  FreshnessStatus,
+  ProbeResult,
+  ServiceHealth,
+  SourceObservation,
+} from "./types.js";
+export { ADAPTER_SCHEMA_VERSION, CHECK_KINDS, FRESHNESS_STATUSES } from "./types.js";

--- a/control-center/connectors/infrastructure/src/live-ports.ts
+++ b/control-center/connectors/infrastructure/src/live-ports.ts
@@ -1,0 +1,118 @@
+import net from "node:net";
+import tls from "node:tls";
+import { parseAgentPayload } from "./agent.js";
+import type { ProbePorts } from "./ports.js";
+import type { AgentPayload, HttpSample, ReachabilitySample, TlsSample } from "./types.js";
+
+export interface LivePortOptions {
+  readonly now?: () => Date;
+  readonly agentBaseUrl?: string;
+  readonly fetchImpl?: typeof fetch;
+}
+
+function assertSafeAgentUrl(raw: string): URL {
+  const url = new URL(raw);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("CONTROL_CENTER_INFRA_AGENT_URL must be http(s)");
+  }
+  if (url.username || url.password) {
+    throw new Error("CONTROL_CENTER_INFRA_AGENT_URL must not embed credentials");
+  }
+  return url;
+}
+
+export function createLivePorts(options: LivePortOptions = {}): ProbePorts {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const agentBase = options.agentBaseUrl ? assertSafeAgentUrl(options.agentBaseUrl) : undefined;
+
+  return {
+    now: () => (options.now ? options.now() : new Date()),
+    reachHost: (host, port, timeoutMs) => tcpReach(host, port, timeoutMs),
+    httpGet: (url, timeoutMs) => httpProbe(url, timeoutMs, fetchImpl),
+    readTls: (host, port, timeoutMs) => tlsProbe(host, port, timeoutMs),
+    readAgent: (targetId) => readAgent(targetId, agentBase, fetchImpl),
+  };
+}
+
+function tcpReach(host: string, port: number, timeoutMs: number): Promise<ReachabilitySample> {
+  const started = Date.now();
+  return new Promise((resolve) => {
+    const socket = net.connect({ host, port });
+    const finish = (sample: ReachabilitySample): void => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(sample);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => finish({ ok: true, latency_ms: Date.now() - started }));
+    socket.once("timeout", () => finish({ ok: false, error: "tcp timeout" }));
+    socket.once("error", (err) => finish({ ok: false, error: err.message }));
+  });
+}
+
+async function httpProbe(url: string, timeoutMs: number, fetchImpl: typeof fetch): Promise<HttpSample> {
+  const started = Date.now();
+  try {
+    const response = await fetchImpl(url, {
+      method: "GET",
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return { status: response.status, elapsed_ms: Date.now() - started };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "http error";
+    return { status: 0, elapsed_ms: Date.now() - started, error: message };
+  }
+}
+
+function tlsProbe(host: string, port: number, timeoutMs: number): Promise<TlsSample> {
+  return new Promise((resolve) => {
+    const socket = tls.connect({ host, port, servername: host, rejectUnauthorized: false });
+    const finish = (sample: TlsSample): void => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(sample);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("secureConnect", () => {
+      const cert = socket.getPeerCertificate();
+      const validTo = cert && "valid_to" in cert ? String(cert.valid_to) : "";
+      const notAfter = Date.parse(validTo);
+      if (Number.isNaN(notAfter)) {
+        finish({ not_after: "1970-01-01T00:00:00.000Z", error: "peer certificate missing notAfter" });
+        return;
+      }
+      finish({ not_after: new Date(notAfter).toISOString() });
+    });
+    socket.once("timeout", () =>
+      finish({ not_after: "1970-01-01T00:00:00.000Z", error: "tls timeout" }),
+    );
+    socket.once("error", (err) =>
+      finish({ not_after: "1970-01-01T00:00:00.000Z", error: err.message }),
+    );
+  });
+}
+
+async function readAgent(
+  targetId: string,
+  agentBase: URL | undefined,
+  fetchImpl: typeof fetch,
+): Promise<AgentPayload | null> {
+  if (!agentBase) {
+    return null;
+  }
+  const url = new URL(`v1/targets/${encodeURIComponent(targetId)}`, `${agentBase.href.replace(/\/?$/, "/")}`);
+  try {
+    const response = await fetchImpl(url, {
+      method: "GET",
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const body: unknown = await response.json();
+    return parseAgentPayload(body);
+  } catch {
+    return null;
+  }
+}

--- a/control-center/connectors/infrastructure/src/log.ts
+++ b/control-center/connectors/infrastructure/src/log.ts
@@ -1,0 +1,27 @@
+const SECRET_KEY = /pass(word)?|secret|token|api[_-]?key|authorization|private[_-]?key|ssh|credential|cookie/i;
+
+export function redact(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redact);
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = SECRET_KEY.test(k) ? "[redacted]" : redact(v);
+    }
+    return out;
+  }
+  if (typeof value === "string" && /BEGIN [A-Z ]*PRIVATE KEY/.test(value)) {
+    return "[redacted]";
+  }
+  return value;
+}
+
+export function logEvent(event: string, fields: Readonly<Record<string, unknown>> = {}): void {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    event,
+    ...((redact(fields) as Record<string, unknown>) ?? {}),
+  });
+  process.stderr.write(`${line}\n`);
+}

--- a/control-center/connectors/infrastructure/src/map.ts
+++ b/control-center/connectors/infrastructure/src/map.ts
@@ -1,0 +1,268 @@
+import {
+  coalesceServiceStatus,
+  confidenceFor,
+  daysUntil,
+  freshnessFromProbe,
+  worstFreshness,
+} from "./freshness.js";
+import { observationId, toUtcIso } from "./ids.js";
+import type {
+  Allowlist,
+  AllowlistTarget,
+  ProbeResult,
+  ServiceCheck,
+  ServiceHealth,
+  ServiceStatus,
+  SourceObservation,
+} from "./types.js";
+
+function targetById(allowlist: Allowlist, id: string): AllowlistTarget {
+  const found = allowlist.targets.find((t) => t.id === id);
+  if (!found) {
+    throw new Error(`probe referenced unknown target ${id}`);
+  }
+  return found;
+}
+
+function numeric(payload: Readonly<Record<string, unknown>>, key: string): number | undefined {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function nestedNumber(payload: Readonly<Record<string, unknown>>, path: readonly string[]): number | undefined {
+  let node: unknown = payload;
+  for (const key of path) {
+    if (!node || typeof node !== "object" || Array.isArray(node)) {
+      return undefined;
+    }
+    node = (node as Record<string, unknown>)[key];
+  }
+  return typeof node === "number" && Number.isFinite(node) ? node : undefined;
+}
+
+function serviceStatusForCheck(
+  probe: ProbeResult,
+  allowlist: Allowlist,
+  now: Date,
+): { status: ServiceStatus; summary: string } {
+  if (probe.status === "timeout") {
+    return { status: "unhealthy", summary: probe.summary };
+  }
+  if (probe.status === "error") {
+    return { status: "unhealthy", summary: probe.summary };
+  }
+  if (probe.status === "missing") {
+    return { status: "unknown", summary: probe.summary };
+  }
+
+  const thresholds = allowlist.thresholds;
+  switch (probe.check) {
+    case "reachability":
+    case "http":
+      return { status: "healthy", summary: probe.summary };
+    case "tls": {
+      const notAfter = probe.payload.not_after;
+      if (typeof notAfter !== "string") {
+        return { status: "unknown", summary: "TLS not_after missing" };
+      }
+      const days = daysUntil(notAfter, now);
+      if (Number.isNaN(days)) {
+        return { status: "unknown", summary: "TLS not_after unusable" };
+      }
+      if (days < 0) {
+        return {
+          status: "unhealthy",
+          summary: `TLS certificate expired ${Math.abs(Math.floor(days))} day(s) ago`,
+        };
+      }
+      if (days <= thresholds.tls_crit_days) {
+        return {
+          status: "unhealthy",
+          summary: `TLS certificate expires in ${days.toFixed(1)} days (crit ${thresholds.tls_crit_days})`,
+        };
+      }
+      if (days <= thresholds.tls_warn_days) {
+        return {
+          status: "degraded",
+          summary: `TLS certificate expires in ${days.toFixed(1)} days (warn ${thresholds.tls_warn_days})`,
+        };
+      }
+      return { status: "healthy", summary: `TLS valid for ${days.toFixed(1)} more days` };
+    }
+    case "host_metrics": {
+      const disk = nestedNumber(probe.payload, ["disk", "used_pct"]);
+      const mem = nestedNumber(probe.payload, ["memory", "used_pct"]);
+      if (disk !== undefined && disk >= thresholds.disk_crit_pct) {
+        return { status: "unhealthy", summary: `disk ${disk.toFixed(0)}% >= crit ${thresholds.disk_crit_pct}%` };
+      }
+      if (mem !== undefined && mem >= thresholds.mem_warn_pct) {
+        return { status: "degraded", summary: `memory ${mem.toFixed(0)}% >= warn ${thresholds.mem_warn_pct}%` };
+      }
+      if (disk !== undefined && disk >= thresholds.disk_warn_pct) {
+        return { status: "degraded", summary: `disk ${disk.toFixed(0)}% >= warn ${thresholds.disk_warn_pct}%` };
+      }
+      return { status: "healthy", summary: probe.summary };
+    }
+    case "docker": {
+      const services = probe.payload.services;
+      if (!Array.isArray(services) || services.length === 0) {
+        return { status: "unknown", summary: "Docker/service list empty" };
+      }
+      const unhealthy = services.filter((item) => {
+        if (!item || typeof item !== "object") {
+          return true;
+        }
+        const health = (item as Record<string, unknown>).health;
+        return typeof health !== "string" || health.toLowerCase() !== "healthy";
+      });
+      if (unhealthy.length > 0) {
+        const names = unhealthy
+          .map((item) => {
+            if (item && typeof item === "object" && "name" in item) {
+              return String((item as Record<string, unknown>).name);
+            }
+            return "unknown-service";
+          })
+          .join(", ");
+        return { status: "unhealthy", summary: `unhealthy Docker/services: ${names}` };
+      }
+      return { status: "healthy", summary: probe.summary };
+    }
+    case "backup": {
+      const status = probe.payload.status;
+      const last = probe.payload.last_success_at;
+      if (typeof status !== "string" || status.toLowerCase() === "missing") {
+        return { status: "unhealthy", summary: "backup last-success signal missing" };
+      }
+      if (status.toLowerCase() === "failed" || status.toLowerCase() === "error") {
+        return { status: "unhealthy", summary: `backup last-success status=${status}` };
+      }
+      if (typeof last !== "string" || last.length === 0) {
+        return { status: "unhealthy", summary: "backup last-success timestamp missing" };
+      }
+      const lastMs = Date.parse(last);
+      if (Number.isNaN(lastMs)) {
+        return { status: "unhealthy", summary: "backup last-success timestamp unusable" };
+      }
+      const ageSec = (now.getTime() - lastMs) / 1000;
+      if (ageSec > thresholds.backup_max_age_seconds) {
+        return {
+          status: "unhealthy",
+          summary: `backup last-success is ${Math.floor(ageSec)}s old (max ${thresholds.backup_max_age_seconds}s)`,
+        };
+      }
+      return { status: "healthy", summary: `backup last-success at ${last}` };
+    }
+    case "uptime":
+      return { status: "healthy", summary: probe.summary };
+  }
+}
+
+export function mapObservation(
+  probe: ProbeResult,
+  allowlist: Allowlist,
+  now: Date,
+): SourceObservation {
+  const freshnessArgs: {
+    probeStatus: ProbeResult["status"];
+    now: Date;
+    staleAfterSeconds: number;
+    agentObservedAt?: string;
+  } = {
+    probeStatus: probe.status,
+    now,
+    staleAfterSeconds: allowlist.thresholds.stale_after_seconds,
+  };
+  if (probe.agent_observed_at) {
+    freshnessArgs.agentObservedAt = probe.agent_observed_at;
+  }
+  const freshness = freshnessFromProbe(freshnessArgs);
+  const classified = serviceStatusForCheck(probe, allowlist, now);
+  const observation: SourceObservation = {
+    observation_id: observationId(allowlist.source, probe.target_id, probe.check),
+    source: allowlist.source,
+    observed_at: probe.observed_at,
+    freshness_status: freshness,
+    scope: "infrastructure",
+    target_id: probe.target_id,
+    check: probe.check,
+    summary: classified.summary,
+    payload: {
+      ...probe.payload,
+      probe_status: probe.status,
+      service_status: classified.status,
+      agent_observed_at: probe.agent_observed_at ?? null,
+    },
+    confidence: confidenceFor(freshness, probe.status),
+  };
+  return observation;
+}
+
+export function mapServiceHealth(
+  target: AllowlistTarget,
+  observations: readonly SourceObservation[],
+  allowlist: Allowlist,
+  now: Date,
+): ServiceHealth {
+  const owned = observations.filter((obs) => obs.target_id === target.id);
+  const checks: ServiceCheck[] = owned.map((obs) => {
+    const status = obs.payload.service_status;
+    const checkStatus: ServiceStatus =
+      status === "healthy" || status === "degraded" || status === "unhealthy" || status === "unknown"
+        ? status
+        : "unknown";
+    return {
+      check: obs.check,
+      status: checkStatus,
+      freshness_status: obs.freshness_status,
+      summary: obs.summary,
+    };
+  });
+  const freshness = worstFreshness(checks.map((c) => c.freshness_status));
+  const status = coalesceServiceStatus(
+    checks.map((c) => c.status),
+    freshness,
+  );
+  const uptimeObs = owned.find((obs) => obs.check === "uptime");
+  const health: ServiceHealth = {
+    service_id: target.id,
+    display_name: target.display_name,
+    source: allowlist.source,
+    observed_at: owned[0]?.observed_at ?? toUtcIso(now),
+    freshness_status: freshness,
+    status,
+    checks,
+    confidence: owned.length
+      ? Math.min(...owned.map((obs) => obs.confidence ?? 0.2))
+      : 0.2,
+  };
+  const uptime = uptimeObs ? numeric(uptimeObs.payload, "uptime_seconds") : undefined;
+  const restarts = uptimeObs ? numeric(uptimeObs.payload, "restart_count") : undefined;
+  if (uptime !== undefined) {
+    Object.assign(health, { uptime_seconds: uptime });
+  }
+  if (restarts !== undefined) {
+    Object.assign(health, { restart_count: restarts });
+  }
+  return health;
+}
+
+export function mapCollectRecords(
+  allowlist: Allowlist,
+  probes: readonly ProbeResult[],
+  now: Date,
+): { observations: SourceObservation[]; service_health: ServiceHealth[] } {
+  const observations = probes.map((probe) => mapObservation(probe, allowlist, now));
+  observations.sort((a, b) => a.observation_id.localeCompare(b.observation_id));
+  const service_health = allowlist.targets.map((target) =>
+    mapServiceHealth(target, observations, allowlist, now),
+  );
+  service_health.sort((a, b) => a.service_id.localeCompare(b.service_id));
+  return { observations, service_health };
+}
+
+export function assertKnownTargets(allowlist: Allowlist, probes: readonly ProbeResult[]): void {
+  for (const probe of probes) {
+    targetById(allowlist, probe.target_id);
+  }
+}

--- a/control-center/connectors/infrastructure/src/paths.ts
+++ b/control-center/connectors/infrastructure/src/paths.ts
@@ -1,0 +1,14 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function findPackageRoot(startHref = import.meta.url): string {
+  let dir = dirname(fileURLToPath(startHref));
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(dir, "package.json")) && existsSync(join(dir, "fixtures"))) {
+      return dir;
+    }
+    dir = join(dir, "..");
+  }
+  throw new Error("infrastructure collector package root not found");
+}

--- a/control-center/connectors/infrastructure/src/ports.ts
+++ b/control-center/connectors/infrastructure/src/ports.ts
@@ -1,0 +1,14 @@
+import type { AgentPayload, HttpSample, ReachabilitySample, TlsSample } from "./types.js";
+
+/** Injected I/O. Tests and `--fixture` supply recordings; `--live` uses TCP/HTTP/TLS only. */
+export interface ProbePorts {
+  now(): Date;
+  reachHost(host: string, port: number, timeoutMs: number): Promise<ReachabilitySample>;
+  httpGet(url: string, timeoutMs: number): Promise<HttpSample>;
+  readTls(host: string, port: number, timeoutMs: number): Promise<TlsSample>;
+  readAgent(targetId: string): Promise<AgentPayload | null>;
+}
+
+export interface Clock {
+  now(): Date;
+}

--- a/control-center/connectors/infrastructure/src/probes.ts
+++ b/control-center/connectors/infrastructure/src/probes.ts
@@ -1,0 +1,414 @@
+import { parseAgentPayload } from "./agent.js";
+import { timeoutFor } from "./allowlist.js";
+import { toUtcIso } from "./ids.js";
+import type { ProbePorts } from "./ports.js";
+import { withTimeout } from "./timeout.js";
+import type {
+  Allowlist,
+  AllowlistTarget,
+  CheckKind,
+  ProbeResult,
+  ProbeStatus,
+} from "./types.js";
+
+function baseResult(
+  target: AllowlistTarget,
+  check: CheckKind,
+  now: Date,
+  status: ProbeStatus,
+  summary: string,
+  payload: Record<string, unknown>,
+  agentObservedAt?: string,
+): ProbeResult {
+  const result: ProbeResult = {
+    target_id: target.id,
+    check,
+    status,
+    observed_at: toUtcIso(now),
+    summary,
+    payload,
+  };
+  if (agentObservedAt) {
+    Object.assign(result, { agent_observed_at: agentObservedAt });
+  }
+  return result;
+}
+
+async function timed<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+): Promise<{ status: "ok"; value: T } | { status: "timeout" } | { status: "error"; error: string }> {
+  try {
+    const outcome = await withTimeout(work, timeoutMs);
+    if (outcome.timedOut) {
+      return { status: "timeout" };
+    }
+    return { status: "ok", value: outcome.value };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "probe failed";
+    return { status: "error", error: message };
+  }
+}
+
+async function probeReachability(
+  target: AllowlistTarget,
+  ports: ProbePorts,
+  now: Date,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const host = target.host ?? "";
+  const port = target.port ?? 443;
+  const outcome = await timed(ports.reachHost(host, port, timeoutMs), timeoutMs);
+  if (outcome.status === "timeout") {
+    return baseResult(target, "reachability", now, "timeout", `host reachability timed out after ${timeoutMs}ms`, {
+      host,
+      port,
+      timed_out: true,
+    });
+  }
+  if (outcome.status === "error") {
+    return baseResult(target, "reachability", now, "error", `host reachability error: ${outcome.error}`, {
+      host,
+      port,
+      error: outcome.error,
+    });
+  }
+  const sample = outcome.value;
+  if (!sample.ok) {
+    return baseResult(
+      target,
+      "reachability",
+      now,
+      "error",
+      `host ${host}:${port} unreachable${sample.error ? `: ${sample.error}` : ""}`,
+      { host, port, ok: false, error: sample.error ?? "unreachable" },
+    );
+  }
+  const payload: Record<string, unknown> = { host, port, ok: true };
+  if (sample.latency_ms !== undefined) {
+    payload.latency_ms = sample.latency_ms;
+  }
+  return baseResult(target, "reachability", now, "ok", `host ${host}:${port} reachable`, payload);
+}
+
+async function probeHttp(
+  target: AllowlistTarget,
+  ports: ProbePorts,
+  now: Date,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const url = target.url ?? "";
+  const expect = target.expect_status ?? 200;
+  const outcome = await timed(ports.httpGet(url, timeoutMs), timeoutMs);
+  if (outcome.status === "timeout") {
+    return baseResult(target, "http", now, "timeout", `HTTP health timed out after ${timeoutMs}ms`, {
+      url,
+      timed_out: true,
+      expect_status: expect,
+    });
+  }
+  if (outcome.status === "error") {
+    return baseResult(target, "http", now, "error", `HTTP health error: ${outcome.error}`, {
+      url,
+      error: outcome.error,
+      expect_status: expect,
+    });
+  }
+  const sample = outcome.value;
+  if (sample.error && sample.status === 0) {
+    return baseResult(target, "http", now, "error", `HTTP health error: ${sample.error}`, {
+      url,
+      error: sample.error,
+      expect_status: expect,
+    });
+  }
+  const payload: Record<string, unknown> = {
+    url,
+    status: sample.status,
+    expect_status: expect,
+  };
+  if (sample.elapsed_ms !== undefined) {
+    payload.elapsed_ms = sample.elapsed_ms;
+  }
+  if (sample.status === expect) {
+    return baseResult(target, "http", now, "ok", `HTTP ${sample.status} for ${target.id}`, payload);
+  }
+  return baseResult(
+    target,
+    "http",
+    now,
+    "error",
+    `HTTP health failed for ${target.id}: expected ${expect}, got ${sample.status}`,
+    payload,
+  );
+}
+
+async function probeTls(
+  target: AllowlistTarget,
+  ports: ProbePorts,
+  now: Date,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const host = target.host ?? "";
+  const port = target.port ?? 443;
+  const outcome = await timed(ports.readTls(host, port, timeoutMs), timeoutMs);
+  if (outcome.status === "timeout") {
+    return baseResult(target, "tls", now, "timeout", `TLS probe timed out after ${timeoutMs}ms`, {
+      host,
+      port,
+      timed_out: true,
+    });
+  }
+  if (outcome.status === "error") {
+    return baseResult(target, "tls", now, "error", `TLS probe error: ${outcome.error}`, {
+      host,
+      port,
+      error: outcome.error,
+    });
+  }
+  const sample = outcome.value;
+  if (sample.error) {
+    return baseResult(target, "tls", now, "error", `TLS probe error: ${sample.error}`, {
+      host,
+      port,
+      error: sample.error,
+    });
+  }
+  return baseResult(target, "tls", now, "ok", `TLS certificate observed for ${host}`, {
+    host,
+    port,
+    not_after: sample.not_after,
+  });
+}
+
+async function loadAgent(
+  target: AllowlistTarget,
+  ports: ProbePorts,
+  now: Date,
+  timeoutMs: number,
+  check: CheckKind,
+): Promise<
+  | { status: "ok"; payload: NonNullable<ReturnType<typeof parseAgentPayload>> }
+  | { status: Exclude<ProbeStatus, "ok">; result: ProbeResult }
+> {
+  const agentId = target.agent_id ?? target.id;
+  const outcome = await timed(ports.readAgent(agentId), timeoutMs);
+  if (outcome.status === "timeout") {
+    return {
+      status: "timeout",
+      result: baseResult(target, check, now, "timeout", `agent payload timed out after ${timeoutMs}ms`, {
+        agent_id: agentId,
+        timed_out: true,
+      }),
+    };
+  }
+  if (outcome.status === "error") {
+    return {
+      status: "error",
+      result: baseResult(target, check, now, "error", `agent payload error: ${outcome.error}`, {
+        agent_id: agentId,
+        error: outcome.error,
+      }),
+    };
+  }
+  if (outcome.value === null) {
+    return {
+      status: "missing",
+      result: baseResult(
+        target,
+        check,
+        now,
+        "missing",
+        `agent payload missing for ${agentId} (fail-closed)`,
+        { agent_id: agentId, missing: true },
+      ),
+    };
+  }
+  const parsed = parseAgentPayload(outcome.value);
+  if (!parsed) {
+    return {
+      status: "missing",
+      result: baseResult(target, check, now, "missing", `agent payload unusable for ${agentId}`, {
+        agent_id: agentId,
+        unusable: true,
+      }),
+    };
+  }
+  return { status: "ok", payload: parsed };
+}
+
+async function probeHostMetrics(
+  target: AllowlistTarget,
+  ports: ProbePorts,
+  now: Date,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const loaded = await loadAgent(target, ports, now, timeoutMs, "host_metrics");
+  if (loaded.status !== "ok") {
+    return loaded.result;
+  }
+  const { disk, memory, load } = loaded.payload;
+  if (!disk && !memory && !load) {
+    return baseResult(
+      target,
+      "host_metrics",
+      now,
+      "missing",
+      "agent exposed no disk/memory/load metrics",
+      { agent_id: target.agent_id ?? target.id },
+      loaded.payload.observed_at,
+    );
+  }
+  return baseResult(
+    target,
+    "host_metrics",
+    now,
+    "ok",
+    "host disk/memory/load observed",
+    {
+      disk: disk ?? null,
+      memory: memory ?? null,
+      load: load ?? null,
+    },
+    loaded.payload.observed_at,
+  );
+}
+
+async function probeDocker(
+  target: AllowlistTarget,
+  ports: ProbePorts,
+  now: Date,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const loaded = await loadAgent(target, ports, now, timeoutMs, "docker");
+  if (loaded.status !== "ok") {
+    return loaded.result;
+  }
+  const services = loaded.payload.docker?.services ?? [];
+  if (services.length === 0) {
+    return baseResult(
+      target,
+      "docker",
+      now,
+      "missing",
+      "agent exposed no Docker/service health",
+      { services: [] },
+      loaded.payload.observed_at,
+    );
+  }
+  return baseResult(
+    target,
+    "docker",
+    now,
+    "ok",
+    `Docker/service health observed (${services.length} services)`,
+    { services: services.map((s) => ({ ...s })) },
+    loaded.payload.observed_at,
+  );
+}
+
+async function probeBackup(
+  target: AllowlistTarget,
+  ports: ProbePorts,
+  now: Date,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const loaded = await loadAgent(target, ports, now, timeoutMs, "backup");
+  if (loaded.status !== "ok") {
+    return loaded.result;
+  }
+  const backup = loaded.payload.backup;
+  if (!backup) {
+    return baseResult(
+      target,
+      "backup",
+      now,
+      "missing",
+      "backup last-success signal missing",
+      { missing: true },
+      loaded.payload.observed_at,
+    );
+  }
+  return baseResult(
+    target,
+    "backup",
+    now,
+    "ok",
+    `backup signal status=${backup.status}`,
+    { status: backup.status, last_success_at: backup.last_success_at ?? null },
+    loaded.payload.observed_at,
+  );
+}
+
+async function probeUptime(
+  target: AllowlistTarget,
+  ports: ProbePorts,
+  now: Date,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const loaded = await loadAgent(target, ports, now, timeoutMs, "uptime");
+  if (loaded.status !== "ok") {
+    return loaded.result;
+  }
+  const host = loaded.payload.host;
+  if (!host || (host.uptime_seconds === undefined && host.restart_count === undefined)) {
+    return baseResult(
+      target,
+      "uptime",
+      now,
+      "missing",
+      "uptime/restart signal missing",
+      { missing: true },
+      loaded.payload.observed_at,
+    );
+  }
+  return baseResult(
+    target,
+    "uptime",
+    now,
+    "ok",
+    "uptime/restart observed",
+    {
+      uptime_seconds: host.uptime_seconds ?? null,
+      restart_count: host.restart_count ?? null,
+    },
+    loaded.payload.observed_at,
+  );
+}
+
+async function runCheck(
+  target: AllowlistTarget,
+  check: CheckKind,
+  ports: ProbePorts,
+  now: Date,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  switch (check) {
+    case "reachability":
+      return probeReachability(target, ports, now, timeoutMs);
+    case "http":
+      return probeHttp(target, ports, now, timeoutMs);
+    case "tls":
+      return probeTls(target, ports, now, timeoutMs);
+    case "host_metrics":
+      return probeHostMetrics(target, ports, now, timeoutMs);
+    case "docker":
+      return probeDocker(target, ports, now, timeoutMs);
+    case "backup":
+      return probeBackup(target, ports, now, timeoutMs);
+    case "uptime":
+      return probeUptime(target, ports, now, timeoutMs);
+  }
+}
+
+export async function runProbes(allowlist: Allowlist, ports: ProbePorts): Promise<ProbeResult[]> {
+  const now = ports.now();
+  const results: ProbeResult[] = [];
+  for (const target of allowlist.targets) {
+    const timeoutMs = timeoutFor(allowlist, target);
+    for (const check of target.checks) {
+      results.push(await runCheck(target, check, ports, now, timeoutMs));
+    }
+  }
+  return results;
+}

--- a/control-center/connectors/infrastructure/src/timeout.ts
+++ b/control-center/connectors/infrastructure/src/timeout.ts
@@ -1,0 +1,21 @@
+export type TimeoutOutcome<T> =
+  | { readonly timedOut: false; readonly value: T }
+  | { readonly timedOut: true };
+
+export async function withTimeout<T>(work: Promise<T>, timeoutMs: number): Promise<TimeoutOutcome<T>> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<TimeoutOutcome<T>>((resolve) => {
+    timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+  });
+  try {
+    const raced = await Promise.race([
+      work.then((value): TimeoutOutcome<T> => ({ timedOut: false, value })),
+      timeout,
+    ]);
+    return raced;
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/control-center/connectors/infrastructure/src/types.ts
+++ b/control-center/connectors/infrastructure/src/types.ts
@@ -1,0 +1,202 @@
+/**
+ * Local adapter for Control Center contracts that live in the sibling
+ * `control-center/contracts/` workstream (not yet on origin/main).
+ *
+ * Field set is the minimum needed for provenance, freshness, health, and
+ * actionable exceptions. Convergence must reconcile these names with the
+ * canonical schemas — do not import that tree from this collector.
+ */
+
+export const FRESHNESS_STATUSES = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const CHECK_KINDS = [
+  "reachability",
+  "host_metrics",
+  "docker",
+  "http",
+  "tls",
+  "backup",
+  "uptime",
+] as const;
+export type CheckKind = (typeof CHECK_KINDS)[number];
+
+export const SERVICE_STATUSES = ["healthy", "degraded", "unhealthy", "unknown"] as const;
+export type ServiceStatus = (typeof SERVICE_STATUSES)[number];
+
+export const EXCEPTION_SEVERITIES = ["critical", "warning"] as const;
+export type ExceptionSeverity = (typeof EXCEPTION_SEVERITIES)[number];
+
+export const INFRASTRUCTURE_SCOPE = "infrastructure" as const;
+export type InfrastructureScope = typeof INFRASTRUCTURE_SCOPE;
+
+export const ADAPTER_SCHEMA_VERSION = "control-center.infrastructure.v1" as const;
+
+export interface SourceObservation {
+  readonly observation_id: string;
+  readonly source: string;
+  readonly observed_at: string;
+  readonly freshness_status: FreshnessStatus;
+  readonly scope: InfrastructureScope;
+  readonly target_id: string;
+  readonly check: CheckKind;
+  readonly summary: string;
+  readonly payload: Readonly<Record<string, unknown>>;
+  readonly confidence?: number;
+}
+
+export interface ServiceCheck {
+  readonly check: CheckKind;
+  readonly status: ServiceStatus;
+  readonly freshness_status: FreshnessStatus;
+  readonly summary: string;
+}
+
+export interface ServiceHealth {
+  readonly service_id: string;
+  readonly display_name: string;
+  readonly source: string;
+  readonly observed_at: string;
+  readonly freshness_status: FreshnessStatus;
+  readonly status: ServiceStatus;
+  readonly checks: readonly ServiceCheck[];
+  readonly uptime_seconds?: number;
+  readonly restart_count?: number;
+  readonly confidence?: number;
+}
+
+export interface ActionableException {
+  readonly exception_id: string;
+  readonly source: string;
+  readonly timestamp: string;
+  readonly observed_at: string;
+  readonly target_id: string;
+  readonly check: CheckKind;
+  readonly severity: ExceptionSeverity;
+  readonly title: string;
+  readonly evidence: string;
+  readonly freshness_status: FreshnessStatus;
+}
+
+export interface CollectorRun {
+  readonly schema_version: typeof ADAPTER_SCHEMA_VERSION;
+  readonly collector_id: string;
+  readonly source: string;
+  readonly started_at: string;
+  readonly finished_at: string;
+  readonly target_count: number;
+  readonly observation_count: number;
+  readonly exception_count: number;
+}
+
+export interface CollectResult {
+  readonly collector_run: CollectorRun;
+  readonly observations: readonly SourceObservation[];
+  readonly service_health: readonly ServiceHealth[];
+  readonly exceptions: readonly ActionableException[];
+}
+
+export interface AllowlistThresholds {
+  readonly stale_after_seconds: number;
+  readonly disk_warn_pct: number;
+  readonly disk_crit_pct: number;
+  readonly mem_warn_pct: number;
+  readonly backup_max_age_seconds: number;
+  readonly tls_warn_days: number;
+  readonly tls_crit_days: number;
+}
+
+export interface AllowlistTarget {
+  readonly id: string;
+  readonly display_name: string;
+  readonly checks: readonly CheckKind[];
+  readonly host?: string;
+  readonly port?: number;
+  readonly url?: string;
+  readonly expect_status?: number;
+  readonly timeout_ms?: number;
+  readonly agent_id?: string;
+}
+
+export interface Allowlist {
+  readonly version: 1;
+  readonly collector_id: string;
+  readonly source: string;
+  readonly default_timeout_ms: number;
+  readonly thresholds: AllowlistThresholds;
+  readonly targets: readonly AllowlistTarget[];
+}
+
+export interface AgentDisk {
+  readonly used_pct: number;
+  readonly used_bytes?: number;
+  readonly total_bytes?: number;
+}
+
+export interface AgentMemory {
+  readonly used_pct: number;
+  readonly available_bytes?: number;
+  readonly total_bytes?: number;
+}
+
+export interface AgentLoad {
+  readonly load_1: number;
+  readonly load_5: number;
+  readonly load_15: number;
+}
+
+export interface AgentDockerService {
+  readonly name: string;
+  readonly health: string;
+  readonly restart_count?: number;
+  readonly uptime_seconds?: number;
+}
+
+export interface AgentBackup {
+  readonly status: string;
+  readonly last_success_at?: string;
+}
+
+export interface AgentHost {
+  readonly uptime_seconds?: number;
+  readonly restart_count?: number;
+}
+
+export interface AgentPayload {
+  readonly observed_at: string;
+  readonly disk?: AgentDisk;
+  readonly memory?: AgentMemory;
+  readonly load?: AgentLoad;
+  readonly docker?: { readonly services: readonly AgentDockerService[] };
+  readonly backup?: AgentBackup;
+  readonly host?: AgentHost;
+}
+
+export interface ReachabilitySample {
+  readonly ok: boolean;
+  readonly latency_ms?: number;
+  readonly error?: string;
+}
+
+export interface HttpSample {
+  readonly status: number;
+  readonly elapsed_ms?: number;
+  readonly error?: string;
+}
+
+export interface TlsSample {
+  readonly not_after: string;
+  readonly error?: string;
+}
+
+export type ProbeStatus = "ok" | "timeout" | "error" | "missing";
+
+export interface ProbeResult {
+  readonly target_id: string;
+  readonly check: CheckKind;
+  readonly status: ProbeStatus;
+  readonly observed_at: string;
+  readonly summary: string;
+  readonly payload: Readonly<Record<string, unknown>>;
+  readonly agent_observed_at?: string;
+}

--- a/control-center/connectors/infrastructure/tests/allowlist.test.ts
+++ b/control-center/connectors/infrastructure/tests/allowlist.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseAllowlist } from "../src/allowlist.js";
+import { loadFixtureFile } from "./helpers.js";
+
+test("shipped healthy fixture allowlist parses", () => {
+  const allowlist = parseAllowlist(loadFixtureFile("healthy.json").allowlist);
+  assert.equal(allowlist.source, "infrastructure");
+  assert.equal(allowlist.targets.length, 3);
+  assert.ok(allowlist.targets.some((t) => t.checks.includes("backup")));
+  assert.ok(allowlist.targets.some((t) => t.checks.includes("tls")));
+});
+
+test("allowlist rejects secrets, SSH material, and credential URLs", () => {
+  const base = loadFixtureFile("healthy.json").allowlist as Record<string, unknown>;
+  assert.throws(
+    () => parseAllowlist({ ...base, ssh_key: "ssh-ed25519 AAAA" }),
+    /secret/i,
+  );
+  assert.throws(
+    () => parseAllowlist({ ...base, password: "nope" }),
+    /secret/i,
+  );
+  assert.throws(
+    () =>
+      parseAllowlist({
+        ...base,
+        targets: [
+          {
+            id: "bad",
+            display_name: "bad",
+            url: "https://user:pass@example.internal/health",
+            checks: ["http"],
+          },
+        ],
+      }),
+    /credential/i,
+  );
+  assert.throws(
+    () => parseAllowlist({ ...base, note: "-----BEGIN PRIVATE KEY-----" }),
+    /secret or key/i,
+  );
+});
+
+test("allowlist requires unique ids and known checks", () => {
+  const base = loadFixtureFile("healthy.json").allowlist as Record<string, unknown>;
+  assert.throws(
+    () =>
+      parseAllowlist({
+        ...base,
+        targets: [
+          { id: "dup", display_name: "a", host: "h", checks: ["reachability"] },
+          { id: "dup", display_name: "b", host: "h2", checks: ["reachability"] },
+        ],
+      }),
+    /duplicate/i,
+  );
+  assert.throws(
+    () =>
+      parseAllowlist({
+        ...base,
+        targets: [{ id: "x", display_name: "x", checks: ["ping"] }],
+      }),
+    /must be one of/i,
+  );
+});

--- a/control-center/connectors/infrastructure/tests/collect.test.ts
+++ b/control-center/connectors/infrastructure/tests/collect.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "node:test";
+import { parseAllowlist } from "../src/allowlist.js";
+import { collectFromFixtureFile } from "../src/cli.js";
+import { collect, mapCollectResult } from "../src/collect.js";
+import { createFixturePorts } from "../src/fixture-ports.js";
+import { mapObservation } from "../src/map.js";
+import { findPackageRoot } from "../src/paths.js";
+import { runProbes } from "../src/probes.js";
+import type { CollectResult, ProbeResult } from "../src/types.js";
+import { collectFixture, hasProvenance, isHealthyFresh, loadFixtureFile, obs } from "./helpers.js";
+
+function assertProvenance(result: Awaited<ReturnType<typeof collectFixture>>): void {
+  assert.ok(result.observations.length > 0, "expected observations");
+  assert.ok(result.service_health.length > 0, "expected service health");
+  for (const item of result.observations) {
+    assert.equal(hasProvenance(item), true, item.observation_id);
+    assert.equal(item.scope, "infrastructure");
+  }
+  for (const item of result.service_health) {
+    assert.equal(hasProvenance(item), true, item.service_id);
+  }
+}
+
+test("healthy allowlist emits FRESH observations and no incidents", async () => {
+  const result = await collectFixture("healthy.json");
+  assertProvenance(result);
+  assert.equal(result.exceptions.length, 0);
+  assert.equal(isHealthyFresh(result, "netcup-vps-1"), true);
+  assert.equal(isHealthyFresh(result, "extra-contracts"), true);
+  assert.equal(isHealthyFresh(result, "cfg-health"), true);
+  assert.equal(obs(result, "netcup-vps-1", "host_metrics").freshness_status, "FRESH");
+  assert.equal(obs(result, "netcup-vps-1", "docker").freshness_status, "FRESH");
+  assert.equal(obs(result, "netcup-vps-1", "backup").freshness_status, "FRESH");
+  assert.equal(obs(result, "netcup-vps-1", "uptime").payload.uptime_seconds, 604800);
+  assert.equal(obs(result, "netcup-vps-1", "uptime").payload.restart_count, 1);
+});
+
+test("incident fixture yields actionable exceptions with evidence and timestamp", async () => {
+  const result = await collectFixture("incident.json");
+  assertProvenance(result);
+  assert.ok(result.exceptions.length >= 2, "expected HTTP and Docker incidents");
+  const httpExc = result.exceptions.find((item) => item.target_id === "extra-contracts" && item.check === "http");
+  assert.ok(httpExc, "missing HTTP exception");
+  assert.match(httpExc.evidence, /extra-contracts/);
+  assert.match(httpExc.evidence, /http/);
+  assert.match(httpExc.evidence, /503/);
+  assert.ok(httpExc.timestamp.endsWith("Z"));
+  assert.match(httpExc.title, /extra-contracts/i);
+  const dockerExc = result.exceptions.find((item) => item.check === "docker");
+  assert.ok(dockerExc, "missing Docker exception");
+  assert.match(dockerExc.evidence, /extra-crawler/);
+  assert.equal(isHealthyFresh(result, "extra-contracts"), false);
+  assert.equal(isHealthyFresh(result, "cfg-health"), true);
+  assert.equal(obs(result, "cfg-health", "http").freshness_status, "FRESH");
+});
+
+test("host failure is an exception; other targets still emit", async () => {
+  const result = await collectFixture("host-failure.json");
+  assertProvenance(result);
+  const reach = result.exceptions.find((item) => item.check === "reachability");
+  assert.ok(reach);
+  assert.match(reach.evidence, /netcup-vps-1/);
+  assert.equal(obs(result, "netcup-vps-1", "reachability").freshness_status, "ERROR");
+  assert.notEqual(
+    `${obs(result, "netcup-vps-1", "reachability").payload.service_status}-${obs(result, "netcup-vps-1", "reachability").freshness_status}`,
+    "healthy-FRESH",
+  );
+  assert.equal(isHealthyFresh(result, "extra-contracts"), true);
+  assert.equal(isHealthyFresh(result, "cfg-health"), true);
+});
+
+test("expired TLS is an actionable exception", async () => {
+  const result = await collectFixture("tls-expired.json");
+  assertProvenance(result);
+  const tls = result.exceptions.find((item) => item.check === "tls");
+  assert.ok(tls);
+  assert.match(tls.evidence, /tls/i);
+  assert.match(tls.evidence, /netcup-vps-1/);
+  assert.ok(tls.timestamp.endsWith("Z"));
+  assert.equal(obs(result, "netcup-vps-1", "tls").payload.service_status, "unhealthy");
+  assert.equal(isHealthyFresh(result, "cfg-health"), true);
+});
+
+test("missing backup last-success is fail-closed and exceptional", async () => {
+  const result = await collectFixture("backup-missing.json");
+  assertProvenance(result);
+  const backup = result.exceptions.find((item) => item.check === "backup");
+  assert.ok(backup);
+  assert.match(backup.evidence, /backup/);
+  assert.match(backup.evidence, /netcup-vps-1/);
+  const observation = obs(result, "netcup-vps-1", "backup");
+  assert.notEqual(`${observation.payload.service_status}-${observation.freshness_status}`, "healthy-FRESH");
+  assert.equal(isHealthyFresh(result, "cfg-health"), true);
+});
+
+test("timed-out probe is ERROR not healthy-FRESH; siblings still emit", async () => {
+  const result = await collectFixture("timeout.json");
+  assertProvenance(result);
+  const timed = obs(result, "extra-contracts", "http");
+  assert.equal(timed.freshness_status, "ERROR");
+  assert.equal(timed.payload.probe_status, "timeout");
+  assert.notEqual(`${timed.payload.service_status}-${timed.freshness_status}`, "healthy-FRESH");
+  const timeoutExc = result.exceptions.find((item) => item.target_id === "extra-contracts" && item.check === "http");
+  assert.ok(timeoutExc);
+  assert.match(timeoutExc.title, /timed out/i);
+  assert.match(timeoutExc.evidence, /extra-contracts/);
+  assert.ok(timeoutExc.timestamp.endsWith("Z"));
+  assert.equal(isHealthyFresh(result, "cfg-health"), true);
+  assert.equal(isHealthyFresh(result, "netcup-vps-1"), true);
+});
+
+test("partial outage keeps healthy targets FRESH", async () => {
+  const result = await collectFixture("partial-outage.json");
+  assertProvenance(result);
+  assert.equal(isHealthyFresh(result, "extra-contracts"), false);
+  assert.equal(isHealthyFresh(result, "cfg-health"), true);
+  assert.equal(isHealthyFresh(result, "netcup-vps-1"), true);
+  const down = result.exceptions.find((item) => item.target_id === "extra-contracts");
+  assert.ok(down);
+  assert.match(down.evidence, /503/);
+  assert.equal(result.observations.length, 3);
+});
+
+test("stale agent metrics are STALE not healthy-FRESH; live HTTP remains FRESH", async () => {
+  const result = await collectFixture("stale.json");
+  assertProvenance(result);
+  const metrics = obs(result, "netcup-vps-1", "host_metrics");
+  const docker = obs(result, "netcup-vps-1", "docker");
+  assert.equal(metrics.freshness_status, "STALE");
+  assert.equal(docker.freshness_status, "STALE");
+  assert.notEqual(`${metrics.payload.service_status}-${metrics.freshness_status}`, "healthy-FRESH");
+  assert.ok(result.exceptions.some((item) => item.freshness_status === "STALE"));
+  assert.equal(isHealthyFresh(result, "cfg-health"), true);
+  assert.equal(obs(result, "cfg-health", "http").freshness_status, "FRESH");
+});
+
+test("same fixture inputs yield the same observation identity", async () => {
+  const first = await collectFixture("incident.json");
+  const second = await collectFixture("incident.json");
+  assert.deepEqual(
+    first.observations.map((item) => item.observation_id),
+    second.observations.map((item) => item.observation_id),
+  );
+  assert.deepEqual(
+    first.exceptions.map((item) => item.exception_id),
+    second.exceptions.map((item) => item.exception_id),
+  );
+  assert.deepEqual(first.observations, second.observations);
+  assert.deepEqual(first.exceptions, second.exceptions);
+});
+
+test("mapCollectResult and mapObservation are the shipped mappers used by collect", async () => {
+  const fixture = loadFixtureFile("incident.json");
+  const allowlist = parseAllowlist(fixture.allowlist);
+  const ports = createFixturePorts(fixture, allowlist);
+  const probes = await runProbes(allowlist, ports);
+  const mapped = mapCollectResult(allowlist, probes, ports.now());
+  const collected = await collect({ allowlist, ports });
+  assert.deepEqual(mapped.observations, collected.observations);
+  assert.deepEqual(mapped.exceptions, collected.exceptions);
+  const httpProbe = probes.find((item) => item.check === "http" && item.target_id === "extra-contracts");
+  assert.ok(httpProbe);
+  const observation = mapObservation(httpProbe, allowlist, ports.now());
+  assert.equal(observation.source, "infrastructure");
+  assert.equal(observation.freshness_status, "ERROR");
+  assert.equal(observation.payload.service_status, "unhealthy");
+});
+
+test("collectFromFixtureFile shipped entry reports the incident", async () => {
+  const result = (await collectFromFixtureFile(
+    join(findPackageRoot(), "fixtures", "incident.json"),
+  )) as CollectResult;
+  assert.ok(result.exceptions.length > 0);
+  const named = result.exceptions.find(
+    (item) => item.target_id === "extra-contracts" && item.check === "http",
+  );
+  assert.ok(named);
+  assert.match(named.evidence, /503/);
+  assert.ok(named.timestamp.endsWith("Z"));
+  assert.equal(hasProvenance(result.observations[0]!), true);
+});
+
+test("mapCollectResult fail-closes timeout probes without dropping siblings", () => {
+  const fixture = loadFixtureFile("timeout.json");
+  const allowlist = parseAllowlist(fixture.allowlist);
+  const now = new Date("2026-08-20T15:00:00.000Z");
+  const probes: ProbeResult[] = [
+    {
+      target_id: "extra-contracts",
+      check: "http",
+      status: "timeout",
+      observed_at: now.toISOString(),
+      summary: "HTTP health timed out after 40ms",
+      payload: { timed_out: true, url: "http://127.0.0.1:18080/health" },
+    },
+    {
+      target_id: "cfg-health",
+      check: "http",
+      status: "ok",
+      observed_at: now.toISOString(),
+      summary: "HTTP 200",
+      payload: { status: 200, expect_status: 200, url: "http://127.0.0.1:18081/health" },
+    },
+  ];
+  const mapped = mapCollectResult(allowlist, probes, now);
+  const failed = mapped.observations.find((item) => item.target_id === "extra-contracts");
+  const ok = mapped.observations.find((item) => item.target_id === "cfg-health");
+  assert.ok(failed && ok);
+  assert.equal(failed.freshness_status, "ERROR");
+  assert.notEqual(`${failed.payload.service_status}-${failed.freshness_status}`, "healthy-FRESH");
+  assert.equal(ok.freshness_status, "FRESH");
+  assert.equal(ok.payload.service_status, "healthy");
+  assert.ok(mapped.exceptions.some((item) => item.target_id === "extra-contracts"));
+});

--- a/control-center/connectors/infrastructure/tests/helpers.ts
+++ b/control-center/connectors/infrastructure/tests/helpers.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseAllowlist } from "../src/allowlist.js";
+import { collect } from "../src/collect.js";
+import { createFixturePorts, parseFixture, type FixtureFile } from "../src/fixture-ports.js";
+import { findPackageRoot } from "../src/paths.js";
+import type { CollectResult, SourceObservation } from "../src/types.js";
+
+export function loadFixtureFile(name: string): FixtureFile {
+  const raw: unknown = JSON.parse(readFileSync(join(findPackageRoot(), "fixtures", name), "utf8"));
+  return parseFixture(raw);
+}
+
+export async function collectFixture(name: string): Promise<CollectResult> {
+  const fixture = loadFixtureFile(name);
+  const allowlist = parseAllowlist(fixture.allowlist);
+  return collect({
+    allowlist,
+    ports: createFixturePorts(fixture, allowlist),
+  });
+}
+
+export function obs(
+  result: CollectResult,
+  targetId: string,
+  check: string,
+): SourceObservation {
+  const found = result.observations.find((item) => item.target_id === targetId && item.check === check);
+  if (!found) {
+    throw new Error(`missing observation ${targetId}:${check}`);
+  }
+  return found;
+}
+
+export function hasProvenance(item: {
+  source: string;
+  observed_at: string;
+  freshness_status: string;
+}): boolean {
+  return (
+    item.source.length > 0 &&
+    /^\d{4}-\d{2}-\d{2}T/.test(item.observed_at) &&
+    item.observed_at.endsWith("Z") &&
+    ["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(item.freshness_status)
+  );
+}
+
+export function isHealthyFresh(result: CollectResult, targetId: string): boolean {
+  const health = result.service_health.find((item) => item.service_id === targetId);
+  return health?.status === "healthy" && health.freshness_status === "FRESH";
+}

--- a/control-center/connectors/infrastructure/tests/live-http.test.ts
+++ b/control-center/connectors/infrastructure/tests/live-http.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { test } from "node:test";
+import { parseAllowlist } from "../src/allowlist.js";
+import { collect } from "../src/collect.js";
+import { createLivePorts } from "../src/live-ports.js";
+
+function listen(handler: http.RequestListener): Promise<http.Server> {
+  const server = http.createServer(handler);
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function portOf(server: http.Server): number {
+  const address = server.address() as AddressInfo | null;
+  if (!address) {
+    throw new Error("server has no address");
+  }
+  return address.port;
+}
+
+test("live HTTP probe turns 503 into an evidenced exception", async () => {
+  const down = await listen((_req, res) => {
+    res.writeHead(503, { "content-type": "text/plain" });
+    res.end("down");
+  });
+  const up = await listen((_req, res) => {
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("ok");
+  });
+  try {
+    const allowlist = parseAllowlist({
+      version: 1,
+      collector_id: "infrastructure.netcup",
+      source: "infrastructure",
+      default_timeout_ms: 200,
+      targets: [
+        {
+          id: "svc-down",
+          display_name: "svc-down",
+          url: `http://127.0.0.1:${portOf(down)}/health`,
+          expect_status: 200,
+          checks: ["http"],
+        },
+        {
+          id: "svc-up",
+          display_name: "svc-up",
+          url: `http://127.0.0.1:${portOf(up)}/health`,
+          expect_status: 200,
+          checks: ["http"],
+        },
+      ],
+    });
+    const now = new Date("2026-08-20T15:00:00.000Z");
+    const result = await collect({
+      allowlist,
+      ports: createLivePorts({ now: () => now }),
+    });
+    const failed = result.exceptions.find((item) => item.target_id === "svc-down");
+    assert.ok(failed);
+    assert.match(failed.evidence, /svc-down/);
+    assert.match(failed.evidence, /503/);
+    assert.equal(failed.timestamp, now.toISOString());
+    const upHealth = result.service_health.find((item) => item.service_id === "svc-up");
+    assert.equal(upHealth?.status, "healthy");
+    assert.equal(upHealth?.freshness_status, "FRESH");
+  } finally {
+    down.closeAllConnections();
+    up.closeAllConnections();
+    down.close();
+    up.close();
+  }
+});
+
+test("live HTTP hang is a timeout exception, not healthy-FRESH", async () => {
+  const hung = await listen(() => {
+    /* never respond */
+  });
+  const up = await listen((_req, res) => {
+    res.writeHead(200);
+    res.end("ok");
+  });
+  try {
+    const allowlist = parseAllowlist({
+      version: 1,
+      collector_id: "infrastructure.netcup",
+      source: "infrastructure",
+      default_timeout_ms: 40,
+      targets: [
+        {
+          id: "svc-hang",
+          display_name: "svc-hang",
+          url: `http://127.0.0.1:${portOf(hung)}/health`,
+          expect_status: 200,
+          checks: ["http"],
+        },
+        {
+          id: "svc-up",
+          display_name: "svc-up",
+          url: `http://127.0.0.1:${portOf(up)}/health`,
+          expect_status: 200,
+          checks: ["http"],
+        },
+      ],
+    });
+    const result = await collect({
+      allowlist,
+      ports: createLivePorts({ now: () => new Date("2026-08-20T15:00:00.000Z") }),
+    });
+    const hungObs = result.observations.find((item) => item.target_id === "svc-hang");
+    assert.ok(hungObs);
+    assert.equal(hungObs.freshness_status, "ERROR");
+    assert.notEqual(`${hungObs.payload.service_status}-${hungObs.freshness_status}`, "healthy-FRESH");
+    assert.ok(result.exceptions.some((item) => item.target_id === "svc-hang"));
+    const upHealth = result.service_health.find((item) => item.service_id === "svc-up");
+    assert.equal(upHealth?.status, "healthy");
+    assert.equal(upHealth?.freshness_status, "FRESH");
+  } finally {
+    hung.closeAllConnections();
+    up.closeAllConnections();
+    hung.close();
+    up.close();
+  }
+});

--- a/control-center/connectors/infrastructure/tsconfig.json
+++ b/control-center/connectors/infrastructure/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "rootDir": ".",
+    "outDir": "dist",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
Draft PR for Control Center workstream **cc/09-infra-health**.

## What
Read-only collector under `control-center/connectors/infrastructure/` that turns allowlisted Netcup/24x7 probes into `SourceObservation`, `ServiceHealth`, and **actionable exceptions** with UTC `source` / `observed_at` / `freshness_status` (and `confidence`).

Probes: host reachability, disk/memory/load (when a read-only agent exposes them), Docker/service health, HTTP health, TLS expiry, backup last-success, restart count/uptime.

## Guarantees
- Fail-closed: timeout, stale metrics, missing backup, and unhealthy probes are never `healthy`+`FRESH`.
- Partial outage still emits healthy siblings.
- Same inputs yield the same observation identity (idempotent upsert key).
- Allowlist rejects secrets / SSH / credential URLs. No root SSH in the app runtime. No Prometheus/Grafana required.
- Local adapter documented in `ADAPTER.md` because canonical `control-center/contracts/` is a sibling workstream.

## Test
```bash
cd control-center/connectors/infrastructure
npm install
npm test
node dist/src/cli.js --fixture fixtures/incident.json
```
Incident fixture yields exceptions naming `extra-contracts` HTTP 503 and unhealthy Docker service `extra-crawler`, with evidence and timestamp.

## Out of scope
Does not touch `commercial/`, `decisions/`, `scripts/`, root README, extra-cli, Warmbly, web-cfg, or PR #8. Does not mutate external systems.

Do not merge automatically — this is a draft for the later convergence campaign.