### PR TITLE
feat(control-center): canonical Control Center contracts v1

### DIFF
--- a/control-center/contracts/.gitignore
+++ b/control-center/contracts/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.tsx-cache/

--- a/control-center/contracts/README.md
+++ b/control-center/contracts/README.md
@@ -1,0 +1,128 @@
+# Control Center contracts (v1)
+
+Canonical machine contract for the Confenge Control Center. Other workstreams (persistence, context service, MCP server, collectors, UI) MUST implement against this tree and MUST NOT guess field names, enums, or authority.
+
+This package is **schemas, types, HTTP/MCP documentation, fixtures, and a validator**. It is not a service, not a UI, not a database, and not an MCP runtime.
+
+## Decisions (frozen)
+
+1. Governance is strategic/canonical authority (catalog, terms, directives).
+2. Warmbly is commercial/CRM operational runtime. `CommercialSnapshot` is a read model, not a second catalog.
+3. Collectors and snapshots are read-only aggregates with `provenance`.
+4. Aggregated information carries `source`, `observed_at`, `freshness_status`, and `confidence`.
+5. Freshness ∈ `FRESH | STALE | UNKNOWN | ERROR` and is **not** confidence. Confidence is `[0, 1]`.
+6. Directive kinds: `decision`, `directive`, `fact`, `constraint`, `priority`, `risk`, `hypothesis`. Required: `scope`, `status`, `effective_from`, `expires_at`, `supersedes`, `created_by`, plus `audit`.
+7. Agents query **by scope**. Empty scope lists are invalid. There is no whole-company dump.
+8. MCP is the principal agent interface (`docs/mcp.v1.json`). HTTP is the internal companion (`docs/http.openapi.json`).
+9. Financial/provider mutations are forbidden: cobrança, checkout, refund, cancelamento, Asaas writes, commercial send.
+10. Homepage consumes exceptions (`AttentionItem`) and at most three `PriorityRecommendation`s — not a KPI wall.
+11. Money is integer cents + ISO-4217 currency. Timestamps are UTC with a `Z` suffix. Presentation MAY use `America/Sao_Paulo`.
+12. IDs: `cc:<type-kebab>:<ulid-or-slug>` as listed in `catalog.json`.
+13. Fail-closed: no secrets in git, logs, URLs, or payloads. `ActorRef.id` is an opaque handle, not a password.
+
+See `docs/ADR-CC-001-ARCHITECTURE-BOUNDARIES.md`.
+
+## Scope taxonomy
+
+Exact v1 literals:
+
+- `company`
+- `commercial`
+- `finance`
+- `clients`
+- `infrastructure`
+- `inbound`
+
+Parameterized:
+
+- `repo:<name>` — short name or `owner/name`
+- `client:<slug>` — kebab-case; `ClientStatus.scope` MUST equal `client:<client_slug>`
+
+Non-breaking extension: additional `<prefix>:<id>` namespaces (lowercase prefix). Consumers MUST treat unknown namespaced scopes as opaque and MUST NOT grant them by default. New **bare** literals require an additive schema revision.
+
+## The 13 resource types
+
+| Type | `schema_version` | ID type |
+|---|---|---|
+| Directive | `control-center.directive.v1` | `directive` |
+| OperationalSnapshot | `control-center.operational-snapshot.v1` | `operational-snapshot` |
+| SourceObservation | `control-center.source-observation.v1` | `source-observation` |
+| AttentionItem | `control-center.attention-item.v1` | `attention-item` |
+| PriorityRecommendation | `control-center.priority-recommendation.v1` | `priority-recommendation` |
+| AgentSession | `control-center.agent-session.v1` | `agent-session` |
+| ClientStatus | `control-center.client-status.v1` | `client-status` |
+| CommercialSnapshot | `control-center.commercial-snapshot.v1` | `commercial-snapshot` |
+| FinanceSnapshot | `control-center.finance-snapshot.v1` | `finance-snapshot` |
+| EngineeringSnapshot | `control-center.engineering-snapshot.v1` | `engineering-snapshot` |
+| ServiceHealth | `control-center.service-health.v1` | `service-health` |
+| CollectorRun | `control-center.collector-run.v1` | `collector-run` |
+| AuditEvent | `control-center.audit-event.v1` | `audit-event` |
+
+`AgentContext` (`control-center.agent-context.v1`) is the HTTP/MCP envelope, not a stored core resource.
+
+## Layout
+
+```
+catalog.json                 # machine index of the 13 types
+schemas/                     # JSON Schema 2020-12
+src/types.ts                 # TypeScript types in lockstep
+src/validate.ts              # shipped validator (Ajv + semantic checks)
+src/cli.ts                   # shipped CLI entry
+fixtures/valid|invalid/      # at least one each per type
+docs/http.openapi.json
+docs/mcp.v1.json
+docs/ADR-CC-001-ARCHITECTURE-BOUNDARIES.md
+tests/contract.test.ts
+```
+
+## Run validation and tests
+
+Requires Node.js ≥ 20. No other services.
+
+```bash
+cd control-center/contracts
+npm install
+npm test
+npm run typecheck
+npx tsx src/cli.ts --list-types
+npx tsx src/cli.ts --type Directive fixtures/valid/directive.json
+npx tsx src/cli.ts --type Directive fixtures/invalid/directive.json
+```
+
+The CLI prints JSON with `"ok": true` or `"ok": false` plus `errors`. Exit 0 only when valid.
+
+A non-test consumer of the same shipped `validate` function:
+
+```bash
+npx tsx scripts/consume-validate.ts fixtures/valid/directive.json
+```
+
+## Environment variables
+
+This package has **no required environment variables** and ships no `.env`.
+
+Later workstreams (not implemented here) are expected to introduce their own, for example:
+
+| Variable | Later owner | Notes |
+|---|---|---|
+| `DATABASE_URL` | persistence | PostgreSQL for snapshots and memory |
+| `CC_ACTOR_ID` | auth | Opaque `ActorRef.id`; never a password in git |
+| `WARMBLY_READ_BASE_URL` | collectors | Read-only |
+| `GITHUB_TOKEN` | github collector | Server-side only; never in client bundle or URLs |
+
+Absence of a variable is fail-closed in those services. Do not invent defaults that open writes.
+
+## Expected convergence (later campaign)
+
+Do **not** implement these from this package:
+
+- Wire `control-center/` into the Governance root README, `commercial/`, `decisions/`, or `scripts/`.
+- Absorb PR Governance #8 (partner program).
+- Edit Warmbly, web-cfg, or extra-cli.
+- Boot HTTP/MCP servers or migrate PostgreSQL.
+
+Convergence should pin `catalog.json` + schema `$id`s, consume `AgentContext` by scope, and keep origin systems authoritative. Collectors remain idempotent and read-only.
+
+## Versioning
+
+Breaking change → `v2` file and new `schema_version` const; keep `v1`. Additive optional fields → `v1.1`. v1 schemas set `additionalProperties: false`.

--- a/control-center/contracts/README.md
+++ b/control-center/contracts/README.md
@@ -40,7 +40,9 @@ Parameterized:
 
 Non-breaking extension: additional `<prefix>:<id>` namespaces (lowercase prefix) that are **not** the reserved literals or `repo`/`client`. `company:foo` and `client:Acme` are invalid. Consumers MUST treat unknown namespaced scopes as opaque and MUST NOT grant them by default. New **bare** literals require an additive schema revision.
 
-## The 13 resource types
+## Public resource types
+
+The catalog (`catalog.json`) is the index. Do not freeze a type count in consumers; additively cataloged types are listed there.
 
 | Type | `schema_version` | ID type |
 |---|---|---|
@@ -50,6 +52,7 @@ Non-breaking extension: additional `<prefix>:<id>` namespaces (lowercase prefix)
 | AttentionItem | `control-center.attention-item.v1` | `attention-item` |
 | PriorityRecommendation | `control-center.priority-recommendation.v1` | `priority-recommendation` |
 | AgentSession | `control-center.agent-session.v1` | `agent-session` |
+| AgentActivity | `control-center.agent-activity.v1` | `agent-activity` |
 | ClientStatus | `control-center.client-status.v1` | `client-status` |
 | CommercialSnapshot | `control-center.commercial-snapshot.v1` | `commercial-snapshot` |
 | FinanceSnapshot | `control-center.finance-snapshot.v1` | `finance-snapshot` |
@@ -58,21 +61,30 @@ Non-breaking extension: additional `<prefix>:<id>` namespaces (lowercase prefix)
 | CollectorRun | `control-center.collector-run.v1` | `collector-run` |
 | AuditEvent | `control-center.audit-event.v1` | `audit-event` |
 
-`AgentContext` (`control-center.agent-context.v1`) is the HTTP/MCP envelope, not a stored core resource.
+`AgentContext` (`control-center.agent-context.v1`) is the HTTP/MCP envelope, not a stored core resource. Directive `draft` plus OperationalSnapshot / AgentContext compose proposal and today envelopes; those are not separate cataloged types.
+
+`AgentActivity` is the execution ledger (what an agent ran). `AgentSession` is the scoped context-consult grant (`open\|closed\|denied`). They are not aliases.
+
+FinanceSnapshot is a read-only aggregate (`provider_mutations: "forbidden"`) with integer-cents money: contracted, billed, paid, effectively_received, overdue, receivable, refunds, chargebacks. `cash_in`, `mrr`, and `runway` are omitted unless evidenced / applicable / cash+expense reliable.
+
+CommercialSnapshot is a Warmbly read model that pins Governance catalog identity (`offer_pin`) and MUST NOT copy names, prices, terms, or offer copy. Funnel: new_leads, qualified, opportunities, proposals, clients. `pipeline_weighted` is omitted unless probability is reliable. Attention refs cover aging / stalled / missing-next-action.
 
 ## Layout
 
 ```
-catalog.json                 # machine index of the 13 types
+catalog.json                 # machine index of public types
 schemas/                     # JSON Schema 2020-12
 src/types.ts                 # TypeScript types in lockstep
 src/validate.ts              # shipped validator (Ajv + semantic checks)
+src/compatibility.ts         # compatibility table classifier
+src/fingerprint.ts           # deterministic CONTRACT_FINGERPRINT
 src/cli.ts                   # shipped CLI entry
 fixtures/valid|invalid/      # at least one each per type
 docs/http.openapi.json
 docs/mcp.v1.json
+docs/compatibility.v1.json
 docs/ADR-CC-001-ARCHITECTURE-BOUNDARIES.md
-tests/contract.test.ts
+tests/
 ```
 
 ## Run validation and tests
@@ -85,8 +97,10 @@ npm install
 npm test
 npm run typecheck
 npx tsx src/cli.ts --list-types
+npx tsx src/cli.ts --fingerprint
 npx tsx src/cli.ts --type Directive fixtures/valid/directive.json
 npx tsx src/cli.ts --type Directive fixtures/invalid/directive.json
+npx tsx src/cli.ts --type AgentActivity fixtures/valid/agent-activity.json
 ```
 
 The CLI prints JSON with `"ok": true` or `"ok": false` plus `errors`. Exit 0 only when valid.

--- a/control-center/contracts/README.md
+++ b/control-center/contracts/README.md
@@ -38,7 +38,7 @@ Parameterized:
 - `repo:<name>` — short name or `owner/name`
 - `client:<slug>` — kebab-case; `ClientStatus.scope` MUST equal `client:<client_slug>`
 
-Non-breaking extension: additional `<prefix>:<id>` namespaces (lowercase prefix). Consumers MUST treat unknown namespaced scopes as opaque and MUST NOT grant them by default. New **bare** literals require an additive schema revision.
+Non-breaking extension: additional `<prefix>:<id>` namespaces (lowercase prefix) that are **not** the reserved literals or `repo`/`client`. `company:foo` and `client:Acme` are invalid. Consumers MUST treat unknown namespaced scopes as opaque and MUST NOT grant them by default. New **bare** literals require an additive schema revision.
 
 ## The 13 resource types
 

--- a/control-center/contracts/catalog.json
+++ b/control-center/contracts/catalog.json
@@ -55,6 +55,14 @@
       "invalid_fixture": "fixtures/invalid/agent-session.json"
     },
     {
+      "name": "AgentActivity",
+      "schema_version": "control-center.agent-activity.v1",
+      "id_type": "agent-activity",
+      "schema": "schemas/agent-activity.v1.schema.json",
+      "valid_fixture": "fixtures/valid/agent-activity.json",
+      "invalid_fixture": "fixtures/invalid/agent-activity.json"
+    },
+    {
       "name": "ClientStatus",
       "schema_version": "control-center.client-status.v1",
       "id_type": "client-status",

--- a/control-center/contracts/catalog.json
+++ b/control-center/contracts/catalog.json
@@ -1,0 +1,114 @@
+{
+  "package": "@confenge/control-center-contracts",
+  "schema_family": "control-center",
+  "release": "v1",
+  "id_convention": "cc:<type-kebab>:<ulid-or-slug>",
+  "datetime": "UTC RFC3339 with mandatory Z suffix; never a civil-time offset.",
+  "money": "integer cents plus ISO-4217 currency; floats are invalid.",
+  "types": [
+    {
+      "name": "Directive",
+      "schema_version": "control-center.directive.v1",
+      "id_type": "directive",
+      "schema": "schemas/directive.v1.schema.json",
+      "valid_fixture": "fixtures/valid/directive.json",
+      "invalid_fixture": "fixtures/invalid/directive.json"
+    },
+    {
+      "name": "OperationalSnapshot",
+      "schema_version": "control-center.operational-snapshot.v1",
+      "id_type": "operational-snapshot",
+      "schema": "schemas/operational-snapshot.v1.schema.json",
+      "valid_fixture": "fixtures/valid/operational-snapshot.json",
+      "invalid_fixture": "fixtures/invalid/operational-snapshot.json"
+    },
+    {
+      "name": "SourceObservation",
+      "schema_version": "control-center.source-observation.v1",
+      "id_type": "source-observation",
+      "schema": "schemas/source-observation.v1.schema.json",
+      "valid_fixture": "fixtures/valid/source-observation.json",
+      "invalid_fixture": "fixtures/invalid/source-observation.json"
+    },
+    {
+      "name": "AttentionItem",
+      "schema_version": "control-center.attention-item.v1",
+      "id_type": "attention-item",
+      "schema": "schemas/attention-item.v1.schema.json",
+      "valid_fixture": "fixtures/valid/attention-item.json",
+      "invalid_fixture": "fixtures/invalid/attention-item.json"
+    },
+    {
+      "name": "PriorityRecommendation",
+      "schema_version": "control-center.priority-recommendation.v1",
+      "id_type": "priority-recommendation",
+      "schema": "schemas/priority-recommendation.v1.schema.json",
+      "valid_fixture": "fixtures/valid/priority-recommendation.json",
+      "invalid_fixture": "fixtures/invalid/priority-recommendation.json"
+    },
+    {
+      "name": "AgentSession",
+      "schema_version": "control-center.agent-session.v1",
+      "id_type": "agent-session",
+      "schema": "schemas/agent-session.v1.schema.json",
+      "valid_fixture": "fixtures/valid/agent-session.json",
+      "invalid_fixture": "fixtures/invalid/agent-session.json"
+    },
+    {
+      "name": "ClientStatus",
+      "schema_version": "control-center.client-status.v1",
+      "id_type": "client-status",
+      "schema": "schemas/client-status.v1.schema.json",
+      "valid_fixture": "fixtures/valid/client-status.json",
+      "invalid_fixture": "fixtures/invalid/client-status.json"
+    },
+    {
+      "name": "CommercialSnapshot",
+      "schema_version": "control-center.commercial-snapshot.v1",
+      "id_type": "commercial-snapshot",
+      "schema": "schemas/commercial-snapshot.v1.schema.json",
+      "valid_fixture": "fixtures/valid/commercial-snapshot.json",
+      "invalid_fixture": "fixtures/invalid/commercial-snapshot.json"
+    },
+    {
+      "name": "FinanceSnapshot",
+      "schema_version": "control-center.finance-snapshot.v1",
+      "id_type": "finance-snapshot",
+      "schema": "schemas/finance-snapshot.v1.schema.json",
+      "valid_fixture": "fixtures/valid/finance-snapshot.json",
+      "invalid_fixture": "fixtures/invalid/finance-snapshot.json"
+    },
+    {
+      "name": "EngineeringSnapshot",
+      "schema_version": "control-center.engineering-snapshot.v1",
+      "id_type": "engineering-snapshot",
+      "schema": "schemas/engineering-snapshot.v1.schema.json",
+      "valid_fixture": "fixtures/valid/engineering-snapshot.json",
+      "invalid_fixture": "fixtures/invalid/engineering-snapshot.json"
+    },
+    {
+      "name": "ServiceHealth",
+      "schema_version": "control-center.service-health.v1",
+      "id_type": "service-health",
+      "schema": "schemas/service-health.v1.schema.json",
+      "valid_fixture": "fixtures/valid/service-health.json",
+      "invalid_fixture": "fixtures/invalid/service-health.json"
+    },
+    {
+      "name": "CollectorRun",
+      "schema_version": "control-center.collector-run.v1",
+      "id_type": "collector-run",
+      "schema": "schemas/collector-run.v1.schema.json",
+      "valid_fixture": "fixtures/valid/collector-run.json",
+      "invalid_fixture": "fixtures/invalid/collector-run.json"
+    },
+    {
+      "name": "AuditEvent",
+      "schema_version": "control-center.audit-event.v1",
+      "id_type": "audit-event",
+      "schema": "schemas/audit-event.v1.schema.json",
+      "valid_fixture": "fixtures/valid/audit-event.json",
+      "invalid_fixture": "fixtures/invalid/audit-event.json"
+    }
+  ]
+}

--- a/control-center/contracts/docs/ADR-CC-001-ARCHITECTURE-BOUNDARIES.md
+++ b/control-center/contracts/docs/ADR-CC-001-ARCHITECTURE-BOUNDARIES.md
@@ -50,7 +50,7 @@ Finance snapshots set `read_model_only: true` and `provider_mutations: "forbidde
 
 ### 4. Control Center is an aggregation + memory plane, not chat and not ERP
 
-It stores operational snapshots, exceptions (`AttentionItem`), at most three current priorities for the homepage, human directives with audit, and scoped agent sessions. It is not a chatbot log and not a general ledger.
+It stores operational snapshots, exceptions (`AttentionItem`), at most three current priorities for the homepage, human directives with audit, scoped agent sessions (`AgentSession`), and agent execution records (`AgentActivity`). `AgentActivity` is not `AgentSession`. It is not a chatbot log and not a general ledger.
 
 ### 5. Agents consume by scope
 

--- a/control-center/contracts/docs/ADR-CC-001-ARCHITECTURE-BOUNDARIES.md
+++ b/control-center/contracts/docs/ADR-CC-001-ARCHITECTURE-BOUNDARIES.md
@@ -1,0 +1,76 @@
+# ADR-CC-001 — Control Center architecture boundaries
+
+- **Status:** Accepted for campaign `CONFENGE-CONTROL-CENTER-FANOUT-2026-08-20`
+- **Date:** 2026-08-20
+- **Package:** `control-center/contracts/`
+- **Does not:** implement UI, PostgreSQL, collectors, authentication, or MCP runtime.
+
+## Context
+
+CONFENGE needs a private operational cockpit and structured strategic memory that agents can consume. Today commercial catalog authority lives in Governance `commercial/`, CRM runtime lives in Warmbly, and engineering state lives in GitHub and other origin systems. Mixing those planes produced duplicate catalogs, unsafe identity shortcuts, and the temptation to drive cobrança from a dashboard.
+
+This ADR freezes the boundaries so later workstreams (persistence, context service, MCP server, collectors, UI) can implement without renegotiating authority.
+
+## Decision
+
+### 1. Governance is strategic / canonical authority
+
+Governance remains the source of truth for:
+
+- commercial offer catalog, terms, capacity, production gates (`commercial/`);
+- strategic directives, constraints, decisions, facts, priorities, risks, hypotheses stored as `Directive` in Control Center;
+- this contract family.
+
+Control Center does **not** replace `commercial/` and MUST NOT copy a second writable catalog.
+
+### 2. Warmbly is commercial / CRM operational runtime
+
+Warmbly remains the system of record for pipeline, inbound, client conversations, and commercial send. Control Center may *observe* Warmbly through read-only collectors and expose `CommercialSnapshot` / `ClientStatus` as read models stamped:
+
+```
+authority.catalog_authority = "governance"
+authority.commercial_runtime = "warmbly"
+authority.this_document = "read_model"
+```
+
+Control Center MUST NOT send commercial messages.
+
+### 3. Collectors and read models are read-only aggregates
+
+Collectors produce `SourceObservation` and `CollectorRun` with `idempotency_key` and `read_only: true`. They attach `provenance` (`source`, `observed_at`, `freshness_status`, `confidence`).
+
+They MUST NOT:
+
+- execute cobrança, checkout, refund, cancelamento;
+- write to Asaas or any payment provider;
+- mutate Warmbly commercially;
+- invent catalog prices or offer codes.
+
+Finance snapshots set `read_model_only: true` and `provider_mutations: "forbidden"`.
+
+### 4. Control Center is an aggregation + memory plane, not chat and not ERP
+
+It stores operational snapshots, exceptions (`AttentionItem`), at most three current priorities for the homepage, human directives with audit, and scoped agent sessions. It is not a chatbot log and not a general ledger.
+
+### 5. Agents consume by scope
+
+MCP (`docs/mcp.v1.json`) is the principal agent interface. HTTP (`docs/http.openapi.json`) is the internal companion. Both require explicit scopes. `company` is a scope that MUST be requested and granted; it is not the default. Future `prefix:id` scopes are opaque until documented.
+
+### 6. Fail-closed security
+
+No secrets in git, logs, URLs, analytics, or client bundles. Audit `detail` property names that look like secrets are schema-invalid. Identity is an opaque `ActorRef`; this package does not hard-code a human password. Single-user comes later via auth, not via a baked credential.
+
+## Consequences
+
+- Persistence, context, MCP, GitHub collector, and UI workstreams implement *against these contracts* only.
+- Convergence with Warmbly / web-cfg / extra-cli is a later campaign; this package does not edit those repos.
+- PR Governance #8 (partner program) is out of scope and must not be absorbed here.
+
+## Schema versioning
+
+- File: `<resource>.v1.schema.json`
+- Field: `schema_version` const `control-center.<resource>.v1`
+- Breaking change → new `v2` file; keep `v1`.
+- Additive optional fields → `v1.1` (new const). `additionalProperties: false` on v1, so unknown fields are rejected.
+- Scope extension via new `prefix:id` namespaces does **not** require a breaking bump.
+- New bare literals (`hr`, `legal`, …) **do** require an additive revision of `SCOPE_LITERALS`.

--- a/control-center/contracts/docs/compatibility.v1.json
+++ b/control-center/contracts/docs/compatibility.v1.json
@@ -1,0 +1,37 @@
+{
+  "schema_family": "control-center",
+  "release": "v1",
+  "rule": "Incompatible shapes MUST NOT be silently accepted. Each row is either reject (fail-closed) or adapter_required (translate at a boundary, then re-validate the canonical document).",
+  "shapes": [
+    {
+      "id": "lowercase_freshness",
+      "description": "freshness_status encoded in lowercase (fresh|stale|unknown|error).",
+      "verdict": "reject",
+      "reason": "Canonical freshness is FRESH|STALE|UNKNOWN|ERROR. Silent uppercasing is forbidden."
+    },
+    {
+      "id": "expired_as_freshness",
+      "description": "expired used as a freshness or error stand-in.",
+      "verdict": "reject",
+      "reason": "expired is a Directive status, not a freshness value. Persistence 'expired' is not ERROR and requires an adapter before it can enter this ontology."
+    },
+    {
+      "id": "withdrawn_or_inactive_status",
+      "description": "status encoded as withdrawn or inactive.",
+      "verdict": "reject",
+      "reason": "Canonical Directive status is draft|active|superseded|revoked|expired. withdrawn and inactive are not in the closed set."
+    },
+    {
+      "id": "scope_object",
+      "description": "scope encoded as an object instead of a string.",
+      "verdict": "adapter_required",
+      "reason": "Canonical scope is a STRING: company|commercial|finance|clients|infrastructure|inbound|repo:<name>|client:<slug>|prefix:id. Object scopes must be adapted, never silently coerced."
+    },
+    {
+      "id": "raw_uuid_id",
+      "description": "external resource id is a bare UUID.",
+      "verdict": "adapter_required",
+      "reason": "Canonical external ids are cc:<type>:<id>. Persistence UUIDs must be adapted at a boundary; a raw UUID is not a Control Center resource id."
+    }
+  ]
+}

--- a/control-center/contracts/docs/http.openapi.json
+++ b/control-center/contracts/docs/http.openapi.json
@@ -31,8 +31,8 @@
             "name": "scopes",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "minLength": 2, "examples": ["finance", "finance,client:acme-industria"] },
