### PR TITLE
feat(control-center): isolated Confenge MCP server

### DIFF
--- a/control-center/services/mcp/.env.example
+++ b/control-center/services/mcp/.env.example
@@ -1,0 +1,11 @@
+# Injected at runtime. Never commit a real value.
+# The server refuses to serve context if this is empty.
+CONFENGE_MCP_AUTH_TOKEN=
+
+# Optional. Defaults shown.
+# CONFENGE_MCP_RATE_LIMIT_MAX=30
+# CONFENGE_MCP_RATE_LIMIT_WINDOW_MS=60000
+
+# Optional HTTP JSON-RPC transport (POST /mcp). If unset, the process speaks stdio NDJSON.
+# CONFENGE_MCP_HTTP_PORT=
+# CONFENGE_MCP_HTTP_HOST=127.0.0.1

--- a/control-center/services/mcp/.gitignore
+++ b/control-center/services/mcp/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.log
+.env
+.env.*
+!.env.example
+coverage/

--- a/control-center/services/mcp/README.md
+++ b/control-center/services/mcp/README.md
@@ -1,0 +1,126 @@
+# Confenge Control Center MCP
+
+Isolated MCP server for Grok, Codex, and other agents. It exposes **scoped operational context** and two session-report writes. It is not chat, not an ERP, and not a payment console.
+
+This package lives only under `control-center/services/mcp/`. It boots against **local fixtures** through a **stub Context API adapter**. It does not import or call a sibling Context API, PostgreSQL, Warmbly, Asaas, or any other workstream.
+
+## Decisions
+
+- Governance remains the strategic/canonical authority. Warmbly remains the operational commercial/CRM authority. This server only **aggregates and serves** state.
+- Transport default is **stdio NDJSON** (MCP). Optional `POST /mcp` JSON-RPC when `CONFENGE_MCP_HTTP_PORT` is set.
+- Protocol subset: `initialize` + `notifications/initialized`, `tools/*`, `resources/*`, `prompts/*`, `ping`. JSON-RPC 2.0. Protocol versions `2024-11-05`, `2025-03-26`, `2025-06-18`.
+- Auth token is injected via `CONFENGE_MCP_AUTH_TOKEN`. Requests present `Authorization: Bearer …` (HTTP) or `params._meta.authorization`. Missing env, missing token, or wrong token **fail closed** and do not serve context.
+- Every `tools/call` is validated, rate-limited, and tagged with a `correlation_id`.
+- Reads are first-class. Writes are only `confenge.report_session_result` and `confenge.report_blocker`. Agents cannot create or alter `decision`, `constraint`, or authoritative `directive`.
+- No cobrança, checkout, refund, cancelamento, or Asaas/provider mutation tools exist.
+- Aggregated records carry `source`, `observed_at` (UTC), `freshness_status`, and `confidence` when applicable. Money in fixtures is integer cents + currency.
+- Scope-taking tools require `scope` or `client` and never return the whole-company dump.
+
+## Run
+
+```bash
+cd control-center/services/mcp
+npm install
+npm test
+npm run build
+CONFENGE_MCP_AUTH_TOKEN="$(cat /run/secrets/confenge-mcp-token)" npm start
+```
+
+Dev (TypeScript, same entry as production):
+
+```bash
+CONFENGE_MCP_AUTH_TOKEN="inject-me" npm run dev
+```
+
+Optional HTTP JSON-RPC:
+
+```bash
+CONFENGE_MCP_AUTH_TOKEN="inject-me" CONFENGE_MCP_HTTP_PORT=8787 npm start
+# POST /mcp   Authorization: Bearer …
+# GET  /healthz
+```
+
+Clients must send `initialize`, then `notifications/initialized`, then preflight (`prompts/get confenge.session_preflight` and/or `resources/read confenge://preflight/checklist`) before acting.
+
+## Environment
+
+| Variable | Required | Meaning |
+| --- | --- | --- |
+| `CONFENGE_MCP_AUTH_TOKEN` | yes, to serve context | Shared bearer token. Inject from a secret manager. Never commit a real value. |
+| `CONFENGE_MCP_RATE_LIMIT_MAX` | no (default 30) | Max `tools/call` per window per token fingerprint |
+| `CONFENGE_MCP_RATE_LIMIT_WINDOW_MS` | no (default 60000) | Rate-limit window |
+| `CONFENGE_MCP_HTTP_PORT` | no | If set, listen HTTP instead of stdio |
+| `CONFENGE_MCP_HTTP_HOST` | no (default 127.0.0.1) | HTTP bind host |
+
+Logs are structured JSON on **stderr**. Authorization values, tokens, and secrets are redacted. Do not put the token in URLs, query strings, or analytics.
+
+## MCP surface
+
+Tools (exact names):
+
+- `confenge.get_company_state`
+- `confenge.get_context` (`scope` required)
+- `confenge.get_active_directives` (`scope` required)
+- `confenge.get_priorities`
+- `confenge.get_client_context` (`client` required)
+- `confenge.get_decisions` (`since` optional, ISO-8601 UTC)
+- `confenge.report_session_result`
+- `confenge.report_blocker`
+
+Resources:
+
+- `confenge://preflight/checklist`
+- `confenge://preflight/scopes`
+- `confenge://session/operating-rules`
+
+Prompts:
+
+- `confenge.session_preflight`
+- `confenge.session_close`
+
+## Stub Context API contract
+
+Local port: `ContextApiPort` in `src/types.ts`. Fixture adapter: `src/stub-adapter.ts`.
+
+```ts
+interface ContextApiPort {
+  getCompanyState(): Promise<CompanyState>;
+  getContext(scope: string): Promise<ScopedContext>;
+  getActiveDirectives(scope: string): Promise<DirectiveRecord[]>;
+  getPriorities(): Promise<PriorityRecord[]>;
+  getClientContext(client: string): Promise<ClientContext>;
+  getDecisions(since?: string): Promise<DecisionRecord[]>;
+  reportSessionResult(input: SessionResultInput): Promise<WriteReceipt>;
+  reportBlocker(input: BlockerInput): Promise<WriteReceipt>;
+}
+```
+
+Rules the adapter must keep:
+
+- Unknown `scope` / `client` fail closed (no dump of everything).
+- `getContext` / `getActiveDirectives` return only the requested scope.
+- `getClientContext` returns only that client.
+- Whole-company internal memory is never a tool response.
+- Directive records include `kind`, `scope`, `status`, `effective_from`, `expires_at`, `supersedes`, `created_by`, and `audit`.
+- Provenance fields on every aggregated record.
+
+This campaign does **not** HTTP-call a future Context service. The stub is the integration seam.
+
+## Convergence (later campaign)
+
+A later campaign should:
+
+1. Implement `ContextApiPort` against the real Control Center Context API / PostgreSQL read model (owned by other workstreams). Inject it in `src/index.ts` instead of `createStubContextApi()`.
+2. Keep these eight tool names, resource URIs, and prompt names stable.
+3. Continue injecting `CONFENGE_MCP_AUTH_TOKEN` from secret storage; do not add identity/password hardcoding.
+4. Keep financial/provider mutation out of this process. Collectors and Asaas stay elsewhere.
+5. Preserve fail-closed auth, rate limits, structured errors, and correlation ids.
+6. Do not fold this package into `commercial/`, Warmbly, extra-cli, or PR Governance #8.
+
+## Tests
+
+```bash
+npm test
+```
+
+Protocol tests drive the shipped JSON-RPC handler. Abuse tests cover missing/wrong token, malformed JSON-RPC, unknown tool, missing scope/client, and rate limits. Launch tests spawn `src/index.ts` over stdio and run preflight → `get_context` → `report_session_result` twice.

--- a/control-center/services/mcp/package-lock.json
+++ b/control-center/services/mcp/package-lock.json
@@ -1,0 +1,584 @@
+{
+  "name": "@confenge/control-center-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      },
+      "bin": {
+        "confenge-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "tsx": "^4.20.3",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/control-center/services/mcp/package.json
+++ b/control-center/services/mcp/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@confenge/control-center-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Confenge Control Center MCP server: scoped agent context and session reports.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "bin": {
+    "confenge-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "tsx --test tests/**/*.test.ts"
+  },
+  "dependencies": {
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "tsx": "^4.20.3",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/services/mcp/src/catalog.ts
+++ b/control-center/services/mcp/src/catalog.ts
@@ -1,0 +1,326 @@
+import { ERROR_CODES, McpAppError } from "./errors.js";
+import { FIXTURE_CLIENTS, FIXTURE_SCOPES, MARKERS } from "./fixtures.js";
+import { UnknownClientError, UnknownScopeError } from "./stub-adapter.js";
+import {
+  PROMPT_NAMES,
+  RESOURCE_URIS,
+  TOOL_NAMES,
+  type ContextApiPort,
+} from "./types.js";
+import {
+  asBlocker,
+  asSessionResult,
+  emptyArgsSchema,
+  getActiveDirectivesArgsSchema,
+  getClientContextArgsSchema,
+  getContextArgsSchema,
+  getDecisionsArgsSchema,
+  jsonSchema,
+  parseArgs,
+  reportBlockerArgsSchema,
+  reportSessionResultArgsSchema,
+} from "./validation.js";
+import { assertNoAuthoritativeMutation } from "./security.js";
+
+export interface ToolDefinition {
+  name: (typeof TOOL_NAMES)[number];
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface ResourceDefinition {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: "text/markdown" | "application/json";
+}
+
+export interface PromptDefinition {
+  name: string;
+  description: string;
+  arguments: Array<{ name: string; description: string; required: boolean }>;
+}
+
+export const toolDefinitions: ToolDefinition[] = [
+  {
+    name: "confenge.get_company_state",
+    description:
+      "Aggregated company operational state: the three current priorities and open exceptions, with provenance. Not a KPI wall and not the whole-company memory dump.",
+    inputSchema: jsonSchema(emptyArgsSchema),
+  },
+  {
+    name: "confenge.get_context",
+    description:
+      "Scoped operational context. Requires `scope`. Does not return other scopes or the whole-company dump.",
+    inputSchema: jsonSchema(getContextArgsSchema),
+  },
+  {
+    name: "confenge.get_active_directives",
+    description:
+      "Active human directives for a single `scope` (kind, status, effective window, audit). Requires `scope`.",
+    inputSchema: jsonSchema(getActiveDirectivesArgsSchema),
+  },
+  {
+    name: "confenge.get_priorities",
+    description: "The current ranked priorities (the three most important things now).",
+    inputSchema: jsonSchema(emptyArgsSchema),
+  },
+  {
+    name: "confenge.get_client_context",
+    description: "Context for one client identifier. Requires `client`. Does not return other clients.",
+    inputSchema: jsonSchema(getClientContextArgsSchema),
+  },
+  {
+    name: "confenge.get_decisions",
+    description: "Read-only decisions. Optional `since` (ISO-8601 UTC) filters by decided_at.",
+    inputSchema: jsonSchema(getDecisionsArgsSchema),
+  },
+  {
+    name: "confenge.report_session_result",
+    description:
+      "Record the outcome of an agent session. The only write besides report_blocker. Cannot create or alter decisions, constraints, or authoritative directives.",
+    inputSchema: jsonSchema(reportSessionResultArgsSchema),
+  },
+  {
+    name: "confenge.report_blocker",
+    description:
+      "Record a blocker encountered during a session. Cannot create or alter decisions, constraints, or authoritative directives.",
+    inputSchema: jsonSchema(reportBlockerArgsSchema),
+  },
+];
+
+export const resourceDefinitions: ResourceDefinition[] = [
+  {
+    uri: RESOURCE_URIS.checklist,
+    name: "Session preflight checklist",
+    description: "What an agent must load before acting in a Confenge Control Center session.",
+    mimeType: "text/markdown",
+  },
+  {
+    uri: RESOURCE_URIS.scopes,
+    name: "Known scopes and clients",
+    description: "Fixture scopes and client identifiers this isolated server can serve.",
+    mimeType: "application/json",
+  },
+  {
+    uri: RESOURCE_URIS.rules,
+    name: "Operating rules",
+    description: "Hard limits: read-first, no authoritative memory writes, no provider mutations.",
+    mimeType: "text/markdown",
+  },
+];
+
+export const promptDefinitions: PromptDefinition[] = [
+  {
+    name: PROMPT_NAMES.preflight,
+    description: "Instructions to load scoped context before taking any action.",
+    arguments: [
+      {
+        name: "scope",
+        description: "Operational scope to load, e.g. ops.commercial",
+        required: false,
+      },
+    ],
+  },
+  {
+    name: PROMPT_NAMES.close,
+    description: "Instructions to report session result or blocker when the session ends.",
+    arguments: [
+      {
+        name: "scope",
+        description: "Scope the session acted in",
+        required: false,
+      },
+    ],
+  },
+];
+
+export async function executeTool(
+  context: ContextApiPort,
+  name: string,
+  args: unknown,
+  correlationId: string,
+): Promise<unknown> {
+  assertNoAuthoritativeMutation(name, args, correlationId);
+
+  switch (name) {
+    case "confenge.get_company_state":
+      parseArgs(emptyArgsSchema, args, correlationId);
+      return context.getCompanyState();
+    case "confenge.get_context": {
+      const parsed = parseArgs(getContextArgsSchema, args, correlationId, ERROR_CODES.MISSING_SCOPE);
+      return wrapUnknownScope(correlationId, () => context.getContext(parsed.scope));
+    }
+    case "confenge.get_active_directives": {
+      const parsed = parseArgs(
+        getActiveDirectivesArgsSchema,
+        args,
+        correlationId,
+        ERROR_CODES.MISSING_SCOPE,
+      );
+      const directives = await wrapUnknownScope(correlationId, () =>
+        context.getActiveDirectives(parsed.scope),
+      );
+      return {
+        scope: parsed.scope,
+        directives,
+        source: directives[0]?.source ?? "control-center.stub.fixtures",
+        observed_at: directives[0]?.observed_at ?? new Date().toISOString(),
+        freshness_status: directives[0]?.freshness_status ?? "unknown",
+        confidence: directives[0]?.confidence,
+      };
+    }
+    case "confenge.get_priorities":
+      parseArgs(emptyArgsSchema, args, correlationId);
+      return { priorities: await context.getPriorities() };
+    case "confenge.get_client_context": {
+      const parsed = parseArgs(
+        getClientContextArgsSchema,
+        args,
+        correlationId,
+        ERROR_CODES.MISSING_CLIENT,
+      );
+      return wrapUnknownClient(correlationId, () => context.getClientContext(parsed.client));
+    }
+    case "confenge.get_decisions": {
+      const parsed = parseArgs(getDecisionsArgsSchema, args, correlationId);
+      const list = await context.getDecisions(parsed.since);
+      return { since: parsed.since ?? null, decisions: list };
+    }
+    case "confenge.report_session_result": {
+      const parsed = parseArgs(reportSessionResultArgsSchema, args, correlationId, ERROR_CODES.MISSING_SCOPE);
+      return context.reportSessionResult(asSessionResult(parsed));
+    }
+    case "confenge.report_blocker": {
+      const parsed = parseArgs(reportBlockerArgsSchema, args, correlationId, ERROR_CODES.MISSING_SCOPE);
+      return context.reportBlocker(asBlocker(parsed));
+    }
+    default:
+      throw new McpAppError(ERROR_CODES.UNKNOWN_TOOL, `unknown tool: ${name}`, correlationId);
+  }
+}
+
+export function readResource(uri: string, correlationId: string): { mimeType: string; text: string } {
+  switch (uri) {
+    case RESOURCE_URIS.checklist:
+      return { mimeType: "text/markdown", text: PREFLIGHT_CHECKLIST };
+    case RESOURCE_URIS.scopes:
+      return {
+        mimeType: "application/json",
+        text: JSON.stringify(
+          {
+            scopes: FIXTURE_SCOPES,
+            clients: FIXTURE_CLIENTS,
+            note: "Unknown scopes fail closed. Whole-company dump is not a scope.",
+          },
+          null,
+          2,
+        ),
+      };
+    case RESOURCE_URIS.rules:
+      return { mimeType: "text/markdown", text: OPERATING_RULES };
+    default:
+      throw new McpAppError(ERROR_CODES.UNKNOWN_RESOURCE, `unknown resource: ${uri}`, correlationId);
+  }
+}
+
+export function getPrompt(
+  name: string,
+  args: Record<string, string> | undefined,
+  correlationId: string,
+): { description: string; messages: Array<{ role: "user"; content: { type: "text"; text: string } }> } {
+  const scope = args?.["scope"]?.trim() || "ops.commercial";
+  if (name === PROMPT_NAMES.preflight) {
+    return {
+      description: "Load scoped Confenge context before acting.",
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: [
+              "You are entering a Confenge Control Center session.",
+              "This is not chat, not ERP, and not a payment console.",
+              "Before taking any action:",
+              "1. Read resource confenge://preflight/checklist and confenge://session/operating-rules.",
+              "2. Call confenge.get_company_state for the current exceptions and three priorities.",
+              `3. Call confenge.get_context with scope \"${scope}\" (never omit scope; never request all memory).`,
+              `4. Call confenge.get_active_directives with the same scope \"${scope}\".`,
+              "5. If the work is about a named client, call confenge.get_client_context with that client id.",
+              "6. You may call confenge.get_decisions with optional since.",
+              "7. You MUST NOT create or alter a decision, constraint, or authoritative directive.",
+              "8. You MUST NOT charge, checkout, refund, cancel, or mutate Asaas/providers.",
+              "When finished, call confenge.report_session_result or confenge.report_blocker.",
+            ].join("\n"),
+          },
+        },
+      ],
+    };
+  }
+  if (name === PROMPT_NAMES.close) {
+    return {
+      description: "Close a session by reporting result or blocker.",
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: [
+              `Close the session for scope \"${scope}\".`,
+              "Call confenge.report_session_result with scope, summary, and outcome (completed|partial|failed|blocked).",
+              "If work cannot continue, call confenge.report_blocker instead.",
+              "Do not smuggle directive/decision/constraint mutations into the report.",
+            ].join("\n"),
+          },
+        },
+      ],
+    };
+  }
+  throw new McpAppError(ERROR_CODES.UNKNOWN_PROMPT, `unknown prompt: ${name}`, correlationId);
+}
+
+async function wrapUnknownScope<T>(correlationId: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof UnknownScopeError) {
+      throw new McpAppError(ERROR_CODES.UNKNOWN_SCOPE, err.message, correlationId);
+    }
+    throw err;
+  }
+}
+
+async function wrapUnknownClient<T>(correlationId: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof UnknownClientError) {
+      throw new McpAppError(ERROR_CODES.UNKNOWN_CLIENT, err.message, correlationId);
+    }
+    throw err;
+  }
+}
+
+const PREFLIGHT_CHECKLIST = `# Confenge session preflight
+
+Load these before acting:
+
+1. \`confenge.get_company_state\` — exceptions and the three current priorities.
+2. \`confenge.get_context\` with an explicit \`scope\` (fixture scopes: ${FIXTURE_SCOPES.join(", ")}).
+3. \`confenge.get_active_directives\` with the same \`scope\`.
+4. \`confenge.get_client_context\` when the work names a client (fixture clients: ${FIXTURE_CLIENTS.join(", ")}).
+5. \`confenge.get_decisions\` with optional \`since\` if historical decisions matter.
+
+Do not request whole-company memory. Marker ${MARKERS.companyDump} must never appear in tool output.
+Writes allowed: \`confenge.report_session_result\`, \`confenge.report_blocker\` only.
+`;
+
+const OPERATING_RULES = `# Operating rules
+
+- Read-first. Writes are only session result and blocker reports.
+- Agents cannot create or alter \`decision\`, \`constraint\`, or authoritative \`directive\`.
+- No cobrança, checkout, refund, cancelamento, or Asaas/provider mutation.
+- Every aggregated record carries \`source\`, \`observed_at\`, \`freshness_status\`, and \`confidence\` when applicable.
+- Auth token is injected via env/secret; never embed it in URLs, logs, or the client bundle.
+- Fail closed: missing or invalid auth does not serve context.
+`;

--- a/control-center/services/mcp/src/errors.ts
+++ b/control-center/services/mcp/src/errors.ts
@@ -1,0 +1,95 @@
+export const ERROR_CODES = {
+  PARSE_ERROR: "PARSE_ERROR",
+  INVALID_REQUEST: "INVALID_REQUEST",
+  UNAUTHENTICATED: "UNAUTHENTICATED",
+  INVALID_TOKEN: "INVALID_TOKEN",
+  RATE_LIMITED: "RATE_LIMITED",
+  NOT_INITIALIZED: "NOT_INITIALIZED",
+  METHOD_NOT_FOUND: "METHOD_NOT_FOUND",
+  UNKNOWN_TOOL: "UNKNOWN_TOOL",
+  INVALID_PARAMS: "INVALID_PARAMS",
+  MISSING_SCOPE: "MISSING_SCOPE",
+  MISSING_CLIENT: "MISSING_CLIENT",
+  UNKNOWN_SCOPE: "UNKNOWN_SCOPE",
+  UNKNOWN_CLIENT: "UNKNOWN_CLIENT",
+  UNKNOWN_RESOURCE: "UNKNOWN_RESOURCE",
+  UNKNOWN_PROMPT: "UNKNOWN_PROMPT",
+  FORBIDDEN_MUTATION: "FORBIDDEN_MUTATION",
+  INTERNAL: "INTERNAL",
+} as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+
+export interface StructuredError {
+  error: {
+    code: ErrorCode;
+    message: string;
+    correlation_id: string;
+  };
+}
+
+export const JSON_RPC = {
+  PARSE_ERROR: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL: -32603,
+  UNAUTHENTICATED: -32001,
+  INVALID_TOKEN: -32002,
+  RATE_LIMITED: -32003,
+  FORBIDDEN_MUTATION: -32004,
+  NOT_INITIALIZED: -32000,
+} as const;
+
+export function jsonRpcCode(code: ErrorCode): number {
+  switch (code) {
+    case ERROR_CODES.PARSE_ERROR:
+      return JSON_RPC.PARSE_ERROR;
+    case ERROR_CODES.INVALID_REQUEST:
+      return JSON_RPC.INVALID_REQUEST;
+    case ERROR_CODES.METHOD_NOT_FOUND:
+    case ERROR_CODES.UNKNOWN_TOOL:
+    case ERROR_CODES.UNKNOWN_RESOURCE:
+    case ERROR_CODES.UNKNOWN_PROMPT:
+      return JSON_RPC.METHOD_NOT_FOUND;
+    case ERROR_CODES.INVALID_PARAMS:
+    case ERROR_CODES.MISSING_SCOPE:
+    case ERROR_CODES.MISSING_CLIENT:
+    case ERROR_CODES.UNKNOWN_SCOPE:
+    case ERROR_CODES.UNKNOWN_CLIENT:
+      return JSON_RPC.INVALID_PARAMS;
+    case ERROR_CODES.UNAUTHENTICATED:
+      return JSON_RPC.UNAUTHENTICATED;
+    case ERROR_CODES.INVALID_TOKEN:
+      return JSON_RPC.INVALID_TOKEN;
+    case ERROR_CODES.RATE_LIMITED:
+      return JSON_RPC.RATE_LIMITED;
+    case ERROR_CODES.FORBIDDEN_MUTATION:
+      return JSON_RPC.FORBIDDEN_MUTATION;
+    case ERROR_CODES.NOT_INITIALIZED:
+      return JSON_RPC.NOT_INITIALIZED;
+    default:
+      return JSON_RPC.INTERNAL;
+  }
+}
+
+export class McpAppError extends Error {
+  override readonly name = "McpAppError";
+  constructor(
+    public readonly code: ErrorCode,
+    message: string,
+    public readonly correlationId: string,
+  ) {
+    super(message);
+  }
+
+  toStructured(): StructuredError {
+    return {
+      error: {
+        code: this.code,
+        message: this.message,
+        correlation_id: this.correlationId,
+      },
+    };
+  }
+}