-            "description": "Comma-separated scopes. minItems 1 after split."
+            "schema": { "$ref": "#/components/schemas/ScopeCsv" },
+            "description": "Comma-separated scopes. minItems 1 after split. Each token matches Scope."
           },
           {
             "name": "include_directives",
@@ -74,7 +74,7 @@
             "name": "scopes",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": { "$ref": "#/components/schemas/ScopeCsv" }
           },
           {
             "name": "status",
@@ -119,7 +119,7 @@
             "name": "scopes",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": { "$ref": "#/components/schemas/ScopeCsv" }
           },
           {
             "name": "status",
@@ -158,7 +158,7 @@
             "name": "scopes",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": { "$ref": "#/components/schemas/ScopeCsv" }
           },
           {
             "name": "limit",
@@ -193,7 +193,7 @@
         "tags": ["snapshots"],
         "operationId": "getOperationalSnapshot",
         "parameters": [
-          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+          { "name": "scope", "in": "query", "required": true, "schema": { "$ref": "#/components/schemas/Scope" } }
         ],
         "responses": {
           "200": {
@@ -212,7 +212,7 @@
         "tags": ["snapshots"],
         "operationId": "getCommercialSnapshot",
         "parameters": [
-          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+          { "name": "scope", "in": "query", "required": true, "schema": { "$ref": "#/components/schemas/Scope" } }
         ],
         "responses": {
           "200": {
@@ -232,7 +232,7 @@
         "operationId": "getFinanceSnapshot",
         "description": "Read-only finance aggregate. Does not create charges.",
         "parameters": [
-          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+          { "name": "scope", "in": "query", "required": true, "schema": { "$ref": "#/components/schemas/Scope" } }
         ],
         "responses": {
           "200": {
@@ -251,7 +251,7 @@
         "tags": ["snapshots"],
         "operationId": "getEngineeringSnapshot",
         "parameters": [
-          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+          { "name": "scope", "in": "query", "required": true, "schema": { "$ref": "#/components/schemas/Scope" } }
         ],
         "responses": {
           "200": {
@@ -294,7 +294,7 @@
         "tags": ["cockpit"],
         "operationId": "listServiceHealth",
         "parameters": [
-          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+          { "name": "scope", "in": "query", "required": true, "schema": { "$ref": "#/components/schemas/Scope" } }
         ],
         "responses": {
           "200": {
@@ -322,7 +322,7 @@
         "tags": ["collectors"],
         "operationId": "listCollectorRuns",
         "parameters": [
-          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+          { "name": "scope", "in": "query", "required": true, "schema": { "$ref": "#/components/schemas/Scope" } }
         ],
         "responses": {
           "200": {
@@ -363,7 +363,9 @@
                   "requested_scopes": {
                     "type": "array",
                     "minItems": 1,
-                    "items": { "type": "string" }
+                    "maxItems": 32,
+                    "uniqueItems": true,
+                    "items": { "$ref": "#/components/schemas/Scope" }
                   },
                   "purpose": { "type": "string" },
                   "include_directives": { "type": "boolean" },
@@ -412,7 +414,13 @@
         "tags": ["memory"],
         "operationId": "listAuditEvents",
         "parameters": [
-          { "name": "scope", "in": "query", "schema": { "type": "string" } },
+          {
+            "name": "scope",
+            "in": "query",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/Scope" },
+            "description": "Required. Unscoped audit lists are a whole-company dump and are 400."
+          },
           { "name": "resource_id", "in": "query", "schema": { "type": "string" } }
         ],
         "responses": {
@@ -441,7 +449,7 @@
         "tags": ["collectors"],
         "operationId": "listSourceObservations",
         "parameters": [
-          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+          { "name": "scope", "in": "query", "required": true, "schema": { "$ref": "#/components/schemas/Scope" } }
         ],
         "responses": {
           "200": {
@@ -477,6 +485,18 @@
       }
     },
     "schemas": {
+      "Scope": {
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 128,
+        "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
+      },
+      "ScopeCsv": {
+        "type": "string",
+        "minLength": 2,
+        "description": "Comma-separated scopes. Empty list is 400. Each token must match Scope.",
+        "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)(?:,(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+))*$"
+      },
       "ErrorBody": {
         "type": "object",
         "additionalProperties": false,

--- a/control-center/contracts/docs/http.openapi.json
+++ b/control-center/contracts/docs/http.openapi.json
@@ -1,0 +1,521 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Confenge Control Center internal HTTP API",
+    "version": "1.0.0",
+    "description": "Internal HTTP contract for the Control Center cockpit and context service. MCP is the principal agent interface; this HTTP API is the human UI and service-to-service companion. Financial and provider mutations are forbidden. Agents and UIs query by scope; there is no whole-company dump endpoint."
+  },
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "servers": [
+    {
+      "url": "http://127.0.0.1:8080",
+      "description": "Local loopback. Not a public internet surface."
+    }
+  ],
+  "tags": [
+    { "name": "context", "description": "Scoped agent/human context" },
+    { "name": "memory", "description": "Directives and audit" },
+    { "name": "cockpit", "description": "Exceptions and top priorities" },
+    { "name": "snapshots", "description": "Aggregated read models" },
+    { "name": "collectors", "description": "Read-only collector runs" }
+  ],
+  "paths": {
+    "/v1/context": {
+      "get": {
+        "tags": ["context"],
+        "operationId": "getContext",
+        "summary": "Fetch AgentContext for one or more scopes",
+        "description": "Query parameter scopes is required (CSV). Empty scopes is 400. The server returns only granted_scopes. MCP equivalent: cc_get_context.",
+        "parameters": [
+          {
+            "name": "scopes",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "minLength": 2, "examples": ["finance", "finance,client:acme-industria"] },
+            "description": "Comma-separated scopes. minItems 1 after split."
+          },
+          {
+            "name": "include_directives",
+            "in": "query",
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "include_snapshots",
+            "in": "query",
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "include_attention",
+            "in": "query",
+            "schema": { "type": "boolean", "default": true }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AgentContext",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "../schemas/agent-context.v1.schema.json" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/Error" },
+          "403": { "$ref": "#/components/responses/Error" }
+        }
+      }
+    },
+    "/v1/directives": {
+      "get": {
+        "tags": ["memory"],
+        "operationId": "listDirectives",
+        "summary": "List directives for requested scopes",
+        "parameters": [
+          {
+            "name": "scopes",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["draft", "active", "superseded", "revoked", "expired"] }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["decision", "directive", "fact", "constraint", "priority", "risk", "hypothesis"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Directive list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["items"],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "../schemas/directive.v1.schema.json" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/Error" }
+        }
+      }
+    },
+    "/v1/attention": {
+      "get": {
+        "tags": ["cockpit"],
+        "operationId": "listAttention",
+        "summary": "List attention items (exceptions) for requested scopes. Homepage consumes homepage_eligible=true.",
+        "parameters": [
+          {
+            "name": "scopes",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["open", "acknowledged", "resolved", "dismissed"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AttentionItem list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["items"],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "../schemas/attention-item.v1.schema.json" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/priorities": {
+      "get": {
+        "tags": ["cockpit"],
+        "operationId": "listPriorities",
+        "summary": "The current most important things. Default and max limit is 3.",
+        "parameters": [
+          {
+            "name": "scopes",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 3, "default": 3 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PriorityRecommendation list, max 3",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["items"],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "maxItems": 3,
+                      "items": { "$ref": "../schemas/priority-recommendation.v1.schema.json" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/snapshots/operational": {
+      "get": {
+        "tags": ["snapshots"],
+        "operationId": "getOperationalSnapshot",
+        "parameters": [
+          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "OperationalSnapshot",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "../schemas/operational-snapshot.v1.schema.json" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/snapshots/commercial": {
+      "get": {
+        "tags": ["snapshots"],
+        "operationId": "getCommercialSnapshot",
+        "parameters": [
+          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "CommercialSnapshot read model",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "../schemas/commercial-snapshot.v1.schema.json" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/snapshots/finance": {
+      "get": {
+        "tags": ["snapshots"],
+        "operationId": "getFinanceSnapshot",
+        "description": "Read-only finance aggregate. Does not create charges.",
+        "parameters": [
+          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "FinanceSnapshot",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "../schemas/finance-snapshot.v1.schema.json" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/snapshots/engineering": {
+      "get": {
+        "tags": ["snapshots"],
+        "operationId": "getEngineeringSnapshot",
+        "parameters": [
+          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "EngineeringSnapshot",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "../schemas/engineering-snapshot.v1.schema.json" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/clients/{slug}/status": {
+      "get": {
+        "tags": ["snapshots"],
+        "operationId": "getClientStatus",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ClientStatus",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "../schemas/client-status.v1.schema.json" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/health/services": {
+      "get": {
+        "tags": ["cockpit"],
+        "operationId": "listServiceHealth",
+        "parameters": [
+          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "ServiceHealth list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["items"],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "../schemas/service-health.v1.schema.json" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/collectors/runs": {
+      "get": {
+        "tags": ["collectors"],
+        "operationId": "listCollectorRuns",
+        "parameters": [
+          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "CollectorRun list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["items"],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "../schemas/collector-run.v1.schema.json" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/agent-sessions": {
+      "post": {
+        "tags": ["context"],
+        "operationId": "createAgentSession",
+        "summary": "Open a scoped agent session. requested_scopes minItems 1.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["agent_id", "requested_scopes", "purpose"],
+                "properties": {
+                  "agent_id": { "type": "string" },
+                  "requested_scopes": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "type": "string" }
+                  },
+                  "purpose": { "type": "string" },
+                  "include_directives": { "type": "boolean" },
+                  "include_snapshots": { "type": "boolean" },
+                  "include_attention": { "type": "boolean" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "AgentSession",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "../schemas/agent-session.v1.schema.json" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/Error" },
+          "403": { "$ref": "#/components/responses/Error" }
+        }
+      }
+    },
+    "/v1/agent-sessions/{id}": {
+      "get": {
+        "tags": ["context"],
+        "operationId": "getAgentSession",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "AgentSession",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "../schemas/agent-session.v1.schema.json" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/audit": {
+      "get": {
+        "tags": ["memory"],
+        "operationId": "listAuditEvents",
+        "parameters": [
+          { "name": "scope", "in": "query", "schema": { "type": "string" } },
+          { "name": "resource_id", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "AuditEvent list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["items"],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "../schemas/audit-event.v1.schema.json" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/observations": {
+      "get": {
+        "tags": ["collectors"],
+        "operationId": "listSourceObservations",
+        "parameters": [
+          { "name": "scope", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "SourceObservation list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["items"],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "../schemas/source-observation.v1.schema.json" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "Error": {
+        "description": "Fail-closed error",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorBody" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "ErrorBody": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["code", "message"],
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string", "description": "No secrets, no PII." }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-principal-agent-interface": "MCP (docs/mcp.v1.json)",
+  "x-forbidden-paths": [
+    { "path": "/v1/charges", "reason": "Cobrança is forbidden in this campaign." },
+    { "path": "/v1/checkout", "reason": "Checkout is forbidden." },
+    { "path": "/v1/refunds", "reason": "Refund is forbidden." },
+    { "path": "/v1/cancellations", "reason": "Cancelamento is forbidden." },
+    { "path": "/v1/asaas", "reason": "Asaas writes/proxy are forbidden." },
+    { "path": "/v1/asaas/payments", "reason": "Asaas payment creation is forbidden." },
+    { "path": "/v1/billing", "reason": "Billing mutation surface is forbidden." },
+    { "path": "/v1/messages/send", "reason": "Commercial send remains in Warmbly." },
+    { "path": "/v1/memory/dump", "reason": "Whole-company memory dump is forbidden." }
+  ],
+  "x-scope-taxonomy": [
+    "company",
+    "commercial",
+    "finance",
+    "clients",
+    "infrastructure",
+    "inbound",
+    "repo:<name>",
+    "client:<slug>"
+  ],
+  "x-scope-extension": "Additional prefix:id namespaces are non-breaking. New bare literals require an additive schema revision. Unknown scopes are opaque and not granted by default."
+}

--- a/control-center/contracts/docs/http.openapi.json
+++ b/control-center/contracts/docs/http.openapi.json
@@ -409,6 +409,40 @@
         }
       }
     },
+    "/v1/agent-activities": {
+      "get": {
+        "tags": ["context"],
+        "operationId": "listAgentActivities",
+        "summary": "List AgentActivity execution records for requested scopes. Distinct from AgentSession.",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "query",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/Scope" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AgentActivity list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["items"],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "../schemas/agent-activity.v1.schema.json" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/audit": {
       "get": {
         "tags": ["memory"],

--- a/control-center/contracts/docs/mcp.v1.json
+++ b/control-center/contracts/docs/mcp.v1.json
@@ -156,6 +156,28 @@
       }
     },
     {
+      "name": "cc_list_agent_activity",
+      "description": "List AgentActivity execution-ledger records for requested scopes. Distinct from AgentSession (context-consult grant).",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scopes"],
+        "properties": {
+          "scopes": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 32,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
+            }
+          }
+        }
+      },
+      "output_schema_ref": "schemas/agent-activity.v1.schema.json"
+    },
+    {
       "name": "cc_get_service_health",
       "description": "List ServiceHealth for a scope.",
       "input_schema": {
@@ -185,6 +207,11 @@
     {
       "uri_template": "cc://attention/{scope}",
       "name": "Scoped attention items"
+    },
+    {
+      "uri_template": "cc://agent-activity/{scope}",
+      "name": "Scoped agent activity",
+      "description": "AgentActivity execution records for a single scope. Not AgentSession."
     }
   ],
   "forbidden_operations": [

--- a/control-center/contracts/docs/mcp.v1.json
+++ b/control-center/contracts/docs/mcp.v1.json
@@ -22,7 +22,7 @@
             "uniqueItems": true,
             "items": {
               "type": "string",
-              "pattern": "^(company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
+              "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
             }
           },
           "include_directives": { "type": "boolean" },
@@ -43,7 +43,12 @@
           "scopes": {
             "type": "array",
             "minItems": 1,
-            "items": { "type": "string" }
+            "maxItems": 32,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
+            }
           },
           "status": {
             "type": "string",
@@ -68,7 +73,12 @@
           "scopes": {
             "type": "array",
             "minItems": 1,
-            "items": { "type": "string" }
+            "maxItems": 32,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
+            }
           },
           "status": {
             "type": "string",
@@ -89,7 +99,12 @@
           "scopes": {
             "type": "array",
             "minItems": 1,
-            "items": { "type": "string" }
+            "maxItems": 32,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
+            }
           },
           "limit": { "type": "integer", "minimum": 1, "maximum": 3, "default": 3 }
         }
@@ -104,7 +119,10 @@
         "additionalProperties": false,
         "required": ["scope", "kind"],
         "properties": {
-          "scope": { "type": "string" },
+          "scope": {
+            "type": "string",
+            "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
+          },
           "kind": {
             "type": "string",
             "enum": ["operational", "commercial", "finance", "engineering"]
@@ -145,7 +163,10 @@
         "additionalProperties": false,
         "required": ["scope"],
         "properties": {
-          "scope": { "type": "string" }
+          "scope": {
+            "type": "string",
+            "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
+          }
         }
       },
       "output_schema_ref": "schemas/service-health.v1.schema.json"

--- a/control-center/contracts/docs/mcp.v1.json
+++ b/control-center/contracts/docs/mcp.v1.json
@@ -1,0 +1,203 @@
+{
+  "mcp_version": "2024-11-05",
+  "server_name": "confenge-control-center",
+  "interface_role": "principal_agent_interface",
+  "schema_family": "control-center",
+  "schema_release": "v1",
+  "scope_rule": "Agents MUST query context by scope. requested_scopes minItems is 1. There is no whole-company dump tool. granted_scopes is a fail-closed subset of requested_scopes. Unknown future prefix:id scopes are opaque and not granted by default.",
+  "read_only_default": true,
+  "tools": [
+    {
+      "name": "cc_get_context",
+      "description": "Return AgentContext for the granted subset of requested scopes. Primary agent entry. Empty scopes are invalid.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scopes"],
+        "properties": {
+          "scopes": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 32,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^(company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$"
+            }
+          },
+          "include_directives": { "type": "boolean" },
+          "include_snapshots": { "type": "boolean" },
+          "include_attention": { "type": "boolean" }
+        }
+      },
+      "output_schema_ref": "schemas/agent-context.v1.schema.json"
+    },
+    {
+      "name": "cc_list_directives",
+      "description": "List directives whose scope is in the requested scopes.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scopes"],
+        "properties": {
+          "scopes": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string" }
+          },
+          "status": {
+            "type": "string",
+            "enum": ["draft", "active", "superseded", "revoked", "expired"]
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["decision", "directive", "fact", "constraint", "priority", "risk", "hypothesis"]
+          }
+        }
+      },
+      "output_schema_ref": "schemas/directive.v1.schema.json"
+    },
+    {
+      "name": "cc_list_attention",
+      "description": "List attention items (exceptions) for requested scopes.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scopes"],
+        "properties": {
+          "scopes": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string" }
+          },
+          "status": {
+            "type": "string",
+            "enum": ["open", "acknowledged", "resolved", "dismissed"]
+          }
+        }
+      },
+      "output_schema_ref": "schemas/attention-item.v1.schema.json"
+    },
+    {
+      "name": "cc_list_priorities",
+      "description": "List the current priority recommendations. Default limit 3 for homepage/cockpit.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scopes"],
+        "properties": {
+          "scopes": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string" }
+          },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 3, "default": 3 }
+        }
+      },
+      "output_schema_ref": "schemas/priority-recommendation.v1.schema.json"
+    },
+    {
+      "name": "cc_get_snapshot",
+      "description": "Fetch a named snapshot for a single scope.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scope", "kind"],
+        "properties": {
+          "scope": { "type": "string" },
+          "kind": {
+            "type": "string",
+            "enum": ["operational", "commercial", "finance", "engineering"]
+          }
+        }
+      }
+    },
+    {
+      "name": "cc_get_client_status",
+      "description": "Fetch ClientStatus for client:<slug>.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["client_slug"],
+        "properties": {
+          "client_slug": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        }
+      },
+      "output_schema_ref": "schemas/client-status.v1.schema.json"
+    },
+    {
+      "name": "cc_list_scopes",
+      "description": "List scopes the caller may request. Does not return memory payloads.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+      }
+    },
+    {
+      "name": "cc_get_service_health",
+      "description": "List ServiceHealth for a scope.",
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scope"],
+        "properties": {
+          "scope": { "type": "string" }
+        }
+      },
+      "output_schema_ref": "schemas/service-health.v1.schema.json"
+    }
+  ],
+  "resources": [
+    {
+      "uri_template": "cc://context/{scope}",
+      "name": "Scoped agent context",
+      "description": "AgentContext for a single scope. Substituting a missing or ungranted scope is denied."
+    },
+    {
+      "uri_template": "cc://directives/{scope}",
+      "name": "Scoped directives"
+    },
+    {
+      "uri_template": "cc://attention/{scope}",
+      "name": "Scoped attention items"
+    }
+  ],
+  "forbidden_operations": [
+    {
+      "name": "cc_charge",
+      "reason": "Cobrança is a financial provider mutation. Forbidden in this campaign."
+    },
+    {
+      "name": "cc_checkout",
+      "reason": "Checkout is a financial mutation. Forbidden."
+    },
+    {
+      "name": "cc_refund",
+      "reason": "Refund is a financial mutation. Forbidden."
+    },
+    {
+      "name": "cc_cancel_subscription",
+      "reason": "Cancelamento is a financial mutation. Forbidden."
+    },
+    {
+      "name": "cc_asaas_write",
+      "reason": "Asaas writes remain in origin systems. Control Center is read-only toward providers."
+    },
+    {
+      "name": "cc_asaas_create_payment",
+      "reason": "Asaas payment creation is forbidden."
+    },
+    {
+      "name": "cc_send_commercial",
+      "reason": "Commercial send remains in Warmbly. Control Center does not send."
+    },
+    {
+      "name": "cc_dump_company_memory",
+      "reason": "Agents consult by scope; whole-company memory dump is forbidden."
+    }
+  ]
+}

--- a/control-center/contracts/fixtures/invalid/agent-activity.json
+++ b/control-center/contracts/fixtures/invalid/agent-activity.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "control-center.agent-activity.v1",
+  "id": "cc:agent-session:01K3CC-NOT-ACTIVITY",
+  "agent_id": "agent:cc-context",
+  "scope": "finance",
+  "status": "open",
+  "started_at": "2026-08-20T17:50:00Z",
+  "finished_at": null,
+  "goal": "This document uses AgentSession id type and status; it is not AgentActivity.",
+  "summary": "Invalid mix of session identity into the activity ledger.",
+  "provenance": {
+    "source": {
+      "system": "collector",
+      "kind": "report",
+      "locator": "agent-activity/bad"
+    },
+    "observed_at": "2026-08-20T18:10:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.9
+  },
+  "actor": { "kind": "agent", "id": "agent:cc-context" }
+}

--- a/control-center/contracts/fixtures/invalid/agent-session.json
+++ b/control-center/contracts/fixtures/invalid/agent-session.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "control-center.agent-session.v1",
+  "id": "cc:agent-session:01K3CC-EMPTY-SCOPES",
+  "agent_id": "agent:cc-context",
+  "requested_scopes": [],
+  "granted_scopes": [],
+  "purpose": "Empty requested_scopes would dump all memory; forbidden.",
+  "started_at": "2026-08-20T17:50:00Z",
+  "ended_at": null,
+  "status": "open",
+  "created_by": { "kind": "agent", "id": "agent:cc-context" },
+  "include_directives": true,
+  "include_snapshots": true,
+  "include_attention": true
+}

--- a/control-center/contracts/fixtures/invalid/attention-item.json
+++ b/control-center/contracts/fixtures/invalid/attention-item.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "control-center.attention-item.v1",
+  "id": "cc:attention-item:01K3CC-MISSING-SOURCE",
+  "scope": "client:acme-industria",
+  "severity": "high",
+  "status": "open",
+  "title": "Missing provenance source",
+  "summary": "Aggregated items require source, observed_at, freshness_status and confidence.",
+  "provenance": {
+    "observed_at": "2026-08-20T17:00:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.8
+  },
+  "detected_at": "2026-08-20T17:00:00Z",
+  "homepage_eligible": true
+}

--- a/control-center/contracts/fixtures/invalid/audit-event.json
+++ b/control-center/contracts/fixtures/invalid/audit-event.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "control-center.audit-event.v1",
+  "id": "cc:audit-event:01K3CC-SECRET-DETAIL",
+  "at": "2026-08-20T17:50:01Z",
+  "actor": { "kind": "agent", "id": "agent:cc-context" },
+  "action": "context.get",
+  "resource_type": "AgentSession",
+  "resource_id": "cc:agent-session:01K3CC-CTX-FINANCE",
+  "scope": "finance",
+  "outcome": "success",
+  "detail": {
+    "password": "this-must-be-rejected"
+  }
+}

--- a/control-center/contracts/fixtures/invalid/client-status.json
+++ b/control-center/contracts/fixtures/invalid/client-status.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "control-center.client-status.v1",
+  "id": "cc:client-status:acme-industria",
+  "scope": "company",
+  "client_slug": "acme-industria",
+  "display_name": "Acme Indústria",
+  "lifecycle": "churn_risk",
+  "provenance": {
+    "source": {
+      "system": "warmbly",
+      "kind": "client-record",
+      "locator": "clients/acme-industria"
+    },
+    "observed_at": "2026-08-20T16:30:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.8
+  }
+}

--- a/control-center/contracts/fixtures/invalid/collector-run.json
+++ b/control-center/contracts/fixtures/invalid/collector-run.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "control-center.collector-run.v1",
+  "id": "cc:collector-run:01K3CC-NO-IDEM",
+  "collector_name": "github-repo",
+  "scope": "repo:tjsasakifln/Governance",
+  "status": "succeeded",
+  "started_at": "2026-08-20T17:54:00Z",
+  "finished_at": "2026-08-20T17:54:08Z",
+  "read_only": true,
+  "observations_emitted": 1
+}

--- a/control-center/contracts/fixtures/invalid/commercial-snapshot.json
+++ b/control-center/contracts/fixtures/invalid/commercial-snapshot.json
@@ -18,6 +18,21 @@
     "commercial_runtime": "warmbly",
     "this_document": "read_model"
   },
+  "offer_pin": {
+    "catalog_authority": "governance",
+    "catalog_id": "CFG-OFFER-CATALOG-v1"
+  },
+  "funnel": {
+    "new_leads": 6,
+    "qualified": 4,
+    "opportunities": 3,
+    "proposals": 2,
+    "clients": 1
+  },
+  "pipeline_nominal": { "amount_cents": 4800000, "currency": "BRL" },
+  "aging_count": 0,
+  "stalled_count": 0,
+  "missing_next_action_count": 0,
   "pipeline_open_count": 4,
   "inbound_unread_count": 3,
   "at_risk_client_count": 1

--- a/control-center/contracts/fixtures/invalid/commercial-snapshot.json
+++ b/control-center/contracts/fixtures/invalid/commercial-snapshot.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "control-center.commercial-snapshot.v1",
+  "id": "cc:commercial-snapshot:01K3CC-BAD-AUTHORITY",
+  "scope": "commercial",
+  "generated_at": "2026-08-20T17:40:00Z",
+  "provenance": {
+    "source": {
+      "system": "warmbly",
+      "kind": "crm-read-model",
+      "locator": "commercial/pipeline"
+    },
+    "observed_at": "2026-08-20T17:39:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.84
+  },
+  "authority": {
+    "catalog_authority": "warmbly",
+    "commercial_runtime": "warmbly",
+    "this_document": "read_model"
+  },
+  "pipeline_open_count": 4,
+  "inbound_unread_count": 3,
+  "at_risk_client_count": 1
+}

--- a/control-center/contracts/fixtures/invalid/compatibility-lowercase-freshness.json
+++ b/control-center/contracts/fixtures/invalid/compatibility-lowercase-freshness.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "control-center.finance-snapshot.v1",
-  "id": "cc:finance-snapshot:01K3CC-FLOAT-MONEY",
+  "id": "cc:finance-snapshot:01K3CC-LOWER-FRESH",
   "scope": "finance",
   "generated_at": "2026-08-20T17:20:00Z",
   "provenance": {
@@ -10,17 +10,17 @@
       "locator": "finance/receivables"
     },
     "observed_at": "2026-08-20T17:10:00Z",
-    "freshness_status": "FRESH",
+    "freshness_status": "fresh",
     "confidence": 0.7
   },
   "read_model_only": true,
   "provider_mutations": "forbidden",
-  "contracted": { "amount_cents": 5000000, "currency": "BRL" },
-  "billed": { "amount_cents": 4000000, "currency": "BRL" },
-  "paid": { "amount_cents": 2500000, "currency": "BRL" },
-  "effectively_received": { "amount_cents": 2300000, "currency": "BRL" },
-  "overdue": { "amount_cents": 1500000, "currency": "BRL" },
-  "receivable": { "amount_cents": 25000.5, "currency": "BRL" },
+  "contracted": { "amount_cents": 0, "currency": "BRL" },
+  "billed": { "amount_cents": 0, "currency": "BRL" },
+  "paid": { "amount_cents": 0, "currency": "BRL" },
+  "effectively_received": { "amount_cents": 0, "currency": "BRL" },
+  "overdue": { "amount_cents": 0, "currency": "BRL" },
+  "receivable": { "amount_cents": 0, "currency": "BRL" },
   "refunds": { "amount_cents": 0, "currency": "BRL" },
   "chargebacks": { "amount_cents": 0, "currency": "BRL" }
 }

--- a/control-center/contracts/fixtures/invalid/directive.json
+++ b/control-center/contracts/fixtures/invalid/directive.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "control-center.directive.v1",
+  "id": "cc:directive:01K3CC-BAD-KIND",
+  "kind": "note",
+  "scope": "finance",
+  "status": "active",
+  "title": "Invalid kind",
+  "body": "kind must be one of decision, directive, fact, constraint, priority, risk, hypothesis.",
+  "effective_from": "2026-08-20T00:00:00Z",
+  "expires_at": null,
+  "supersedes": null,
+  "created_by": { "kind": "human", "id": "human:operator" },
+  "created_at": "2026-08-20T12:00:00Z",
+  "updated_at": "2026-08-20T12:00:00Z",
+  "audit": [
+    {
+      "at": "2026-08-20T12:00:00Z",
+      "actor": { "kind": "human", "id": "human:operator" },
+      "action": "created"
+    }
+  ]
+}

--- a/control-center/contracts/fixtures/invalid/engineering-snapshot.json
+++ b/control-center/contracts/fixtures/invalid/engineering-snapshot.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "control-center.engineering-snapshot.v1",
+  "id": "cc:engineering-snapshot:01K3CC-OFFSET-TS",
+  "scope": "repo:tjsasakifln/Governance",
+  "generated_at": "2026-08-20T14:55:00-03:00",
+  "provenance": {
+    "source": {
+      "system": "github",
+      "kind": "repo-read",
+      "locator": "repos/tjsasakifln/Governance"
+    },
+    "observed_at": "2026-08-20T17:54:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.95
+  },
+  "open_pr_count": 1,
+  "failing_check_count": 0,
+  "open_incident_count": 0
+}

--- a/control-center/contracts/fixtures/invalid/finance-snapshot.json
+++ b/control-center/contracts/fixtures/invalid/finance-snapshot.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "control-center.finance-snapshot.v1",
+  "id": "cc:finance-snapshot:01K3CC-FLOAT-MONEY",
+  "scope": "finance",
+  "generated_at": "2026-08-20T17:20:00Z",
+  "provenance": {
+    "source": {
+      "system": "asaas",
+      "kind": "receivable-read",
+      "locator": "finance/receivables"
+    },
+    "observed_at": "2026-08-20T17:10:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.7
+  },
+  "read_model_only": true,
+  "provider_mutations": "forbidden",
+  "receivables_open": { "amount_cents": 25000.5, "currency": "BRL" },
+  "receivables_overdue": { "amount_cents": 1500000, "currency": "BRL" }
+}

--- a/control-center/contracts/fixtures/invalid/operational-snapshot.json
+++ b/control-center/contracts/fixtures/invalid/operational-snapshot.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "control-center.operational-snapshot.v1",
+  "id": "cc:operational-snapshot:01K3CC-NO-PROVENANCE",
+  "scope": "company",
+  "generated_at": "2026-08-20T17:59:00Z",
+  "headline": "Missing provenance must be rejected.",
+  "top_priorities": [],
+  "attention_items": [],
+  "health": [],
+  "commercial_snapshot_id": null,
+  "finance_snapshot_id": null,
+  "engineering_snapshot_id": null,
+  "client_status_ids": []
+}

--- a/control-center/contracts/fixtures/invalid/priority-recommendation.json
+++ b/control-center/contracts/fixtures/invalid/priority-recommendation.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "control-center.priority-recommendation.v1",
+  "id": "cc:priority-recommendation:01K3CC-RANK-ZERO",
+  "scope": "company",
+  "rank": 0,
+  "title": "Invalid rank",
+  "rationale": "rank minimum is 1; homepage uses 1, 2, 3.",
+  "provenance": {
+    "source": {
+      "system": "warmbly",
+      "kind": "inbound-queue",
+      "locator": "inbound/unread"
+    },
+    "observed_at": "2026-08-20T17:45:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.88
+  },
+  "generated_at": "2026-08-20T17:46:00Z",
+  "horizon": "now"
+}

--- a/control-center/contracts/fixtures/invalid/service-health.json
+++ b/control-center/contracts/fixtures/invalid/service-health.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "control-center.service-health.v1",
+  "id": "cc:service-health:01K3CC-BAD-STATUS",
+  "scope": "infrastructure",
+  "service_name": "context-service",
+  "status": "ok",
+  "provenance": {
+    "source": {
+      "system": "collector",
+      "kind": "health-probe",
+      "locator": "health/context-service"
+    },
+    "observed_at": "2026-08-20T17:58:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.99
+  },
+  "checked_at": "2026-08-20T17:58:00Z"
+}

--- a/control-center/contracts/fixtures/invalid/source-observation.json
+++ b/control-center/contracts/fixtures/invalid/source-observation.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "control-center.source-observation.v1",
+  "id": "cc:source-observation:01K3CC-BAD-FRESHNESS",
+  "scope": "inbound",
+  "provenance": {
+    "source": {
+      "system": "warmbly",
+      "kind": "inbound-queue",
+      "locator": "inbound/unread"
+    },
+    "observed_at": "2026-08-20T17:45:00Z",
+    "freshness_status": "OLD",
+    "confidence": 0.91
+  },
+  "collected_at": "2026-08-20T17:45:12Z",
+  "idempotency_key": "warmbly:inbound:unread:2026-08-20T17:45:00Z",
+  "payload": {
+    "unread_count": 3
+  }
+}

--- a/control-center/contracts/fixtures/valid/agent-activity.json
+++ b/control-center/contracts/fixtures/valid/agent-activity.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "control-center.agent-activity.v1",
+  "id": "cc:agent-activity:01K3CC-LEDGER-PARTIAL",
+  "agent_id": "agent:cc-context",
+  "session_id": "cc:agent-session:01K3CC-CTX-FINANCE",
+  "scope": "finance",
+  "status": "partial",
+  "started_at": "2026-08-20T17:50:00Z",
+  "finished_at": "2026-08-20T18:10:00Z",
+  "goal": "Prepare a scoped finance briefing for overdue receivables.",
+  "summary": "Read finance snapshot; leftover: confirm settlement evidence for one invoice.",
+  "provenance": {
+    "source": {
+      "system": "collector",
+      "kind": "report",
+      "locator": "agent-activity/01K3CC-LEDGER-PARTIAL"
+    },
+    "observed_at": "2026-08-20T18:10:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.9
+  },
+  "actor": { "kind": "agent", "id": "agent:cc-context" },
+  "evidence_refs": ["cc:finance-snapshot:01K3CC-RO-RECEIVABLES"],
+  "residual_work": ["Confirm settlement evidence for invoice overdue more than 30 days"]
+}

--- a/control-center/contracts/fixtures/valid/agent-session.json
+++ b/control-center/contracts/fixtures/valid/agent-session.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "control-center.agent-session.v1",
+  "id": "cc:agent-session:01K3CC-CTX-FINANCE",
+  "agent_id": "agent:cc-context",
+  "requested_scopes": ["finance", "client:acme-industria"],
+  "granted_scopes": ["finance", "client:acme-industria"],
+  "purpose": "Prepare a scoped briefing for overdue receivables. Must not dump company-wide memory.",
+  "started_at": "2026-08-20T17:50:00Z",
+  "ended_at": null,
+  "status": "open",
+  "created_by": { "kind": "agent", "id": "agent:cc-context" },
+  "include_directives": true,
+  "include_snapshots": true,
+  "include_attention": true
+}

--- a/control-center/contracts/fixtures/valid/attention-item.json
+++ b/control-center/contracts/fixtures/valid/attention-item.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "control-center.attention-item.v1",
+  "id": "cc:attention-item:01K3CC-OVERDUE-INVOICE",
+  "scope": "client:acme-industria",
+  "severity": "high",
+  "status": "open",
+  "title": "Overdue invoice for acme-industria",
+  "summary": "Open receivable older than the agreed window. Origin system is Asaas via read-only observation; do not charge from Control Center.",
+  "provenance": {
+    "source": {
+      "system": "asaas",
+      "kind": "receivable-read",
+      "locator": "finance/receivables/open"
+    },
+    "observed_at": "2026-08-20T17:00:00Z",
+    "freshness_status": "STALE",
+    "confidence": 0.74,
+    "freshness_window_seconds": 1800
+  },
+  "detected_at": "2026-08-20T17:00:00Z",
+  "homepage_eligible": true,
+  "recommended_action": "Review in Warmbly/Asaas origin; do not mutate from this cockpit."
+}

--- a/control-center/contracts/fixtures/valid/audit-event.json
+++ b/control-center/contracts/fixtures/valid/audit-event.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "control-center.audit-event.v1",
+  "id": "cc:audit-event:01K3CC-GET-CONTEXT",
+  "at": "2026-08-20T17:50:01Z",
+  "actor": { "kind": "agent", "id": "agent:cc-context" },
+  "action": "context.get",
+  "resource_type": "AgentSession",
+  "resource_id": "cc:agent-session:01K3CC-CTX-FINANCE",
+  "scope": "finance",
+  "outcome": "success",
+  "detail": {
+    "requested_scopes": ["finance", "client:acme-industria"],
+    "granted_scopes": ["finance", "client:acme-industria"]
+  },
+  "request_id": "req-01K3CC-CONTEXT"
+}

--- a/control-center/contracts/fixtures/valid/client-status.json
+++ b/control-center/contracts/fixtures/valid/client-status.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "control-center.client-status.v1",
+  "id": "cc:client-status:acme-industria",
+  "scope": "client:acme-industria",
+  "client_slug": "acme-industria",
+  "display_name": "Acme Indústria",
+  "lifecycle": "churn_risk",
+  "provenance": {
+    "source": {
+      "system": "warmbly",
+      "kind": "client-record",
+      "locator": "clients/acme-industria"
+    },
+    "observed_at": "2026-08-20T16:30:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.8
+  },
+  "open_receivables": {
+    "amount_cents": 1500000,
+    "currency": "BRL"
+  },
+  "attention_item_ids": ["cc:attention-item:01K3CC-OVERDUE-INVOICE"]
+}

--- a/control-center/contracts/fixtures/valid/collector-run.json
+++ b/control-center/contracts/fixtures/valid/collector-run.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "control-center.collector-run.v1",
+  "id": "cc:collector-run:01K3CC-GITHUB-HOURLY",
+  "collector_name": "github-repo",
+  "scope": "repo:tjsasakifln/Governance",
+  "status": "succeeded",
+  "started_at": "2026-08-20T17:54:00Z",
+  "finished_at": "2026-08-20T17:54:08Z",
+  "idempotency_key": "github-repo:tjsasakifln/Governance:2026-08-20T17:00:00Z",
+  "read_only": true,
+  "observations_emitted": 1,
+  "cursor": "github:etag:abc123"
+}

--- a/control-center/contracts/fixtures/valid/commercial-snapshot.json
+++ b/control-center/contracts/fixtures/valid/commercial-snapshot.json
@@ -18,7 +18,29 @@
     "commercial_runtime": "warmbly",
     "this_document": "read_model"
   },
+  "offer_pin": {
+    "catalog_authority": "governance",
+    "catalog_id": "CFG-OFFER-CATALOG-v1",
+    "known_offer_ids": ["CFG-DIAG-EXP-v1", "CFG-DIRB2G-FLEX-v1"]
+  },
+  "funnel": {
+    "new_leads": 6,
+    "qualified": 4,
+    "opportunities": 3,
+    "proposals": 2,
+    "clients": 1
+  },
+  "pipeline_nominal": { "amount_cents": 4800000, "currency": "BRL" },
+  "pipeline_weighted": {
+    "amount_cents": 2100000,
+    "currency": "BRL",
+    "probability_reliable": true
+  },
+  "aging_count": 1,
+  "stalled_count": 1,
+  "missing_next_action_count": 2,
   "pipeline_open_count": 4,
   "inbound_unread_count": 3,
-  "at_risk_client_count": 1
+  "at_risk_client_count": 1,
+  "attention_item_ids": ["cc:attention-item:01K3CC-STALLED-DEAL"]
 }

--- a/control-center/contracts/fixtures/valid/commercial-snapshot.json
+++ b/control-center/contracts/fixtures/valid/commercial-snapshot.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "control-center.commercial-snapshot.v1",
+  "id": "cc:commercial-snapshot:01K3CC-WARMBLY-OPS",
+  "scope": "commercial",
+  "generated_at": "2026-08-20T17:40:00Z",
+  "provenance": {
+    "source": {
+      "system": "warmbly",
+      "kind": "crm-read-model",
+      "locator": "commercial/pipeline"
+    },
+    "observed_at": "2026-08-20T17:39:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.84
+  },
+  "authority": {
+    "catalog_authority": "governance",
+    "commercial_runtime": "warmbly",
+    "this_document": "read_model"
+  },
+  "pipeline_open_count": 4,
+  "inbound_unread_count": 3,
+  "at_risk_client_count": 1
+}