--- a/control-center/services/mcp/src/fixtures.ts
+++ b/control-center/services/mcp/src/fixtures.ts
@@ -1,0 +1,293 @@
+import type {
+  ClientContext,
+  CompanyState,
+  ContextRecord,
+  DecisionRecord,
+  DirectiveRecord,
+  ExceptionRecord,
+  PriorityRecord,
+} from "./types.js";
+
+/** Distinctive strings used by protocol tests to prove scoping. */
+export const MARKERS = {
+  companyDump: "COMPANY_WIDE_MEMORY_DUMP_DO_NOT_EXPOSE",
+  commercial: "SCOPE_COMMERCIAL_MARKER",
+  finance: "SCOPE_FINANCE_MARKER",
+  acme: "CLIENT_ACME_MARKER",
+  beta: "CLIENT_BETA_MARKER",
+} as const;
+
+export const FIXTURE_SCOPES = ["company", "ops.commercial", "ops.finance"] as const;
+export const FIXTURE_CLIENTS = ["acme-ltda", "beta-industria"] as const;
+
+const OBSERVED = "2026-08-20T15:00:00.000Z";
+const SOURCE = "control-center.stub.fixtures";
+
+function prov(
+  extra?: { source?: string; observed_at?: string; freshness_status?: ContextRecord["freshness_status"]; confidence?: number },
+) {
+  return {
+    source: extra?.source ?? SOURCE,
+    observed_at: extra?.observed_at ?? OBSERVED,
+    freshness_status: extra?.freshness_status ?? ("fresh" as const),
+    confidence: extra?.confidence ?? 0.9,
+  };
+}
+
+export const companyDumpSecret = {
+  id: "mem-dump-1",
+  body: MARKERS.companyDump,
+};
+
+export const priorities: PriorityRecord[] = [
+  {
+    id: "pri-1",
+    rank: 1,
+    title: "Unblock ACME onboarding exception",
+    body: "ACME legal packet is stale; do not send commercial follow-up until Governance confirms.",
+    scope: "ops.commercial",
+    kind: "priority",
+    ...prov({ confidence: 0.94 }),
+  },
+  {
+    id: "pri-2",
+    rank: 2,
+    title: "Reconcile overdue Diagnóstico invoice",
+    body: "Invoice 150000 BRL cents is past due; observe only — no Asaas mutation from agents.",
+    scope: "ops.finance",
+    kind: "priority",
+    ...prov({ confidence: 0.88 }),
+  },
+  {
+    id: "pri-3",
+    rank: 3,
+    title: "Keep Control Center read-only toward providers",
+    body: "This layer aggregates state. It does not charge, refund, checkout, or cancel.",
+    scope: "company",
+    kind: "priority",
+    ...prov({ confidence: 1 }),
+  },
+];
+
+export const exceptions: ExceptionRecord[] = [
+  {
+    id: "exc-1",
+    title: "ACME onboarding blocked",
+    body: "Missing founder-approved legal packet freshness.",
+    scope: "ops.commercial",
+    severity: "high",
+    ...prov({ freshness_status: "stale", confidence: 0.8 }),
+  },
+  {
+    id: "exc-2",
+    title: "Diagnóstico invoice overdue",
+    body: "Open amount 150000 cents BRL. Collection systems remain the operational authority.",
+    scope: "ops.finance",
+    severity: "medium",
+    ...prov({ confidence: 0.91 }),
+  },
+];
+
+export const companyState: CompanyState = {
+  company_id: "confenge",
+  display_timezone: "America/Sao_Paulo",
+  top_three: priorities,
+  exceptions,
+  ...prov({ confidence: 0.9 }),
+};
+
+export const contextRecords: ContextRecord[] = [
+  {
+    id: "ctx-company-1",
+    kind: "fact",
+    title: "Control Center is not chat and not ERP",
+    body: "Aggregates exceptions, priorities, directives, and agent activity for a single human operator.",
+    scope: "company",
+    ...prov(),
+  },
+  {
+    id: "ctx-comm-1",
+    kind: "fact",
+    title: "Commercial pipeline snapshot",
+    body: `${MARKERS.commercial}: Warmbly remains CRM authority. Two Diagnóstico conversations need human review; no outbound send from this layer.`,
+    scope: "ops.commercial",
+    ...prov({ source: "warmbly.crm.read-model", confidence: 0.84 }),
+  },
+  {
+    id: "ctx-fin-1",
+    kind: "risk",
+    title: "Finance observation only",
+    body: `${MARKERS.finance}: Asaas is the payment provider; MCP tools must not charge, refund, checkout, or cancel. Open Diagnóstico receivable is 150000 cents BRL.`,
+    scope: "ops.finance",
+    ...prov({ source: "finance.ledger.read-model", freshness_status: "stale", confidence: 0.7 }),
+  },
+];
+
+export const directives: DirectiveRecord[] = [
+  {
+    id: "dir-comm-1",
+    kind: "directive",
+    body: "Do not send commercial follow-up to ACME until the legal packet is fresh.",
+    scope: "ops.commercial",
+    status: "active",
+    effective_from: "2026-08-01T00:00:00.000Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: "founder",
+    audit: {
+      created_at: "2026-08-01T00:00:00.000Z",
+      updated_at: "2026-08-01T00:00:00.000Z",
+      events: [{ at: "2026-08-01T00:00:00.000Z", action: "created", by: "founder" }],
+    },
+    ...prov({ source: "governance.memory", confidence: 1 }),
+  },
+  {
+    id: "dir-fin-1",
+    kind: "constraint",
+    body: "Agents must not mutate Asaas or any payment provider from Control Center.",
+    scope: "ops.finance",
+    status: "active",
+    effective_from: "2026-07-01T00:00:00.000Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: "founder",
+    audit: {
+      created_at: "2026-07-01T00:00:00.000Z",
+      updated_at: "2026-07-01T00:00:00.000Z",
+      events: [{ at: "2026-07-01T00:00:00.000Z", action: "created", by: "founder" }],
+    },
+    ...prov({ source: "governance.memory", confidence: 1 }),
+  },
+  {
+    id: "dir-company-1",
+    kind: "constraint",
+    body: "Human directives of kind decision, constraint, or authoritative directive are founder-owned.",
+    scope: "company",
+    status: "active",
+    effective_from: "2026-06-01T00:00:00.000Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: "founder",
+    audit: {
+      created_at: "2026-06-01T00:00:00.000Z",
+      updated_at: "2026-06-01T00:00:00.000Z",
+      events: [{ at: "2026-06-01T00:00:00.000Z", action: "created", by: "founder" }],
+    },
+    ...prov({ source: "governance.memory", confidence: 1 }),
+  },
+  {
+    id: "dir-comm-old",
+    kind: "directive",
+    body: "Superseded commercial cadence experiment.",
+    scope: "ops.commercial",
+    status: "superseded",
+    effective_from: "2026-05-01T00:00:00.000Z",
+    expires_at: "2026-08-01T00:00:00.000Z",
+    supersedes: null,
+    created_by: "founder",
+    audit: {
+      created_at: "2026-05-01T00:00:00.000Z",
+      updated_at: "2026-08-01T00:00:00.000Z",
+      events: [
+        { at: "2026-05-01T00:00:00.000Z", action: "created", by: "founder" },
+        { at: "2026-08-01T00:00:00.000Z", action: "superseded", by: "founder" },
+      ],
+    },
+    ...prov({ source: "governance.memory", confidence: 1 }),
+  },
+];
+
+export const decisions: DecisionRecord[] = [
+  {
+    id: "dec-1",
+    kind: "decision",
+    title: "Governance is strategic authority",
+    body: "Warmbly remains operational commercial/CRM authority.",
+    scope: "company",
+    status: "active",
+    decided_at: "2026-07-01T12:00:00.000Z",
+    effective_from: "2026-07-01T12:00:00.000Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: "founder",
+    audit: {
+      created_at: "2026-07-01T12:00:00.000Z",
+      updated_at: "2026-07-01T12:00:00.000Z",
+      events: [{ at: "2026-07-01T12:00:00.000Z", action: "created", by: "founder" }],
+    },
+    ...prov({ source: "governance.decisions", observed_at: "2026-07-01T12:00:00.000Z", confidence: 1 }),
+  },
+  {
+    id: "dec-2",
+    kind: "decision",
+    title: "MCP is the agent interface",
+    body: "Agents consume scoped context via MCP; they do not receive the whole-company dump.",
+    scope: "company",
+    status: "active",
+    decided_at: "2026-08-10T09:00:00.000Z",
+    effective_from: "2026-08-10T09:00:00.000Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: "founder",
+    audit: {
+      created_at: "2026-08-10T09:00:00.000Z",
+      updated_at: "2026-08-10T09:00:00.000Z",
+      events: [{ at: "2026-08-10T09:00:00.000Z", action: "created", by: "founder" }],
+    },
+    ...prov({ source: "governance.decisions", observed_at: "2026-08-10T09:00:00.000Z", confidence: 1 }),
+  },
+  {
+    id: "dec-3",
+    kind: "decision",
+    title: "Money is integer cents",
+    body: "Aggregated financial figures use amount_cents plus currency. Display tz America/Sao_Paulo; storage UTC.",
+    scope: "ops.finance",
+    status: "active",
+    decided_at: "2026-08-18T14:30:00.000Z",
+    effective_from: "2026-08-18T14:30:00.000Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: "founder",
+    audit: {
+      created_at: "2026-08-18T14:30:00.000Z",
+      updated_at: "2026-08-18T14:30:00.000Z",
+      events: [{ at: "2026-08-18T14:30:00.000Z", action: "created", by: "founder" }],
+    },
+    ...prov({ source: "governance.decisions", observed_at: "2026-08-18T14:30:00.000Z", confidence: 1 }),
+  },
+];
+
+export const clients: Record<string, ClientContext> = {
+  "acme-ltda": {
+    client: "acme-ltda",
+    display_name: "ACME Ltda",
+    open_amount: { amount_cents: 0, currency: "BRL" },
+    records: [
+      {
+        id: "cli-acme-1",
+        kind: "fact",
+        title: "ACME onboarding",
+        body: `${MARKERS.acme}: legal packet stale; commercial send blocked by active directive dir-comm-1.`,
+        scope: "client.acme-ltda",
+        ...prov({ source: "warmbly.crm.read-model", freshness_status: "stale", confidence: 0.81 }),
+      },
+    ],
+    ...prov({ source: "warmbly.crm.read-model", freshness_status: "stale", confidence: 0.81 }),
+  },
+  "beta-industria": {
+    client: "beta-industria",
+    display_name: "Beta Indústria",
+    open_amount: { amount_cents: 150000, currency: "BRL" },
+    records: [
+      {
+        id: "cli-beta-1",
+        kind: "fact",
+        title: "Beta receivable",
+        body: `${MARKERS.beta}: Diagnóstico invoice 150000 cents BRL overdue. Observation only.`,
+        scope: "client.beta-industria",
+        ...prov({ source: "finance.ledger.read-model", confidence: 0.91 }),
+      },
+    ],
+    ...prov({ source: "finance.ledger.read-model", confidence: 0.91 }),
+  },
+};

--- a/control-center/services/mcp/src/http.ts
+++ b/control-center/services/mcp/src/http.ts
@@ -1,0 +1,72 @@
+import http from "node:http";
+import type { Logger } from "./logging.js";
+import type { McpRuntime } from "./server.js";
+
+export function serveHttp(
+  runtime: McpRuntime,
+  logger: Logger,
+  options: { host: string; port: number },
+): http.Server {
+  const server = http.createServer((req, res) => {
+    void handle(req, res);
+  });
+
+  async function handle(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    if (req.method === "GET" && req.url === "/healthz") {
+      json(res, 200, { ok: true, service: "confenge-control-center-mcp" });
+      return;
+    }
+    if (req.method !== "POST" || req.url !== "/mcp") {
+      json(res, 404, { error: { code: "NOT_FOUND", message: "POST /mcp" } });
+      return;
+    }
+    try {
+      const body = await readBody(req);
+      const authorization = header(req, "authorization");
+      const reply = await runtime.handleRaw(body, { authorization });
+      if (reply === null) {
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json; charset=utf-8");
+      res.end(reply);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "internal error";
+      logger.error("mcp.http_error", { err: message });
+      json(res, 500, { error: { code: "INTERNAL", message: "internal error" } });
+    }
+  }
+
+  server.listen(options.port, options.host, () => {
+    logger.info("mcp.listen", { transport: "http", host: options.host, port: options.port });
+  });
+  return server;
+}
+
+function header(req: http.IncomingMessage, name: string): string | undefined {
+  const value = req.headers[name];
+  if (Array.isArray(value)) {
+    const first = value[0];
+    return first;
+  }
+  return value;
+}
+
+function json(res: http.ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer | string) => {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}

--- a/control-center/services/mcp/src/index.ts
+++ b/control-center/services/mcp/src/index.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { createLogger } from "./logging.js";
+import { serveHttp } from "./http.js";
+import { createMcpRuntime, loadAuthTokenFromEnv, loadRateLimitFromEnv } from "./server.js";
+import { serveStdio } from "./stdio.js";
+import { createStubContextApi } from "./stub-adapter.js";
+
+async function main(): Promise<void> {
+  const logger = createLogger();
+  const authToken = loadAuthTokenFromEnv();
+  if (authToken === undefined) {
+    logger.error("mcp.boot_fail_closed", {
+      reason: "CONFENGE_MCP_AUTH_TOKEN is missing; context will not be served",
+    });
+  }
+
+  const runtime = createMcpRuntime({
+    context: createStubContextApi(),
+    authToken,
+    logger,
+    rateLimit: loadRateLimitFromEnv(),
+    secretsToRedact: authToken ? [authToken] : [],
+  });
+
+  const portRaw = process.env["CONFENGE_MCP_HTTP_PORT"];
+  if (portRaw !== undefined && portRaw.trim().length > 0) {
+    const port = Number.parseInt(portRaw, 10);
+    if (!Number.isFinite(port) || port <= 0) {
+      logger.error("mcp.boot_invalid_port", { reason: "CONFENGE_MCP_HTTP_PORT is not a valid port" });
+      process.exitCode = 1;
+      return;
+    }
+    const host = process.env["CONFENGE_MCP_HTTP_HOST"]?.trim() || "127.0.0.1";
+    serveHttp(runtime, logger, { host, port });
+    return;
+  }
+
+  await serveStdio(runtime, logger);
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : "boot failed";
+  process.stderr.write(`${JSON.stringify({ ts: new Date().toISOString(), level: "error", msg: "mcp.crash", err: message })}\n`);
+  process.exit(1);
+});