--- a/control-center/contracts/fixtures/valid/directive.json
+++ b/control-center/contracts/fixtures/valid/directive.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "control-center.directive.v1",
+  "id": "cc:directive:01K3CC-NO-PROVIDER-MUTATION",
+  "kind": "constraint",
+  "scope": "finance",
+  "status": "active",
+  "title": "No provider financial mutations in Control Center",
+  "body": "Control Center collectors and agents MUST NOT execute cobrança, checkout, refund, cancelamento, Asaas writes, or commercial send. Those remain in origin systems under separate authority.",
+  "effective_from": "2026-08-20T00:00:00Z",
+  "expires_at": null,
+  "supersedes": null,
+  "created_by": { "kind": "human", "id": "human:operator" },
+  "created_at": "2026-08-20T12:00:00Z",
+  "updated_at": "2026-08-20T12:00:00Z",
+  "audit": [
+    {
+      "at": "2026-08-20T12:00:00Z",
+      "actor": { "kind": "human", "id": "human:operator" },
+      "action": "created",
+      "to_status": "active"
+    }
+  ],
+  "tags": ["fail-closed", "finance"]
+}

--- a/control-center/contracts/fixtures/valid/engineering-snapshot.json
+++ b/control-center/contracts/fixtures/valid/engineering-snapshot.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "control-center.engineering-snapshot.v1",
+  "id": "cc:engineering-snapshot:01K3CC-GOVERNANCE-REPO",
+  "scope": "repo:tjsasakifln/Governance",
+  "generated_at": "2026-08-20T17:55:00Z",
+  "provenance": {
+    "source": {
+      "system": "github",
+      "kind": "repo-read",
+      "locator": "repos/tjsasakifln/Governance"
+    },
+    "observed_at": "2026-08-20T17:54:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.95
+  },
+  "open_pr_count": 1,
+  "failing_check_count": 0,
+  "open_incident_count": 0,
+  "repo_scopes": ["repo:tjsasakifln/Governance"]
+}

--- a/control-center/contracts/fixtures/valid/finance-snapshot.json
+++ b/control-center/contracts/fixtures/valid/finance-snapshot.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "control-center.finance-snapshot.v1",
+  "id": "cc:finance-snapshot:01K3CC-RO-RECEIVABLES",
+  "scope": "finance",
+  "generated_at": "2026-08-20T17:20:00Z",
+  "provenance": {
+    "source": {
+      "system": "asaas",
+      "kind": "receivable-read",
+      "locator": "finance/receivables"
+    },
+    "observed_at": "2026-08-20T17:10:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.7
+  },
+  "read_model_only": true,
+  "provider_mutations": "forbidden",
+  "receivables_open": { "amount_cents": 2500000, "currency": "BRL" },
+  "receivables_overdue": { "amount_cents": 1500000, "currency": "BRL" }
+}

--- a/control-center/contracts/fixtures/valid/finance-snapshot.json
+++ b/control-center/contracts/fixtures/valid/finance-snapshot.json
@@ -15,6 +15,39 @@
   },
   "read_model_only": true,
   "provider_mutations": "forbidden",
-  "receivables_open": { "amount_cents": 2500000, "currency": "BRL" },
-  "receivables_overdue": { "amount_cents": 1500000, "currency": "BRL" }
+  "contracted": { "amount_cents": 5000000, "currency": "BRL" },
+  "billed": { "amount_cents": 4000000, "currency": "BRL" },
+  "paid": { "amount_cents": 2500000, "currency": "BRL" },
+  "effectively_received": { "amount_cents": 2300000, "currency": "BRL" },
+  "overdue": { "amount_cents": 1500000, "currency": "BRL" },
+  "receivable": { "amount_cents": 2500000, "currency": "BRL" },
+  "refunds": { "amount_cents": 100000, "currency": "BRL" },
+  "chargebacks": { "amount_cents": 100000, "currency": "BRL" },
+  "cash_in": {
+    "amount_cents": 2300000,
+    "currency": "BRL",
+    "evidenced": true,
+    "source": {
+      "system": "asaas",
+      "kind": "settlement-read",
+      "locator": "finance/settlements"
+    },
+    "window": {
+      "from": "2026-08-01T00:00:00Z",
+      "to": "2026-08-20T17:10:00Z"
+    }
+  },
+  "mrr": {
+    "amount_cents": 180000,
+    "currency": "BRL",
+    "applicable": true,
+    "basis": "recurring_monthly"
+  },
+  "runway": {
+    "months": 8,
+    "cash_balance": { "amount_cents": 16000000, "currency": "BRL" },
+    "monthly_expense": { "amount_cents": 2000000, "currency": "BRL" },
+    "cash_reliable": true,
+    "expense_reliable": true
+  }
 }

--- a/control-center/contracts/fixtures/valid/operational-snapshot.json
+++ b/control-center/contracts/fixtures/valid/operational-snapshot.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": "control-center.operational-snapshot.v1",
+  "id": "cc:operational-snapshot:01K3CC-COMPANY-NOW",
+  "scope": "company",
+  "generated_at": "2026-08-20T17:59:00Z",
+  "provenance": {
+    "source": {
+      "system": "collector",
+      "kind": "snapshot-composer",
+      "locator": "snapshots/company"
+    },
+    "observed_at": "2026-08-20T17:58:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.82
+  },
+  "headline": "Three inbound items unread; one overdue receivable; GitHub collector healthy.",
+  "top_priorities": [
+    {
+      "schema_version": "control-center.priority-recommendation.v1",
+      "id": "cc:priority-recommendation:01K3CC-RANK-1-INBOUND",
+      "scope": "company",
+      "rank": 1,
+      "title": "Clear three unread inbound items",
+      "rationale": "Inbound queue has unread items older than four hours.",
+      "provenance": {
+        "source": {
+          "system": "warmbly",
+          "kind": "inbound-queue",
+          "locator": "inbound/unread"
+        },
+        "observed_at": "2026-08-20T17:45:00Z",
+        "freshness_status": "FRESH",
+        "confidence": 0.88
+      },
+      "generated_at": "2026-08-20T17:46:00Z",
+      "horizon": "now"
+    },
+    {
+      "schema_version": "control-center.priority-recommendation.v1",
+      "id": "cc:priority-recommendation:01K3CC-RANK-2-RECEIVABLE",
+      "scope": "company",
+      "rank": 2,
+      "title": "Review overdue receivable for acme-industria",
+      "rationale": "Open receivable is stale in the origin read model.",
+      "provenance": {
+        "source": {
+          "system": "asaas",
+          "kind": "receivable-read",
+          "locator": "finance/receivables/open"
+        },
+        "observed_at": "2026-08-20T17:00:00Z",
+        "freshness_status": "STALE",
+        "confidence": 0.74
+      },
+      "generated_at": "2026-08-20T17:46:00Z",
+      "horizon": "today"
+    },
+    {
+      "schema_version": "control-center.priority-recommendation.v1",
+      "id": "cc:priority-recommendation:01K3CC-RANK-3-DIRECTIVE",
+      "scope": "company",
+      "rank": 3,
+      "title": "Keep provider mutations out of this cockpit",
+      "rationale": "Active constraint forbids cobrança, checkout, refund and Asaas writes from Control Center.",
+      "provenance": {
+        "source": {
+          "system": "governance",
+          "kind": "directive",
+          "locator": "cc:directive:01K3CC-NO-PROVIDER-MUTATION"
+        },
+        "observed_at": "2026-08-20T12:00:00Z",
+        "freshness_status": "FRESH",
+        "confidence": 1
+      },
+      "generated_at": "2026-08-20T17:46:00Z",
+      "horizon": "this_week",
+      "directive_ids": ["cc:directive:01K3CC-NO-PROVIDER-MUTATION"]
+    }
+  ],
+  "attention_items": [
+    {
+      "schema_version": "control-center.attention-item.v1",
+      "id": "cc:attention-item:01K3CC-OVERDUE-INVOICE",
+      "scope": "client:acme-industria",
+      "severity": "high",
+      "status": "open",
+      "title": "Overdue invoice for acme-industria",
+      "summary": "Open receivable older than the agreed window.",
+      "provenance": {
+        "source": {
+          "system": "asaas",
+          "kind": "receivable-read",
+          "locator": "finance/receivables/open"
+        },
+        "observed_at": "2026-08-20T17:00:00Z",
+        "freshness_status": "STALE",
+        "confidence": 0.74
+      },
+      "detected_at": "2026-08-20T17:00:00Z",
+      "homepage_eligible": true
+    }
+  ],
+  "health": [
+    {
+      "schema_version": "control-center.service-health.v1",
+      "id": "cc:service-health:01K3CC-CONTEXT-API",
+      "scope": "infrastructure",
+      "service_name": "context-service",
+      "status": "healthy",
+      "provenance": {
+        "source": {
+          "system": "collector",
+          "kind": "health-probe",
+          "locator": "health/context-service"
+        },
+        "observed_at": "2026-08-20T17:58:00Z",
+        "freshness_status": "FRESH",
+        "confidence": 0.99
+      },
+      "checked_at": "2026-08-20T17:58:00Z"
+    }
+  ],
+  "commercial_snapshot_id": "cc:commercial-snapshot:01K3CC-WARMBLY-OPS",
+  "finance_snapshot_id": "cc:finance-snapshot:01K3CC-RO-RECEIVABLES",
+  "engineering_snapshot_id": "cc:engineering-snapshot:01K3CC-GOVERNANCE-REPO",
+  "client_status_ids": ["cc:client-status:acme-industria"]
+}

--- a/control-center/contracts/fixtures/valid/priority-recommendation.json
+++ b/control-center/contracts/fixtures/valid/priority-recommendation.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "control-center.priority-recommendation.v1",
+  "id": "cc:priority-recommendation:01K3CC-RANK-1-INBOUND",
+  "scope": "company",
+  "rank": 1,
+  "title": "Clear three unread inbound items",
+  "rationale": "Inbound queue has unread items older than four hours. Homepage shows this as the first of at most three current priorities.",
+  "provenance": {
+    "source": {
+      "system": "warmbly",
+      "kind": "inbound-queue",
+      "locator": "inbound/unread"
+    },
+    "observed_at": "2026-08-20T17:45:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.88
+  },
+  "generated_at": "2026-08-20T17:46:00Z",
+  "horizon": "now",
+  "attention_item_ids": ["cc:attention-item:01K3CC-OVERDUE-INVOICE"]
+}

--- a/control-center/contracts/fixtures/valid/service-health.json
+++ b/control-center/contracts/fixtures/valid/service-health.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "control-center.service-health.v1",
+  "id": "cc:service-health:01K3CC-CONTEXT-API",
+  "scope": "infrastructure",
+  "service_name": "context-service",
+  "status": "healthy",
+  "provenance": {
+    "source": {
+      "system": "collector",
+      "kind": "health-probe",
+      "locator": "health/context-service"
+    },
+    "observed_at": "2026-08-20T17:58:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.99,
+    "freshness_window_seconds": 60
+  },
+  "checked_at": "2026-08-20T17:58:00Z",
+  "latency_ms": 42,
+  "checks": [
+    { "name": "ready", "status": "healthy" }
+  ]
+}

--- a/control-center/contracts/fixtures/valid/source-observation.json
+++ b/control-center/contracts/fixtures/valid/source-observation.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "control-center.source-observation.v1",
+  "id": "cc:source-observation:01K3CC-WARMBLY-INBOUND",
+  "scope": "inbound",
+  "provenance": {
+    "source": {
+      "system": "warmbly",
+      "kind": "inbound-queue",
+      "locator": "inbound/unread"
+    },
+    "observed_at": "2026-08-20T17:45:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 0.91,
+    "freshness_window_seconds": 600
+  },
+  "collected_at": "2026-08-20T17:45:12Z",
+  "idempotency_key": "warmbly:inbound:unread:2026-08-20T17:45:00Z",
+  "payload": {
+    "unread_count": 3,
+    "oldest_unread_at": "2026-08-20T14:02:00Z"
+  }
+}

--- a/control-center/contracts/package-lock.json
+++ b/control-center/contracts/package-lock.json
@@ -1,0 +1,646 @@
+{
+  "name": "@confenge/control-center-contracts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-contracts",
+      "version": "1.0.0",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1"
+      },
+      "bin": {
+        "cc-contracts-validate": "src/cli.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^22.18.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/control-center/contracts/package.json
+++ b/control-center/contracts/package.json
@@ -11,8 +11,9 @@
     "cc-contracts-validate": "./src/cli.ts"
   },
   "scripts": {
-    "test": "tsx --test tests/contract.test.ts",
+    "test": "tsx --test tests/*.test.ts",
     "validate": "tsx src/cli.ts",
+    "fingerprint": "tsx src/cli.ts --fingerprint",
     "typecheck": "tsc --noEmit"
   },
   "engines": {

--- a/control-center/contracts/package.json
+++ b/control-center/contracts/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@confenge/control-center-contracts",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Canonical Control Center contracts: JSON Schema, TypeScript types, HTTP/MCP docs, fixtures, and validator. No services.",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "cc-contracts-validate": "./src/cli.ts"
+  },
+  "scripts": {
+    "test": "tsx --test tests/contract.test.ts",
+    "validate": "tsx src/cli.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/contracts/schemas/agent-activity.v1.schema.json
+++ b/control-center/contracts/schemas/agent-activity.v1.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/agent-activity.v1.schema.json",
+  "title": "AgentActivity v1",
+  "description": "Execution ledger record of what an agent ran (goal, evidence, leftover work). Distinct from AgentSession, which is a scoped context-consult grant with status open|closed|denied. Not a chat log. Founder/human approval is never implied by this document.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "agent_id",
+    "scope",
+    "status",
+    "started_at",
+    "finished_at",
+    "goal",
+    "summary",
+    "provenance",
+    "actor"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.agent-activity.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "agent_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9._:@-]+$"
+    },
+    "session_id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["running", "done", "partial", "blocked", "failed"]
+    },
+    "started_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "finished_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/nullable_utc_datetime"
+    },
+    "goal": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "summary": { "type": "string", "minLength": 1, "maxLength": 2000 },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "actor": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/actor_ref"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1, "maxLength": 512 }
+    },
+    "residual_work": {
+      "type": "array",
+      "maxItems": 32,
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 }
+    },
+    "related_ids": {
+      "type": "array",
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    }
+  },
+  "if": {
+    "properties": { "status": { "const": "running" } },
+    "required": ["status"]
+  },
+  "then": {
+    "properties": {
+      "finished_at": { "type": "null" }
+    }
+  }
+}

--- a/control-center/contracts/schemas/agent-context.v1.schema.json
+++ b/control-center/contracts/schemas/agent-context.v1.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/agent-context.v1.schema.json",
+  "title": "AgentContext v1",
+  "description": "HTTP/MCP response envelope. Not a core resource. Returned only for granted_scopes. Empty requested_scopes is invalid.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "requested_scopes",
+    "granted_scopes",
+    "as_of",
+    "directives",
+    "attention_items",
+    "top_priorities",
+    "snapshots",
+    "client_statuses",
+    "truncated"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.agent-context.v1" },
+    "requested_scopes": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+      }
+    },
+    "granted_scopes": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+      }
+    },
+    "as_of": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "directives": {
+      "type": "array",
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/directive.v1.schema.json"
+      }
+    },
+    "attention_items": {
+      "type": "array",
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/attention-item.v1.schema.json"
+      }
+    },
+    "top_priorities": {
+      "type": "array",
+      "maxItems": 3,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/priority-recommendation.v1.schema.json"
+      }
+    },
+    "snapshots": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "operational": {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/operational-snapshot.v1.schema.json"
+        },
+        "commercial": {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/commercial-snapshot.v1.schema.json"
+        },
+        "finance": {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/finance-snapshot.v1.schema.json"
+        },
+        "engineering": {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/engineering-snapshot.v1.schema.json"
+        }
+      }
+    },
+    "client_statuses": {
+      "type": "array",
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/client-status.v1.schema.json"
+      }
+    },
+    "truncated": { "type": "boolean" }
+  }
+}

--- a/control-center/contracts/schemas/agent-session.v1.schema.json
+++ b/control-center/contracts/schemas/agent-session.v1.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/agent-session.v1.schema.json",
+  "title": "AgentSession v1",
+  "description": "Agent context session. Agents consult by scope. requested_scopes minItems 1 — there is no implicit whole-company dump. granted_scopes is fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "agent_id",
+    "requested_scopes",
+    "granted_scopes",
+    "purpose",
+    "started_at",
+    "ended_at",
+    "status",
+    "created_by",
+    "include_directives",
+    "include_snapshots",
+    "include_attention"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.agent-session.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "agent_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9._:@-]+$"
+    },
+    "requested_scopes": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+      }
+    },
+    "granted_scopes": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+      }
+    },
+    "purpose": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "started_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "ended_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/nullable_utc_datetime"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["open", "closed", "denied"]
+    },
+    "created_by": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/actor_ref"
+    },
+    "include_directives": { "type": "boolean" },
+    "include_snapshots": { "type": "boolean" },
+    "include_attention": { "type": "boolean" }
+  },
+  "if": {
+    "properties": { "status": { "const": "denied" } },
+    "required": ["status"]
+  },
+  "then": {
+    "properties": {
+      "granted_scopes": { "type": "array", "maxItems": 0 }
+    }
+  }
+}

--- a/control-center/contracts/schemas/attention-item.v1.schema.json
+++ b/control-center/contracts/schemas/attention-item.v1.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/attention-item.v1.schema.json",
+  "title": "AttentionItem v1",
+  "description": "Exception or item requiring human attention. The homepage privileges these over KPI walls.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scope",
+    "severity",
+    "status",
+    "title",
+    "summary",
+    "provenance",
+    "detected_at",
+    "homepage_eligible"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.attention-item.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"]
+    },
+    "status": {
+      "type": "string",
+      "enum": ["open", "acknowledged", "resolved", "dismissed"]
+    },
+    "title": { "type": "string", "minLength": 1, "maxLength": 200 },
+    "summary": { "type": "string", "minLength": 1, "maxLength": 2000 },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "detected_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "homepage_eligible": { "type": "boolean" },
+    "recommended_action": { "type": "string", "minLength": 1, "maxLength": 1000 },
+    "related_ids": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    }
+  }
+}

--- a/control-center/contracts/schemas/audit-event.v1.schema.json
+++ b/control-center/contracts/schemas/audit-event.v1.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/audit-event.v1.schema.json",
+  "title": "AuditEvent v1",
+  "description": "Immutable audit trail entry. detail MUST NOT contain secrets. Structured logs of Control Center MUST follow the same rule.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "at",
+    "actor",
+    "action",
+    "resource_type",
+    "resource_id",
+    "scope",
+    "outcome",
+    "detail"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.audit-event.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "actor": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/actor_ref"
+    },
+    "action": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z][a-z0-9._-]*$"
+    },
+    "resource_type": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[A-Za-z][A-Za-z0-9]*$"
+    },
+    "resource_id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/nullable_resource_id"
+    },
+    "scope": {
+      "oneOf": [
+        {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+        },
+        { "type": "null" }
+      ]
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["success", "denied", "error"]
+    },
+    "detail": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/non_secret_property_names"
+      }
+    },
+    "request_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9._:-]+$"
+    }
+  }
+}

--- a/control-center/contracts/schemas/client-status.v1.schema.json
+++ b/control-center/contracts/schemas/client-status.v1.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/client-status.v1.schema.json",
+  "title": "ClientStatus v1",
+  "description": "Aggregated per-client operational status. scope MUST equal client:<client_slug>.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scope",
+    "client_slug",
+    "display_name",
+    "lifecycle",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.client-status.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/client_scope"
+    },
+    "client_slug": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/client_slug"
+    },
+    "display_name": { "type": "string", "minLength": 1, "maxLength": 200 },
+    "lifecycle": {
+      "type": "string",
+      "enum": ["lead", "active", "paused", "churn_risk", "churned", "unknown"]
+    },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "attention_item_ids": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    },
+    "open_receivables": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "notes": { "type": "string", "minLength": 1, "maxLength": 2000 }
+  }
+}

--- a/control-center/contracts/schemas/collector-run.v1.schema.json
+++ b/control-center/contracts/schemas/collector-run.v1.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/collector-run.v1.schema.json",
+  "title": "CollectorRun v1",
+  "description": "Idempotent collector execution. Collectors are read-only by default. Re-running the same idempotency_key MUST NOT duplicate observations.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "collector_name",
+    "scope",
+    "status",
+    "started_at",
+    "finished_at",
+    "idempotency_key",
+    "read_only",
+    "observations_emitted"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.collector-run.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "collector_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "scope": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["started", "succeeded", "failed", "skipped"]
+    },
+    "started_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "finished_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/nullable_utc_datetime"
+    },
+    "idempotency_key": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/idempotency_key"
+    },
+    "read_only": { "const": true },
+    "observations_emitted": { "type": "integer", "minimum": 0 },
+    "error": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/error_object"
+    },
+    "cursor": {
+      "type": ["string", "null"],
+      "maxLength": 256
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "status": { "const": "failed" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/error_object"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "started" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "finished_at": { "type": "null" }
+        }
+      }
+    }
+  ]
+}

--- a/control-center/contracts/schemas/commercial-snapshot.v1.schema.json
+++ b/control-center/contracts/schemas/commercial-snapshot.v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/commercial-snapshot.v1.schema.json",
   "title": "CommercialSnapshot v1",
-  "description": "Read model of commercial/CRM operational state. Warmbly is the commercial runtime; Governance remains catalog/terms authority. This document is not a second catalog and does not authorize checkout or send.",
+  "description": "Warmbly commercial/CRM read model. Governance remains catalog/terms authority; this document pins catalog identity and MUST NOT copy names, prices, terms, or offer copy. Funnel counts: new_leads, qualified, opportunities, proposals, clients. pipeline_weighted is absent unless probability is reliable. Not a checkout or send surface.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -12,6 +12,12 @@
     "generated_at",
     "provenance",
     "authority",
+    "offer_pin",
+    "funnel",
+    "pipeline_nominal",
+    "aging_count",
+    "stalled_count",
+    "missing_next_action_count",
     "pipeline_open_count",
     "inbound_unread_count",
     "at_risk_client_count"
@@ -48,6 +54,60 @@
         "this_document": { "const": "read_model" }
       }
     },
+    "offer_pin": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Identity pin of the Governance catalog. IDs only. Names, prices, terms, and copy are forbidden here.",
+      "required": ["catalog_authority", "catalog_id"],
+      "properties": {
+        "catalog_authority": { "const": "governance" },
+        "catalog_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9._:-]+$"
+        },
+        "known_offer_ids": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9._:-]+$"
+          }
+        }
+      }
+    },
+    "funnel": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Warmbly funnel counts. new_leads=novos leads, qualified=qualificados, opportunities=oportunidades, proposals=propostas, clients=clientes.",
+      "required": [
+        "new_leads",
+        "qualified",
+        "opportunities",
+        "proposals",
+        "clients"
+      ],
+      "properties": {
+        "new_leads": { "type": "integer", "minimum": 0 },
+        "qualified": { "type": "integer", "minimum": 0 },
+        "opportunities": { "type": "integer", "minimum": 0 },
+        "proposals": { "type": "integer", "minimum": 0 },
+        "clients": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "pipeline_nominal": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "pipeline_weighted": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/weighted_pipeline"
+    },
+    "aging_count": { "type": "integer", "minimum": 0 },
+    "stalled_count": { "type": "integer", "minimum": 0 },
+    "missing_next_action_count": { "type": "integer", "minimum": 0 },
     "pipeline_open_count": { "type": "integer", "minimum": 0 },
     "inbound_unread_count": { "type": "integer", "minimum": 0 },
     "at_risk_client_count": { "type": "integer", "minimum": 0 },

--- a/control-center/contracts/schemas/commercial-snapshot.v1.schema.json
+++ b/control-center/contracts/schemas/commercial-snapshot.v1.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/commercial-snapshot.v1.schema.json",
+  "title": "CommercialSnapshot v1",
+  "description": "Read model of commercial/CRM operational state. Warmbly is the commercial runtime; Governance remains catalog/terms authority. This document is not a second catalog and does not authorize checkout or send.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scope",
+    "generated_at",
+    "provenance",
+    "authority",
+    "pipeline_open_count",
+    "inbound_unread_count",
+    "at_risk_client_count"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.commercial-snapshot.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "oneOf": [
+        { "const": "commercial" },
+        { "const": "company" },
+        { "const": "inbound" },
+        { "const": "clients" },
+        {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/client_scope"
+        }
+      ]
+    },
+    "generated_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["catalog_authority", "commercial_runtime", "this_document"],
+      "properties": {
+        "catalog_authority": { "const": "governance" },
+        "commercial_runtime": { "const": "warmbly" },
+        "this_document": { "const": "read_model" }
+      }
+    },
+    "pipeline_open_count": { "type": "integer", "minimum": 0 },
+    "inbound_unread_count": { "type": "integer", "minimum": 0 },
+    "at_risk_client_count": { "type": "integer", "minimum": 0 },
+    "attention_item_ids": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    }
+  }
+}

--- a/control-center/contracts/schemas/directive.v1.schema.json
+++ b/control-center/contracts/schemas/directive.v1.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/directive.v1.schema.json",
+  "title": "Directive v1",
+  "description": "Human-authored structured memory. Governance is canonical for strategic directives. Not a chat message.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "kind",
+    "scope",
+    "status",
+    "title",
+    "body",
+    "effective_from",
+    "expires_at",
+    "supersedes",
+    "created_by",
+    "created_at",
+    "updated_at",
+    "audit"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.directive.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "decision",
+        "directive",
+        "fact",
+        "constraint",
+        "priority",
+        "risk",
+        "hypothesis"
+      ]
+    },
+    "scope": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "superseded", "revoked", "expired"]
+    },
+    "title": { "type": "string", "minLength": 1, "maxLength": 200 },
+    "body": { "type": "string", "minLength": 1, "maxLength": 8000 },
+    "effective_from": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "expires_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/nullable_utc_datetime"
+    },
+    "supersedes": {
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      },
+      "maxItems": 32,
+      "uniqueItems": true
+    },
+    "created_by": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/actor_ref"
+    },
+    "created_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "updated_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "audit": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 256,
+      "items": { "$ref": "#/$defs/audit_entry" }
+    },
+    "tags": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1, "maxLength": 48, "pattern": "^[a-z0-9][a-z0-9-]*$" }
+    },
+    "related_ids": {
+      "type": "array",
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    }
+  },
+  "if": {
+    "properties": { "status": { "const": "expired" } },
+    "required": ["status"]
+  },
+  "then": {
+    "required": ["expires_at"],
+    "properties": {
+      "expires_at": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+      }
+    }
+  },
+  "$defs": {
+    "audit_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["at", "actor", "action"],
+      "properties": {
+        "at": {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+        },
+        "actor": {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/actor_ref"
+        },
+        "action": {
+          "type": "string",
+          "enum": ["created", "updated", "status_changed", "superseded", "revoked"]
+        },
+        "from_status": {
+          "type": "string",
+          "enum": ["draft", "active", "superseded", "revoked", "expired"]
+        },
+        "to_status": {
+          "type": "string",
+          "enum": ["draft", "active", "superseded", "revoked", "expired"]
+        },
+        "note": { "type": "string", "minLength": 1, "maxLength": 512 }
+      }
+    }
+  }
+}

--- a/control-center/contracts/schemas/engineering-snapshot.v1.schema.json
+++ b/control-center/contracts/schemas/engineering-snapshot.v1.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/engineering-snapshot.v1.schema.json",
+  "title": "EngineeringSnapshot v1",
+  "description": "Aggregated engineering/repo state. Scope is company, infrastructure, or repo:<name>.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scope",
+    "generated_at",
+    "provenance",
+    "open_pr_count",
+    "failing_check_count",
+    "open_incident_count"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.engineering-snapshot.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "oneOf": [
+        { "const": "infrastructure" },
+        { "const": "company" },
+        {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/repo_scope"
+        }
+      ]
+    },
+    "generated_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "open_pr_count": { "type": "integer", "minimum": 0 },
+    "failing_check_count": { "type": "integer", "minimum": 0 },
+    "open_incident_count": { "type": "integer", "minimum": 0 },
+    "repo_scopes": {
+      "type": "array",
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/repo_scope"
+      }
+    },
+    "attention_item_ids": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    }
+  }
+}

--- a/control-center/contracts/schemas/finance-snapshot.v1.schema.json
+++ b/control-center/contracts/schemas/finance-snapshot.v1.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/finance-snapshot.v1.schema.json",
+  "title": "FinanceSnapshot v1",
+  "description": "Read-only aggregated finance state. Provider/financial mutations (cobrança, checkout, refund, cancelamento, Asaas writes) are forbidden in this campaign and MUST NOT appear on this document.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scope",
+    "generated_at",
+    "provenance",
+    "read_model_only",
+    "provider_mutations",
+    "receivables_open",
+    "receivables_overdue"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.finance-snapshot.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "oneOf": [
+        { "const": "finance" },
+        { "const": "company" },
+        {
+          "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/client_scope"
+        }
+      ]
+    },
+    "generated_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "read_model_only": { "const": true },
+    "provider_mutations": { "const": "forbidden" },
+    "receivables_open": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "receivables_overdue": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "attention_item_ids": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    }
+  }
+}

--- a/control-center/contracts/schemas/finance-snapshot.v1.schema.json
+++ b/control-center/contracts/schemas/finance-snapshot.v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/finance-snapshot.v1.schema.json",
   "title": "FinanceSnapshot v1",
-  "description": "Read-only aggregated finance state. Provider/financial mutations (cobrança, checkout, refund, cancelamento, Asaas writes) are forbidden in this campaign and MUST NOT appear on this document.",
+  "description": "Read-only aggregated finance state. Stages are not aliases: contracted (signed obligation), billed (invoiced), paid (provider-confirmed, not caixa), effectively_received (settlement), overdue, receivable (open AR, includes overdue). Refunds and chargebacks are aggregated. cash_in, mrr, and runway are absent-or-gated. Provider/financial mutations (cobrança, checkout, refund, cancelamento, Asaas writes) are forbidden and MUST NOT appear on this document.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -13,8 +13,14 @@
     "provenance",
     "read_model_only",
     "provider_mutations",
-    "receivables_open",
-    "receivables_overdue"
+    "contracted",
+    "billed",
+    "paid",
+    "effectively_received",
+    "overdue",
+    "receivable",
+    "refunds",
+    "chargebacks"
   ],
   "properties": {
     "schema_version": { "const": "control-center.finance-snapshot.v1" },
@@ -38,11 +44,38 @@
     },
     "read_model_only": { "const": true },
     "provider_mutations": { "const": "forbidden" },
-    "receivables_open": {
+    "contracted": {
       "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
     },
-    "receivables_overdue": {
+    "billed": {
       "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "paid": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "effectively_received": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "overdue": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "receivable": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "refunds": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "chargebacks": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "cash_in": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/evidenced_cash_in"
+    },
+    "mrr": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/applicable_mrr"
+    },
+    "runway": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/reliable_runway"
     },
     "attention_item_ids": {
       "type": "array",

--- a/control-center/contracts/schemas/operational-snapshot.v1.schema.json
+++ b/control-center/contracts/schemas/operational-snapshot.v1.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/operational-snapshot.v1.schema.json",
+  "title": "OperationalSnapshot v1",
+  "description": "Cockpit roll-up for a scope. Privileges exceptions and at most three current priorities. Not a KPI wall.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scope",
+    "generated_at",
+    "provenance",
+    "headline",
+    "top_priorities",
+    "attention_items",
+    "health",
+    "commercial_snapshot_id",
+    "finance_snapshot_id",
+    "engineering_snapshot_id",
+    "client_status_ids"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.operational-snapshot.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+    },
+    "generated_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "headline": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 280,
+      "description": "One-line 'what matters now' for the homepage."
+    },
+    "top_priorities": {
+      "type": "array",
+      "maxItems": 3,
+      "description": "At most the three most important things now for this scope.",
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/priority-recommendation.v1.schema.json"
+      }
+    },
+    "attention_items": {
+      "type": "array",
+      "maxItems": 50,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/attention-item.v1.schema.json"
+      }
+    },
+    "health": {
+      "type": "array",
+      "maxItems": 32,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/service-health.v1.schema.json"
+      }
+    },
+    "commercial_snapshot_id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/nullable_resource_id"
+    },
+    "finance_snapshot_id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/nullable_resource_id"
+    },
+    "engineering_snapshot_id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/nullable_resource_id"
+    },
+    "client_status_ids": {
+      "type": "array",
+      "maxItems": 256,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    }
+  }
+}

--- a/control-center/contracts/schemas/primitives.v1.schema.json
+++ b/control-center/contracts/schemas/primitives.v1.schema.json
@@ -144,6 +144,79 @@
         }
       }
     },
+    "time_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to"],
+      "properties": {
+        "from": { "$ref": "#/$defs/utc_datetime" },
+        "to": { "$ref": "#/$defs/utc_datetime" }
+      }
+    },
+    "evidenced_cash_in": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Cash-in aggregate. MUST be omitted unless settlement/cash movement is evidenced. Silent invention of caixa is forbidden.",
+      "required": ["amount_cents", "currency", "evidenced", "source"],
+      "properties": {
+        "amount_cents": { "type": "integer", "minimum": 0 },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "evidenced": { "const": true },
+        "source": { "$ref": "#/$defs/source_ref" },
+        "window": { "$ref": "#/$defs/time_window" }
+      }
+    },
+    "applicable_mrr": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "MRR aggregate. MUST be omitted unless recurring monthly billing is applicable. One-off revenue is not MRR.",
+      "required": ["amount_cents", "currency", "applicable", "basis"],
+      "properties": {
+        "amount_cents": { "type": "integer", "minimum": 0 },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "applicable": { "const": true },
+        "basis": { "const": "recurring_monthly" }
+      }
+    },
+    "reliable_runway": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Runway in months. MUST be omitted unless both cash balance and expense/burn are reliable.",
+      "required": [
+        "months",
+        "cash_balance",
+        "monthly_expense",
+        "cash_reliable",
+        "expense_reliable"
+      ],
+      "properties": {
+        "months": { "type": "number", "minimum": 0 },
+        "cash_balance": { "$ref": "#/$defs/unsigned_money" },
+        "monthly_expense": { "$ref": "#/$defs/unsigned_money" },
+        "cash_reliable": { "const": true },
+        "expense_reliable": { "const": true }
+      }
+    },
+    "weighted_pipeline": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Probability-weighted pipeline. MUST be omitted unless win probability is reliable. Do not invent weights.",
+      "required": ["amount_cents", "currency", "probability_reliable"],
+      "properties": {
+        "amount_cents": { "type": "integer", "minimum": 0 },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "probability_reliable": { "const": true }
+      }
+    },
     "provenance": {
       "type": "object",
       "additionalProperties": false,

--- a/control-center/contracts/schemas/primitives.v1.schema.json
+++ b/control-center/contracts/schemas/primitives.v1.schema.json
@@ -18,8 +18,8 @@
     },
     "scope": {
       "type": "string",
-      "description": "Exact v1 literals: company, commercial, finance, clients, infrastructure, inbound. Parameterized: repo:<name>, client:<slug>. Non-breaking extension: additional lowercase prefix:id namespaces. New bare literals require an additive schema revision. Agents MUST query by scope; they MUST NOT receive a whole-company dump unless they explicitly requested and were granted `company`.",
-      "pattern": "^(company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$",
+      "description": "Exact v1 literals: company, commercial, finance, clients, infrastructure, inbound. Parameterized: repo:<name>, client:<slug>. Non-breaking extension: additional lowercase prefix:id namespaces that are not those reserved names. New bare literals require an additive schema revision. Agents MUST query by scope; they MUST NOT receive a whole-company dump unless they explicitly requested and were granted `company`.",
+      "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$",
       "minLength": 2,
       "maxLength": 128
     },

--- a/control-center/contracts/schemas/primitives.v1.schema.json
+++ b/control-center/contracts/schemas/primitives.v1.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json",
+  "title": "Control Center shared primitives v1",
+  "description": "Shared taxonomies for Control Center resources. Scope, freshness, confidence, IDs, money, UTC timestamps, provenance.",
+  "type": "object",
+  "$defs": {
+    "utc_datetime": {
+      "type": "string",
+      "description": "UTC timestamp. RFC3339 with mandatory Z suffix. Internally always UTC; presentation layers MAY convert to America/Sao_Paulo.",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$",
+      "minLength": 20,
+      "maxLength": 40
+    },
+    "nullable_utc_datetime": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$"
+    },
+    "scope": {
+      "type": "string",
+      "description": "Exact v1 literals: company, commercial, finance, clients, infrastructure, inbound. Parameterized: repo:<name>, client:<slug>. Non-breaking extension: additional lowercase prefix:id namespaces. New bare literals require an additive schema revision. Agents MUST query by scope; they MUST NOT receive a whole-company dump unless they explicitly requested and were granted `company`.",
+      "pattern": "^(company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$",
+      "minLength": 2,
+      "maxLength": 128
+    },
+    "client_slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "client_scope": {
+      "type": "string",
+      "pattern": "^client:[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "minLength": 8,
+      "maxLength": 72
+    },
+    "repo_scope": {
+      "type": "string",
+      "pattern": "^repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$",
+      "minLength": 6,
+      "maxLength": 128
+    },
+    "freshness_status": {
+      "type": "string",
+      "description": "Recency of the observation, independent of confidence. FRESH: within freshness_window. STALE: observation exists but older than window. UNKNOWN: no usable observation. ERROR: last collection failed.",
+      "enum": ["FRESH", "STALE", "UNKNOWN", "ERROR"]
+    },
+    "confidence": {
+      "type": "number",
+      "description": "Trustworthiness of the observation or derivation in [0, 1]. Independent of freshness_status. Do not encode recency here.",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "resource_id": {
+      "type": "string",
+      "description": "Stable ID: cc:<type-kebab>:<ulid-or-slug>. Type kebab is frozen in catalog.json. ULID preferred for generated IDs; slugs allowed for human-stable resources.",
+      "pattern": "^cc:[a-z][a-z0-9-]*:[A-Za-z0-9._~-]+$",
+      "minLength": 6,
+      "maxLength": 128
+    },
+    "nullable_resource_id": {
+      "type": ["string", "null"],
+      "pattern": "^cc:[a-z][a-z0-9-]*:[A-Za-z0-9._~-]+$"
+    },
+    "source_system": {
+      "type": "string",
+      "description": "Well-known: governance, warmbly, github, asaas, web-cfg, extra-cli, manual, collector, unknown. Additional lowercase kebab systems are a non-breaking extension.",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "source_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system", "kind", "locator"],
+      "properties": {
+        "system": { "$ref": "#/$defs/source_system" },
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[a-z][a-z0-9._-]*$"
+        },
+        "locator": {
+          "type": "string",
+          "description": "Opaque locator in the source system (path, issue, record id). MUST NOT contain secrets.",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      }
+    },
+    "actor_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Identity handle. Single-user human initially, but MUST NOT hard-code a person or password. Auth is out of scope for this contract package.",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["human", "agent", "system"]
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9._:@-]+$",
+          "description": "Opaque stable handle such as human:founder or agent:cc-context. Not an email, not a secret."
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      }
+    },
+    "money": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Signed integer cents plus ISO-4217 currency. Floats are invalid.",
+      "required": ["amount_cents", "currency"],
+      "properties": {
+        "amount_cents": { "type": "integer" },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        }
+      }
+    },
+    "unsigned_money": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["amount_cents", "currency"],
+      "properties": {
+        "amount_cents": { "type": "integer", "minimum": 0 },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Required on aggregated information. Confidence is required here and is NOT a freshness synonym.",
+      "required": ["source", "observed_at", "freshness_status", "confidence"],
+      "properties": {
+        "source": { "$ref": "#/$defs/source_ref" },
+        "observed_at": { "$ref": "#/$defs/utc_datetime" },
+        "freshness_status": { "$ref": "#/$defs/freshness_status" },
+        "confidence": { "$ref": "#/$defs/confidence" },
+        "freshness_window_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2592000,
+          "description": "Window used to classify FRESH vs STALE. Optional; consumers MUST NOT infer it from confidence."
+        }
+      }
+    },
+    "error_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[A-Z][A-Z0-9_]*$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "Human-readable, no secrets, no PII."
+        }
+      }
+    },
+    "idempotency_key": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^[A-Za-z0-9._:~/-]+$"
+    },
+    "non_secret_property_names": {
+      "type": "string",
+      "pattern": "^(?![Ss]ecret|[Tt]oken|[Pp]assword|[Aa]uthorization|[Aa]pi[_-]?[Kk]ey|[Cc]ookie|[Cc]redential|[Pp]rivate[_-]?[Kk]ey).+"
+    }
+  }
+}

--- a/control-center/contracts/schemas/priority-recommendation.v1.schema.json
+++ b/control-center/contracts/schemas/priority-recommendation.v1.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/priority-recommendation.v1.schema.json",
+  "title": "PriorityRecommendation v1",
+  "description": "Ranked 'what matters now' item. Homepage consumes ranks 1–3 for the requested scope. Not a KPI tile.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scope",
+    "rank",
+    "title",
+    "rationale",
+    "provenance",
+    "generated_at",
+    "horizon"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.priority-recommendation.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+    },
+    "rank": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 99,
+      "description": "1 is most important. Homepage uses 1, 2, 3."
+    },
+    "title": { "type": "string", "minLength": 1, "maxLength": 200 },
+    "rationale": { "type": "string", "minLength": 1, "maxLength": 2000 },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "generated_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "horizon": {
+      "type": "string",
+      "enum": ["now", "today", "this_week"]
+    },
+    "attention_item_ids": {
+      "type": "array",
+      "maxItems": 16,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    },
+    "directive_ids": {
+      "type": "array",
+      "maxItems": 16,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+      }
+    }
+  }
+}

--- a/control-center/contracts/schemas/service-health.v1.schema.json
+++ b/control-center/contracts/schemas/service-health.v1.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/service-health.v1.schema.json",
+  "title": "ServiceHealth v1",
+  "description": "Health of a named service or component, with provenance.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scope",
+    "service_name",
+    "status",
+    "provenance",
+    "checked_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.service-health.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+    },
+    "service_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["healthy", "degraded", "down", "unknown"]
+    },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "checked_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "latency_ms": { "type": "integer", "minimum": 0, "maximum": 600000 },
+    "message": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "checks": {
+      "type": "array",
+      "maxItems": 32,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "status"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "pattern": "^[a-z][a-z0-9-]*$"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["healthy", "degraded", "down", "unknown"]
+          },
+          "detail": { "type": "string", "minLength": 1, "maxLength": 256 }
+        }
+      }
+    }
+  }
+}