--- a/control-center/services/mcp/src/logging.ts
+++ b/control-center/services/mcp/src/logging.ts
@@ -1,0 +1,72 @@
+const REDACT_KEYS = new Set([
+  "authorization",
+  "auth_token",
+  "token",
+  "password",
+  "secret",
+  "api_key",
+  "apikey",
+  "CONFENGE_MCP_AUTH_TOKEN",
+]);
+
+export interface LogFields {
+  [key: string]: unknown;
+}
+
+export interface Logger {
+  info(msg: string, fields?: LogFields): void;
+  warn(msg: string, fields?: LogFields): void;
+  error(msg: string, fields?: LogFields): void;
+}
+
+export interface LoggerOptions {
+  write?: (line: string) => void;
+  now?: () => string;
+}
+
+export function redact(value: unknown, extraSecrets: string[] = []): unknown {
+  return redactInner(value, extraSecrets.filter((s) => s.length > 0));
+}
+
+function redactInner(value: unknown, extraSecrets: string[]): unknown {
+  if (typeof value === "string") {
+    return extraSecrets.reduce((acc, secret) => acc.split(secret).join("[REDACTED]"), value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactInner(item, extraSecrets));
+  }
+  if (typeof value === "object" && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      if (REDACT_KEYS.has(key) || REDACT_KEYS.has(key.toLowerCase())) {
+        out[key] = "[REDACTED]";
+      } else {
+        out[key] = redactInner(nested, extraSecrets);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+export function createLogger(options: LoggerOptions = {}): Logger {
+  const write = options.write ?? ((line: string) => process.stderr.write(`${line}\n`));
+  const now = options.now ?? (() => new Date().toISOString());
+
+  const emit = (level: string, msg: string, fields?: LogFields): void => {
+    const payload = redact({
+      ts: now(),
+      level,
+      msg,
+      service: "confenge-control-center-mcp",
+      ...(fields ?? {}),
+    });
+    write(JSON.stringify(payload));
+  };
+
+  return {
+    info: (msg, fields) => emit("info", msg, fields),
+    warn: (msg, fields) => emit("warn", msg, fields),
+    error: (msg, fields) => emit("error", msg, fields),
+  };
+}

--- a/control-center/services/mcp/src/security.ts
+++ b/control-center/services/mcp/src/security.ts
@@ -1,0 +1,195 @@
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { ERROR_CODES, McpAppError } from "./errors.js";
+
+export interface RequestExtras {
+  authorization?: string;
+}
+
+export interface RateLimitConfig {
+  max: number;
+  windowMs: number;
+}
+
+export class RateLimiter {
+  private readonly hits = new Map<string, number[]>();
+
+  constructor(private readonly config: RateLimitConfig) {}
+
+  allow(key: string, now = Date.now()): boolean {
+    const windowStart = now - this.config.windowMs;
+    const previous = this.hits.get(key) ?? [];
+    const recent = previous.filter((ts) => ts > windowStart);
+    if (recent.length >= this.config.max) {
+      this.hits.set(key, recent);
+      return false;
+    }
+    recent.push(now);
+    this.hits.set(key, recent);
+    return true;
+  }
+}
+
+export function newCorrelationId(): string {
+  return `cc-mcp-${randomUUID()}`;
+}
+
+export function extractCorrelationId(params: unknown, extras?: RequestExtras): string {
+  void extras;
+  if (isRecord(params)) {
+    const meta = params["_meta"];
+    if (isRecord(meta)) {
+      const fromMeta = meta["correlation_id"];
+      if (typeof fromMeta === "string" && fromMeta.trim().length > 0) {
+        return fromMeta.trim();
+      }
+    }
+  }
+  return newCorrelationId();
+}
+
+export function extractPresentedToken(params: unknown, extras?: RequestExtras): string | undefined {
+  const header = extras?.authorization;
+  const fromHeader = bearer(header);
+  if (fromHeader !== undefined) {
+    return fromHeader;
+  }
+  if (!isRecord(params)) {
+    return undefined;
+  }
+  const meta = params["_meta"];
+  if (!isRecord(meta)) {
+    return undefined;
+  }
+  return bearer(typeof meta["authorization"] === "string" ? meta["authorization"] : undefined);
+}
+
+export function authenticate(args: {
+  expectedToken: string | undefined;
+  presentedToken: string | undefined;
+  correlationId: string;
+}): void {
+  const expected = args.expectedToken?.trim() ?? "";
+  if (expected.length === 0) {
+    throw new McpAppError(
+      ERROR_CODES.UNAUTHENTICATED,
+      "auth token is not configured; refusing to serve context",
+      args.correlationId,
+    );
+  }
+  if (args.presentedToken === undefined || args.presentedToken.length === 0) {
+    throw new McpAppError(
+      ERROR_CODES.UNAUTHENTICATED,
+      "missing auth token",
+      args.correlationId,
+    );
+  }
+  if (!tokensEqual(expected, args.presentedToken)) {
+    throw new McpAppError(ERROR_CODES.INVALID_TOKEN, "invalid auth token", args.correlationId);
+  }
+}
+
+export function tokenFingerprint(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 12);
+}
+
+export function tokensEqual(expected: string, presented: string): boolean {
+  const left = Buffer.from(expected);
+  const right = Buffer.from(presented);
+  if (left.length !== right.length) {
+    if (left.length > 0) {
+      timingSafeEqual(left, left);
+    }
+    return false;
+  }
+  return timingSafeEqual(left, right);
+}
+
+function bearer(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  const match = /^Bearer\s+(.+)$/i.exec(trimmed);
+  if (match?.[1]) {
+    return match[1].trim();
+  }
+  return undefined;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export const FORBIDDEN_MUTATION_TOOLS = [
+  "confenge.create_directive",
+  "confenge.update_directive",
+  "confenge.create_decision",
+  "confenge.update_decision",
+  "confenge.create_constraint",
+  "confenge.update_constraint",
+  "confenge.charge",
+  "confenge.checkout",
+  "confenge.refund",
+  "confenge.cancel",
+  "confenge.asaas",
+] as const;
+
+const FORBIDDEN_WRITE_KEYS = [
+  "create_directive",
+  "update_directive",
+  "upsert_directive",
+  "create_decision",
+  "update_decision",
+  "create_constraint",
+  "update_constraint",
+  "authoritative_directive",
+  "mutate_decision",
+  "mutate_constraint",
+  "mutate_directive",
+];
+
+export function assertNoAuthoritativeMutation(
+  toolName: string,
+  args: unknown,
+  correlationId: string,
+): void {
+  if (FORBIDDEN_MUTATION_TOOLS.includes(toolName as (typeof FORBIDDEN_MUTATION_TOOLS)[number])) {
+    throw new McpAppError(
+      ERROR_CODES.FORBIDDEN_MUTATION,
+      "agents cannot create or alter decisions, constraints, or authoritative directives",
+      correlationId,
+    );
+  }
+  if (looksLikeForbiddenMutation(args)) {
+    throw new McpAppError(
+      ERROR_CODES.FORBIDDEN_MUTATION,
+      "agents cannot create or alter decisions, constraints, or authoritative directives",
+      correlationId,
+    );
+  }
+}
+
+function looksLikeForbiddenMutation(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(looksLikeForbiddenMutation);
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_WRITE_KEYS.includes(key)) {
+      return true;
+    }
+  }
+  const action = value["action"];
+  const kind = value["kind"];
+  if (
+    typeof action === "string" &&
+    /^(create|update|upsert|supersede|delete)$/i.test(action) &&
+    typeof kind === "string" &&
+    /^(decision|constraint|directive)$/i.test(kind)
+  ) {
+    return true;
+  }
+  return Object.values(value).some(looksLikeForbiddenMutation);
+}

--- a/control-center/services/mcp/src/server.ts
+++ b/control-center/services/mcp/src/server.ts
@@ -1,0 +1,368 @@
+import { executeTool, getPrompt, promptDefinitions, readResource, resourceDefinitions, toolDefinitions } from "./catalog.js";
+import { ERROR_CODES, jsonRpcCode, McpAppError, type ErrorCode } from "./errors.js";
+import { createLogger, redact, type Logger } from "./logging.js";
+import {
+  authenticate,
+  extractCorrelationId,
+  extractPresentedToken,
+  isRecord,
+  RateLimiter,
+  tokenFingerprint,
+  type RateLimitConfig,
+  type RequestExtras,
+} from "./security.js";
+import { createStubContextApi } from "./stub-adapter.js";
+import type { ContextApiPort } from "./types.js";
+
+export const PROTOCOL_VERSIONS = ["2024-11-05", "2025-03-26", "2025-06-18"] as const;
+export const DEFAULT_PROTOCOL_VERSION = "2025-03-26";
+export const SERVER_INFO = { name: "confenge-control-center", version: "0.1.0" } as const;
+
+const INITIALIZE_INSTRUCTIONS = [
+  "Confenge Control Center MCP. Scoped operational context for agents.",
+  "Before acting, get prompt confenge.session_preflight and read resource confenge://preflight/checklist.",
+  "Reads are first-class. The only writes are confenge.report_session_result and confenge.report_blocker.",
+  "Do not create or alter decisions, constraints, or authoritative directives.",
+  "Do not charge, checkout, refund, cancel, or mutate payment providers.",
+].join(" ");
+
+export interface McpRuntimeOptions {
+  context?: ContextApiPort;
+  authToken?: string;
+  logger?: Logger;
+  rateLimit?: RateLimitConfig;
+  secretsToRedact?: string[];
+}
+
+export interface McpRuntime {
+  handleRaw(line: string, extras?: RequestExtras): Promise<string | null>;
+}
+
+interface RpcRequest {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  method: string;
+  params?: unknown;
+}
+
+interface RpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+export function createMcpRuntime(options: McpRuntimeOptions = {}): McpRuntime {
+  const context = options.context ?? createStubContextApi();
+  const logger = options.logger ?? createLogger();
+  const limiter = new RateLimiter(options.rateLimit ?? { max: 30, windowMs: 60_000 });
+  const expectedToken = options.authToken;
+  const extraSecrets = [
+    ...(options.secretsToRedact ?? []),
+    ...(expectedToken ? [expectedToken] : []),
+  ];
+  let initialized = false;
+
+  const runtime: McpRuntime = {
+    async handleRaw(line: string, extras?: RequestExtras): Promise<string | null> {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) {
+        return null;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed) as unknown;
+      } catch {
+        const correlationId = extractCorrelationId(undefined, extras);
+        logger.warn("mcp.parse_error", { correlation_id: correlationId });
+        return serializeError(null, ERROR_CODES.PARSE_ERROR, "Parse error", correlationId, extraSecrets);
+      }
+
+      if (Array.isArray(parsed)) {
+        const correlationId = extractCorrelationId(undefined, extras);
+        return serializeError(
+          null,
+          ERROR_CODES.INVALID_REQUEST,
+          "JSON-RPC batches are not supported",
+          correlationId,
+          extraSecrets,
+        );
+      }
+
+      if (!isRecord(parsed) || parsed["jsonrpc"] !== "2.0") {
+        const correlationId = extractCorrelationId(isRecord(parsed) ? parsed["params"] : undefined, extras);
+        const id = isRecord(parsed) ? asId(parsed["id"]) : null;
+        return serializeError(
+          id,
+          ERROR_CODES.INVALID_REQUEST,
+          "Invalid Request",
+          correlationId,
+          extraSecrets,
+        );
+      }
+
+      const method = parsed["method"];
+      if (typeof method !== "string" || method.length === 0) {
+        const correlationId = extractCorrelationId(parsed["params"], extras);
+        return serializeError(
+          asId(parsed["id"]),
+          ERROR_CODES.INVALID_REQUEST,
+          "method is required",
+          correlationId,
+          extraSecrets,
+        );
+      }
+
+      const idPresent = Object.prototype.hasOwnProperty.call(parsed, "id");
+      const params = parsed["params"];
+      const correlationId = extractCorrelationId(params, extras);
+
+      if (!idPresent) {
+        await handleNotification({ jsonrpc: "2.0", method, params }, extras, correlationId);
+        return null;
+      }
+      const id = asId(parsed["id"]);
+
+      try {
+        const result = await handleRequest(
+          { jsonrpc: "2.0", id, method, params },
+          extras,
+          correlationId,
+        );
+        return JSON.stringify(
+          redact({ jsonrpc: "2.0", id, result }, extraSecrets),
+        );
+      } catch (err) {
+        if (err instanceof McpAppError) {
+          logger.warn("mcp.request_error", {
+            method,
+            code: err.code,
+            correlation_id: err.correlationId,
+          });
+          return serializeError(id, err.code, err.message, err.correlationId, extraSecrets);
+        }
+        const message = err instanceof Error ? err.message : "internal error";
+        logger.error("mcp.internal_error", { method, correlation_id: correlationId, err: message });
+        return serializeError(id, ERROR_CODES.INTERNAL, "internal error", correlationId, extraSecrets);
+      }
+    },
+  };
+
+  async function handleNotification(
+    note: RpcNotification,
+    extras: RequestExtras | undefined,
+    correlationId: string,
+  ): Promise<void> {
+    if (note.method === "notifications/initialized") {
+      initialized = true;
+      logger.info("mcp.initialized", { correlation_id: correlationId });
+      return;
+    }
+    if (note.method === "notifications/cancelled") {
+      return;
+    }
+    logger.warn("mcp.unknown_notification", { method: note.method, correlation_id: correlationId });
+    void extras;
+  }
+
+  async function handleRequest(
+    req: RpcRequest,
+    extras: RequestExtras | undefined,
+    correlationId: string,
+  ): Promise<unknown> {
+    switch (req.method) {
+      case "initialize":
+        return handleInitialize(req.params, correlationId);
+      case "ping":
+        return {};
+      case "tools/list":
+        requireInitialized(correlationId);
+        return { tools: toolDefinitions };
+      case "resources/list":
+        requireInitialized(correlationId);
+        return { resources: resourceDefinitions };
+      case "prompts/list":
+        requireInitialized(correlationId);
+        return { prompts: promptDefinitions };
+      case "resources/read": {
+        requireInitialized(correlationId);
+        requireAuth(req.params, extras, correlationId);
+        const uri = readStringField(req.params, "uri");
+        if (uri === undefined) {
+          throw new McpAppError(ERROR_CODES.INVALID_PARAMS, "uri is required", correlationId);
+        }
+        const body = readResource(uri, correlationId);
+        return { contents: [{ uri, mimeType: body.mimeType, text: body.text }] };
+      }
+      case "prompts/get": {
+        requireInitialized(correlationId);
+        requireAuth(req.params, extras, correlationId);
+        const name = readStringField(req.params, "name");
+        if (name === undefined) {
+          throw new McpAppError(ERROR_CODES.INVALID_PARAMS, "name is required", correlationId);
+        }
+        const argMap = promptArgs(req.params);
+        return getPrompt(name, argMap, correlationId);
+      }
+      case "tools/call":
+        return handleToolCall(req.params, extras, correlationId);
+      default:
+        throw new McpAppError(ERROR_CODES.METHOD_NOT_FOUND, `method not found: ${req.method}`, correlationId);
+    }
+  }
+
+  function handleInitialize(params: unknown, correlationId: string): unknown {
+    const requested =
+      isRecord(params) && typeof params["protocolVersion"] === "string"
+        ? params["protocolVersion"]
+        : DEFAULT_PROTOCOL_VERSION;
+    const protocolVersion = (PROTOCOL_VERSIONS as readonly string[]).includes(requested)
+      ? requested
+      : DEFAULT_PROTOCOL_VERSION;
+    initialized = false;
+    logger.info("mcp.initialize", { protocolVersion, correlation_id: correlationId });
+    return {
+      protocolVersion,
+      capabilities: {
+        tools: {},
+        resources: {},
+        prompts: {},
+      },
+      serverInfo: SERVER_INFO,
+      instructions: INITIALIZE_INSTRUCTIONS,
+    };
+  }
+
+  async function handleToolCall(
+    params: unknown,
+    extras: RequestExtras | undefined,
+    correlationId: string,
+  ): Promise<unknown> {
+    requireInitialized(correlationId);
+    requireAuth(params, extras, correlationId);
+
+    const presented = extractPresentedToken(params, extras) ?? "anonymous";
+    const limitKey = tokenFingerprint(presented);
+    if (!limiter.allow(limitKey)) {
+      throw new McpAppError(ERROR_CODES.RATE_LIMITED, "rate limit exceeded", correlationId);
+    }
+
+    const name = readStringField(params, "name");
+    if (name === undefined) {
+      throw new McpAppError(ERROR_CODES.INVALID_PARAMS, "tool name is required", correlationId);
+    }
+    const args = isRecord(params) ? params["arguments"] : undefined;
+
+    logger.info("mcp.tools_call", { tool: name, correlation_id: correlationId });
+    const payload = await executeTool(context, name, args, correlationId);
+    return {
+      content: [{ type: "text", text: JSON.stringify({ correlation_id: correlationId, data: payload }) }],
+      isError: false,
+      structuredContent: { correlation_id: correlationId, data: payload },
+    };
+  }
+
+  function requireInitialized(correlationId: string): void {
+    if (!initialized) {
+      throw new McpAppError(
+        ERROR_CODES.NOT_INITIALIZED,
+        "server is not initialized; send initialize then notifications/initialized",
+        correlationId,
+      );
+    }
+  }
+
+  function requireAuth(params: unknown, extras: RequestExtras | undefined, correlationId: string): void {
+    authenticate({
+      expectedToken,
+      presentedToken: extractPresentedToken(params, extras),
+      correlationId,
+    });
+  }
+
+  return runtime;
+}
+
+function asId(value: unknown): string | number | null {
+  if (typeof value === "string" || typeof value === "number") {
+    return value;
+  }
+  return null;
+}
+
+function readStringField(params: unknown, key: string): string | undefined {
+  if (!isRecord(params)) {
+    return undefined;
+  }
+  const value = params[key];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function promptArgs(params: unknown): Record<string, string> | undefined {
+  if (!isRecord(params)) {
+    return undefined;
+  }
+  const raw = params["arguments"];
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === "string") {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+function serializeError(
+  id: string | number | null,
+  code: ErrorCode,
+  message: string,
+  correlationId: string,
+  extraSecrets: string[],
+): string {
+  return JSON.stringify(
+    redact(
+      {
+        jsonrpc: "2.0",
+        id,
+        error: {
+          code: jsonRpcCode(code),
+          message,
+          data: {
+            error: { code, message, correlation_id: correlationId },
+            correlation_id: correlationId,
+          },
+        },
+      },
+      extraSecrets,
+    ),
+  );
+}
+
+export function loadAuthTokenFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const value = env["CONFENGE_MCP_AUTH_TOKEN"];
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function loadRateLimitFromEnv(env: NodeJS.ProcessEnv = process.env): RateLimitConfig {
+  const maxRaw = env["CONFENGE_MCP_RATE_LIMIT_MAX"];
+  const windowRaw = env["CONFENGE_MCP_RATE_LIMIT_WINDOW_MS"];
+  const max = maxRaw !== undefined ? Number.parseInt(maxRaw, 10) : 30;
+  const windowMs = windowRaw !== undefined ? Number.parseInt(windowRaw, 10) : 60_000;
+  return {
+    max: Number.isFinite(max) && max > 0 ? max : 30,
+    windowMs: Number.isFinite(windowMs) && windowMs > 0 ? windowMs : 60_000,
+  };
+}

--- a/control-center/services/mcp/src/stdio.ts
+++ b/control-center/services/mcp/src/stdio.ts
@@ -1,0 +1,14 @@
+import readline from "node:readline";
+import type { Logger } from "./logging.js";
+import type { McpRuntime } from "./server.js";
+
+export async function serveStdio(runtime: McpRuntime, logger: Logger): Promise<void> {
+  const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  logger.info("mcp.listen", { transport: "stdio" });
+  for await (const line of rl) {
+    const reply = await runtime.handleRaw(line);
+    if (reply !== null) {
+      process.stdout.write(`${reply}\n`);
+    }
+  }
+}

--- a/control-center/services/mcp/src/stub-adapter.ts
+++ b/control-center/services/mcp/src/stub-adapter.ts
@@ -1,0 +1,158 @@
+import {
+  clients,
+  companyDumpSecret,
+  companyState,
+  contextRecords,
+  decisions,
+  directives,
+  FIXTURE_CLIENTS,
+  FIXTURE_SCOPES,
+  priorities,
+} from "./fixtures.js";
+import type {
+  BlockerInput,
+  ClientContext,
+  CompanyState,
+  ContextApiPort,
+  DecisionRecord,
+  DirectiveRecord,
+  PriorityRecord,
+  ScopedContext,
+  SessionResultInput,
+  WriteReceipt,
+} from "./types.js";
+
+export class UnknownScopeError extends Error {
+  override readonly name = "UnknownScopeError";
+  constructor(public readonly scope: string) {
+    super(`unknown scope: ${scope}`);
+  }
+}
+
+export class UnknownClientError extends Error {
+  override readonly name = "UnknownClientError";
+  constructor(public readonly client: string) {
+    super(`unknown client: ${client}`);
+  }
+}
+
+function utcNow(): string {
+  return new Date().toISOString();
+}
+
+function receipt(kind: WriteReceipt["kind"], id: string): WriteReceipt {
+  const observed_at = utcNow();
+  return {
+    accepted: true,
+    id,
+    kind,
+    recorded_at: observed_at,
+    source: "mcp.agent-report",
+    observed_at,
+    freshness_status: "fresh",
+    confidence: 1,
+  };
+}
+
+/**
+ * Local Context API adapter backed by in-process fixtures.
+ * No HTTP and no imports from sibling Control Center services.
+ */
+export class StubContextApi implements ContextApiPort {
+  private readonly sessionResults = new Map<string, WriteReceipt>();
+  private readonly blockers: WriteReceipt[] = [];
+  private seq = 0;
+
+  /** Intentionally unused by MCP tools — whole-company dump must never leak. */
+  getInternalMemoryDump(): { id: string; body: string } {
+    return companyDumpSecret;
+  }
+
+  async getCompanyState(): Promise<CompanyState> {
+    return structuredClone(companyState);
+  }
+
+  async getContext(scope: string): Promise<ScopedContext> {
+    if (!isFixtureScope(scope)) {
+      throw new UnknownScopeError(scope);
+    }
+    const records = contextRecords.filter((row) => row.scope === scope);
+    const first = records[0];
+    return {
+      scope,
+      records: structuredClone(records),
+      source: first?.source ?? "control-center.stub.fixtures",
+      observed_at: first?.observed_at ?? utcNow(),
+      freshness_status: first?.freshness_status ?? "unknown",
+      confidence: first?.confidence,
+    };
+  }
+
+  async getActiveDirectives(scope: string): Promise<DirectiveRecord[]> {
+    if (!isFixtureScope(scope)) {
+      throw new UnknownScopeError(scope);
+    }
+    return structuredClone(
+      directives.filter((row) => row.scope === scope && row.status === "active"),
+    );
+  }
+
+  async getPriorities(): Promise<PriorityRecord[]> {
+    return structuredClone(priorities);
+  }
+
+  async getClientContext(client: string): Promise<ClientContext> {
+    const found = clients[client];
+    if (!found) {
+      throw new UnknownClientError(client);
+    }
+    return structuredClone(found);
+  }
+
+  async getDecisions(since?: string): Promise<DecisionRecord[]> {
+    const rows = structuredClone(decisions);
+    if (since === undefined) {
+      return rows;
+    }
+    const sinceMs = Date.parse(since);
+    return rows.filter((row) => Date.parse(row.decided_at) >= sinceMs);
+  }
+
+  async reportSessionResult(input: SessionResultInput): Promise<WriteReceipt> {
+    const idempotencyKey = input.session_id;
+    if (idempotencyKey !== undefined) {
+      const existing = this.sessionResults.get(idempotencyKey);
+      if (existing) {
+        return structuredClone(existing);
+      }
+    }
+    this.seq += 1;
+    const saved = receipt("session_result", `sr_${this.seq}`);
+    if (idempotencyKey !== undefined) {
+      this.sessionResults.set(idempotencyKey, saved);
+    } else {
+      this.sessionResults.set(saved.id, saved);
+    }
+    return structuredClone(saved);
+  }
+
+  async reportBlocker(input: BlockerInput): Promise<WriteReceipt> {
+    this.seq += 1;
+    const saved = receipt("blocker", `bl_${this.seq}`);
+    this.blockers.push(saved);
+    void input;
+    return structuredClone(saved);
+  }
+}
+
+export function createStubContextApi(): StubContextApi {
+  return new StubContextApi();
+}
+
+export function isFixtureScope(scope: string): boolean {
+  return (FIXTURE_SCOPES as readonly string[]).includes(scope);
+}
+
+export function isFixtureClient(client: string): boolean {
+  return (FIXTURE_CLIENTS as readonly string[]).includes(client);
+}

--- a/control-center/services/mcp/src/types.ts
+++ b/control-center/services/mcp/src/types.ts
@@ -1,0 +1,176 @@
+export const FRESHNESS_STATUSES = ["fresh", "stale", "unknown", "degraded"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const DIRECTIVE_KINDS = [
+  "decision",
+  "directive",
+  "fact",
+  "constraint",
+  "priority",
+  "risk",
+  "hypothesis",
+] as const;
+export type DirectiveKind = (typeof DIRECTIVE_KINDS)[number];
+
+export const DIRECTIVE_STATUSES = ["active", "superseded", "expired", "draft"] as const;
+export type DirectiveStatus = (typeof DIRECTIVE_STATUSES)[number];
+
+export const SESSION_OUTCOMES = ["completed", "partial", "failed", "blocked"] as const;
+export type SessionOutcome = (typeof SESSION_OUTCOMES)[number];
+
+export const BLOCKER_SEVERITIES = ["low", "medium", "high", "critical"] as const;
+export type BlockerSeverity = (typeof BLOCKER_SEVERITIES)[number];
+
+/** Provenance carried by every aggregated record. */
+export interface Provenance {
+  source: string;
+  observed_at: string;
+  freshness_status: FreshnessStatus;
+  confidence?: number;
+}
+
+export interface AuditEvent {
+  at: string;
+  action: string;
+  by: string;
+}
+
+export interface AuditTrail {
+  created_at: string;
+  updated_at: string;
+  events: AuditEvent[];
+}
+
+export interface MoneyCents {
+  amount_cents: number;
+  currency: string;
+}
+
+export interface DirectiveRecord extends Provenance {
+  id: string;
+  kind: DirectiveKind;
+  body: string;
+  scope: string;
+  status: DirectiveStatus;
+  effective_from: string;
+  expires_at: string | null;
+  supersedes: string | null;
+  created_by: string;
+  audit: AuditTrail;
+}
+
+export interface ContextRecord extends Provenance {
+  id: string;
+  kind: DirectiveKind;
+  title: string;
+  body: string;
+  scope: string;
+}
+
+export interface ExceptionRecord extends Provenance {
+  id: string;
+  title: string;
+  body: string;
+  scope: string;
+  severity: BlockerSeverity;
+}
+
+export interface PriorityRecord extends Provenance {
+  id: string;
+  rank: number;
+  title: string;
+  body: string;
+  scope: string;
+  kind: "priority";
+}
+
+export interface DecisionRecord extends Provenance {
+  id: string;
+  kind: "decision";
+  title: string;
+  body: string;
+  scope: string;
+  status: DirectiveStatus;
+  decided_at: string;
+  effective_from: string;
+  expires_at: string | null;
+  supersedes: string | null;
+  created_by: string;
+  audit: AuditTrail;
+}
+
+export interface CompanyState extends Provenance {
+  company_id: string;
+  display_timezone: string;
+  top_three: PriorityRecord[];
+  exceptions: ExceptionRecord[];
+}
+
+export interface ScopedContext extends Provenance {
+  scope: string;
+  records: ContextRecord[];
+}
+
+export interface ClientContext extends Provenance {
+  client: string;
+  display_name: string;
+  records: ContextRecord[];
+  open_amount: MoneyCents;
+}
+
+export interface SessionResultInput {
+  session_id?: string;
+  scope: string;
+  summary: string;
+  outcome: SessionOutcome;
+  notes?: string;
+}
+
+export interface BlockerInput {
+  scope: string;
+  summary: string;
+  severity: BlockerSeverity;
+  blocking: boolean;
+}
+
+export interface WriteReceipt extends Provenance {
+  accepted: true;
+  id: string;
+  kind: "session_result" | "blocker";
+  recorded_at: string;
+}
+
+export interface ContextApiPort {
+  getCompanyState(): Promise<CompanyState>;
+  getContext(scope: string): Promise<ScopedContext>;
+  getActiveDirectives(scope: string): Promise<DirectiveRecord[]>;
+  getPriorities(): Promise<PriorityRecord[]>;
+  getClientContext(client: string): Promise<ClientContext>;
+  getDecisions(since?: string): Promise<DecisionRecord[]>;
+  reportSessionResult(input: SessionResultInput): Promise<WriteReceipt>;
+  reportBlocker(input: BlockerInput): Promise<WriteReceipt>;
+}
+
+export const TOOL_NAMES = [
+  "confenge.get_company_state",
+  "confenge.get_context",
+  "confenge.get_active_directives",
+  "confenge.get_priorities",
+  "confenge.get_client_context",
+  "confenge.get_decisions",
+  "confenge.report_session_result",
+  "confenge.report_blocker",
+] as const;
+
+export type ToolName = (typeof TOOL_NAMES)[number];
+
+export const RESOURCE_URIS = {
+  checklist: "confenge://preflight/checklist",
+  scopes: "confenge://preflight/scopes",
+  rules: "confenge://session/operating-rules",
+} as const;
+
+export const PROMPT_NAMES = {
+  preflight: "confenge.session_preflight",
+  close: "confenge.session_close",
+} as const;

--- a/control-center/services/mcp/src/validation.ts
+++ b/control-center/services/mcp/src/validation.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+import { ERROR_CODES, McpAppError } from "./errors.js";
+import {
+  BLOCKER_SEVERITIES,
+  SESSION_OUTCOMES,
+  type BlockerInput,
+  type SessionResultInput,
+} from "./types.js";
+
+const nonEmpty = z.string().trim().min(1);
+
+export const emptyArgsSchema = z.object({}).passthrough();
+
+export const getContextArgsSchema = z.object({
+  scope: nonEmpty,
+});
+
+export const getActiveDirectivesArgsSchema = z.object({
+  scope: nonEmpty,
+});
+
+export const getClientContextArgsSchema = z.object({
+  client: nonEmpty,
+});
+
+export const getDecisionsArgsSchema = z.object({
+  since: z
+    .string()
+    .trim()
+    .min(1)
+    .refine((value) => !Number.isNaN(Date.parse(value)), "since must be an ISO-8601 timestamp")
+    .optional(),
+});
+
+export const reportSessionResultArgsSchema = z
+  .object({
+    session_id: nonEmpty.optional(),
+    scope: nonEmpty,
+    summary: nonEmpty,
+    outcome: z.enum(SESSION_OUTCOMES),
+    notes: z.string().optional(),
+  })
+  .strict();
+
+export const reportBlockerArgsSchema = z
+  .object({
+    scope: nonEmpty,
+    summary: nonEmpty,
+    severity: z.enum(BLOCKER_SEVERITIES),
+    blocking: z.boolean().default(true),
+  })
+  .strict();
+
+export function parseArgs<S extends z.ZodType>(
+  schema: S,
+  args: unknown,
+  correlationId: string,
+  missingCode?: typeof ERROR_CODES.MISSING_SCOPE | typeof ERROR_CODES.MISSING_CLIENT,
+): z.output<S> {
+  const result = schema.safeParse(args ?? {});
+  if (result.success) {
+    return result.data;
+  }
+  const first = result.error.issues[0];
+  const path = first?.path[0];
+  if (missingCode === ERROR_CODES.MISSING_SCOPE && path === "scope") {
+    throw new McpAppError(ERROR_CODES.MISSING_SCOPE, "scope is required", correlationId);
+  }
+  if (missingCode === ERROR_CODES.MISSING_CLIENT && path === "client") {
+    throw new McpAppError(ERROR_CODES.MISSING_CLIENT, "client is required", correlationId);
+  }
+  throw new McpAppError(
+    ERROR_CODES.INVALID_PARAMS,
+    first?.message ?? "invalid tool arguments",
+    correlationId,
+  );
+}
+
+export function asSessionResult(data: z.infer<typeof reportSessionResultArgsSchema>): SessionResultInput {
+  const input: SessionResultInput = {
+    scope: data.scope,
+    summary: data.summary,
+    outcome: data.outcome,
+  };
+  if (data.session_id !== undefined) {
+    input.session_id = data.session_id;
+  }
+  if (data.notes !== undefined) {
+    input.notes = data.notes;
+  }
+  return input;
+}
+
+export function asBlocker(data: z.infer<typeof reportBlockerArgsSchema>): BlockerInput {
+  return {
+    scope: data.scope,
+    summary: data.summary,
+    severity: data.severity,
+    blocking: data.blocking ?? true,
+  };
+}
+
+export function jsonSchema(schema: z.ZodType): Record<string, unknown> {
+  return zodToJsonSchema(schema);
+}
+
+function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
+  if (schema instanceof z.ZodOptional) {
+    return zodToJsonSchema(schema.unwrap());
+  }
+  if (schema instanceof z.ZodDefault) {
+    return zodToJsonSchema(schema._def.innerType as z.ZodType);
+  }
+  if (schema instanceof z.ZodObject) {
+    const shape = schema.shape as Record<string, z.ZodType>;
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+    for (const [key, value] of Object.entries(shape)) {
+      properties[key] = zodToJsonSchema(value);
+      if (!(value instanceof z.ZodOptional) && !(value instanceof z.ZodDefault)) {
+        required.push(key);
+      }
+    }
+    const out: Record<string, unknown> = {
+      type: "object",
+      properties,
+      additionalProperties: schema._def.unknownKeys === "passthrough",
+    };
+    if (required.length > 0) {
+      out["required"] = required;
+    }
+    return out;
+  }
+  if (schema instanceof z.ZodEnum) {
+    return { type: "string", enum: [...schema.options] };
+  }
+  if (schema instanceof z.ZodBoolean) {
+    return { type: "boolean" };
+  }
+  if (schema instanceof z.ZodNumber) {
+    return { type: "integer" };
+  }
+  return { type: "string" };
+}

--- a/control-center/services/mcp/tests/abuse.test.ts
+++ b/control-center/services/mcp/tests/abuse.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  authMeta,
+  boot,
+  callTool,
+  errorData,
+  handshake,
+  rpc,
+  TEST_TOKEN,
+} from "./helpers.js";
+
+describe("MCP abuse and protocol failures", () => {
+  it("rejects missing auth token with a correlation id and does not leak the token", async () => {
+    const { runtime, logs } = boot();
+    await handshake(runtime);
+    const reply = await callTool(runtime, "confenge.get_context", { scope: "ops.commercial" }, { token: undefined });
+    const err = errorData(reply);
+    assert.equal(err.code, "UNAUTHENTICATED");
+    assert.ok(err.correlation_id.length > 0);
+    const blob = `${JSON.stringify(reply)}\n${logs.join("\n")}`;
+    assert.doesNotMatch(blob, new RegExp(TEST_TOKEN));
+  });
+
+  it("rejects a wrong token with a correlation id and does not leak either token", async () => {
+    const { runtime, logs } = boot();
+    await handshake(runtime);
+    const wrong = "definitely-not-the-configured-token";
+    const reply = await callTool(runtime, "confenge.get_priorities", {}, { token: wrong });
+    const err = errorData(reply);
+    assert.equal(err.code, "INVALID_TOKEN");
+    assert.ok(err.correlation_id.length > 0);
+    const blob = `${JSON.stringify(reply)}\n${logs.join("\n")}`;
+    assert.doesNotMatch(blob, new RegExp(TEST_TOKEN));
+    assert.doesNotMatch(blob, new RegExp(wrong));
+  });
+
+  it("fail-closes when the server has no configured auth token", async () => {
+    const { runtime } = boot({ authToken: undefined, secretsToRedact: [] });
+    await handshake(runtime, undefined);
+    const reply = await callTool(runtime, "confenge.get_company_state", {}, { token: TEST_TOKEN });
+    const err = errorData(reply);
+    assert.equal(err.code, "UNAUTHENTICATED");
+    assert.match(err.message, /not configured|missing/i);
+  });
+
+  it("returns a structured parse error for malformed JSON-RPC", async () => {
+    const { runtime } = boot();
+    const raw = await runtime.handleRaw("{not-json");
+    assert.ok(raw);
+    const reply = JSON.parse(raw) as Record<string, unknown>;
+    const err = errorData(reply);
+    assert.equal(err.code, "PARSE_ERROR");
+    assert.equal(err.jsonRpcCode, -32700);
+    assert.ok(err.correlation_id.length > 0);
+  });
+
+  it("returns a structured error for an unknown tool", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+    const reply = await callTool(runtime, "confenge.not_a_real_tool", { scope: "ops.commercial" });
+    const err = errorData(reply);
+    assert.equal(err.code, "UNKNOWN_TOOL");
+    assert.ok(err.correlation_id.length > 0);
+  });
+
+  it("requires scope and client on scoped tools", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+
+    const missingScope = await callTool(runtime, "confenge.get_context", {});
+    const scopeErr = errorData(missingScope);
+    assert.equal(scopeErr.code, "MISSING_SCOPE");
+    assert.ok(scopeErr.correlation_id.length > 0);
+
+    const missingDirectiveScope = await callTool(runtime, "confenge.get_active_directives", {});
+    assert.equal(errorData(missingDirectiveScope).code, "MISSING_SCOPE");
+
+    const missingClient = await callTool(runtime, "confenge.get_client_context", {});
+    const clientErr = errorData(missingClient);
+    assert.equal(clientErr.code, "MISSING_CLIENT");
+    assert.ok(clientErr.correlation_id.length > 0);
+  });
+
+  it("rate-limits rapid tools/call traffic with a correlation id", async () => {
+    const { runtime } = boot({ rateLimit: { max: 3, windowMs: 60_000 } });
+    await handshake(runtime);
+    for (let i = 0; i < 3; i += 1) {
+      const reply = await callTool(runtime, "confenge.get_priorities", {}, { id: 20 + i });
+      assert.equal(reply["error"], undefined);
+    }
+    const limited = await callTool(runtime, "confenge.get_priorities", {}, { id: 99 });
+    const err = errorData(limited);
+    assert.equal(err.code, "RATE_LIMITED");
+    assert.ok(err.correlation_id.length > 0);
+  });
+
+  it("propagates a client correlation id on failures", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+    const reply = await rpc(runtime, {
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: {
+        name: "confenge.get_context",
+        arguments: {},
+        _meta: { ...authMeta(TEST_TOKEN), correlation_id: "cc-mcp-fixed-test-id" },
+      },
+    });
+    assert.ok(reply);
+    const err = errorData(reply);
+    assert.equal(err.correlation_id, "cc-mcp-fixed-test-id");
+    assert.equal(err.code, "MISSING_SCOPE");
+  });
+});