--- a/control-center/contracts/schemas/source-observation.v1.schema.json
+++ b/control-center/contracts/schemas/source-observation.v1.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/source-observation.v1.schema.json",
+  "title": "SourceObservation v1",
+  "description": "Atomic collector observation. Collectors are read-only and MUST send idempotency_key.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "scope",
+    "provenance",
+    "collected_at",
+    "idempotency_key",
+    "payload"
+  ],
+  "properties": {
+    "schema_version": { "const": "control-center.source-observation.v1" },
+    "id": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/resource_id"
+    },
+    "scope": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/scope"
+    },
+    "provenance": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/provenance"
+    },
+    "collected_at": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/utc_datetime"
+    },
+    "idempotency_key": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/idempotency_key"
+    },
+    "payload": {
+      "type": "object",
+      "description": "Opaque source payload. Property names MUST NOT look like secrets.",
+      "propertyNames": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/non_secret_property_names"
+      }
+    },
+    "payload_schema_ref": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "error": {
+      "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/error_object"
+    }
+  },
+  "if": {
+    "properties": {
+      "provenance": {
+        "type": "object",
+        "properties": { "freshness_status": { "const": "ERROR" } },
+        "required": ["freshness_status"]
+      }
+    },
+    "required": ["provenance"]
+  },
+  "then": {
+    "required": ["error"],
+    "properties": {
+      "error": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/error_object"
+      }
+    }
+  }
+}

--- a/control-center/contracts/scripts/consume-validate.ts
+++ b/control-center/contracts/scripts/consume-validate.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+/**
+ * Non-test consumer of the shipped validator. Used to prove the public
+ * entry accepts/rejects fixtures without going through the test runner.
+ */
+import { readFileSync } from "node:fs";
+import { validateUnknown } from "../src/index.js";
+
+const file = process.argv[2];
+if (file === undefined) {
+  process.stderr.write("usage: tsx scripts/consume-validate.ts <file.json>\n");
+  process.exit(2);
+}
+
+const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+const result = validateUnknown(parsed);
+const verdict = result.ok ? "ACCEPT" : "REJECT";
+process.stdout.write(`${verdict}\n${JSON.stringify(result, null, 2)}\n`);
+process.exit(result.ok ? 0 : 1);

--- a/control-center/contracts/src/catalog.ts
+++ b/control-center/contracts/src/catalog.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { packageRoot } from "./paths.js";
+import {
+  RESOURCE_TYPE_NAMES,
+  type ResourceTypeName,
+} from "./taxonomy.js";
+
+export interface CatalogType {
+  name: ResourceTypeName;
+  schema_version: string;
+  id_type: string;
+  schema: string;
+  valid_fixture: string;
+  invalid_fixture: string;
+}
+
+export interface Catalog {
+  package: string;
+  schema_family: string;
+  release: string;
+  id_convention: string;
+  datetime: string;
+  money: string;
+  types: CatalogType[];
+}
+
+let cached: Catalog | undefined;
+
+export function loadCatalog(): Catalog {
+  if (cached !== undefined) {
+    return cached;
+  }
+  const raw = readFileSync(path.join(packageRoot(), "catalog.json"), "utf8");
+  const parsed: unknown = JSON.parse(raw);
+  if (!isCatalog(parsed)) {
+    throw new Error("catalog.json is malformed");
+  }
+  if (parsed.types.length !== RESOURCE_TYPE_NAMES.length) {
+    throw new Error(
+      `catalog.json must list exactly ${RESOURCE_TYPE_NAMES.length} types`,
+    );
+  }
+  cached = parsed;
+  return parsed;
+}
+
+export function catalogType(name: ResourceTypeName): CatalogType {
+  const found = loadCatalog().types.find((t) => t.name === name);
+  if (found === undefined) {
+    throw new Error(`unknown catalog type: ${name}`);
+  }
+  return found;
+}
+
+export function schemaVersionToType(version: string): ResourceTypeName | undefined {
+  const found = loadCatalog().types.find((t) => t.schema_version === version);
+  return found?.name;
+}
+
+function isCatalog(value: unknown): value is Catalog {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const rec = value as Record<string, unknown>;
+  if (!Array.isArray(rec.types)) {
+    return false;
+  }
+  const names = new Set<string>(RESOURCE_TYPE_NAMES);
+  for (const t of rec.types) {
+    if (typeof t !== "object" || t === null) {
+      return false;
+    }
+    const row = t as Record<string, unknown>;
+    if (typeof row.name !== "string" || !names.has(row.name)) {
+      return false;
+    }
+    if (
+      typeof row.schema_version !== "string" ||
+      typeof row.id_type !== "string" ||
+      typeof row.schema !== "string" ||
+      typeof row.valid_fixture !== "string" ||
+      typeof row.invalid_fixture !== "string"
+    ) {
+      return false;
+    }
+  }
+  return (
+    typeof rec.package === "string" &&
+    typeof rec.schema_family === "string" &&
+    typeof rec.release === "string" &&
+    typeof rec.id_convention === "string" &&
+    typeof rec.datetime === "string" &&
+    typeof rec.money === "string"
+  );
+}

--- a/control-center/contracts/src/cli.ts
+++ b/control-center/contracts/src/cli.ts
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
 import { validateFile, listResourceTypes } from "./validate.js";
+import { classifyCompatibility } from "./compatibility.js";
+import { contractFingerprint } from "./fingerprint.js";
 import { isResourceTypeName } from "./ids.js";
 import type { ResourceTypeName } from "./taxonomy.js";
+import { readFileSync } from "node:fs";
 
 function printUsage(): void {
   const types = listResourceTypes().join(", ");
   process.stderr.write(
     `Usage:
   tsx src/cli.ts --list-types
+  tsx src/cli.ts --fingerprint
+  tsx src/cli.ts --classify <file.json>
   tsx src/cli.ts [--type <ResourceType>] <file.json>
 
 Resource types: ${types}
@@ -20,16 +25,29 @@ Exit 0 only when ok is true.
 
 function parseArgs(argv: string[]): {
   list: boolean;
+  fingerprint: boolean;
+  classify: boolean;
   type?: ResourceTypeName;
   file?: string;
 } {
   let list = false;
+  let fingerprint = false;
+  let classify = false;
   let type: ResourceTypeName | undefined;
   let file: string | undefined;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--list-types") {
       list = true;
+    } else if (arg === "--fingerprint") {
+      fingerprint = true;
+    } else if (arg === "--classify") {
+      classify = true;
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("-")) {
+        file = next;
+        i += 1;
+      }
     } else if (arg === "--type") {
       const next = argv[i + 1];
       if (next === undefined || !isResourceTypeName(next)) {
@@ -46,7 +64,7 @@ function parseArgs(argv: string[]): {
       throw new Error(`unknown argument: ${arg}`);
     }
   }
-  return { list, type, file };
+  return { list, fingerprint, classify, type, file };
 }
 
 function main(): void {
@@ -65,6 +83,35 @@ function main(): void {
     const payload = { ok: true, types: listResourceTypes() };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
     process.exit(0);
+    return;
+  }
+
+  if (parsed.fingerprint) {
+    const payload = { ok: true, fingerprint: contractFingerprint() };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    process.exit(0);
+    return;
+  }
+
+  if (parsed.classify) {
+    if (parsed.file === undefined) {
+      printUsage();
+      process.exit(2);
+      return;
+    }
+    try {
+      const data: unknown = JSON.parse(readFileSync(parsed.file, "utf8"));
+      const result = classifyCompatibility(data);
+      const ok = result.verdict === "canonical";
+      process.stdout.write(`${JSON.stringify({ ok, ...result }, null, 2)}\n`);
+      process.exit(ok ? 0 : 1);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stdout.write(
+        `${JSON.stringify({ ok: false, verdict: "reject", errors: [{ path: "", message }] }, null, 2)}\n`,
+      );
+      process.exit(1);
+    }
     return;
   }
 

--- a/control-center/contracts/src/cli.ts
+++ b/control-center/contracts/src/cli.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { validateFile, listResourceTypes } from "./validate.js";
+import { isResourceTypeName } from "./ids.js";
+import type { ResourceTypeName } from "./taxonomy.js";
+
+function printUsage(): void {
+  const types = listResourceTypes().join(", ");
+  process.stderr.write(
+    `Usage:
+  tsx src/cli.ts --list-types
+  tsx src/cli.ts [--type <ResourceType>] <file.json>
+
+Resource types: ${types}
+
+Output is JSON: {"ok":true|false,"type":"...","errors":[...]}
+Exit 0 only when ok is true.
+`,
+  );
+}
+
+function parseArgs(argv: string[]): {
+  list: boolean;
+  type?: ResourceTypeName;
+  file?: string;
+} {
+  let list = false;
+  let type: ResourceTypeName | undefined;
+  let file: string | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--list-types") {
+      list = true;
+    } else if (arg === "--type") {
+      const next = argv[i + 1];
+      if (next === undefined || !isResourceTypeName(next)) {
+        throw new Error(`--type requires one of: ${listResourceTypes().join(", ")}`);
+      }
+      type = next;
+      i += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    } else if (arg !== undefined && !arg.startsWith("-")) {
+      file = arg;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return { list, type, file };
+}
+
+function main(): void {
+  let parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${message}\n`);
+    printUsage();
+    process.exit(2);
+    return;
+  }
+
+  if (parsed.list) {
+    const payload = { ok: true, types: listResourceTypes() };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    process.exit(0);
+    return;
+  }
+
+  if (parsed.file === undefined) {
+    printUsage();
+    process.exit(2);
+    return;
+  }
+
+  try {
+    const result = validateFile(parsed.type, parsed.file);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.exit(result.ok ? 0 : 1);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stdout.write(
+      `${JSON.stringify({ ok: false, type: parsed.type ?? "unknown", errors: [{ path: "", message }] }, null, 2)}\n`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/control-center/contracts/src/compatibility.ts
+++ b/control-center/contracts/src/compatibility.ts
@@ -1,0 +1,214 @@
+import { readFileSync } from "node:fs";
+import { resolveInPackage } from "./paths.js";
+
+export type CompatibilityVerdict = "canonical" | "reject" | "adapter_required";
+
+export interface CompatibilityShape {
+  id: string;
+  description: string;
+  verdict: "reject" | "adapter_required";
+  reason: string;
+}
+
+export interface CompatibilityTable {
+  schema_family: string;
+  release: string;
+  rule: string;
+  shapes: CompatibilityShape[];
+}
+
+export interface CompatibilityFinding {
+  shape_id: string;
+  verdict: "reject" | "adapter_required";
+  path: string;
+  message: string;
+}
+
+export interface CompatibilityResult {
+  verdict: CompatibilityVerdict;
+  findings: CompatibilityFinding[];
+}
+
+const REQUIRED_SHAPE_IDS = [
+  "lowercase_freshness",
+  "expired_as_freshness",
+  "withdrawn_or_inactive_status",
+  "scope_object",
+  "raw_uuid_id",
+] as const;
+
+const UUID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+const LOWERCASE_FRESHNESS = new Set(["fresh", "stale", "unknown", "error"]);
+
+const OPAQUE_KEYS = new Set(["payload", "detail", "body", "notes"]);
+
+let tableCache: CompatibilityTable | undefined;
+
+export function loadCompatibilityTable(): CompatibilityTable {
+  if (tableCache !== undefined) {
+    return tableCache;
+  }
+  const raw = readFileSync(resolveInPackage("docs/compatibility.v1.json"), "utf8");
+  const parsed: unknown = JSON.parse(raw);
+  if (!isCompatibilityTable(parsed)) {
+    throw new Error("docs/compatibility.v1.json is malformed");
+  }
+  const ids = new Set(parsed.shapes.map((s) => s.id));
+  for (const required of REQUIRED_SHAPE_IDS) {
+    if (!ids.has(required)) {
+      throw new Error(`compatibility table missing required shape '${required}'`);
+    }
+  }
+  tableCache = parsed;
+  return parsed;
+}
+
+export function compatibilityShape(id: string): CompatibilityShape {
+  const found = loadCompatibilityTable().shapes.find((s) => s.id === id);
+  if (found === undefined) {
+    throw new Error(`unknown compatibility shape: ${id}`);
+  }
+  return found;
+}
+
+/**
+ * Classify a document against the public compatibility table.
+ * Never silently accepts the five incompatible shapes.
+ */
+export function classifyCompatibility(data: unknown): CompatibilityResult {
+  const table = loadCompatibilityTable();
+  const findings: CompatibilityFinding[] = [];
+  walk(data, "", findings, table);
+  return {
+    verdict: aggregateVerdict(findings),
+    findings: dedupeFindings(findings),
+  };
+}
+
+function aggregateVerdict(findings: CompatibilityFinding[]): CompatibilityVerdict {
+  if (findings.some((f) => f.verdict === "reject")) {
+    return "reject";
+  }
+  if (findings.some((f) => f.verdict === "adapter_required")) {
+    return "adapter_required";
+  }
+  return "canonical";
+}
+
+function walk(
+  value: unknown,
+  pathExpr: string,
+  findings: CompatibilityFinding[],
+  table: CompatibilityTable,
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => walk(item, `${pathExpr}/${i}`, findings, table));
+    return;
+  }
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+  const rec = value as Record<string, unknown>;
+
+  const freshness = rec.freshness_status ?? rec.freshness;
+  if (typeof freshness === "string") {
+    if (LOWERCASE_FRESHNESS.has(freshness)) {
+      pushFinding(findings, table, "lowercase_freshness", freshnessPath(pathExpr, rec));
+    }
+    if (freshness === "expired") {
+      pushFinding(findings, table, "expired_as_freshness", freshnessPath(pathExpr, rec));
+    }
+  }
+
+  if (typeof rec.status === "string" && (rec.status === "withdrawn" || rec.status === "inactive")) {
+    pushFinding(findings, table, "withdrawn_or_inactive_status", `${pathExpr}/status`);
+  }
+
+  if (rec.scope !== undefined && typeof rec.scope === "object" && rec.scope !== null) {
+    pushFinding(findings, table, "scope_object", `${pathExpr}/scope`);
+  }
+
+  if (typeof rec.id === "string" && UUID_RE.test(rec.id)) {
+    pushFinding(findings, table, "raw_uuid_id", `${pathExpr}/id`);
+  }
+
+  for (const [key, child] of Object.entries(rec)) {
+    if (OPAQUE_KEYS.has(key)) {
+      continue;
+    }
+    walk(child, `${pathExpr}/${key}`, findings, table);
+  }
+}
+
+function freshnessPath(pathExpr: string, rec: Record<string, unknown>): string {
+  if ("freshness_status" in rec) {
+    return `${pathExpr}/freshness_status`;
+  }
+  if ("freshness" in rec) {
+    return `${pathExpr}/freshness`;
+  }
+  return pathExpr;
+}
+
+function pushFinding(
+  findings: CompatibilityFinding[],
+  table: CompatibilityTable,
+  shapeId: string,
+  pathExpr: string,
+): void {
+  const shape = table.shapes.find((s) => s.id === shapeId);
+  if (shape === undefined) {
+    throw new Error(`compatibility table missing shape '${shapeId}'`);
+  }
+  findings.push({
+    shape_id: shape.id,
+    verdict: shape.verdict,
+    path: pathExpr === "" ? "/" : pathExpr,
+    message: shape.reason,
+  });
+}
+
+function dedupeFindings(findings: CompatibilityFinding[]): CompatibilityFinding[] {
+  const seen = new Set<string>();
+  const out: CompatibilityFinding[] = [];
+  for (const item of findings) {
+    const key = `${item.shape_id}|${item.path}|${item.verdict}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+function isCompatibilityTable(value: unknown): value is CompatibilityTable {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const rec = value as Record<string, unknown>;
+  if (!Array.isArray(rec.shapes)) {
+    return false;
+  }
+  for (const row of rec.shapes) {
+    if (typeof row !== "object" || row === null) {
+      return false;
+    }
+    const shape = row as Record<string, unknown>;
+    if (
+      typeof shape.id !== "string" ||
+      typeof shape.description !== "string" ||
+      typeof shape.reason !== "string" ||
+      (shape.verdict !== "reject" && shape.verdict !== "adapter_required")
+    ) {
+      return false;
+    }
+  }
+  return (
+    typeof rec.schema_family === "string" &&
+    typeof rec.release === "string" &&
+    typeof rec.rule === "string"
+  );
+}

--- a/control-center/contracts/src/docs.ts
+++ b/control-center/contracts/src/docs.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { resolveInPackage } from "./paths.js";
+
+export interface ForbiddenOperation {
+  name: string;
+  reason: string;
+}
+
+export interface McpTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+export interface McpContract {
+  mcp_version: string;
+  server_name: string;
+  interface_role: string;
+  scope_rule: string;
+  tools: McpTool[];
+  forbidden_operations: ForbiddenOperation[];
+  resources: Array<{ uri_template: string; name: string }>;
+}
+
+export interface OpenApiDoc {
+  openapi: string;
+  info: { title: string; version: string; description?: string };
+  paths: Record<string, unknown>;
+  "x-forbidden-paths"?: Array<{ path: string; reason: string }>;
+}
+
+let mcpCache: McpContract | undefined;
+let openApiCache: OpenApiDoc | undefined;
+
+export function loadMcpContract(): McpContract {
+  if (mcpCache !== undefined) {
+    return mcpCache;
+  }
+  const raw = readFileSync(resolveInPackage("docs/mcp.v1.json"), "utf8");
+  const parsed: unknown = JSON.parse(raw);
+  if (!isMcpContract(parsed)) {
+    throw new Error("docs/mcp.v1.json is malformed");
+  }
+  mcpCache = parsed;
+  return parsed;
+}
+
+export function loadOpenApi(): OpenApiDoc {
+  if (openApiCache !== undefined) {
+    return openApiCache;
+  }
+  const raw = readFileSync(resolveInPackage("docs/http.openapi.json"), "utf8");
+  const parsed: unknown = JSON.parse(raw);
+  if (!isOpenApi(parsed)) {
+    throw new Error("docs/http.openapi.json is malformed");
+  }
+  openApiCache = parsed;
+  return parsed;
+}
+
+export function allowedMcpToolNames(): string[] {
+  return loadMcpContract().tools.map((t) => t.name);
+}
+
+export function forbiddenMcpOperationNames(): string[] {
+  return loadMcpContract().forbidden_operations.map((op) => op.name);
+}
+
+export function isForbiddenMcpOperation(name: string): boolean {
+  return forbiddenMcpOperationNames().includes(name);
+}
+
+export function forbiddenHttpPaths(): string[] {
+  const extra = loadOpenApi()["x-forbidden-paths"] ?? [];
+  return extra.map((p) => p.path);
+}
+
+function isMcpContract(value: unknown): value is McpContract {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const rec = value as Record<string, unknown>;
+  return (
+    typeof rec.mcp_version === "string" &&
+    typeof rec.server_name === "string" &&
+    typeof rec.interface_role === "string" &&
+    typeof rec.scope_rule === "string" &&
+    Array.isArray(rec.tools) &&
+    Array.isArray(rec.forbidden_operations) &&
+    Array.isArray(rec.resources)
+  );
+}
+
+function isOpenApi(value: unknown): value is OpenApiDoc {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const rec = value as Record<string, unknown>;
+  return (
+    typeof rec.openapi === "string" &&
+    typeof rec.info === "object" &&
+    rec.info !== null &&
+    typeof rec.paths === "object" &&
+    rec.paths !== null
+  );
+}

--- a/control-center/contracts/src/fingerprint.ts
+++ b/control-center/contracts/src/fingerprint.ts
@@ -1,0 +1,72 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { packageRoot } from "./paths.js";
+
+export interface PublicArtifact {
+  path: string;
+  canonical: string;
+}
+
+const STATIC_JSON_ARTIFACTS = [
+  "catalog.json",
+  "docs/compatibility.v1.json",
+  "docs/http.openapi.json",
+  "docs/mcp.v1.json",
+] as const;
+
+/**
+ * Public ontology inputs whose canonical bytes feed CONTRACT_FINGERPRINT.
+ * Changing a schema, catalog, taxonomy, compatibility table, or HTTP/MCP
+ * contract byte changes the digest.
+ */
+export function publicOntologyArtifacts(root = packageRoot()): PublicArtifact[] {
+  const schemaDir = path.join(root, "schemas");
+  const schemaFiles = readdirSync(schemaDir)
+    .filter((name) => name.endsWith(".schema.json"))
+    .map((name) => `schemas/${name}`);
+  const rels = [...STATIC_JSON_ARTIFACTS, ...schemaFiles, "src/taxonomy.ts"].sort();
+  return rels.map((rel) => ({
+    path: rel,
+    canonical: canonicalize(root, rel),
+  }));
+}
+
+export function fingerprintArtifacts(artifacts: PublicArtifact[]): string {
+  const hash = createHash("sha256");
+  const sorted = [...artifacts].sort((a, b) => a.path.localeCompare(b.path));
+  for (const item of sorted) {
+    hash.update(item.path);
+    hash.update("\n");
+    hash.update(item.canonical);
+    hash.update("\n");
+  }
+  return `sha256:${hash.digest("hex")}`;
+}
+
+export function contractFingerprint(root = packageRoot()): string {
+  return fingerprintArtifacts(publicOntologyArtifacts(root));
+}
+
+function canonicalize(root: string, rel: string): string {
+  const raw = readFileSync(path.join(root, rel), "utf8");
+  if (rel.endsWith(".json")) {
+    return JSON.stringify(sortKeys(JSON.parse(raw) as unknown));
+  }
+  return raw.replace(/\r\n/g, "\n");
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  if (typeof value === "object" && value !== null) {
+    const rec = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(rec).sort()) {
+      out[key] = sortKeys(rec[key]);
+    }
+    return out;
+  }
+  return value;
+}

--- a/control-center/contracts/src/ids.ts
+++ b/control-center/contracts/src/ids.ts
@@ -1,0 +1,73 @@
+import {
+  CLIENT_SLUG_PATTERN,
+  ID_TYPE_BY_RESOURCE,
+  RESOURCE_ID_PATTERN,
+  RESOURCE_TYPE_NAMES,
+  SCOPE_LITERALS,
+  SCOPE_PATTERN,
+  type ResourceTypeName,
+} from "./taxonomy.js";
+
+const RESOURCE_ID_RE = new RegExp(RESOURCE_ID_PATTERN);
+const SCOPE_RE = new RegExp(SCOPE_PATTERN);
+const CLIENT_SLUG_RE = new RegExp(CLIENT_SLUG_PATTERN);
+const ID_TYPES = new Set(Object.values(ID_TYPE_BY_RESOURCE));
+
+export function isResourceId(value: unknown): value is string {
+  return typeof value === "string" && RESOURCE_ID_RE.test(value);
+}
+
+export function isScope(value: unknown): value is string {
+  return typeof value === "string" && SCOPE_RE.test(value);
+}
+
+export function isClientSlug(value: unknown): value is string {
+  return typeof value === "string" && CLIENT_SLUG_RE.test(value);
+}
+
+export function parseResourceId(
+  value: string,
+): { prefix: "cc"; type: string; id: string } | null {
+  if (!isResourceId(value)) {
+    return null;
+  }
+  const parts = value.split(":");
+  const prefix = parts[0];
+  const type = parts[1];
+  const id = parts.slice(2).join(":");
+  if (prefix !== "cc" || type === undefined || id.length === 0) {
+    return null;
+  }
+  return { prefix: "cc", type, id };
+}
+
+export function resourceIdTypeIsKnown(type: string): boolean {
+  return ID_TYPES.has(type);
+}
+
+export function expectedIdType(resource: ResourceTypeName): string {
+  return ID_TYPE_BY_RESOURCE[resource];
+}
+
+export function clientScope(slug: string): string {
+  if (!isClientSlug(slug)) {
+    throw new Error(`invalid client slug: ${slug}`);
+  }
+  return `client:${slug}`;
+}
+
+export function repoScope(name: string): string {
+  const scope = `repo:${name}`;
+  if (!isScope(scope) || !scope.startsWith("repo:")) {
+    throw new Error(`invalid repo name: ${name}`);
+  }
+  return scope;
+}
+
+export function isLiteralScope(value: string): boolean {
+  return (SCOPE_LITERALS as readonly string[]).includes(value);
+}
+
+export function isResourceTypeName(value: string): value is ResourceTypeName {
+  return (RESOURCE_TYPE_NAMES as readonly string[]).includes(value);
+}

--- a/control-center/contracts/src/index.ts
+++ b/control-center/contracts/src/index.ts
@@ -1,0 +1,36 @@
+export {
+  loadCatalog,
+  catalogType,
+  schemaVersionToType,
+  type Catalog,
+  type CatalogType,
+} from "./catalog.js";
+export {
+  validate,
+  validateUnknown,
+  validateFile,
+  listResourceTypes,
+  catalogFixturePath,
+  type ValidationIssue,
+  type ValidationResult,
+} from "./validate.js";
+export {
+  isResourceId,
+  isScope,
+  isClientSlug,
+  parseResourceId,
+  clientScope,
+  repoScope,
+  expectedIdType,
+  isResourceTypeName,
+} from "./ids.js";
+export {
+  loadMcpContract,
+  loadOpenApi,
+  allowedMcpToolNames,
+  forbiddenMcpOperationNames,
+  isForbiddenMcpOperation,
+  forbiddenHttpPaths,
+} from "./docs.js";
+export * from "./taxonomy.js";
+export type * from "./types.js";

--- a/control-center/contracts/src/index.ts
+++ b/control-center/contracts/src/index.ts
@@ -15,6 +15,22 @@ export {
   type ValidationResult,
 } from "./validate.js";
 export {
+  loadCompatibilityTable,
+  classifyCompatibility,
+  compatibilityShape,
+  type CompatibilityTable,
+  type CompatibilityShape,
+  type CompatibilityFinding,
+  type CompatibilityResult,
+  type CompatibilityVerdict,
+} from "./compatibility.js";
+export {
+  contractFingerprint,
+  fingerprintArtifacts,
+  publicOntologyArtifacts,
+  type PublicArtifact,
+} from "./fingerprint.js";
+export {
   isResourceId,
   isScope,
   isClientSlug,

--- a/control-center/contracts/src/paths.ts
+++ b/control-center/contracts/src/paths.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function packageRoot(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+export function resolveInPackage(...segments: string[]): string {
+  return path.join(packageRoot(), ...segments);
+}

--- a/control-center/contracts/src/taxonomy.ts
+++ b/control-center/contracts/src/taxonomy.ts
@@ -1,0 +1,201 @@
+/**
+ * Canonical Control Center taxonomies. JSON Schema patterns MUST match these
+ * string constants; contract tests assert lockstep.
+ */
+
+export const UTC_DATETIME_PATTERN =
+  "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$";
+
+export const RESOURCE_ID_PATTERN = "^cc:[a-z][a-z0-9-]*:[A-Za-z0-9._~-]+$";
+
+export const CURRENCY_PATTERN = "^[A-Z]{3}$";
+
+export const CLIENT_SLUG_PATTERN = "^[a-z0-9]+(?:-[a-z0-9]+)*$";
+
+export const REPO_NAME_PATTERN = "^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$";
+
+/**
+ * v1 well-known literal scopes. These never take a colon.
+ * Adding a new literal (e.g. `hr`) is an additive schema revision, not a
+ * silent change to this frozen list.
+ */
+export const SCOPE_LITERALS = [
+  "company",
+  "commercial",
+  "finance",
+  "clients",
+  "infrastructure",
+  "inbound",
+] as const;
+
+export type ScopeLiteral = (typeof SCOPE_LITERALS)[number];
+
+/**
+ * v1 parameterized prefixes. `repo:<name>` and `client:<slug>` are required.
+ * Future prefixes of the form `<prefix>:<id>` are a non-breaking extension:
+ * consumers MUST treat unknown prefix:id scopes as opaque, MUST NOT grant
+ * them by default, and MUST NOT fail schema validation of the string.
+ */
+export const SCOPE_PREFIXES = ["repo", "client"] as const;
+
+export type ScopePrefix = (typeof SCOPE_PREFIXES)[number];
+
+/**
+ * Full scope pattern:
+ * - the six literals
+ * - repo:<name> (short name or owner/name)
+ * - client:<kebab-slug>
+ * - future namespaced `<prefix>:<id>` (lowercase prefix)
+ */
+export const SCOPE_PATTERN =
+  "^(company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$";
+
+export const FRESHNESS_STATUSES = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+/**
+ * Confidence is a closed unit interval, independent of freshness.
+ * Freshness answers "how recent is this observation?".
+ * Confidence answers "how much should a consumer trust it?".
+ * A FRESH observation MAY have low confidence; an ERROR observation MAY
+ * still carry last-known data with residual confidence.
+ */
+export const CONFIDENCE_MIN = 0;
+export const CONFIDENCE_MAX = 1;
+
+export const DIRECTIVE_KINDS = [
+  "decision",
+  "directive",
+  "fact",
+  "constraint",
+  "priority",
+  "risk",
+  "hypothesis",
+] as const;
+export type DirectiveKind = (typeof DIRECTIVE_KINDS)[number];
+
+export const DIRECTIVE_STATUSES = [
+  "draft",
+  "active",
+  "superseded",
+  "revoked",
+  "expired",
+] as const;
+export type DirectiveStatus = (typeof DIRECTIVE_STATUSES)[number];
+
+export const ATTENTION_SEVERITIES = ["critical", "high", "medium", "low"] as const;
+export type AttentionSeverity = (typeof ATTENTION_SEVERITIES)[number];
+
+export const ATTENTION_STATUSES = [
+  "open",
+  "acknowledged",
+  "resolved",
+  "dismissed",
+] as const;
+export type AttentionStatus = (typeof ATTENTION_STATUSES)[number];
+
+export const PRIORITY_HORIZONS = ["now", "today", "this_week"] as const;
+export type PriorityHorizon = (typeof PRIORITY_HORIZONS)[number];
+
+export const AGENT_SESSION_STATUSES = ["open", "closed", "denied"] as const;
+export type AgentSessionStatus = (typeof AGENT_SESSION_STATUSES)[number];
+
+export const CLIENT_LIFECYCLES = [
+  "lead",
+  "active",
+  "paused",
+  "churn_risk",
+  "churned",
+  "unknown",
+] as const;
+export type ClientLifecycle = (typeof CLIENT_LIFECYCLES)[number];
+
+export const HEALTH_STATUSES = ["healthy", "degraded", "down", "unknown"] as const;
+export type HealthStatus = (typeof HEALTH_STATUSES)[number];
+
+export const COLLECTOR_RUN_STATUSES = [
+  "started",
+  "succeeded",
+  "failed",
+  "skipped",
+] as const;
+export type CollectorRunStatus = (typeof COLLECTOR_RUN_STATUSES)[number];
+
+export const AUDIT_OUTCOMES = ["success", "denied", "error"] as const;
+export type AuditOutcome = (typeof AUDIT_OUTCOMES)[number];
+
+export const ACTOR_KINDS = ["human", "agent", "system"] as const;
+export type ActorKind = (typeof ACTOR_KINDS)[number];
+
+export const RESOURCE_TYPE_NAMES = [
+  "Directive",
+  "OperationalSnapshot",
+  "SourceObservation",
+  "AttentionItem",
+  "PriorityRecommendation",
+  "AgentSession",
+  "ClientStatus",
+  "CommercialSnapshot",
+  "FinanceSnapshot",
+  "EngineeringSnapshot",
+  "ServiceHealth",
+  "CollectorRun",
+  "AuditEvent",
+] as const;
+export type ResourceTypeName = (typeof RESOURCE_TYPE_NAMES)[number];
+
+export const SCHEMA_VERSIONS = {
+  Directive: "control-center.directive.v1",
+  OperationalSnapshot: "control-center.operational-snapshot.v1",
+  SourceObservation: "control-center.source-observation.v1",
+  AttentionItem: "control-center.attention-item.v1",
+  PriorityRecommendation: "control-center.priority-recommendation.v1",
+  AgentSession: "control-center.agent-session.v1",
+  ClientStatus: "control-center.client-status.v1",
+  CommercialSnapshot: "control-center.commercial-snapshot.v1",
+  FinanceSnapshot: "control-center.finance-snapshot.v1",
+  EngineeringSnapshot: "control-center.engineering-snapshot.v1",
+  ServiceHealth: "control-center.service-health.v1",
+  CollectorRun: "control-center.collector-run.v1",
+  AuditEvent: "control-center.audit-event.v1",
+  AgentContext: "control-center.agent-context.v1",
+} as const;
+
+export const ID_TYPE_BY_RESOURCE: Record<ResourceTypeName, string> = {
+  Directive: "directive",
+  OperationalSnapshot: "operational-snapshot",
+  SourceObservation: "source-observation",
+  AttentionItem: "attention-item",
+  PriorityRecommendation: "priority-recommendation",
+  AgentSession: "agent-session",
+  ClientStatus: "client-status",
+  CommercialSnapshot: "commercial-snapshot",
+  FinanceSnapshot: "finance-snapshot",
+  EngineeringSnapshot: "engineering-snapshot",
+  ServiceHealth: "service-health",
+  CollectorRun: "collector-run",
+  AuditEvent: "audit-event",
+};
+
+/** Keys that MUST never appear in payloads, audit detail, or logs. */
+export const FORBIDDEN_SECRET_KEY_PATTERN =
+  "^(?![Ss]ecret|[Tt]oken|[Pp]assword|[Aa]uthorization|[Aa]pi[_-]?[Kk]ey|[Cc]ookie|[Cc]redential|[Pp]rivate[_-]?[Kk]ey).+";
+
+export const FORBIDDEN_SECRET_KEY_REGEX =
+  /^(secret|token|password|authorization|api[_-]?key|cookie|credential|private[_-]?key)$/i;
+
+export const WELL_KNOWN_SOURCE_SYSTEMS = [
+  "governance",
+  "warmbly",
+  "github",
+  "asaas",
+  "web-cfg",
+  "extra-cli",
+  "manual",
+  "collector",
+  "unknown",
+] as const;
+
+export const SOURCE_SYSTEM_PATTERN = "^[a-z][a-z0-9-]*$";
+
+export const HOMEPAGE_PRIORITY_LIMIT = 3;

--- a/control-center/contracts/src/taxonomy.ts
+++ b/control-center/contracts/src/taxonomy.ts
@@ -41,14 +41,24 @@ export const SCOPE_PREFIXES = ["repo", "client"] as const;
 export type ScopePrefix = (typeof SCOPE_PREFIXES)[number];
 
 /**
+ * Unanchored scope alternative used by SCOPE_PATTERN and CSV query params.
+ * Catch-all prefix:id excludes well-known literals and repo/client so those
+ * stay on their dedicated grammars.
+ */
+export const SCOPE_CORE =
+  "(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)";
+
+/**
  * Full scope pattern:
  * - the six literals
  * - repo:<name> (short name or owner/name)
  * - client:<kebab-slug>
- * - future namespaced `<prefix>:<id>` (lowercase prefix)
+ * - future namespaced `<prefix>:<id>` (lowercase prefix, not a reserved name)
  */
-export const SCOPE_PATTERN =
-  "^(company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$";
+export const SCOPE_PATTERN = `^${SCOPE_CORE}$`;
+
+/** Comma-separated scopes for HTTP query parameters. */
+export const SCOPE_CSV_PATTERN = `^${SCOPE_CORE}(?:,${SCOPE_CORE})*$`;
 
 export const FRESHNESS_STATUSES = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
 export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];

--- a/control-center/contracts/src/taxonomy.ts
+++ b/control-center/contracts/src/taxonomy.ts
@@ -110,6 +110,19 @@ export type PriorityHorizon = (typeof PRIORITY_HORIZONS)[number];
 export const AGENT_SESSION_STATUSES = ["open", "closed", "denied"] as const;
 export type AgentSessionStatus = (typeof AGENT_SESSION_STATUSES)[number];
 
+/**
+ * Execution-ledger statuses for AgentActivity. Distinct from AgentSession
+ * (`open|closed|denied`), which is a scoped context-consult grant.
+ */
+export const AGENT_ACTIVITY_STATUSES = [
+  "running",
+  "done",
+  "partial",
+  "blocked",
+  "failed",
+] as const;
+export type AgentActivityStatus = (typeof AGENT_ACTIVITY_STATUSES)[number];
+
 export const CLIENT_LIFECYCLES = [
   "lead",
   "active",
@@ -144,6 +157,7 @@ export const RESOURCE_TYPE_NAMES = [
   "AttentionItem",
   "PriorityRecommendation",
   "AgentSession",
+  "AgentActivity",
   "ClientStatus",
   "CommercialSnapshot",
   "FinanceSnapshot",
@@ -161,6 +175,7 @@ export const SCHEMA_VERSIONS = {
   AttentionItem: "control-center.attention-item.v1",
   PriorityRecommendation: "control-center.priority-recommendation.v1",
   AgentSession: "control-center.agent-session.v1",
+  AgentActivity: "control-center.agent-activity.v1",
   ClientStatus: "control-center.client-status.v1",
   CommercialSnapshot: "control-center.commercial-snapshot.v1",
   FinanceSnapshot: "control-center.finance-snapshot.v1",
@@ -178,6 +193,7 @@ export const ID_TYPE_BY_RESOURCE: Record<ResourceTypeName, string> = {
   AttentionItem: "attention-item",
   PriorityRecommendation: "priority-recommendation",
   AgentSession: "agent-session",
+  AgentActivity: "agent-activity",
   ClientStatus: "client-status",
   CommercialSnapshot: "commercial-snapshot",
   FinanceSnapshot: "finance-snapshot",

--- a/control-center/contracts/src/types.ts
+++ b/control-center/contracts/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   ActorKind,
+  AgentActivityStatus,
   AgentSessionStatus,
   AttentionSeverity,
   AttentionStatus,
@@ -147,6 +148,28 @@ export interface AgentSession {
   include_attention: boolean;
 }
 
+/**
+ * Execution ledger record. Distinct from AgentSession (context-consult grant).
+ * Optional session_id, when present, MUST be a `cc:agent-session:...` id.
+ */
+export interface AgentActivity {
+  schema_version: "control-center.agent-activity.v1";
+  id: ResourceId;
+  agent_id: string;
+  session_id?: ResourceId;
+  scope: Scope;
+  status: AgentActivityStatus;
+  started_at: UtcDateTime;
+  finished_at: UtcDateTime | null;
+  goal: string;
+  summary: string;
+  provenance: Provenance;
+  actor: ActorRef;
+  evidence_refs?: string[];
+  residual_work?: string[];
+  related_ids?: ResourceId[];
+}
+
 export interface ClientStatus {
   schema_version: "control-center.client-status.v1";
   id: ResourceId;
@@ -166,6 +189,27 @@ export interface CommercialAuthorityStamp {
   this_document: "read_model";
 }
 
+/** Identity pin only. MUST NOT carry names, prices, terms, or offer copy. */
+export interface GovernanceOfferPin {
+  catalog_authority: "governance";
+  catalog_id: string;
+  known_offer_ids?: string[];
+}
+
+export interface CommercialFunnelCounts {
+  new_leads: number;
+  qualified: number;
+  opportunities: number;
+  proposals: number;
+  clients: number;
+}
+
+export interface WeightedPipeline {
+  amount_cents: number;
+  currency: string;
+  probability_reliable: true;
+}
+
 export interface CommercialSnapshot {
   schema_version: "control-center.commercial-snapshot.v1";
   id: ResourceId;
@@ -173,10 +217,40 @@ export interface CommercialSnapshot {
   generated_at: UtcDateTime;
   provenance: Provenance;
   authority: CommercialAuthorityStamp;
+  offer_pin: GovernanceOfferPin;
+  funnel: CommercialFunnelCounts;
+  pipeline_nominal: Money;
+  pipeline_weighted?: WeightedPipeline;
+  aging_count: number;
+  stalled_count: number;
+  missing_next_action_count: number;
   pipeline_open_count: number;
   inbound_unread_count: number;
   at_risk_client_count: number;
   attention_item_ids?: ResourceId[];
+}
+
+export interface EvidencedCashIn {
+  amount_cents: number;
+  currency: string;
+  evidenced: true;
+  source: SourceRef;
+  window?: { from: UtcDateTime; to: UtcDateTime };
+}
+
+export interface ApplicableMrr {
+  amount_cents: number;
+  currency: string;
+  applicable: true;
+  basis: "recurring_monthly";
+}
+
+export interface ReliableRunway {
+  months: number;
+  cash_balance: Money;
+  monthly_expense: Money;
+  cash_reliable: true;
+  expense_reliable: true;
 }
 
 export interface FinanceSnapshot {
@@ -187,8 +261,17 @@ export interface FinanceSnapshot {
   provenance: Provenance;
   read_model_only: true;
   provider_mutations: "forbidden";
-  receivables_open: Money;
-  receivables_overdue: Money;
+  contracted: Money;
+  billed: Money;
+  paid: Money;
+  effectively_received: Money;
+  overdue: Money;
+  receivable: Money;
+  refunds: Money;
+  chargebacks: Money;
+  cash_in?: EvidencedCashIn;
+  mrr?: ApplicableMrr;
+  runway?: ReliableRunway;
   attention_item_ids?: ResourceId[];
 }
 
@@ -270,7 +353,7 @@ export interface OperationalSnapshot {
 }
 
 /**
- * HTTP/MCP envelope. Not one of the 13 core resources. Agents receive this
+ * HTTP/MCP envelope. Not a stored core resource. Agents receive this
  * only for the scopes they requested and were granted.
  */
 export interface AgentContext {
@@ -298,6 +381,7 @@ export type ControlCenterResource =
   | AttentionItem
   | PriorityRecommendation
   | AgentSession
+  | AgentActivity
   | ClientStatus
   | CommercialSnapshot
   | FinanceSnapshot

--- a/control-center/contracts/src/types.ts
+++ b/control-center/contracts/src/types.ts
@@ -1,0 +1,307 @@
+import type {
+  ActorKind,
+  AgentSessionStatus,
+  AttentionSeverity,
+  AttentionStatus,
+  AuditOutcome,
+  ClientLifecycle,
+  CollectorRunStatus,
+  DirectiveKind,
+  DirectiveStatus,
+  FreshnessStatus,
+  HealthStatus,
+  PriorityHorizon,
+} from "./taxonomy.js";
+
+/** UTC RFC3339 with mandatory Z. */
+export type UtcDateTime = string;
+
+/** Stable Control Center ID: `cc:<type-kebab>:<ulid-or-slug>`. */
+export type ResourceId = string;
+
+/**
+ * Scope taxonomy v1.
+ * Literals: company | commercial | finance | clients | infrastructure | inbound
+ * Parameterized: `repo:<name>`, `client:<slug>`
+ * Extension (non-breaking): additional `<prefix>:<id>` namespaces.
+ */
+export type Scope = string;
+
+export interface SourceRef {
+  system: string;
+  kind: string;
+  locator: string;
+  label?: string;
+}
+
+export interface ActorRef {
+  kind: ActorKind;
+  id: string;
+  display_name?: string;
+}
+
+export interface Money {
+  amount_cents: number;
+  currency: string;
+}
+
+/**
+ * Provenance of aggregated information.
+ * `freshness_status` is recency; `confidence` is trust. They are not aliases.
+ */
+export interface Provenance {
+  source: SourceRef;
+  observed_at: UtcDateTime;
+  freshness_status: FreshnessStatus;
+  confidence: number;
+  freshness_window_seconds?: number;
+}
+
+export interface ErrorObject {
+  code: string;
+  message: string;
+}
+
+export interface DirectiveAuditEntry {
+  at: UtcDateTime;
+  actor: ActorRef;
+  action: "created" | "updated" | "status_changed" | "superseded" | "revoked";
+  from_status?: DirectiveStatus;
+  to_status?: DirectiveStatus;
+  note?: string;
+}
+
+export interface Directive {
+  schema_version: "control-center.directive.v1";
+  id: ResourceId;
+  kind: DirectiveKind;
+  scope: Scope;
+  status: DirectiveStatus;
+  title: string;
+  body: string;
+  effective_from: UtcDateTime;
+  expires_at: UtcDateTime | null;
+  supersedes: ResourceId[] | null;
+  created_by: ActorRef;
+  created_at: UtcDateTime;
+  updated_at: UtcDateTime;
+  audit: DirectiveAuditEntry[];
+  tags?: string[];
+  related_ids?: ResourceId[];
+}
+
+export interface SourceObservation {
+  schema_version: "control-center.source-observation.v1";
+  id: ResourceId;
+  scope: Scope;
+  provenance: Provenance;
+  collected_at: UtcDateTime;
+  idempotency_key: string;
+  payload: Record<string, unknown>;
+  payload_schema_ref?: string;
+  error?: ErrorObject;
+}
+
+export interface AttentionItem {
+  schema_version: "control-center.attention-item.v1";
+  id: ResourceId;
+  scope: Scope;
+  severity: AttentionSeverity;
+  status: AttentionStatus;
+  title: string;
+  summary: string;
+  provenance: Provenance;
+  detected_at: UtcDateTime;
+  homepage_eligible: boolean;
+  recommended_action?: string;
+  related_ids?: ResourceId[];
+}
+
+export interface PriorityRecommendation {
+  schema_version: "control-center.priority-recommendation.v1";
+  id: ResourceId;
+  scope: Scope;
+  rank: number;
+  title: string;
+  rationale: string;
+  provenance: Provenance;
+  generated_at: UtcDateTime;
+  horizon: PriorityHorizon;
+  attention_item_ids?: ResourceId[];
+  directive_ids?: ResourceId[];
+}
+
+export interface AgentSession {
+  schema_version: "control-center.agent-session.v1";
+  id: ResourceId;
+  agent_id: string;
+  requested_scopes: Scope[];
+  granted_scopes: Scope[];
+  purpose: string;
+  started_at: UtcDateTime;
+  ended_at: UtcDateTime | null;
+  status: AgentSessionStatus;
+  created_by: ActorRef;
+  include_directives: boolean;
+  include_snapshots: boolean;
+  include_attention: boolean;
+}
+
+export interface ClientStatus {
+  schema_version: "control-center.client-status.v1";
+  id: ResourceId;
+  scope: Scope;
+  client_slug: string;
+  display_name: string;
+  lifecycle: ClientLifecycle;
+  provenance: Provenance;
+  attention_item_ids?: ResourceId[];
+  open_receivables?: Money;
+  notes?: string;
+}
+
+export interface CommercialAuthorityStamp {
+  catalog_authority: "governance";
+  commercial_runtime: "warmbly";
+  this_document: "read_model";
+}
+
+export interface CommercialSnapshot {
+  schema_version: "control-center.commercial-snapshot.v1";
+  id: ResourceId;
+  scope: Scope;
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  authority: CommercialAuthorityStamp;
+  pipeline_open_count: number;
+  inbound_unread_count: number;
+  at_risk_client_count: number;
+  attention_item_ids?: ResourceId[];
+}
+
+export interface FinanceSnapshot {
+  schema_version: "control-center.finance-snapshot.v1";
+  id: ResourceId;
+  scope: Scope;
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  read_model_only: true;
+  provider_mutations: "forbidden";
+  receivables_open: Money;
+  receivables_overdue: Money;
+  attention_item_ids?: ResourceId[];
+}
+
+export interface EngineeringSnapshot {
+  schema_version: "control-center.engineering-snapshot.v1";
+  id: ResourceId;
+  scope: Scope;
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  open_pr_count: number;
+  failing_check_count: number;
+  open_incident_count: number;
+  repo_scopes?: Scope[];
+  attention_item_ids?: ResourceId[];
+}
+
+export interface ServiceHealthCheck {
+  name: string;
+  status: HealthStatus;
+  detail?: string;
+}
+
+export interface ServiceHealth {
+  schema_version: "control-center.service-health.v1";
+  id: ResourceId;
+  scope: Scope;
+  service_name: string;
+  status: HealthStatus;
+  provenance: Provenance;
+  checked_at: UtcDateTime;
+  latency_ms?: number;
+  message?: string;
+  checks?: ServiceHealthCheck[];
+}
+
+export interface CollectorRun {
+  schema_version: "control-center.collector-run.v1";
+  id: ResourceId;
+  collector_name: string;
+  scope: Scope;
+  status: CollectorRunStatus;
+  started_at: UtcDateTime;
+  finished_at: UtcDateTime | null;
+  idempotency_key: string;
+  read_only: true;
+  observations_emitted: number;
+  error?: ErrorObject;
+  cursor?: string | null;
+}
+
+export interface AuditEvent {
+  schema_version: "control-center.audit-event.v1";
+  id: ResourceId;
+  at: UtcDateTime;
+  actor: ActorRef;
+  action: string;
+  resource_type: string;
+  resource_id: ResourceId | null;
+  scope: Scope | null;
+  outcome: AuditOutcome;
+  detail: Record<string, unknown>;
+  request_id?: string;
+}
+
+export interface OperationalSnapshot {
+  schema_version: "control-center.operational-snapshot.v1";
+  id: ResourceId;
+  scope: Scope;
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  headline: string;
+  top_priorities: PriorityRecommendation[];
+  attention_items: AttentionItem[];
+  health: ServiceHealth[];
+  commercial_snapshot_id: ResourceId | null;
+  finance_snapshot_id: ResourceId | null;
+  engineering_snapshot_id: ResourceId | null;
+  client_status_ids: ResourceId[];
+}
+
+/**
+ * HTTP/MCP envelope. Not one of the 13 core resources. Agents receive this
+ * only for the scopes they requested and were granted.
+ */
+export interface AgentContext {
+  schema_version: "control-center.agent-context.v1";
+  requested_scopes: Scope[];
+  granted_scopes: Scope[];
+  as_of: UtcDateTime;
+  directives: Directive[];
+  attention_items: AttentionItem[];
+  top_priorities: PriorityRecommendation[];
+  snapshots: {
+    operational?: OperationalSnapshot;
+    commercial?: CommercialSnapshot;
+    finance?: FinanceSnapshot;
+    engineering?: EngineeringSnapshot;
+  };
+  client_statuses: ClientStatus[];
+  truncated: boolean;
+}
+
+export type ControlCenterResource =
+  | Directive
+  | OperationalSnapshot
+  | SourceObservation
+  | AttentionItem
+  | PriorityRecommendation
+  | AgentSession
+  | ClientStatus
+  | CommercialSnapshot
+  | FinanceSnapshot
+  | EngineeringSnapshot
+  | ServiceHealth
+  | CollectorRun
+  | AuditEvent;

--- a/control-center/contracts/src/validate.ts
+++ b/control-center/contracts/src/validate.ts
@@ -1,0 +1,363 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { Ajv2020, type ErrorObject as AjvError } from "ajv/dist/2020.js";
+import { catalogType, loadCatalog, schemaVersionToType } from "./catalog.js";
+import { parseResourceId } from "./ids.js";
+import { packageRoot } from "./paths.js";
+import {
+  FORBIDDEN_SECRET_KEY_REGEX,
+  HOMEPAGE_PRIORITY_LIMIT,
+  RESOURCE_TYPE_NAMES,
+  type ResourceTypeName,
+} from "./taxonomy.js";
+
+export interface ValidationIssue {
+  path: string;
+  message: string;
+  keyword?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  type: ResourceTypeName | "unknown";
+  schema_version?: string;
+  errors: ValidationIssue[];
+}
+
+const SCHEMA_FILES = [
+  "schemas/primitives.v1.schema.json",
+  "schemas/directive.v1.schema.json",
+  "schemas/source-observation.v1.schema.json",
+  "schemas/attention-item.v1.schema.json",
+  "schemas/priority-recommendation.v1.schema.json",
+  "schemas/agent-session.v1.schema.json",
+  "schemas/client-status.v1.schema.json",
+  "schemas/commercial-snapshot.v1.schema.json",
+  "schemas/finance-snapshot.v1.schema.json",
+  "schemas/engineering-snapshot.v1.schema.json",
+  "schemas/service-health.v1.schema.json",
+  "schemas/collector-run.v1.schema.json",
+  "schemas/audit-event.v1.schema.json",
+  "schemas/operational-snapshot.v1.schema.json",
+  "schemas/agent-context.v1.schema.json",
+] as const;
+
+let ajvSingleton: InstanceType<typeof Ajv2020> | undefined;
+
+function loadJson(rel: string): Record<string, unknown> {
+  const raw = readFileSync(path.join(packageRoot(), rel), "utf8");
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`schema file is not an object: ${rel}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function getAjv(): InstanceType<typeof Ajv2020> {
+  if (ajvSingleton !== undefined) {
+    return ajvSingleton;
+  }
+  const ajv = new Ajv2020({
+    allErrors: true,
+    strict: true,
+    validateFormats: false,
+  });
+  for (const file of SCHEMA_FILES) {
+    const schema = loadJson(file);
+    ajv.addSchema(schema);
+  }
+  ajvSingleton = ajv;
+  return ajv;
+}
+
+function schemaIdFor(type: ResourceTypeName): string {
+  const row = catalogType(type);
+  const schema = loadJson(row.schema);
+  const id = schema.$id;
+  if (typeof id !== "string") {
+    throw new Error(`schema missing $id: ${row.schema}`);
+  }
+  return id;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function issue(pathExpr: string, message: string, keyword?: string): ValidationIssue {
+  return { path: pathExpr, message, keyword };
+}
+
+function collectSecretKeyIssues(value: unknown, pathExpr: string, acc: ValidationIssue[]): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => collectSecretKeyIssues(item, `${pathExpr}/${i}`, acc));
+    return;
+  }
+  const rec = asRecord(value);
+  if (rec === null) {
+    return;
+  }
+  for (const [key, child] of Object.entries(rec)) {
+    if (FORBIDDEN_SECRET_KEY_REGEX.test(key)) {
+      acc.push(
+        issue(
+          `${pathExpr}/${key}`,
+          `forbidden secret-like property name '${key}'`,
+          "secret_key",
+        ),
+      );
+    }
+    collectSecretKeyIssues(child, `${pathExpr}/${key}`, acc);
+  }
+}
+
+function stringField(rec: Record<string, unknown>, key: string): string | undefined {
+  const v = rec[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+function semanticChecks(type: ResourceTypeName, data: unknown): ValidationIssue[] {
+  const rec = asRecord(data);
+  if (rec === null) {
+    return [issue("", "document must be an object", "type")];
+  }
+  const errors: ValidationIssue[] = [];
+  collectSecretKeyIssues(data, "", errors);
+
+  const id = stringField(rec, "id");
+  if (id !== undefined) {
+    const parsed = parseResourceId(id);
+    const expected = catalogType(type).id_type;
+    if (parsed === null) {
+      errors.push(issue("/id", "id does not match cc:<type>:<id> convention", "id"));
+    } else if (parsed.type !== expected) {
+      errors.push(
+        issue(
+          "/id",
+          `id type '${parsed.type}' does not match required '${expected}'`,
+          "id_type",
+        ),
+      );
+    }
+  }
+
+  if (type === "ClientStatus") {
+    const slug = stringField(rec, "client_slug");
+    const scope = stringField(rec, "scope");
+    if (slug !== undefined && scope !== undefined && scope !== `client:${slug}`) {
+      errors.push(
+        issue(
+          "/scope",
+          `scope must equal client:<client_slug> (expected client:${slug})`,
+          "client_scope",
+        ),
+      );
+    }
+  }
+
+  if (type === "Directive") {
+    const from = stringField(rec, "effective_from");
+    const expires = rec.expires_at;
+    if (typeof from === "string" && typeof expires === "string" && expires < from) {
+      errors.push(
+        issue("/expires_at", "expires_at must be >= effective_from when not null", "dates"),
+      );
+    }
+    const audit = rec.audit;
+    if (!Array.isArray(audit) || audit.length < 1) {
+      errors.push(issue("/audit", "audit trail must contain at least one entry", "audit"));
+    }
+  }
+
+  if (type === "AgentSession") {
+    const requested = rec.requested_scopes;
+    const granted = rec.granted_scopes;
+    const status = stringField(rec, "status");
+    if (!Array.isArray(requested) || requested.length < 1) {
+      errors.push(
+        issue(
+          "/requested_scopes",
+          "agents MUST request at least one scope; whole-company dump is forbidden",
+          "scope_query",
+        ),
+      );
+    }
+    if (Array.isArray(requested) && Array.isArray(granted)) {
+      const req = new Set(requested.filter((s): s is string => typeof s === "string"));
+      for (const [i, scope] of granted.entries()) {
+        if (typeof scope === "string" && !req.has(scope)) {
+          errors.push(
+            issue(
+              `/granted_scopes/${i}`,
+              "granted scope is not in requested_scopes (fail-closed)",
+              "granted_subset",
+            ),
+          );
+        }
+      }
+      if (status === "open" && granted.length === 0) {
+        errors.push(
+          issue("/granted_scopes", "open session must grant at least one requested scope", "grant"),
+        );
+      }
+    }
+  }
+
+  if (type === "OperationalSnapshot") {
+    const priorities = rec.top_priorities;
+    if (Array.isArray(priorities)) {
+      if (priorities.length > HOMEPAGE_PRIORITY_LIMIT) {
+        errors.push(
+          issue(
+            "/top_priorities",
+            `homepage roll-up allows at most ${HOMEPAGE_PRIORITY_LIMIT} priorities`,
+            "homepage",
+          ),
+        );
+      }
+      const ranks = new Set<number>();
+      for (const [i, item] of priorities.entries()) {
+        const p = asRecord(item);
+        if (p === null) {
+          continue;
+        }
+        const rank = p.rank;
+        if (typeof rank === "number") {
+          if (ranks.has(rank)) {
+            errors.push(issue(`/top_priorities/${i}/rank`, "duplicate rank", "unique_rank"));
+          }
+          ranks.add(rank);
+        }
+      }
+    }
+  }
+
+  if (type === "SourceObservation" || typeHasProvenance(type)) {
+    const provenance = asRecord(rec.provenance);
+    if (provenance !== null) {
+      if (!("freshness_status" in provenance)) {
+        errors.push(issue("/provenance/freshness_status", "freshness_status is required", "required"));
+      }
+      if (!("confidence" in provenance)) {
+        errors.push(issue("/provenance/confidence", "confidence is required and distinct from freshness", "required"));
+      }
+      if (!("source" in provenance) || !("observed_at" in provenance)) {
+        errors.push(issue("/provenance", "source and observed_at are required", "required"));
+      }
+    }
+  }
+
+  return errors;
+}
+
+const PROVENANCE_TYPES = new Set<ResourceTypeName>([
+  "OperationalSnapshot",
+  "SourceObservation",
+  "AttentionItem",
+  "PriorityRecommendation",
+  "ClientStatus",
+  "CommercialSnapshot",
+  "FinanceSnapshot",
+  "EngineeringSnapshot",
+  "ServiceHealth",
+]);
+
+function typeHasProvenance(type: ResourceTypeName): boolean {
+  return PROVENANCE_TYPES.has(type);
+}
+
+function ajvIssues(errors: AjvError[] | null | undefined): ValidationIssue[] {
+  if (!errors) {
+    return [];
+  }
+  return errors.map((err) =>
+    issue(err.instancePath === "" ? "/" : err.instancePath, err.message ?? "invalid", err.keyword),
+  );
+}
+
+export function listResourceTypes(): ResourceTypeName[] {
+  return [...RESOURCE_TYPE_NAMES];
+}
+
+export function validate(type: ResourceTypeName, data: unknown): ValidationResult {
+  const ajv = getAjv();
+  const schemaId = schemaIdFor(type);
+  const validateFn = ajv.getSchema(schemaId);
+  if (validateFn === undefined) {
+    throw new Error(`schema not registered: ${schemaId}`);
+  }
+  const schemaOk = validateFn(data) === true;
+  const errors = [...ajvIssues(validateFn.errors), ...semanticChecks(type, data)];
+  const rec = asRecord(data);
+  const schema_version = rec !== null ? stringField(rec, "schema_version") : undefined;
+  const unique = dedupeIssues(errors);
+  return {
+    ok: schemaOk && unique.length === 0,
+    type,
+    schema_version,
+    errors: unique,
+  };
+}
+
+export function validateUnknown(data: unknown): ValidationResult {
+  const rec = asRecord(data);
+  if (rec === null) {
+    return {
+      ok: false,
+      type: "unknown",
+      errors: [issue("", "document must be an object", "type")],
+    };
+  }
+  const version = stringField(rec, "schema_version");
+  if (version === undefined) {
+    return {
+      ok: false,
+      type: "unknown",
+      errors: [issue("/schema_version", "schema_version is required to infer type", "required")],
+    };
+  }
+  const type = schemaVersionToType(version);
+  if (type === undefined) {
+    return {
+      ok: false,
+      type: "unknown",
+      schema_version: version,
+      errors: [issue("/schema_version", `unsupported schema_version '${version}'`, "schema_version")],
+    };
+  }
+  return validate(type, data);
+}
+
+export function validateFile(type: ResourceTypeName | undefined, filePath: string): ValidationResult {
+  const raw = readFileSync(filePath, "utf8");
+  const parsed: unknown = JSON.parse(raw);
+  if (type === undefined) {
+    return validateUnknown(parsed);
+  }
+  return validate(type, parsed);
+}
+
+function dedupeIssues(issues: ValidationIssue[]): ValidationIssue[] {
+  const seen = new Set<string>();
+  const out: ValidationIssue[] = [];
+  for (const item of issues) {
+    const key = `${item.path}|${item.message}|${item.keyword ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+export function catalogFixturePath(kind: "valid" | "invalid", type: ResourceTypeName): string {
+  const row = catalogType(type);
+  const rel = kind === "valid" ? row.valid_fixture : row.invalid_fixture;
+  return path.join(packageRoot(), rel);
+}
+
+export { loadCatalog };

--- a/control-center/contracts/src/validate.ts
+++ b/control-center/contracts/src/validate.ts
@@ -119,6 +119,12 @@ function stringField(rec: Record<string, unknown>, key: string): string | undefi
   return typeof v === "string" ? v : undefined;
 }
 
+/** Instant compare for UTC RFC3339. String order is not chronological when fractional seconds are mixed. */
+function utcMillis(value: string): number | undefined {
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
 function semanticChecks(type: ResourceTypeName, data: unknown): ValidationIssue[] {
   const rec = asRecord(data);
   if (rec === null) {
@@ -161,10 +167,14 @@ function semanticChecks(type: ResourceTypeName, data: unknown): ValidationIssue[
   if (type === "Directive") {
     const from = stringField(rec, "effective_from");
     const expires = rec.expires_at;
-    if (typeof from === "string" && typeof expires === "string" && expires < from) {
-      errors.push(
-        issue("/expires_at", "expires_at must be >= effective_from when not null", "dates"),
-      );
+    if (typeof from === "string" && typeof expires === "string") {
+      const fromMs = utcMillis(from);
+      const expiresMs = utcMillis(expires);
+      if (fromMs === undefined || expiresMs === undefined || expiresMs < fromMs) {
+        errors.push(
+          issue("/expires_at", "expires_at must be >= effective_from when not null", "dates"),
+        );
+      }
     }
     const audit = rec.audit;
     if (!Array.isArray(audit) || audit.length < 1) {

--- a/control-center/contracts/src/validate.ts
+++ b/control-center/contracts/src/validate.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { Ajv2020, type ErrorObject as AjvError } from "ajv/dist/2020.js";
 import { catalogType, loadCatalog, schemaVersionToType } from "./catalog.js";
+import { classifyCompatibility } from "./compatibility.js";
 import { parseResourceId } from "./ids.js";
 import { packageRoot } from "./paths.js";
 import {
@@ -31,6 +32,7 @@ const SCHEMA_FILES = [
   "schemas/attention-item.v1.schema.json",
   "schemas/priority-recommendation.v1.schema.json",
   "schemas/agent-session.v1.schema.json",
+  "schemas/agent-activity.v1.schema.json",
   "schemas/client-status.v1.schema.json",
   "schemas/commercial-snapshot.v1.schema.json",
   "schemas/finance-snapshot.v1.schema.json",
@@ -182,6 +184,113 @@ function semanticChecks(type: ResourceTypeName, data: unknown): ValidationIssue[
     }
   }
 
+  if (type === "AgentActivity") {
+    const sessionId = stringField(rec, "session_id");
+    if (sessionId !== undefined) {
+      const parsed = parseResourceId(sessionId);
+      if (parsed === null || parsed.type !== "agent-session") {
+        errors.push(
+          issue(
+            "/session_id",
+            "session_id must be a cc:agent-session:... id; AgentActivity is not AgentSession",
+            "session_link",
+          ),
+        );
+      }
+    }
+    const activityId = stringField(rec, "id");
+    if (activityId !== undefined) {
+      const parsed = parseResourceId(activityId);
+      if (parsed !== null && parsed.type === "agent-session") {
+        errors.push(
+          issue("/id", "AgentActivity id type must be agent-activity, not agent-session", "id_type"),
+        );
+      }
+    }
+  }
+
+  if (type === "FinanceSnapshot") {
+    if (rec.provider_mutations !== "forbidden") {
+      errors.push(
+        issue(
+          "/provider_mutations",
+          "provider_mutations must be forbidden; financial provider writes are not in this ontology",
+          "provider_mutations",
+        ),
+      );
+    }
+    collectNonIntegerCents(rec, "", errors);
+    const cashIn = asRecord(rec.cash_in);
+    if (cashIn !== null && cashIn.evidenced !== true) {
+      errors.push(
+        issue("/cash_in", "cash_in may appear only when settlement is evidenced", "cash_in_evidence"),
+      );
+    }
+    const mrr = asRecord(rec.mrr);
+    if (mrr !== null && (mrr.applicable !== true || mrr.basis !== "recurring_monthly")) {
+      errors.push(
+        issue("/mrr", "mrr may appear only when recurring monthly billing is applicable", "mrr_applicable"),
+      );
+    }
+    const runway = asRecord(rec.runway);
+    if (runway !== null && (runway.cash_reliable !== true || runway.expense_reliable !== true)) {
+      errors.push(
+        issue(
+          "/runway",
+          "runway may appear only when cash balance and expense are reliable",
+          "runway_reliable",
+        ),
+      );
+    }
+  }
+
+  if (type === "CommercialSnapshot") {
+    for (const key of Object.keys(rec)) {
+      if (CATALOG_COPY_KEYS.has(key)) {
+        errors.push(
+          issue(
+            `/${key}`,
+            "CommercialSnapshot must pin Governance catalog identity and MUST NOT copy the offer catalog",
+            "catalog_copy",
+          ),
+        );
+      }
+    }
+    const pin = asRecord(rec.offer_pin);
+    if (pin !== null) {
+      for (const key of CATALOG_COPY_KEYS) {
+        if (key in pin) {
+          errors.push(
+            issue(
+              `/offer_pin/${key}`,
+              "offer_pin is identity-only; names, prices, terms, and copied offers are forbidden",
+              "catalog_copy",
+            ),
+          );
+        }
+      }
+      if ("known_offers" in pin) {
+        errors.push(
+          issue(
+            "/offer_pin/known_offers",
+            "pin known_offer_ids (strings) only; do not copy offer objects",
+            "catalog_copy",
+          ),
+        );
+      }
+    }
+    const weighted = asRecord(rec.pipeline_weighted);
+    if (weighted !== null && weighted.probability_reliable !== true) {
+      errors.push(
+        issue(
+          "/pipeline_weighted",
+          "pipeline_weighted may appear only with reliable probability",
+          "probability_reliable",
+        ),
+      );
+    }
+  }
+
   if (type === "AgentSession") {
     const requested = rec.requested_scopes;
     const granted = rec.granted_scopes;
@@ -268,12 +377,55 @@ const PROVENANCE_TYPES = new Set<ResourceTypeName>([
   "SourceObservation",
   "AttentionItem",
   "PriorityRecommendation",
+  "AgentActivity",
   "ClientStatus",
   "CommercialSnapshot",
   "FinanceSnapshot",
   "EngineeringSnapshot",
   "ServiceHealth",
 ]);
+
+const CATALOG_COPY_KEYS = new Set([
+  "catalog",
+  "offers",
+  "products",
+  "prices",
+  "terms",
+  "offer_catalog",
+  "price_list",
+  "copy",
+  "skus",
+]);
+
+function collectNonIntegerCents(
+  value: unknown,
+  pathExpr: string,
+  acc: ValidationIssue[],
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => collectNonIntegerCents(item, `${pathExpr}/${i}`, acc));
+    return;
+  }
+  const rec = asRecord(value);
+  if (rec === null) {
+    return;
+  }
+  if ("amount_cents" in rec) {
+    const cents = rec.amount_cents;
+    if (typeof cents !== "number" || !Number.isInteger(cents)) {
+      acc.push(
+        issue(
+          `${pathExpr}/amount_cents`,
+          "money amount_cents must be an integer (centavos); floats are invalid",
+          "integer_cents",
+        ),
+      );
+    }
+  }
+  for (const [key, child] of Object.entries(rec)) {
+    collectNonIntegerCents(child, `${pathExpr}/${key}`, acc);
+  }
+}
 
 function typeHasProvenance(type: ResourceTypeName): boolean {
   return PROVENANCE_TYPES.has(type);
@@ -301,6 +453,18 @@ export function validate(type: ResourceTypeName, data: unknown): ValidationResul
   }
   const schemaOk = validateFn(data) === true;
   const errors = [...ajvIssues(validateFn.errors), ...semanticChecks(type, data)];
+  const compat = classifyCompatibility(data);
+  if (compat.verdict !== "canonical") {
+    for (const finding of compat.findings) {
+      errors.push(
+        issue(
+          finding.path,
+          `${finding.verdict}: ${finding.message}`,
+          "compatibility",
+        ),
+      );
+    }
+  }
   const rec = asRecord(data);
   const schema_version = rec !== null ? stringField(rec, "schema_version") : undefined;
   const unique = dedupeIssues(errors);
@@ -323,19 +487,35 @@ export function validateUnknown(data: unknown): ValidationResult {
   }
   const version = stringField(rec, "schema_version");
   if (version === undefined) {
+    const compat = classifyCompatibility(data);
+    const errors = [issue("/schema_version", "schema_version is required to infer type", "required")];
+    if (compat.verdict !== "canonical") {
+      for (const finding of compat.findings) {
+        errors.push(issue(finding.path, `${finding.verdict}: ${finding.message}`, "compatibility"));
+      }
+    }
     return {
       ok: false,
       type: "unknown",
-      errors: [issue("/schema_version", "schema_version is required to infer type", "required")],
+      errors: dedupeIssues(errors),
     };
   }
   const type = schemaVersionToType(version);
   if (type === undefined) {
+    const compat = classifyCompatibility(data);
+    const errors = [
+      issue("/schema_version", `unsupported schema_version '${version}'`, "schema_version"),
+    ];
+    if (compat.verdict !== "canonical") {
+      for (const finding of compat.findings) {
+        errors.push(issue(finding.path, `${finding.verdict}: ${finding.message}`, "compatibility"));
+      }
+    }
     return {
       ok: false,
       type: "unknown",
       schema_version: version,
-      errors: [issue("/schema_version", `unsupported schema_version '${version}'`, "schema_version")],
+      errors: dedupeIssues(errors),
     };
   }
   return validate(type, data);

--- a/control-center/contracts/tests/compatibility.test.ts
+++ b/control-center/contracts/tests/compatibility.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  classifyCompatibility,
+  loadCompatibilityTable,
+  validate,
+  validateUnknown,
+} from "../src/index.js";
+
+const REJECT_OR_ADAPTER = new Set(["reject", "adapter_required"]);
+
+describe("compatibility table", () => {
+  it("declares the five incompatible shapes as reject or adapter_required", () => {
+    const table = loadCompatibilityTable();
+    const ids = table.shapes.map((s) => s.id);
+    for (const required of [
+      "lowercase_freshness",
+      "expired_as_freshness",
+      "withdrawn_or_inactive_status",
+      "scope_object",
+      "raw_uuid_id",
+    ]) {
+      assert.ok(ids.includes(required), `missing ${required}`);
+    }
+    for (const shape of table.shapes) {
+      assert.ok(REJECT_OR_ADAPTER.has(shape.verdict), shape.id);
+    }
+  });
+});
+
+describe("shipped classifier on the five incompatible shapes", () => {
+  it("rejects lowercase freshness", () => {
+    const result = classifyCompatibility({
+      provenance: { freshness_status: "fresh" },
+    });
+    assert.equal(result.verdict, "reject");
+    assert.ok(result.findings.some((f) => f.shape_id === "lowercase_freshness"));
+  });
+
+  it("rejects expired used as freshness", () => {
+    const result = classifyCompatibility({
+      provenance: { freshness_status: "expired" },
+    });
+    assert.equal(result.verdict, "reject");
+    assert.ok(result.findings.some((f) => f.shape_id === "expired_as_freshness"));
+  });
+
+  it("rejects withdrawn and inactive statuses", () => {
+    const withdrawn = classifyCompatibility({ status: "withdrawn" });
+    const inactive = classifyCompatibility({ status: "inactive" });
+    assert.equal(withdrawn.verdict, "reject");
+    assert.equal(inactive.verdict, "reject");
+    assert.ok(withdrawn.findings.some((f) => f.shape_id === "withdrawn_or_inactive_status"));
+    assert.ok(inactive.findings.some((f) => f.shape_id === "withdrawn_or_inactive_status"));
+  });
+
+  it("requires an adapter for scope as an object", () => {
+    const result = classifyCompatibility({ scope: { kind: "company" } });
+    assert.equal(result.verdict, "adapter_required");
+    assert.ok(result.findings.some((f) => f.shape_id === "scope_object"));
+  });
+
+  it("requires an adapter for a raw UUID external id", () => {
+    const result = classifyCompatibility({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    assert.equal(result.verdict, "adapter_required");
+    assert.ok(result.findings.some((f) => f.shape_id === "raw_uuid_id"));
+  });
+
+  it("does not silently accept any of the five shapes through the shipped validator", () => {
+    const shapes: unknown[] = [
+      { schema_version: "control-center.directive.v1", provenance: { freshness_status: "stale" } },
+      { schema_version: "control-center.directive.v1", provenance: { freshness_status: "expired" } },
+      { schema_version: "control-center.directive.v1", status: "withdrawn" },
+      { schema_version: "control-center.directive.v1", scope: { type: "finance" } },
+      { schema_version: "control-center.directive.v1", id: "550e8400-e29b-41d4-a716-446655440000" },
+    ];
+    for (const doc of shapes) {
+      const classified = classifyCompatibility(doc);
+      assert.ok(REJECT_OR_ADAPTER.has(classified.verdict), JSON.stringify(classified));
+      const validated = validateUnknown(doc);
+      assert.equal(validated.ok, false);
+    }
+  });
+
+  it("still classifies a canonical freshness/id/scope document as canonical on those axes", () => {
+    const result = classifyCompatibility({
+      id: "cc:directive:01K3CC-NO-PROVIDER-MUTATION",
+      scope: "finance",
+      status: "active",
+      provenance: { freshness_status: "FRESH", confidence: 0.7 },
+    });
+    assert.equal(result.verdict, "canonical");
+    assert.equal(result.findings.length, 0);
+  });
+});
+
+describe("validator surfaces compatibility on typed documents", () => {
+  it("marks lowercase freshness as not ok for FinanceSnapshot", () => {
+    const result = validate("FinanceSnapshot", {
+      schema_version: "control-center.finance-snapshot.v1",
+      id: "cc:finance-snapshot:01K3CC-LOWER",
+      provenance: { freshness_status: "fresh" },
+    });
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.keyword === "compatibility" || e.keyword === "enum"));
+  });
+});

--- a/control-center/contracts/tests/contract.test.ts
+++ b/control-center/contracts/tests/contract.test.ts
@@ -3,9 +3,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, it } from "node:test";
 import {
+  ACTOR_KINDS,
   allowedMcpToolNames,
   catalogFixturePath,
   catalogType,
+  DIRECTIVE_STATUSES,
   FRESHNESS_STATUSES,
   forbiddenHttpPaths,
   forbiddenMcpOperationNames,
@@ -39,28 +41,23 @@ const catalog = loadCatalog();
 const types = listResourceTypes();
 
 describe("Control Center catalog", () => {
-  it("lists exactly the 13 named types", () => {
-    assert.deepEqual([...RESOURCE_TYPE_NAMES], [
-      "Directive",
-      "OperationalSnapshot",
-      "SourceObservation",
-      "AttentionItem",
-      "PriorityRecommendation",
-      "AgentSession",
-      "ClientStatus",
-      "CommercialSnapshot",
-      "FinanceSnapshot",
-      "EngineeringSnapshot",
-      "ServiceHealth",
-      "CollectorRun",
-      "AuditEvent",
-    ]);
-    assert.equal(catalog.types.length, 13);
+  it("stays in lockstep with RESOURCE_TYPE_NAMES and catalogs AgentActivity apart from AgentSession", () => {
     assert.deepEqual(
       catalog.types.map((t) => t.name),
       [...RESOURCE_TYPE_NAMES],
     );
     assert.deepEqual(types, [...RESOURCE_TYPE_NAMES]);
+    assert.equal(catalog.types.length, RESOURCE_TYPE_NAMES.length);
+    assert.ok(RESOURCE_TYPE_NAMES.includes("AgentActivity"));
+    assert.ok(RESOURCE_TYPE_NAMES.includes("AgentSession"));
+    const activity = catalogType("AgentActivity");
+    const session = catalogType("AgentSession");
+    assert.notEqual(activity.schema_version, session.schema_version);
+    assert.notEqual(activity.id_type, session.id_type);
+    assert.equal(activity.schema_version, "control-center.agent-activity.v1");
+    assert.equal(activity.id_type, "agent-activity");
+    assert.equal(session.schema_version, "control-center.agent-session.v1");
+    assert.equal(session.id_type, "agent-session");
   });
 });
 
@@ -80,6 +77,20 @@ describe("primitives lockstep with JSON Schema", () => {
   it("encodes UTC Z timestamps and resource IDs", () => {
     assert.equal(primitives.$defs.utc_datetime?.pattern, UTC_DATETIME_PATTERN);
     assert.equal(primitives.$defs.resource_id?.pattern, RESOURCE_ID_PATTERN);
+  });
+
+  it("encodes Directive status draft|active|superseded|revoked|expired and typed ActorRef", () => {
+    const directive = readJson("schemas/directive.v1.schema.json") as {
+      properties: { status: { enum: string[] }; supersedes: { type: string[] | string } };
+    };
+    assert.deepEqual(directive.properties.status.enum, [...DIRECTIVE_STATUSES]);
+    assert.ok(
+      Array.isArray(directive.properties.supersedes.type)
+        ? directive.properties.supersedes.type.includes("array")
+        : directive.properties.supersedes.type === "array",
+    );
+    const actor = primitives.$defs.actor_ref as { properties?: { kind?: { enum?: string[] } } };
+    assert.deepEqual(actor.properties?.kind?.enum, [...ACTOR_KINDS]);
   });
 
   it("requires provenance fields source, observed_at, freshness_status, confidence", () => {
@@ -281,12 +292,31 @@ describe("OperationalSnapshot homepage limit", () => {
 });
 
 describe("FinanceSnapshot money and mutations", () => {
+  it("accepts the named aggregates on the valid fixture", () => {
+    const valid = readJson("fixtures/valid/finance-snapshot.json") as Record<string, unknown>;
+    for (const field of [
+      "contracted",
+      "billed",
+      "paid",
+      "effectively_received",
+      "overdue",
+      "receivable",
+      "refunds",
+      "chargebacks",
+    ]) {
+      assert.ok(field in valid, `missing ${field}`);
+    }
+    assert.equal(valid.provider_mutations, "forbidden");
+    const result = validate("FinanceSnapshot", valid);
+    assert.equal(result.ok, true, JSON.stringify(result.errors));
+  });
+
   it("rejects non-integer cents", () => {
     const valid = readJson("fixtures/valid/finance-snapshot.json") as {
-      receivables_open: { amount_cents: number; currency: string };
+      receivable: { amount_cents: number; currency: string };
     };
     const doc = clone(valid);
-    doc.receivables_open.amount_cents = 10.5;
+    doc.receivable.amount_cents = 10.5;
     assert.equal(validate("FinanceSnapshot", doc).ok, false);
   });
 
@@ -295,6 +325,71 @@ describe("FinanceSnapshot money and mutations", () => {
     const doc = clone(valid);
     doc.provider_mutations = "allowed";
     assert.equal(validate("FinanceSnapshot", doc).ok, false);
+  });
+
+  it("rejects missing provider_mutations", () => {
+    const valid = readJson("fixtures/valid/finance-snapshot.json") as Record<string, unknown>;
+    const doc = clone(valid);
+    delete doc.provider_mutations;
+    assert.equal(validate("FinanceSnapshot", doc).ok, false);
+  });
+
+  it("rejects cash_in without evidence", () => {
+    const valid = readJson("fixtures/valid/finance-snapshot.json") as Record<string, unknown>;
+    const doc = clone(valid);
+    doc.cash_in = { amount_cents: 100, currency: "BRL" };
+    assert.equal(validate("FinanceSnapshot", doc).ok, false);
+  });
+
+  it("rejects mrr without applicability", () => {
+    const valid = readJson("fixtures/valid/finance-snapshot.json") as Record<string, unknown>;
+    const doc = clone(valid);
+    doc.mrr = { amount_cents: 100, currency: "BRL" };
+    assert.equal(validate("FinanceSnapshot", doc).ok, false);
+  });
+
+  it("rejects runway without reliable cash and expense", () => {
+    const valid = readJson("fixtures/valid/finance-snapshot.json") as Record<string, unknown>;
+    const doc = clone(valid);
+    doc.runway = {
+      months: 3,
+      cash_balance: { amount_cents: 1, currency: "BRL" },
+      monthly_expense: { amount_cents: 1, currency: "BRL" },
+    };
+    assert.equal(validate("FinanceSnapshot", doc).ok, false);
+  });
+});
+
+describe("CommercialSnapshot funnel and catalog pin", () => {
+  it("accepts funnel, nominal pipeline, gated weighted pipeline, and attention refs", () => {
+    const valid = readJson("fixtures/valid/commercial-snapshot.json") as {
+      funnel: Record<string, number>;
+      offer_pin: Record<string, unknown>;
+      attention_item_ids: string[];
+    };
+    for (const key of ["new_leads", "qualified", "opportunities", "proposals", "clients"]) {
+      assert.ok(key in valid.funnel, `missing funnel.${key}`);
+    }
+    assert.equal(valid.offer_pin.catalog_authority, "governance");
+    assert.ok(valid.attention_item_ids.length > 0);
+    const result = validate("CommercialSnapshot", valid);
+    assert.equal(result.ok, true, JSON.stringify(result.errors));
+  });
+
+  it("rejects pipeline_weighted without reliable probability", () => {
+    const valid = readJson("fixtures/valid/commercial-snapshot.json") as Record<string, unknown>;
+    const doc = clone(valid);
+    doc.pipeline_weighted = { amount_cents: 1000, currency: "BRL" };
+    assert.equal(validate("CommercialSnapshot", doc).ok, false);
+  });
+
+  it("rejects a copied offer catalog inside CommercialSnapshot", () => {
+    const valid = readJson("fixtures/valid/commercial-snapshot.json") as Record<string, unknown>;
+    const doc = clone(valid);
+    doc.offers = [{ name: "Diagnóstico", price_cents: 100000, terms: "net 15" }];
+    const result = validate("CommercialSnapshot", doc);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.keyword === "catalog_copy" || e.keyword === "additionalProperties"));
   });
 });
 
@@ -361,7 +456,7 @@ describe("MCP principal agent interface", () => {
 describe("internal HTTP contract", () => {
   const spec = loadOpenApi();
 
-  it("requires scopes on the context endpoint and names all 13 resources", () => {
+  it("requires scopes on the context endpoint and names all cataloged resources", () => {
     const context = spec.paths["/v1/context"] as {
       get: { parameters: Array<{ name: string; required?: boolean }> };
     };

--- a/control-center/contracts/tests/contract.test.ts
+++ b/control-center/contracts/tests/contract.test.ts
@@ -1,0 +1,341 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import {
+  allowedMcpToolNames,
+  catalogFixturePath,
+  catalogType,
+  FRESHNESS_STATUSES,
+  forbiddenHttpPaths,
+  forbiddenMcpOperationNames,
+  HOMEPAGE_PRIORITY_LIMIT,
+  isForbiddenMcpOperation,
+  listResourceTypes,
+  loadCatalog,
+  loadMcpContract,
+  loadOpenApi,
+  RESOURCE_ID_PATTERN,
+  RESOURCE_TYPE_NAMES,
+  SCOPE_PATTERN,
+  UTC_DATETIME_PATTERN,
+  validate,
+  validateFile,
+  type ResourceTypeName,
+} from "../src/index.js";
+import { packageRoot } from "../src/paths.js";
+
+function readJson(rel: string): unknown {
+  return JSON.parse(readFileSync(path.join(packageRoot(), rel), "utf8"));
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const catalog = loadCatalog();
+const types = listResourceTypes();
+
+describe("Control Center catalog", () => {
+  it("lists exactly the 13 named types", () => {
+    assert.deepEqual([...RESOURCE_TYPE_NAMES], [
+      "Directive",
+      "OperationalSnapshot",
+      "SourceObservation",
+      "AttentionItem",
+      "PriorityRecommendation",
+      "AgentSession",
+      "ClientStatus",
+      "CommercialSnapshot",
+      "FinanceSnapshot",
+      "EngineeringSnapshot",
+      "ServiceHealth",
+      "CollectorRun",
+      "AuditEvent",
+    ]);
+    assert.equal(catalog.types.length, 13);
+    assert.deepEqual(
+      catalog.types.map((t) => t.name),
+      [...RESOURCE_TYPE_NAMES],
+    );
+    assert.deepEqual(types, [...RESOURCE_TYPE_NAMES]);
+  });
+});
+
+describe("primitives lockstep with JSON Schema", () => {
+  const primitives = readJson("schemas/primitives.v1.schema.json") as {
+    $defs: Record<string, { pattern?: string; enum?: string[] }>;
+  };
+
+  it("keeps scope pattern identical", () => {
+    assert.equal(primitives.$defs.scope?.pattern, SCOPE_PATTERN);
+  });
+
+  it("encodes FRESH|STALE|UNKNOWN|ERROR", () => {
+    assert.deepEqual(primitives.$defs.freshness_status?.enum, [...FRESHNESS_STATUSES]);
+  });
+
+  it("encodes UTC Z timestamps and resource IDs", () => {
+    assert.equal(primitives.$defs.utc_datetime?.pattern, UTC_DATETIME_PATTERN);
+    assert.equal(primitives.$defs.resource_id?.pattern, RESOURCE_ID_PATTERN);
+  });
+
+  it("requires provenance fields source, observed_at, freshness_status, confidence", () => {
+    const schema = readJson("schemas/primitives.v1.schema.json") as {
+      $defs: { provenance: { required: string[] } };
+    };
+    assert.deepEqual(schema.$defs.provenance.required, [
+      "source",
+      "observed_at",
+      "freshness_status",
+      "confidence",
+    ]);
+  });
+});
+
+for (const typeName of types) {
+  describe(typeName, () => {
+    const row = catalogType(typeName);
+
+    it("accepts the valid fixture via the shipped validator", () => {
+      const file = catalogFixturePath("valid", typeName);
+      const result = validateFile(typeName, file);
+      assert.equal(result.ok, true, JSON.stringify(result.errors));
+      assert.equal(result.type, typeName);
+      assert.equal(result.schema_version, row.schema_version);
+    });
+
+    it("rejects the invalid fixture via the shipped validator", () => {
+      const file = catalogFixturePath("invalid", typeName);
+      const result = validateFile(typeName, file);
+      assert.equal(result.ok, false, `${typeName} invalid fixture was accepted`);
+      assert.ok(result.errors.length > 0);
+    });
+
+    it("schema_version is a required const in the JSON Schema", () => {
+      const schema = readJson(row.schema) as {
+        required: string[];
+        properties: { schema_version: { const: string } };
+      };
+      assert.ok(schema.required.includes("schema_version"));
+      assert.equal(schema.properties.schema_version.const, row.schema_version);
+    });
+  });
+}
+
+describe("Directive semantics", () => {
+  const valid = readJson("fixtures/valid/directive.json");
+
+  it("rejects unknown kind", () => {
+    const doc = clone(valid) as Record<string, unknown>;
+    doc.kind = "note";
+    const result = validate("Directive", doc);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => /kind/i.test(e.path) || /enum/i.test(e.keyword ?? "")));
+  });
+
+  it("requires scope, status, effective_from, expires_at, supersedes, created_by, audit", () => {
+    const schema = readJson("schemas/directive.v1.schema.json") as { required: string[] };
+    for (const field of [
+      "scope",
+      "status",
+      "effective_from",
+      "expires_at",
+      "supersedes",
+      "created_by",
+      "audit",
+    ]) {
+      assert.ok(schema.required.includes(field), `missing required ${field}`);
+    }
+    const doc = clone(valid) as Record<string, unknown>;
+    delete doc.scope;
+    assert.equal(validate("Directive", doc).ok, false);
+  });
+
+  it("rejects expires_at before effective_from", () => {
+    const doc = clone(valid) as Record<string, unknown>;
+    doc.effective_from = "2026-08-20T12:00:00Z";
+    doc.expires_at = "2026-08-19T12:00:00Z";
+    const result = validate("Directive", doc);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.path === "/expires_at"));
+  });
+});
+
+describe("freshness vs confidence", () => {
+  const valid = readJson("fixtures/valid/source-observation.json") as {
+    provenance: Record<string, unknown>;
+  } & Record<string, unknown>;
+
+  it("accepts FRESH with low confidence (fields are independent)", () => {
+    const doc = clone(valid);
+    doc.provenance.freshness_status = "FRESH";
+    doc.provenance.confidence = 0.2;
+    const result = validate("SourceObservation", doc);
+    assert.equal(result.ok, true, JSON.stringify(result.errors));
+  });
+
+  it("accepts ERROR with residual confidence when error is present", () => {
+    const doc = clone(valid);
+    doc.provenance.freshness_status = "ERROR";
+    doc.provenance.confidence = 0.9;
+    doc.error = { code: "COLLECTOR_FAILED", message: "origin timeout" };
+    const result = validate("SourceObservation", doc);
+    assert.equal(result.ok, true, JSON.stringify(result.errors));
+  });
+
+  it("rejects ERROR without error object", () => {
+    const doc = clone(valid);
+    doc.provenance.freshness_status = "ERROR";
+    delete doc.error;
+    assert.equal(validate("SourceObservation", doc).ok, false);
+  });
+
+  it("rejects confidence above 1", () => {
+    const doc = clone(valid);
+    doc.provenance.confidence = 1.5;
+    assert.equal(validate("SourceObservation", doc).ok, false);
+  });
+
+  it("rejects substituting freshness with a confidence-like value", () => {
+    const doc = clone(valid);
+    doc.provenance.freshness_status = "HIGH";
+    assert.equal(validate("SourceObservation", doc).ok, false);
+  });
+});
+
+describe("AgentSession scope query", () => {
+  const valid = readJson("fixtures/valid/agent-session.json");
+
+  it("rejects empty requested_scopes", () => {
+    const doc = clone(valid) as Record<string, unknown>;
+    doc.requested_scopes = [];
+    assert.equal(validate("AgentSession", doc).ok, false);
+  });
+
+  it("rejects granted scope outside requested (fail-closed)", () => {
+    const doc = clone(valid) as Record<string, unknown>;
+    doc.requested_scopes = ["finance"];
+    doc.granted_scopes = ["finance", "company"];
+    const result = validate("AgentSession", doc);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.keyword === "granted_subset"));
+  });
+});
+
+describe("ClientStatus scope binding", () => {
+  it("rejects scope that is not client:<slug>", () => {
+    const valid = readJson("fixtures/valid/client-status.json") as Record<string, unknown>;
+    const doc = clone(valid);
+    doc.scope = "clients";
+    assert.equal(validate("ClientStatus", doc).ok, false);
+  });
+});
+
+describe("OperationalSnapshot homepage limit", () => {
+  it(`rejects more than ${HOMEPAGE_PRIORITY_LIMIT} top_priorities`, () => {
+    const valid = readJson("fixtures/valid/operational-snapshot.json") as {
+      top_priorities: unknown[];
+    };
+    const doc = clone(valid);
+    const extra = clone(doc.top_priorities[0]) as Record<string, unknown>;
+    extra.id = "cc:priority-recommendation:01K3CC-RANK-4";
+    extra.rank = 4;
+    doc.top_priorities.push(extra);
+    const result = validate("OperationalSnapshot", doc);
+    assert.equal(result.ok, false);
+  });
+});
+
+describe("FinanceSnapshot money and mutations", () => {
+  it("rejects non-integer cents", () => {
+    const valid = readJson("fixtures/valid/finance-snapshot.json") as {
+      receivables_open: { amount_cents: number; currency: string };
+    };
+    const doc = clone(valid);
+    doc.receivables_open.amount_cents = 10.5;
+    assert.equal(validate("FinanceSnapshot", doc).ok, false);
+  });
+
+  it("rejects flipping provider_mutations off forbidden", () => {
+    const valid = readJson("fixtures/valid/finance-snapshot.json") as Record<string, unknown>;
+    const doc = clone(valid);
+    doc.provider_mutations = "allowed";
+    assert.equal(validate("FinanceSnapshot", doc).ok, false);
+  });
+});
+
+describe("AuditEvent secret property names", () => {
+  it("rejects detail.password via the shipped validator", () => {
+    const valid = readJson("fixtures/valid/audit-event.json") as {
+      detail: Record<string, unknown>;
+    };
+    const doc = clone(valid);
+    doc.detail.password = "nope";
+    assert.equal(validate("AuditEvent", doc).ok, false);
+  });
+});
+
+describe("MCP principal agent interface", () => {
+  const mcp = loadMcpContract();
+
+  it("declares MCP as the principal agent interface and requires scoped tools", () => {
+    assert.equal(mcp.interface_role, "principal_agent_interface");
+    assert.match(mcp.scope_rule, /scope/i);
+    const names = allowedMcpToolNames();
+    assert.ok(names.includes("cc_get_context"));
+    const getContext = mcp.tools.find((t) => t.name === "cc_get_context");
+    assert.ok(getContext);
+    const required = (getContext.input_schema.required as string[]) ?? [];
+    assert.ok(required.includes("scopes"));
+  });
+
+  it("forbids financial and provider mutations and company-memory dump", () => {
+    const forbidden = forbiddenMcpOperationNames();
+    for (const name of [
+      "cc_charge",
+      "cc_checkout",
+      "cc_refund",
+      "cc_cancel_subscription",
+      "cc_asaas_write",
+      "cc_send_commercial",
+      "cc_dump_company_memory",
+    ]) {
+      assert.ok(forbidden.includes(name), `missing forbidden ${name}`);
+      assert.equal(isForbiddenMcpOperation(name), true);
+    }
+    const allowed = new Set(allowedMcpToolNames());
+    for (const name of forbidden) {
+      assert.equal(allowed.has(name), false, `${name} must not be an allowed tool`);
+    }
+  });
+});
+
+describe("internal HTTP contract", () => {
+  const spec = loadOpenApi();
+
+  it("requires scopes on the context endpoint and names all 13 resources", () => {
+    const context = spec.paths["/v1/context"] as {
+      get: { parameters: Array<{ name: string; required?: boolean }> };
+    };
+    const scopesParam = context.get.parameters.find((p) => p.name === "scopes");
+    assert.equal(scopesParam?.required, true);
+    const dumped = JSON.stringify(spec);
+    for (const name of RESOURCE_TYPE_NAMES) {
+      assert.ok(dumped.includes(name) || dumped.includes(catalogType(name).schema), name);
+    }
+  });
+
+  it("lists forbidden financial/provider paths and does not define them", () => {
+    const forbidden = forbiddenHttpPaths();
+    assert.ok(forbidden.includes("/v1/charges"));
+    assert.ok(forbidden.includes("/v1/checkout"));
+    assert.ok(forbidden.includes("/v1/refunds"));
+    assert.ok(forbidden.includes("/v1/asaas"));
+    assert.ok(forbidden.includes("/v1/messages/send"));
+    assert.ok(forbidden.includes("/v1/memory/dump"));
+    for (const p of forbidden) {
+      assert.equal(p in spec.paths, false, `forbidden path defined: ${p}`);
+    }
+  });
+});

--- a/control-center/contracts/tests/contract.test.ts
+++ b/control-center/contracts/tests/contract.test.ts
@@ -11,12 +11,14 @@ import {
   forbiddenMcpOperationNames,
   HOMEPAGE_PRIORITY_LIMIT,
   isForbiddenMcpOperation,
+  isScope,
   listResourceTypes,
   loadCatalog,
   loadMcpContract,
   loadOpenApi,
   RESOURCE_ID_PATTERN,
   RESOURCE_TYPE_NAMES,
+  SCOPE_CSV_PATTERN,
   SCOPE_PATTERN,
   UTC_DATETIME_PATTERN,
   validate,
@@ -160,6 +162,37 @@ describe("Directive semantics", () => {
     assert.equal(result.ok, false);
     assert.ok(result.errors.some((e) => e.path === "/expires_at"));
   });
+
+  it("compares instants, not RFC3339 strings, when fractional seconds are mixed", () => {
+    const laterFrac = clone(valid) as Record<string, unknown>;
+    laterFrac.effective_from = "2026-08-20T12:00:00Z";
+    laterFrac.expires_at = "2026-08-20T12:00:00.001Z";
+    const laterResult = validate("Directive", laterFrac);
+    assert.equal(laterResult.ok, true, JSON.stringify(laterResult.errors));
+
+    const earlierWhole = clone(valid) as Record<string, unknown>;
+    earlierWhole.effective_from = "2026-08-20T12:00:00.500Z";
+    earlierWhole.expires_at = "2026-08-20T12:00:00Z";
+    const earlierResult = validate("Directive", earlierWhole);
+    assert.equal(earlierResult.ok, false);
+    assert.ok(earlierResult.errors.some((e) => e.path === "/expires_at"));
+  });
+});
+
+describe("scope taxonomy exclusivity", () => {
+  it("accepts literals, repo, kebab client, and extra prefix:id", () => {
+    assert.equal(isScope("company"), true);
+    assert.equal(isScope("repo:tjsasakifln/Governance"), true);
+    assert.equal(isScope("client:acme-industria"), true);
+    assert.equal(isScope("campaign:CONFENGE-CC"), true);
+  });
+
+  it("rejects reserved names with a colon and ill-formed client slugs", () => {
+    assert.equal(isScope("company:foo"), false);
+    assert.equal(isScope("client:Acme"), false);
+    assert.equal(isScope("client:foo_bar"), false);
+    assert.equal(isScope("hr"), false);
+  });
 });
 
 describe("freshness vs confidence", () => {
@@ -290,6 +323,20 @@ describe("MCP principal agent interface", () => {
     assert.ok(required.includes("scopes"));
   });
 
+  it("encodes SCOPE_PATTERN on every scoped MCP tool input", () => {
+    const skip = new Set(["cc_list_scopes", "cc_get_client_status"]);
+    for (const tool of mcp.tools) {
+      if (skip.has(tool.name)) {
+        continue;
+      }
+      const props = tool.input_schema.properties as Record<string, unknown>;
+      const scopes = props.scopes as { items?: { pattern?: string } } | undefined;
+      const scope = props.scope as { pattern?: string } | undefined;
+      const pattern = scopes?.items?.pattern ?? scope?.pattern;
+      assert.equal(pattern, SCOPE_PATTERN, `${tool.name} missing SCOPE_PATTERN`);
+    }
+  });
+
   it("forbids financial and provider mutations and company-memory dump", () => {
     const forbidden = forbiddenMcpOperationNames();
     for (const name of [
@@ -337,5 +384,17 @@ describe("internal HTTP contract", () => {
     for (const p of forbidden) {
       assert.equal(p in spec.paths, false, `forbidden path defined: ${p}`);
     }
+  });
+
+  it("requires scope on GET /v1/audit and encodes ScopeCsv", () => {
+    const audit = spec.paths["/v1/audit"] as {
+      get: { parameters: Array<{ name: string; required?: boolean }> };
+    };
+    const scopeParam = audit.get.parameters.find((p) => p.name === "scope");
+    assert.equal(scopeParam?.required, true);
+    const schemas = (spec as unknown as { components: { schemas: Record<string, { pattern?: string }> } })
+      .components.schemas;
+    assert.equal(schemas.Scope?.pattern, SCOPE_PATTERN);
+    assert.equal(schemas.ScopeCsv?.pattern, SCOPE_CSV_PATTERN);
   });
 });

--- a/control-center/contracts/tests/fingerprint.test.ts
+++ b/control-center/contracts/tests/fingerprint.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  contractFingerprint,
+  fingerprintArtifacts,
+  publicOntologyArtifacts,
+} from "../src/index.js";
+
+describe("CONTRACT_FINGERPRINT", () => {
+  it("is deterministic across two shipped runs on the same tree", () => {
+    const first = contractFingerprint();
+    const second = contractFingerprint();
+    assert.match(first, /^sha256:[0-9a-f]{64}$/);
+    assert.equal(first, second);
+    assert.equal(fingerprintArtifacts(publicOntologyArtifacts()), first);
+  });
+
+  it("changes when a public catalog byte changes", () => {
+    const artifacts = publicOntologyArtifacts();
+    const original = fingerprintArtifacts(artifacts);
+    const mutated = artifacts.map((item) =>
+      item.path === "catalog.json"
+        ? { path: item.path, canonical: item.canonical.replace("Directive", "DirectiveX") }
+        : item,
+    );
+    const after = fingerprintArtifacts(mutated);
+    assert.notEqual(after, original);
+    assert.equal(fingerprintArtifacts(artifacts), original);
+  });
+
+  it("changes when a public schema byte changes", () => {
+    const artifacts = publicOntologyArtifacts();
+    const original = fingerprintArtifacts(artifacts);
+    const target = artifacts.find((item) => item.path.endsWith("finance-snapshot.v1.schema.json"));
+    assert.ok(target, "finance snapshot schema is a public ontology input");
+    const mutated = artifacts.map((item) =>
+      item.path === target.path
+        ? { path: item.path, canonical: `${item.canonical} ` }
+        : item,
+    );
+    assert.notEqual(fingerprintArtifacts(mutated), original);
+  });
+
+  it("changes when a taxonomy byte changes", () => {
+    const artifacts = publicOntologyArtifacts();
+    const original = fingerprintArtifacts(artifacts);
+    const mutated = artifacts.map((item) =>
+      item.path === "src/taxonomy.ts"
+        ? { path: item.path, canonical: item.canonical.replace("FRESH", "FRESHX") }
+        : item,
+    );
+    assert.notEqual(fingerprintArtifacts(mutated), original);
+  });
+});

--- a/control-center/contracts/tsconfig.json
+++ b/control-center/contracts/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Canonical contract package for the Confenge Control Center, isolated under `control-center/contracts/`. Other workstreams can implement persistence, context, MCP runtime, collectors, and UI against these artifacts without guessing field names, enums, or authority.

This PR does **not** implement UI, PostgreSQL, collectors, authentication, or an MCP/HTTP server. It does **not** touch `commercial/`, `decisions/`, `scripts/`, root README, or PR #8. Do **not** merge until campaign gate D01.

## CONTRACT_FINGERPRINT

```
sha256:f57935216241cce7bcafb0d1840148d96af09fd3f8a9865dd225b7a472b8e80d
```

Produced by the shipped CLI (`npx tsx src/cli.ts --fingerprint`) from a canonical serialization of `catalog.json`, `schemas/*.schema.json`, `src/taxonomy.ts`, `docs/compatibility.v1.json`, `docs/http.openapi.json`, and `docs/mcp.v1.json`. Same tree → same digest; changing a public schema/taxonomy/catalog byte changes it.

## Conserved canon

- `scope` STRING: `company` | `commercial` | `finance` | `clients` | `infrastructure` | `inbound` | `repo:name` | `client:slug` | `prefix:id`
- `freshness` `FRESH|STALE|UNKNOWN|ERROR` (not confidence)
- external resource IDs `cc:type:id` (example: `cc:directive:01K3CC-NO-PROVIDER-MUTATION`)
- `provenance.source` is a structured SourceRef; `confidence` is independent of freshness
- Directive `status` `draft|active|superseded|revoked|expired`; `Directive.supersedes` is a list; ActorRef is `human|agent|system`

## What is in the contract

- Versioned JSON Schema **and** TypeScript types for the cataloged resources: `Directive`, `OperationalSnapshot`, `SourceObservation`, `AttentionItem`, `PriorityRecommendation`, `AgentSession`, `AgentActivity`, `ClientStatus`, `CommercialSnapshot`, `FinanceSnapshot`, `EngineeringSnapshot`, `ServiceHealth`, `CollectorRun`, `AuditEvent`.
- `AgentActivity` is the execution ledger (what an agent ran). `AgentSession` remains the scoped context-consult grant (`open|closed|denied`). They are not aliases.
- `FinanceSnapshot` is a read-only aggregate (`provider_mutations` = forbidden) with integer-cents+currency money: contracted, billed, paid, effectively_received, overdue, receivable, refunds, chargebacks. `cash_in` only when evidenced; `mrr` only when recurring monthly is applicable; `runway` only when cash+expense are reliable.
- `CommercialSnapshot` is a Warmbly read model that **pins** Governance catalog identity (`offer_pin`) and MUST NOT copy names, prices, terms, or offer copy. Funnel: new_leads, qualified, opportunities, proposals, clients. `pipeline_weighted` only with reliable probability. Aging / stalled / missing-next-action counts plus attention refs.
- Directive `draft` plus OperationalSnapshot / AgentContext compose proposal and today envelopes; those are not extra cataloged types.
- Compatibility table (`docs/compatibility.v1.json`) plus shipped classifier: lowercase freshness and `expired`-as-freshness and `withdrawn`/`inactive` are **reject**; object `scope` and raw UUID ids are **adapter_required**. Never silent accept.
- Internal HTTP OpenAPI (`docs/http.openapi.json`) and MCP (`docs/mcp.v1.json`). Agents query **by scope**. Financial/provider mutations are absent and explicitly forbidden.
- ADR: Governance = strategic/canonical; Warmbly = commercial runtime; collectors/read models = read-only aggregates.
- Valid and invalid fixtures for every cataloged type; shipped validator (`src/validate.ts` + CLI) driven by local contract tests.

## How to run

```bash
cd control-center/contracts
npm install
npm test
npm run typecheck
npx tsx src/cli.ts --list-types
npx tsx src/cli.ts --fingerprint
npx tsx src/cli.ts --type Directive fixtures/valid/directive.json
npx tsx src/cli.ts --type FinanceSnapshot fixtures/valid/finance-snapshot.json
npx tsx src/cli.ts --type CommercialSnapshot fixtures/valid/commercial-snapshot.json
npx tsx src/cli.ts --type AgentActivity fixtures/valid/agent-activity.json
```

## Convergence

Later campaign. Do not wire this into root README, Warmbly, web-cfg, or extra-cli from this PR.