--- a/control-center/services/mcp/tests/helpers.ts
+++ b/control-center/services/mcp/tests/helpers.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { createLogger } from "../src/logging.js";
+import { createMcpRuntime, type McpRuntime, type McpRuntimeOptions } from "../src/server.js";
+import { createStubContextApi } from "../src/stub-adapter.js";
+import { FRESHNESS_STATUSES } from "../src/types.js";
+
+export const TEST_TOKEN = "cc-test-token-fixture-not-a-secret";
+export const PROTOCOL_VERSION = "2025-03-26";
+
+export interface Booted {
+  runtime: McpRuntime;
+  logs: string[];
+}
+
+export function boot(overrides: McpRuntimeOptions = {}): Booted {
+  const logs: string[] = [];
+  const runtime = createMcpRuntime({
+    context: createStubContextApi(),
+    authToken: TEST_TOKEN,
+    logger: createLogger({ write: (line) => logs.push(line) }),
+    rateLimit: { max: 30, windowMs: 60_000 },
+    secretsToRedact: [TEST_TOKEN],
+    ...overrides,
+  });
+  return { runtime, logs };
+}
+
+export async function rpc(
+  runtime: McpRuntime,
+  message: Record<string, unknown>,
+  extras?: { authorization?: string },
+): Promise<Record<string, unknown> | null> {
+  const raw = await runtime.handleRaw(JSON.stringify(message), extras);
+  if (raw === null) {
+    return null;
+  }
+  const parsed: unknown = JSON.parse(raw);
+  assert.ok(parsed !== null && typeof parsed === "object");
+  return parsed as Record<string, unknown>;
+}
+
+export function authMeta(token: string | undefined, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  const meta: Record<string, unknown> = { ...extra };
+  if (token !== undefined) {
+    meta["authorization"] = `Bearer ${token}`;
+  }
+  return meta;
+}
+
+export async function handshake(
+  runtime: McpRuntime,
+  token: string | undefined = TEST_TOKEN,
+): Promise<Record<string, unknown>> {
+  const init = await rpc(runtime, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: "confenge-mcp-tests", version: "0.0.0" },
+      _meta: authMeta(token),
+    },
+  });
+  assert.ok(init);
+  await rpc(runtime, {
+    jsonrpc: "2.0",
+    method: "notifications/initialized",
+    params: { _meta: authMeta(token) },
+  });
+  return init;
+}
+
+export async function callTool(
+  runtime: McpRuntime,
+  name: string,
+  args: Record<string, unknown> | undefined,
+  options: { token?: string | undefined; id?: number; extras?: { authorization?: string } } = {},
+): Promise<Record<string, unknown>> {
+  const token = Object.prototype.hasOwnProperty.call(options, "token") ? options.token : TEST_TOKEN;
+  const reply = await rpc(
+    runtime,
+    {
+      jsonrpc: "2.0",
+      id: options.id ?? 2,
+      method: "tools/call",
+      params: {
+        name,
+        arguments: args ?? {},
+        _meta: authMeta(token),
+      },
+    },
+    options.extras,
+  );
+  assert.ok(reply);
+  return reply;
+}
+
+export function toolPayload(reply: Record<string, unknown>): {
+  correlation_id: string;
+  data: unknown;
+  isError: boolean;
+} {
+  if (reply["error"]) {
+    throw new Error(`expected tool result, got error: ${JSON.stringify(reply["error"])}`);
+  }
+  const result = reply["result"];
+  assert.ok(isRecord(result), "missing result");
+  const isError = result["isError"] === true;
+  const content = result["content"];
+  assert.ok(Array.isArray(content) && content.length > 0, "missing content");
+  const first = content[0];
+  assert.ok(isRecord(first) && first["type"] === "text" && typeof first["text"] === "string");
+  const parsed: unknown = JSON.parse(first["text"]);
+  assert.ok(isRecord(parsed));
+  assert.equal(typeof parsed["correlation_id"], "string");
+  return {
+    correlation_id: parsed["correlation_id"] as string,
+    data: parsed["data"],
+    isError,
+  };
+}
+
+export function errorData(reply: Record<string, unknown>): {
+  jsonRpcCode: number;
+  code: string;
+  message: string;
+  correlation_id: string;
+} {
+  const error = reply["error"];
+  assert.ok(isRecord(error), "expected JSON-RPC error");
+  assert.equal(typeof error["code"], "number");
+  assert.equal(typeof error["message"], "string");
+  const data = error["data"];
+  assert.ok(isRecord(data), "expected structured error data");
+  const correlationId =
+    typeof data["correlation_id"] === "string"
+      ? data["correlation_id"]
+      : isRecord(data["error"]) && typeof data["error"]["correlation_id"] === "string"
+        ? data["error"]["correlation_id"]
+        : undefined;
+  assert.ok(correlationId, "structured error must include correlation_id");
+  const nested = isRecord(data["error"]) ? data["error"] : data;
+  const code = typeof nested["code"] === "string" ? nested["code"] : "UNKNOWN";
+  return {
+    jsonRpcCode: error["code"] as number,
+    code,
+    message: error["message"] as string,
+    correlation_id: correlationId,
+  };
+}
+
+export function assertProvenance(value: unknown, label: string): void {
+  assert.ok(isRecord(value), `${label} must be an object`);
+  assert.equal(typeof value["source"], "string", `${label}.source`);
+  assert.ok((value["source"] as string).length > 0, `${label}.source non-empty`);
+  assert.equal(typeof value["observed_at"], "string", `${label}.observed_at`);
+  assert.ok(!Number.isNaN(Date.parse(value["observed_at"] as string)), `${label}.observed_at ISO`);
+  assert.ok(
+    (FRESHNESS_STATUSES as readonly string[]).includes(value["freshness_status"] as string),
+    `${label}.freshness_status`,
+  );
+  if (value["confidence"] !== undefined) {
+    assert.equal(typeof value["confidence"], "number", `${label}.confidence`);
+  }
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function encode(value: unknown): string {
+  return JSON.stringify(value);
+}

--- a/control-center/services/mcp/tests/launch.test.ts
+++ b/control-center/services/mcp/tests/launch.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { MARKERS } from "../src/fixtures.js";
+import { PROMPT_NAMES, RESOURCE_URIS } from "../src/types.js";
+import { PROTOCOL_VERSION, TEST_TOKEN, errorData, isRecord, toolPayload } from "./helpers.js";
+
+const root = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+const tsxCli = path.join(root, "node_modules/tsx/dist/cli.mjs");
+const entry = path.join(root, "src/index.ts");
+
+describe("real entry point against fixtures", () => {
+  it("completes preflight → get_context → report_session_result over stdio twice", async () => {
+    const first = await runLaunchFlow("launch-1");
+    const second = await runLaunchFlow("launch-2");
+    assert.equal(first.contextMarker, MARKERS.commercial);
+    assert.equal(second.contextMarker, MARKERS.commercial);
+    assert.equal(first.reportAccepted, true);
+    assert.equal(second.reportAccepted, true);
+    assert.equal(first.protocolVersion, second.protocolVersion);
+    assert.deepEqual(first.capabilities, second.capabilities);
+    assert.equal(first.scope, second.scope);
+    process.stdout.write(`${JSON.stringify({ event: "launch-flow-consistent", first, second })}\n`);
+  });
+});
+
+interface LaunchSummary {
+  protocolVersion: string;
+  capabilities: string[];
+  scope: string;
+  contextMarker: string;
+  reportAccepted: boolean;
+  reportId: string;
+}
+
+async function runLaunchFlow(label: string): Promise<LaunchSummary> {
+  const child = spawn(process.execPath, [tsxCli, entry], {
+    cwd: root,
+    env: {
+      ...process.env,
+      CONFENGE_MCP_AUTH_TOKEN: TEST_TOKEN,
+      CONFENGE_MCP_RATE_LIMIT_MAX: "30",
+      CONFENGE_MCP_HTTP_PORT: "",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const stderrChunks: string[] = [];
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderrChunks.push(chunk);
+  });
+
+  const client = new StdioClient(child);
+  try {
+    const init = await client.request({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "confenge-mcp-launch", version: "0.0.0" },
+        _meta: { authorization: `Bearer ${TEST_TOKEN}` },
+      },
+    });
+    const initResult = init["result"];
+    assert.ok(isRecord(initResult), `${label} initialize result`);
+    assert.equal(typeof initResult["protocolVersion"], "string");
+    const capabilities = initResult["capabilities"];
+    assert.ok(isRecord(capabilities));
+    assert.ok(isRecord(capabilities["tools"]));
+    assert.ok(isRecord(capabilities["resources"]));
+    assert.ok(isRecord(capabilities["prompts"]));
+
+    client.notify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: { _meta: { authorization: `Bearer ${TEST_TOKEN}` } },
+    });
+
+    const prompt = await client.request({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "prompts/get",
+      params: {
+        name: PROMPT_NAMES.preflight,
+        arguments: { scope: "ops.commercial" },
+        _meta: { authorization: `Bearer ${TEST_TOKEN}` },
+      },
+    });
+    const promptResult = prompt["result"];
+    assert.ok(isRecord(promptResult));
+    assert.match(JSON.stringify(promptResult), /confenge\.get_context/);
+
+    const resource = await client.request({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "resources/read",
+      params: {
+        uri: RESOURCE_URIS.checklist,
+        _meta: { authorization: `Bearer ${TEST_TOKEN}` },
+      },
+    });
+    const resourceResult = resource["result"];
+    assert.ok(isRecord(resourceResult));
+    assert.match(JSON.stringify(resourceResult), /preflight/i);
+
+    const contextReply = await client.request({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: {
+        name: "confenge.get_context",
+        arguments: { scope: "ops.commercial" },
+        _meta: { authorization: `Bearer ${TEST_TOKEN}` },
+      },
+    });
+    const contextPayload = toolPayload(contextReply);
+    assert.equal(contextPayload.isError, false);
+    assert.ok(isRecord(contextPayload.data));
+    assert.equal(contextPayload.data["scope"], "ops.commercial");
+    assert.equal(typeof contextPayload.data["source"], "string");
+    assert.equal(typeof contextPayload.data["observed_at"], "string");
+    assert.equal(typeof contextPayload.data["freshness_status"], "string");
+    const encoded = JSON.stringify(contextPayload.data);
+    assert.match(encoded, new RegExp(MARKERS.commercial));
+    assert.doesNotMatch(encoded, new RegExp(MARKERS.companyDump));
+
+    const reportReply = await client.request({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: {
+        name: "confenge.report_session_result",
+        arguments: {
+          session_id: `launch-${label}`,
+          scope: "ops.commercial",
+          summary: "Preflight and scoped context loaded; no provider mutation.",
+          outcome: "completed",
+        },
+        _meta: { authorization: `Bearer ${TEST_TOKEN}` },
+      },
+    });
+    const reportPayload = toolPayload(reportReply);
+    assert.equal(reportPayload.isError, false);
+    assert.ok(isRecord(reportPayload.data));
+    assert.equal(reportPayload.data["accepted"], true);
+
+    const stderr = stderrChunks.join("");
+    assert.doesNotMatch(stderr, new RegExp(TEST_TOKEN));
+    assert.match(stderr, /"msg":"mcp.listen"/);
+
+    return {
+      protocolVersion: String(initResult["protocolVersion"]),
+      capabilities: Object.keys(capabilities).sort(),
+      scope: String(contextPayload.data["scope"]),
+      contextMarker: MARKERS.commercial,
+      reportAccepted: reportPayload.data["accepted"] === true,
+      reportId: String(reportPayload.data["id"]),
+    };
+  } catch (err) {
+    const extra = stderrChunks.join("");
+    throw new Error(`${label} failed: ${err instanceof Error ? err.message : String(err)}\nstderr=${extra}`);
+  } finally {
+    await client.close();
+  }
+}
+
+class StdioClient {
+  private buffer = "";
+  private readonly pending = new Map<
+    string | number,
+    { resolve: (value: Record<string, unknown>) => void; reject: (err: Error) => void }
+  >();
+
+  constructor(private readonly child: ChildProcessWithoutNullStreams) {
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => this.onData(chunk));
+    child.on("error", (err) => {
+      for (const wait of this.pending.values()) {
+        wait.reject(err);
+      }
+      this.pending.clear();
+    });
+  }
+
+  notify(message: Record<string, unknown>): void {
+    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  request(message: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const id = message["id"];
+    if (typeof id !== "string" && typeof id !== "number") {
+      return Promise.reject(new Error("request id required"));
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`timeout waiting for id=${id}`));
+      }, 10_000);
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
+      this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    });
+  }
+
+  async close(): Promise<void> {
+    if (!this.child.killed) {
+      this.child.kill("SIGTERM");
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.child.kill("SIGKILL");
+        resolve();
+      }, 2000);
+      this.child.on("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  private onData(chunk: string): void {
+    this.buffer += chunk;
+    let idx = this.buffer.indexOf("\n");
+    while (idx >= 0) {
+      const line = this.buffer.slice(0, idx).trim();
+      this.buffer = this.buffer.slice(idx + 1);
+      if (line.length > 0) {
+        this.onLine(line);
+      }
+      idx = this.buffer.indexOf("\n");
+    }
+  }
+
+  private onLine(line: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (!isRecord(parsed)) {
+      return;
+    }
+    const id = parsed["id"];
+    if (typeof id !== "string" && typeof id !== "number") {
+      return;
+    }
+    const wait = this.pending.get(id);
+    if (!wait) {
+      return;
+    }
+    this.pending.delete(id);
+    if (parsed["error"]) {
+      try {
+        errorData(parsed);
+      } catch {
+        wait.reject(new Error(line));
+        return;
+      }
+    }
+    wait.resolve(parsed);
+  }
+}

--- a/control-center/services/mcp/tests/protocol.test.ts
+++ b/control-center/services/mcp/tests/protocol.test.ts
@@ -1,0 +1,341 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MARKERS } from "../src/fixtures.js";
+import { PROMPT_NAMES, RESOURCE_URIS, TOOL_NAMES } from "../src/types.js";
+import {
+  assertProvenance,
+  authMeta,
+  boot,
+  callTool,
+  errorData,
+  handshake,
+  isRecord,
+  rpc,
+  TEST_TOKEN,
+  toolPayload,
+} from "./helpers.js";
+
+describe("MCP protocol", () => {
+  it("initialize advertises tools, resources, and prompts capabilities", async () => {
+    const { runtime } = boot();
+    const init = await handshake(runtime);
+    const result = init["result"];
+    assert.ok(isRecord(result));
+    assert.equal(typeof result["protocolVersion"], "string");
+    const capabilities = result["capabilities"];
+    assert.ok(isRecord(capabilities));
+    assert.ok(isRecord(capabilities["tools"]));
+    assert.ok(isRecord(capabilities["resources"]));
+    assert.ok(isRecord(capabilities["prompts"]));
+    const serverInfo = result["serverInfo"];
+    assert.ok(isRecord(serverInfo));
+    assert.equal(serverInfo["name"], "confenge-control-center");
+  });
+
+  it("lists the eight Confenge tools by exact name", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+    const listed = await rpc(runtime, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: { _meta: authMeta(TEST_TOKEN) },
+    });
+    assert.ok(listed);
+    const result = listed["result"];
+    assert.ok(isRecord(result));
+    const tools = result["tools"];
+    assert.ok(Array.isArray(tools));
+    const names = tools.map((tool) => {
+      assert.ok(isRecord(tool));
+      assert.equal(typeof tool["name"], "string");
+      return tool["name"] as string;
+    });
+    assert.deepEqual(names, [...TOOL_NAMES]);
+    for (const banned of [
+      "confenge.create_directive",
+      "confenge.charge",
+      "confenge.checkout",
+      "confenge.refund",
+      "confenge.cancel",
+      "confenge.asaas",
+      "cobranca",
+    ]) {
+      assert.equal(
+        names.some((name) => name.toLowerCase().includes(banned.replace("confenge.", ""))),
+        false,
+        `must not advertise ${banned}`,
+      );
+    }
+  });
+
+  it("serves preflight resources and prompts", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+
+    const resources = await rpc(runtime, {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "resources/list",
+      params: { _meta: authMeta(TEST_TOKEN) },
+    });
+    assert.ok(resources);
+    const resourceResult = resources["result"];
+    assert.ok(isRecord(resourceResult));
+    const resourceList = resourceResult["resources"];
+    assert.ok(Array.isArray(resourceList));
+    const uris = resourceList.map((row) => {
+      assert.ok(isRecord(row));
+      return row["uri"];
+    });
+    assert.ok(uris.includes(RESOURCE_URIS.checklist));
+    assert.ok(uris.includes(RESOURCE_URIS.rules));
+
+    const read = await rpc(runtime, {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "resources/read",
+      params: { uri: RESOURCE_URIS.checklist, _meta: authMeta(TEST_TOKEN) },
+    });
+    assert.ok(read);
+    const readResult = read["result"];
+    assert.ok(isRecord(readResult));
+    const contents = readResult["contents"];
+    assert.ok(Array.isArray(contents));
+    const doc = contents[0];
+    assert.ok(isRecord(doc));
+    assert.match(String(doc["text"]), /confenge\.get_context/);
+    assert.match(String(doc["text"]), /preflight/i);
+
+    const prompts = await rpc(runtime, {
+      jsonrpc: "2.0",
+      id: 5,
+      method: "prompts/list",
+      params: { _meta: authMeta(TEST_TOKEN) },
+    });
+    assert.ok(prompts);
+    const promptResult = prompts["result"];
+    assert.ok(isRecord(promptResult));
+    const promptList = promptResult["prompts"];
+    assert.ok(Array.isArray(promptList));
+    const promptNames = promptList.map((row) => {
+      assert.ok(isRecord(row));
+      return row["name"];
+    });
+    assert.ok(promptNames.includes(PROMPT_NAMES.preflight));
+
+    const got = await rpc(runtime, {
+      jsonrpc: "2.0",
+      id: 6,
+      method: "prompts/get",
+      params: {
+        name: PROMPT_NAMES.preflight,
+        arguments: { scope: "ops.commercial" },
+        _meta: authMeta(TEST_TOKEN),
+      },
+    });
+    assert.ok(got);
+    const gotResult = got["result"];
+    assert.ok(isRecord(gotResult));
+    const messages = gotResult["messages"];
+    assert.ok(Array.isArray(messages));
+    const message = messages[0];
+    assert.ok(isRecord(message));
+    const content = message["content"];
+    assert.ok(isRecord(content));
+    assert.match(String(content["text"]), /confenge\.get_context/);
+    assert.match(String(content["text"]), /ops\.commercial/);
+  });
+
+  it("returns scoped context with provenance and omits other scopes and the company dump", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+    const reply = await callTool(runtime, "confenge.get_context", { scope: "ops.commercial" });
+    const payload = toolPayload(reply);
+    assert.equal(payload.isError, false);
+    assert.ok(isRecord(payload.data));
+    assert.equal(payload.data["scope"], "ops.commercial");
+    assertProvenance(payload.data, "get_context");
+    const encoded = JSON.stringify(payload.data);
+    assert.match(encoded, new RegExp(MARKERS.commercial));
+    assert.doesNotMatch(encoded, new RegExp(MARKERS.finance));
+    assert.doesNotMatch(encoded, new RegExp(MARKERS.companyDump));
+    assert.doesNotMatch(encoded, new RegExp(MARKERS.beta));
+    const records = payload.data["records"];
+    assert.ok(Array.isArray(records) && records.length > 0);
+    for (const record of records) {
+      assertProvenance(record, "get_context.record");
+      assert.ok(isRecord(record));
+      assert.equal(record["scope"], "ops.commercial");
+    }
+  });
+
+  it("scopes active directives and client context", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+
+    const directivesReply = await callTool(runtime, "confenge.get_active_directives", {
+      scope: "ops.commercial",
+    });
+    const directivesPayload = toolPayload(directivesReply);
+    assert.equal(directivesPayload.isError, false);
+    assert.ok(isRecord(directivesPayload.data));
+    assertProvenance(directivesPayload.data, "get_active_directives");
+    const directives = directivesPayload.data["directives"];
+    assert.ok(Array.isArray(directives) && directives.length > 0);
+    const encoded = JSON.stringify(directives);
+    assert.match(encoded, /dir-comm-1/);
+    assert.doesNotMatch(encoded, /dir-fin-1/);
+    assert.doesNotMatch(encoded, /dir-comm-old/);
+    assert.doesNotMatch(encoded, new RegExp(MARKERS.companyDump));
+    for (const row of directives) {
+      assert.ok(isRecord(row));
+      assertProvenance(row, "directive");
+      assert.equal(row["scope"], "ops.commercial");
+      assert.equal(row["status"], "active");
+      assert.equal(typeof row["effective_from"], "string");
+      assert.equal(typeof row["created_by"], "string");
+      assert.ok("expires_at" in row);
+      assert.ok("supersedes" in row);
+      assert.ok(isRecord(row["audit"]));
+    }
+
+    const clientReply = await callTool(runtime, "confenge.get_client_context", { client: "acme-ltda" });
+    const clientPayload = toolPayload(clientReply);
+    assert.equal(clientPayload.isError, false);
+    assert.ok(isRecord(clientPayload.data));
+    assertProvenance(clientPayload.data, "get_client_context");
+    const clientEncoded = JSON.stringify(clientPayload.data);
+    assert.match(clientEncoded, new RegExp(MARKERS.acme));
+    assert.doesNotMatch(clientEncoded, new RegExp(MARKERS.beta));
+    assert.doesNotMatch(clientEncoded, new RegExp(MARKERS.companyDump));
+    assert.doesNotMatch(clientEncoded, new RegExp(MARKERS.finance));
+  });
+
+  it("honors get_decisions since and returns provenance", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+
+    const allReply = await callTool(runtime, "confenge.get_decisions", {});
+    const allPayload = toolPayload(allReply);
+    assert.ok(isRecord(allPayload.data));
+    const all = allPayload.data["decisions"];
+    assert.ok(Array.isArray(all));
+    assert.equal(all.length, 3);
+    for (const row of all) {
+      assertProvenance(row, "decision");
+    }
+
+    const sinceReply = await callTool(runtime, "confenge.get_decisions", {
+      since: "2026-08-01T00:00:00.000Z",
+    });
+    const sincePayload = toolPayload(sinceReply);
+    assert.ok(isRecord(sincePayload.data));
+    const since = sincePayload.data["decisions"];
+    assert.ok(Array.isArray(since));
+    const ids = since.map((row) => {
+      assert.ok(isRecord(row));
+      return row["id"];
+    });
+    assert.deepEqual(ids, ["dec-2", "dec-3"]);
+    assert.ok(!ids.includes("dec-1"));
+  });
+
+  it("returns company state and priorities without the memory dump", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+
+    const stateReply = await callTool(runtime, "confenge.get_company_state", {});
+    const state = toolPayload(stateReply);
+    assert.equal(state.isError, false);
+    assert.ok(isRecord(state.data));
+    assertProvenance(state.data, "company_state");
+    const encoded = JSON.stringify(state.data);
+    assert.doesNotMatch(encoded, new RegExp(MARKERS.companyDump));
+    const top = state.data["top_three"];
+    assert.ok(Array.isArray(top) && top.length === 3);
+    for (const row of top) {
+      assertProvenance(row, "priority");
+    }
+
+    const priReply = await callTool(runtime, "confenge.get_priorities", {});
+    const pri = toolPayload(priReply);
+    assert.ok(isRecord(pri.data));
+    const list = pri.data["priorities"];
+    assert.ok(Array.isArray(list) && list.length === 3);
+  });
+
+  it("accepts session result and blocker writes", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+
+    const resultReply = await callTool(runtime, "confenge.report_session_result", {
+      session_id: "sess-1",
+      scope: "ops.commercial",
+      summary: "Reviewed ACME exception; no outbound send.",
+      outcome: "completed",
+    });
+    const resultPayload = toolPayload(resultReply);
+    assert.equal(resultPayload.isError, false);
+    assert.ok(isRecord(resultPayload.data));
+    assert.equal(resultPayload.data["accepted"], true);
+    assert.equal(resultPayload.data["kind"], "session_result");
+    assertProvenance(resultPayload.data, "session_result");
+
+    const again = await callTool(runtime, "confenge.report_session_result", {
+      session_id: "sess-1",
+      scope: "ops.commercial",
+      summary: "duplicate",
+      outcome: "completed",
+    });
+    const againPayload = toolPayload(again);
+    assert.ok(isRecord(againPayload.data));
+    assert.equal(againPayload.data["id"], resultPayload.data["id"]);
+
+    const blockerReply = await callTool(runtime, "confenge.report_blocker", {
+      scope: "ops.commercial",
+      summary: "Legal packet still stale",
+      severity: "high",
+      blocking: true,
+    });
+    const blockerPayload = toolPayload(blockerReply);
+    assert.equal(blockerPayload.isError, false);
+    assert.ok(isRecord(blockerPayload.data));
+    assert.equal(blockerPayload.data["accepted"], true);
+    assert.equal(blockerPayload.data["kind"], "blocker");
+    assertProvenance(blockerPayload.data, "blocker");
+  });
+
+  it("rejects attempts to create or alter decisions, constraints, or authoritative directives", async () => {
+    const { runtime } = boot();
+    await handshake(runtime);
+
+    const smuggle = await callTool(runtime, "confenge.report_session_result", {
+      scope: "ops.commercial",
+      summary: "trying to write memory",
+      outcome: "completed",
+      create_directive: { kind: "directive", body: "new rule" },
+    });
+    const smuggleErr = errorData(smuggle);
+    assert.equal(smuggleErr.code, "FORBIDDEN_MUTATION");
+    assert.ok(smuggleErr.correlation_id.length > 0);
+
+    const create = await callTool(runtime, "confenge.create_directive", {
+      kind: "directive",
+      body: "nope",
+      action: "create",
+    });
+    const createErr = errorData(create);
+    assert.equal(createErr.code, "FORBIDDEN_MUTATION");
+
+    const decision = await callTool(runtime, "confenge.report_blocker", {
+      scope: "company",
+      summary: "mutate",
+      severity: "low",
+      action: "create",
+      kind: "decision",
+    });
+    const decisionErr = errorData(decision);
+    assert.equal(decisionErr.code, "FORBIDDEN_MUTATION");
+  });
+});

--- a/control-center/services/mcp/tsconfig.json
+++ b/control-center/services/mcp/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Isolated Confenge Control Center MCP server for Grok/Codex and other agents. **Does not merge automatically.**

## What
Adds `control-center/services/mcp/` only:
- MCP JSON-RPC over stdio (optional HTTP `POST /mcp`)
- Eight tools: `confenge.get_company_state`, `get_context`, `get_active_directives`, `get_priorities`, `get_client_context`, `get_decisions`, `report_session_result`, `report_blocker`
- Preflight resources and prompts
- Env-injected auth, rate limiting, runtime validation, structured errors, correlation ids
- Local stub Context API + fixtures (no sibling/HTTP coupling)
- Writes limited to session result / blocker; authoritative decision/constraint/directive mutations fail closed
- No financial/provider mutation tools

## Out of scope
No changes under `commercial/`, `decisions/`, `scripts/`, root README, Warmbly, or other Control Center workstreams. Does not absorb PR #8.

## Verify
```bash
cd control-center/services/mcp
npm install && npm test
```

## Convergence later
Replace `createStubContextApi()` with a real `ContextApiPort` implementation. Keep tool names, fail-closed auth, and the read-first write policy.