### PR TITLE
fix(control-center): align context service ontology with Control Center canon

### DIFF
--- a/control-center/services/context/.env.example
+++ b/control-center/services/context/.env.example
@@ -2,8 +2,9 @@
 # Not a password. Do not put secrets, emails, or personal names here.
 CONTROL_CENTER_FOUNDER_ACTOR_ID=founder-local
 
-# Company key used when get_priorities / get_decisions are called without a scope.
-CONTROL_CENTER_COMPANY=confenge
+# Optional. Explicit repo → domain map for inheritance.
+# Query repo:Governance receives company + commercial + repo:Governance.
+CONTROL_CENTER_REPO_DOMAINS=Governance:commercial,Warmbly:commercial
 
 # Optional. When set, this workstream refuses to start with the fixture store
 # (fail-closed). Wire the real adapter from control-center/persistence at
@@ -17,6 +18,6 @@ CONTEXT_SERVICE_FIXTURE=representative
 HOST=127.0.0.1
 PORT=8787
 
-# CLI actor (required for src/cli.ts). Role is founder | agent.
+# CLI actor (required for src/cli.ts). Kind is human | agent | system.
 CONTEXT_ACTOR_ID=founder-local
-CONTEXT_ACTOR_ROLE=founder
+CONTEXT_ACTOR_KIND=human

--- a/control-center/services/context/.env.example
+++ b/control-center/services/context/.env.example
@@ -1,0 +1,22 @@
+# Required. Opaque founder actor id used to authorize mutations.
+# Not a password. Do not put secrets, emails, or personal names here.
+CONTROL_CENTER_FOUNDER_ACTOR_ID=founder-local
+
+# Company key used when get_priorities / get_decisions are called without a scope.
+CONTROL_CENTER_COMPANY=confenge
+
+# Optional. When set, this workstream refuses to start with the fixture store
+# (fail-closed). Wire the real adapter from control-center/persistence at
+# convergence. Never commit the value.
+# DATABASE_URL=postgresql://USER:PASSWORD@127.0.0.1:5432/control_center
+
+# Load the documented representative fixture (deterministic ids) on boot.
+CONTEXT_SERVICE_FIXTURE=representative
+
+# HTTP bind. Default is loopback; this service is private.
+HOST=127.0.0.1
+PORT=8787
+
+# CLI actor (required for src/cli.ts). Role is founder | agent.
+CONTEXT_ACTOR_ID=founder-local
+CONTEXT_ACTOR_ROLE=founder

--- a/control-center/services/context/.gitignore
+++ b/control-center/services/context/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+*.log
+coverage/

--- a/control-center/services/context/README.md
+++ b/control-center/services/context/README.md
@@ -1,0 +1,127 @@
+# Control Center — context service
+
+Serviço de memória estratégica e diretivas do Confenge Control Center.
+
+Não é chat. Não é ERP. Não substitui Warmbly. Agrega estado canônico mínimo para uma sessão de agente **por escopo**, com proveniência, herança controlada e trilha de auditoria.
+
+Este pacote é autônomo: o repositório ainda não tem toolchain TypeScript na raiz. A convergência posterior deve ligar `control-center/contracts/`, `control-center/persistence/` e `control-center/services/mcp/` sem reescrever a política daqui.
+
+## Decisões
+
+1. **Sete kinds** fechados: `decision`, `directive`, `fact`, `constraint`, `priority`, `risk`, `hypothesis`. Kind é imutável na linhagem; mudar kind exige `supersede`.
+2. **CRUD lógico** = create + read + nova versão + supersede + expire + activate/deactivate. Sem delete físico. Revisões anteriores permanecem legíveis.
+3. **Mutação é founder-only**, fail-closed. Identidade vem de `CONTROL_CENTER_FOUNDER_ACTOR_ID` + headers/CLI `X-Actor-Id` / `CONTEXT_ACTOR_*`. Não há senha ou identidade hardcoded.
+4. **Agente** lê por escopo e **só** escreve em `/v1/proposals`. Proposal **não** ativa, expira ou substitui `constraint`/`decision` ativas.
+5. **Herança controlada**: um lookup em recurso recebe `company` + aquele `domain` + aquele `resource`. Não desce para filhos, não vaza irmãos, não despeja a memória da empresa.
+6. **`hypothesis` não é `fact` nem `decision`**. `get_decisions()` nunca devolve hypothesis. `get_context` separa as listas.
+7. Toda diretiva carrega `scope`, `status`, `effective_from`, `expires_at`, `supersedes`, `created_by`. Itens agregados carregam `source`, `observed_at`, `freshness_status` e `confidence` quando definido.
+8. Datas internas em UTC (`...Z`). Valores financeiros, se citados no texto, são centavos inteiros + currency — este serviço não persiste ledger.
+9. Logs JSON estruturados. Proibido logar body, PII, secrets, `DATABASE_URL` ou nomes de campos secretos.
+10. PostgreSQL é a persistência alvo da campanha, mas **este workstream não é dono do schema**. Adapter local = fixture in-memory. Se `DATABASE_URL` estiver setado, o boot recusa fallback silencioso.
+
+## Operações expostas (contrato para MCP / UI)
+
+| Operação | Quem | Efeito |
+|---|---|---|
+| `createDirective` | founder | cria revisão 1 |
+| `createVersion` | founder | nova revisão, linhagem preservada |
+| `supersede` | founder | fecha a linhagem antiga (`superseded`) e cria sucessora |
+| `expire` / `activate` / `deactivate` | founder | nova revisão de status |
+| `getDirective` / `listRevisions` | founder, agent | leitura, inclusive histórico |
+| `submitProposal` | agent | sugestão pendente; **não** altera o conjunto ativo |
+| `get_context(scope)` | founder, agent | contexto mínimo determinístico do escopo |
+| `get_active_directives(scope)` | founder, agent | conjunto ativo com herança |
+| `get_priorities()` | founder, agent | priorities ativas no escopo company (ou query) |
+| `get_decisions()` | founder, agent | **somente** `kind=decision` |
+
+HTTP (privado, bind default `127.0.0.1`):
+
+```
+GET  /healthz
+GET  /v1/context?company=&domain=&resource=
+GET  /v1/active-directives?company=&domain=&resource=
+GET  /v1/priorities
+GET  /v1/decisions
+POST /v1/directives
+POST /v1/directives/:id/versions
+POST /v1/directives/:id/supersede
+POST /v1/directives/:id/expire
+POST /v1/directives/:id/activate
+POST /v1/directives/:id/deactivate
+GET  /v1/directives/:id
+GET  /v1/directives/:id/revisions
+POST /v1/proposals
+GET  /v1/proposals
+```
+
+Headers obrigatórios em tudo exceto `/healthz`: `X-Actor-Id`, `X-Actor-Role` (`founder` | `agent`).
+
+## Como rodar
+
+```bash
+cd control-center/services/context
+npm install
+npm test
+```
+
+Entrada HTTP (fixture representativa):
+
+```bash
+CONTROL_CENTER_FOUNDER_ACTOR_ID=founder-local \
+CONTEXT_SERVICE_FIXTURE=representative \
+CONTROL_CENTER_COMPANY=confenge \
+HOST=127.0.0.1 PORT=8787 \
+npm start
+```
+
+Entrada in-process / CLI (mesmo `bootFromEnv` + `createContextService`):
+
+```bash
+CONTROL_CENTER_FOUNDER_ACTOR_ID=founder-local \
+CONTEXT_ACTOR_ID=agent-session-1 \
+CONTEXT_ACTOR_ROLE=agent \
+CONTEXT_SERVICE_FIXTURE=representative \
+npx tsx src/cli.ts get_context --company confenge --domain commercial --resource offer:CFG-DIAG-EXP-v1
+```
+
+Comandos CLI: `get_context`, `get_active_directives`, `get_priorities`, `get_decisions`.
+
+## Variáveis de ambiente
+
+Valores abaixo são **nomes e exemplos não-secretos**. Não commitar `.env`.
+
+| Variável | Obrigatória | Função |
+|---|---|---|
+| `CONTROL_CENTER_FOUNDER_ACTOR_ID` | sim | id opaco do founder (não é senha) |
+| `CONTROL_CENTER_COMPANY` | não | default `confenge` para priorities/decisions sem scope |
+| `CONTEXT_SERVICE_FIXTURE` | não | `empty` (default) ou `representative` |
+| `CONTEXT_ACTOR_ID` / `CONTEXT_ACTOR_ROLE` | CLI sim | ator da sessão CLI |
+| `HOST` / `PORT` | não | bind HTTP; default loopback `127.0.0.1:8787` |
+| `DATABASE_URL` | não | se setada, o processo **recusa** o fixture (convergência) |
+
+## Adapter de persistência (handoff)
+
+Interface: `src/store/adapter.ts` (`PersistenceAdapter`, versão `control-center.context.persistence.v1`).
+
+Implementação desta onda: `src/store/fixture.ts`.
+
+SQL esperado (não aplicar daqui): `src/store/expected-schema.sql`.
+
+Regra de convergência: `control-center/persistence/` deve implementar o adapter e gravar o audit **na mesma transação** da mutação. Este serviço não importa essa árvore.
+
+## Handoff esperado
+
+| Destino | O que consome |
+|---|---|
+| `control-center/contracts/` | kinds, scope, provenance, payload de `get_context` |
+| `control-center/persistence/` | `PersistenceAdapter` + SQL |
+| `control-center/services/mcp/` | as quatro operações de leitura + proposals; **sem** mutação financeira |
+
+Fora de escopo aqui: UI, MCP, collectors, Warmbly, Asaas, `commercial/`, PR Governance #8.
+
+## Limites
+
+- JSON ≤ 32 KiB
+- title ≤ 200, body ≤ 8000, rationale ≤ 4000
+- campos desconhecidos rejeitados
+- `created_by` é sempre o ator autenticado

--- a/control-center/services/context/README.md
+++ b/control-center/services/context/README.md
@@ -9,37 +9,37 @@ Este pacote é autônomo: o repositório ainda não tem toolchain TypeScript na 
 ## Decisões
 
 1. **Sete kinds** fechados: `decision`, `directive`, `fact`, `constraint`, `priority`, `risk`, `hypothesis`. Kind é imutável na linhagem; mudar kind exige `supersede`.
-2. **CRUD lógico** = create + read + nova versão + supersede + expire + activate/deactivate. Sem delete físico. Revisões anteriores permanecem legíveis.
-3. **Mutação é founder-only**, fail-closed. Identidade vem de `CONTROL_CENTER_FOUNDER_ACTOR_ID` + headers/CLI `X-Actor-Id` / `CONTEXT_ACTOR_*`. Não há senha ou identidade hardcoded.
-4. **Agente** lê por escopo e **só** escreve em `/v1/proposals`. Proposal **não** ativa, expira ou substitui `constraint`/`decision` ativas.
-5. **Herança controlada**: um lookup em recurso recebe `company` + aquele `domain` + aquele `resource`. Não desce para filhos, não vaza irmãos, não despeja a memória da empresa.
+2. **CRUD lógico** = create + read + nova versão + supersede + expire + activate/revoke. Sem delete físico. Revisões anteriores permanecem legíveis. Status canônicos: `draft|active|superseded|revoked|expired`.
+3. **Mutação é founder/human-only**, fail-closed. Identidade vem de `CONTROL_CENTER_FOUNDER_ACTOR_ID` + headers/CLI `X-Actor-Id` / `X-Actor-Kind` / `CONTEXT_ACTOR_*`. Não há senha, identidade hardcoded ou admin bypass.
+4. **Agente** lê por escopo e **só** escreve em `/v1/proposals` (`DirectiveProposal`). Proposal **não** ativa, expira, revoga ou substitui `constraint`/`decision` ativas.
+5. **Herança controlada**: `repo:x` recebe `company` + domínio **explicitamente configurado** para aquele repo + `repo:x`. `client:y` recebe `company` + `clients` + `client:y`. Não desce para filhos, não vaza irmãos, não despeja a memória da empresa.
 6. **`hypothesis` não é `fact` nem `decision`**. `get_decisions()` nunca devolve hypothesis. `get_context` separa as listas.
-7. Toda diretiva carrega `scope`, `status`, `effective_from`, `expires_at`, `supersedes`, `created_by`. Itens agregados carregam `source`, `observed_at`, `freshness_status` e `confidence` quando definido.
+7. Toda diretiva carrega `scope` (string), `status`, `effective_from`, `expires_at`, `supersedes` (lista de IDs `cc:*` ou null), `created_by` (`ActorRef`). Itens agregados carregam proveniência `source` (`SourceRef`), `observed_at`, `freshness_status` (`FRESH|STALE|UNKNOWN|ERROR`) e `confidence`. `ERROR` nunca é reescrito como `UNKNOWN`.
 8. Datas internas em UTC (`...Z`). Valores financeiros, se citados no texto, são centavos inteiros + currency — este serviço não persiste ledger.
 9. Logs JSON estruturados. Proibido logar body, PII, secrets, `DATABASE_URL` ou nomes de campos secretos.
-10. PostgreSQL é a persistência alvo da campanha, mas **este workstream não é dono do schema**. Adapter local = fixture in-memory. Se `DATABASE_URL` estiver setado, o boot recusa fallback silencioso.
+10. PostgreSQL é a persistência alvo da campanha, mas **este workstream não é dono do schema**. Adapter local = fixture in-memory (`PersistencePort`). Se `DATABASE_URL` estiver setado, o boot recusa fallback silencioso. `expected-schema.sql` é contrato de teste, não autoridade de runtime.
 
 ## Operações expostas (contrato para MCP / UI)
 
 | Operação | Quem | Efeito |
 |---|---|---|
-| `createDirective` | founder | cria revisão 1 |
-| `createVersion` | founder | nova revisão, linhagem preservada |
-| `supersede` | founder | fecha a linhagem antiga (`superseded`) e cria sucessora |
-| `expire` / `activate` / `deactivate` | founder | nova revisão de status |
-| `getDirective` / `listRevisions` | founder, agent | leitura, inclusive histórico |
+| `createDirective` | human founder | cria revisão 1; `supersedes` lista fecha predecessores |
+| `createVersion` | human founder | nova revisão, linhagem preservada |
+| `supersede` | human founder | fecha uma ou mais linhagens (`superseded`) e cria sucessora |
+| `expire` / `activate` / `revoke` | human founder | nova revisão de status |
+| `getDirective` / `listRevisions` | human founder, agent | leitura, inclusive histórico |
 | `submitProposal` | agent | sugestão pendente; **não** altera o conjunto ativo |
-| `get_context(scope)` | founder, agent | contexto mínimo determinístico do escopo |
-| `get_active_directives(scope)` | founder, agent | conjunto ativo com herança |
-| `get_priorities()` | founder, agent | priorities ativas no escopo company (ou query) |
-| `get_decisions()` | founder, agent | **somente** `kind=decision` |
+| `get_context(scope)` | human founder, agent | contexto mínimo determinístico do escopo |
+| `get_active_directives(scope)` | human founder, agent | conjunto ativo com herança |
+| `get_priorities()` | human founder, agent | priorities ativas no escopo `company` (ou query) |
+| `get_decisions()` | human founder, agent | **somente** `kind=decision` |
 
 HTTP (privado, bind default `127.0.0.1`):
 
 ```
 GET  /healthz
-GET  /v1/context?company=&domain=&resource=
-GET  /v1/active-directives?company=&domain=&resource=
+GET  /v1/context?scope=
+GET  /v1/active-directives?scope=
 GET  /v1/priorities
 GET  /v1/decisions
 POST /v1/directives
@@ -47,14 +47,14 @@ POST /v1/directives/:id/versions
 POST /v1/directives/:id/supersede
 POST /v1/directives/:id/expire
 POST /v1/directives/:id/activate
-POST /v1/directives/:id/deactivate
+POST /v1/directives/:id/revoke
 GET  /v1/directives/:id
 GET  /v1/directives/:id/revisions
 POST /v1/proposals
 GET  /v1/proposals
 ```
 
-Headers obrigatórios em tudo exceto `/healthz`: `X-Actor-Id`, `X-Actor-Role` (`founder` | `agent`).
+Headers obrigatórios em tudo exceto `/healthz`: `X-Actor-Id`, `X-Actor-Kind` (`human` | `agent` | `system`).
 
 ## Como rodar
 
@@ -69,7 +69,6 @@ Entrada HTTP (fixture representativa):
 ```bash
 CONTROL_CENTER_FOUNDER_ACTOR_ID=founder-local \
 CONTEXT_SERVICE_FIXTURE=representative \
-CONTROL_CENTER_COMPANY=confenge \
 HOST=127.0.0.1 PORT=8787 \
 npm start
 ```
@@ -79,9 +78,9 @@ Entrada in-process / CLI (mesmo `bootFromEnv` + `createContextService`):
 ```bash
 CONTROL_CENTER_FOUNDER_ACTOR_ID=founder-local \
 CONTEXT_ACTOR_ID=agent-session-1 \
-CONTEXT_ACTOR_ROLE=agent \
+CONTEXT_ACTOR_KIND=agent \
 CONTEXT_SERVICE_FIXTURE=representative \
-npx tsx src/cli.ts get_context --company confenge --domain commercial --resource offer:CFG-DIAG-EXP-v1
+npx tsx src/cli.ts get_context --scope repo:Governance
 ```
 
 Comandos CLI: `get_context`, `get_active_directives`, `get_priorities`, `get_decisions`.
@@ -92,32 +91,32 @@ Valores abaixo são **nomes e exemplos não-secretos**. Não commitar `.env`.
 
 | Variável | Obrigatória | Função |
 |---|---|---|
-| `CONTROL_CENTER_FOUNDER_ACTOR_ID` | sim | id opaco do founder (não é senha) |
-| `CONTROL_CENTER_COMPANY` | não | default `confenge` para priorities/decisions sem scope |
+| `CONTROL_CENTER_FOUNDER_ACTOR_ID` | sim | id opaco do founder human (não é senha) |
+| `CONTROL_CENTER_REPO_DOMAINS` | não | mapa `repo:domain` para herança; default representativo `Governance:commercial,Warmbly:commercial` |
 | `CONTEXT_SERVICE_FIXTURE` | não | `empty` (default) ou `representative` |
-| `CONTEXT_ACTOR_ID` / `CONTEXT_ACTOR_ROLE` | CLI sim | ator da sessão CLI |
+| `CONTEXT_ACTOR_ID` / `CONTEXT_ACTOR_KIND` | CLI sim | ator da sessão CLI (`human` \| `agent` \| `system`) |
 | `HOST` / `PORT` | não | bind HTTP; default loopback `127.0.0.1:8787` |
 | `DATABASE_URL` | não | se setada, o processo **recusa** o fixture (convergência) |
 
 ## Adapter de persistência (handoff)
 
-Interface: `src/store/adapter.ts` (`PersistenceAdapter`, versão `control-center.context.persistence.v1`).
+Interface: `src/store/adapter.ts` (`PersistencePort`, versão `control-center.context.persistence.v1`).
 
 Implementação desta onda: `src/store/fixture.ts`.
 
-SQL esperado (não aplicar daqui): `src/store/expected-schema.sql`.
+SQL esperado (contrato de teste; **não** aplicar e **não** carregar em runtime): `src/store/expected-schema.sql`.
 
-Regra de convergência: `control-center/persistence/` deve implementar o adapter e gravar o audit **na mesma transação** da mutação. Este serviço não importa essa árvore.
+Regra de convergência: `control-center/persistence/` deve implementar o port e gravar o audit **na mesma transação** da mutação. Este serviço não importa essa árvore.
 
 ## Handoff esperado
 
 | Destino | O que consome |
 |---|---|
-| `control-center/contracts/` | kinds, scope, provenance, payload de `get_context` |
-| `control-center/persistence/` | `PersistenceAdapter` + SQL |
+| `control-center/contracts/` | kinds, scope string, ActorRef, SourceRef, freshness, payload de `get_context` |
+| `control-center/persistence/` | `PersistencePort` + SQL de teste |
 | `control-center/services/mcp/` | as quatro operações de leitura + proposals; **sem** mutação financeira |
 
-Fora de escopo aqui: UI, MCP, collectors, Warmbly, Asaas, `commercial/`, PR Governance #8.
+Fora de escopo aqui: UI, MCP, collectors, Warmbly, Asaas, `commercial/`, PR Governance #8, adapter Postgres real.
 
 ## Limites
 
@@ -125,3 +124,4 @@ Fora de escopo aqui: UI, MCP, collectors, Warmbly, Asaas, `commercial/`, PR Gove
 - title ≤ 200, body ≤ 8000, rationale ≤ 4000
 - campos desconhecidos rejeitados
 - `created_by` é sempre o ator autenticado
+- IDs `cc:<type-kebab>:<ulid-or-slug>`

--- a/control-center/services/context/package-lock.json
+++ b/control-center/services/context/package-lock.json
@@ -1,0 +1,593 @@
+{
+  "name": "@confenge/control-center-context",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-context",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.3.tgz",
+      "integrity": "sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/control-center/services/context/package.json
+++ b/control-center/services/context/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@confenge/control-center-context",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Confenge Control Center — strategic memory and directives (scoped context for agents).",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "tsx --test test/*.test.ts",
+    "start": "tsx src/server.ts",
+    "cli": "tsx src/cli.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/services/context/src/actor.ts
+++ b/control-center/services/context/src/actor.ts
@@ -1,24 +1,24 @@
 import { authError, forbidden } from "./errors.ts";
 import { sanitizeActorId } from "./sanitize.ts";
-import { ACTOR_ROLES, type Actor, type ActorRole } from "./types.ts";
+import { ACTOR_KINDS, type ActorKind, type ActorRef } from "./types.ts";
 
-export function parseActorRole(value: unknown): ActorRole {
+export function parseActorKind(value: unknown): ActorKind {
   if (typeof value !== "string" || value.trim() === "") {
-    throw authError("missing_actor", "actor role is required");
+    throw authError("missing_actor", "actor kind is required");
   }
-  const role = value.trim();
-  if (!(ACTOR_ROLES as readonly string[]).includes(role)) {
-    throw authError("unknown_actor_role", "actor role is unknown");
+  const kind = value.trim();
+  if (!(ACTOR_KINDS as readonly string[]).includes(kind)) {
+    throw authError("unknown_actor_role", "actor kind is unknown");
   }
-  return role as ActorRole;
+  return kind as ActorKind;
 }
 
-export function parseActor(idRaw: unknown, roleRaw: unknown): Actor {
+export function parseActor(idRaw: unknown, kindRaw: unknown): ActorRef {
   if (idRaw === undefined || idRaw === null || idRaw === "") {
     throw authError("missing_actor", "actor id is required");
   }
-  if (roleRaw === undefined || roleRaw === null || roleRaw === "") {
-    throw authError("missing_actor", "actor role is required");
+  if (kindRaw === undefined || kindRaw === null || kindRaw === "") {
+    throw authError("missing_actor", "actor kind is required");
   }
   let id: string;
   try {
@@ -26,32 +26,36 @@ export function parseActor(idRaw: unknown, roleRaw: unknown): Actor {
   } catch {
     throw authError("invalid_actor_id", "actor id is invalid");
   }
-  const role = parseActorRole(roleRaw);
-  return { id, role };
+  const kind = parseActorKind(kindRaw);
+  return { kind, id };
 }
 
-export function assertReadable(actor: Actor, founderActorId: string): void {
+export function sameActor(a: ActorRef, b: ActorRef): boolean {
+  return a.kind === b.kind && a.id === b.id;
+}
+
+export function assertReadable(actor: ActorRef, founderActorId: string): void {
   if (!founderActorId) {
     throw authError("unknown_actor", "founder identity is not configured");
   }
-  if (actor.role === "founder" && actor.id !== founderActorId) {
+  if (actor.kind === "human" && actor.id !== founderActorId) {
     throw authError("unknown_actor", "founder identity does not match");
   }
 }
 
-export function assertFounder(actor: Actor, founderActorId: string): void {
+export function assertFounder(actor: ActorRef, founderActorId: string): void {
   assertReadable(actor, founderActorId);
-  if (actor.role !== "founder") {
-    throw forbidden("agent_mutation_forbidden", "only the founder may mutate directives");
+  if (actor.kind !== "human") {
+    throw forbidden("agent_mutation_forbidden", "only the configured human founder may mutate directives");
   }
   if (actor.id !== founderActorId) {
     throw authError("unknown_actor", "founder identity does not match");
   }
 }
 
-export function assertAgent(actor: Actor, founderActorId: string): void {
+export function assertAgent(actor: ActorRef, founderActorId: string): void {
   assertReadable(actor, founderActorId);
-  if (actor.role !== "agent") {
+  if (actor.kind !== "agent") {
     throw forbidden("agent_mutation_forbidden", "proposals are submitted by agents");
   }
 }

--- a/control-center/services/context/src/actor.ts
+++ b/control-center/services/context/src/actor.ts
@@ -1,0 +1,57 @@
+import { authError, forbidden } from "./errors.ts";
+import { sanitizeActorId } from "./sanitize.ts";
+import { ACTOR_ROLES, type Actor, type ActorRole } from "./types.ts";
+
+export function parseActorRole(value: unknown): ActorRole {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw authError("missing_actor", "actor role is required");
+  }
+  const role = value.trim();
+  if (!(ACTOR_ROLES as readonly string[]).includes(role)) {
+    throw authError("unknown_actor_role", "actor role is unknown");
+  }
+  return role as ActorRole;
+}
+
+export function parseActor(idRaw: unknown, roleRaw: unknown): Actor {
+  if (idRaw === undefined || idRaw === null || idRaw === "") {
+    throw authError("missing_actor", "actor id is required");
+  }
+  if (roleRaw === undefined || roleRaw === null || roleRaw === "") {
+    throw authError("missing_actor", "actor role is required");
+  }
+  let id: string;
+  try {
+    id = sanitizeActorId(idRaw, "actor_id");
+  } catch {
+    throw authError("invalid_actor_id", "actor id is invalid");
+  }
+  const role = parseActorRole(roleRaw);
+  return { id, role };
+}
+
+export function assertReadable(actor: Actor, founderActorId: string): void {
+  if (!founderActorId) {
+    throw authError("unknown_actor", "founder identity is not configured");
+  }
+  if (actor.role === "founder" && actor.id !== founderActorId) {
+    throw authError("unknown_actor", "founder identity does not match");
+  }
+}
+
+export function assertFounder(actor: Actor, founderActorId: string): void {
+  assertReadable(actor, founderActorId);
+  if (actor.role !== "founder") {
+    throw forbidden("agent_mutation_forbidden", "only the founder may mutate directives");
+  }
+  if (actor.id !== founderActorId) {
+    throw authError("unknown_actor", "founder identity does not match");
+  }
+}
+
+export function assertAgent(actor: Actor, founderActorId: string): void {
+  assertReadable(actor, founderActorId);
+  if (actor.role !== "agent") {
+    throw forbidden("agent_mutation_forbidden", "proposals are submitted by agents");
+  }
+}

--- a/control-center/services/context/src/boot.ts
+++ b/control-center/services/context/src/boot.ts
@@ -3,18 +3,20 @@ import { frozenClock, systemClock, type Clock } from "./clock.ts";
 import { invalid } from "./errors.ts";
 import { cryptoIds } from "./ids.ts";
 import { createLogger, type Logger } from "./log.ts";
-import { REPRESENTATIVE_NOW, seedRepresentative } from "./representative.ts";
+import { REPRESENTATIVE_NOW, REPRESENTATIVE_REPO_DOMAINS, seedRepresentative } from "./representative.ts";
+import { parseRepoDomainMap, type RepoDomainMap } from "./scope.ts";
 import { createContextService, type ContextService } from "./service.ts";
 import { createStoreFromEnv } from "./store/from-env.ts";
 import { sanitizeActorId } from "./sanitize.ts";
-import type { Actor } from "./types.ts";
+import type { ActorRef, Scope } from "./types.ts";
 
 export interface BootResult {
   service: ContextService;
   founderActorId: string;
-  defaultCompany: string;
+  defaultScope: Scope;
   fixture: string;
   storeName: "fixture";
+  repoDomains: RepoDomainMap;
 }
 
 export function readFounderActorId(env: NodeJS.ProcessEnv): string {
@@ -25,12 +27,20 @@ export function readFounderActorId(env: NodeJS.ProcessEnv): string {
   return sanitizeActorId(raw, "CONTROL_CENTER_FOUNDER_ACTOR_ID");
 }
 
+function repoDomainsFromEnv(env: NodeJS.ProcessEnv, fixture: string): RepoDomainMap {
+  const parsed = parseRepoDomainMap(env.CONTROL_CENTER_REPO_DOMAINS);
+  if (fixture === "representative") {
+    return { ...REPRESENTATIVE_REPO_DOMAINS, ...parsed };
+  }
+  return parsed;
+}
+
 export function bootFromEnv(
   env: NodeJS.ProcessEnv,
   opts?: { logger?: Logger; clock?: Clock },
 ): BootResult {
   const founderActorId = readFounderActorId(env);
-  const defaultCompany = (env.CONTROL_CENTER_COMPANY ?? "confenge").trim() || "confenge";
+  const defaultScope: Scope = "company";
   const store = createStoreFromEnv(env);
   const fixture = (env.CONTEXT_SERVICE_FIXTURE ?? "empty").trim() || "empty";
   const clock =
@@ -41,6 +51,7 @@ export function bootFromEnv(
   } else if (fixture !== "empty") {
     throw invalid("CONTEXT_SERVICE_FIXTURE must be representative or empty");
   }
+  const repoDomains = repoDomainsFromEnv(env, fixture);
   const logger = opts?.logger ?? createLogger();
   const service = createContextService({
     store,
@@ -48,11 +59,12 @@ export function bootFromEnv(
     ids: cryptoIds,
     founderActorId,
     logger,
-    defaultCompany,
+    defaultScope,
+    repoDomains,
   });
-  return { service, founderActorId, defaultCompany, fixture, storeName: "fixture" };
+  return { service, founderActorId, defaultScope, fixture, storeName: "fixture", repoDomains };
 }
 
-export function actorFromEnv(env: NodeJS.ProcessEnv): Actor {
-  return parseActor(env.CONTEXT_ACTOR_ID, env.CONTEXT_ACTOR_ROLE);
+export function actorFromEnv(env: NodeJS.ProcessEnv): ActorRef {
+  return parseActor(env.CONTEXT_ACTOR_ID, env.CONTEXT_ACTOR_KIND);
 }

--- a/control-center/services/context/src/boot.ts
+++ b/control-center/services/context/src/boot.ts
@@ -1,0 +1,58 @@
+import { parseActor } from "./actor.ts";
+import { frozenClock, systemClock, type Clock } from "./clock.ts";
+import { invalid } from "./errors.ts";
+import { cryptoIds } from "./ids.ts";
+import { createLogger, type Logger } from "./log.ts";
+import { REPRESENTATIVE_NOW, seedRepresentative } from "./representative.ts";
+import { createContextService, type ContextService } from "./service.ts";
+import { createStoreFromEnv } from "./store/from-env.ts";
+import { sanitizeActorId } from "./sanitize.ts";
+import type { Actor } from "./types.ts";
+
+export interface BootResult {
+  service: ContextService;
+  founderActorId: string;
+  defaultCompany: string;
+  fixture: string;
+  storeName: "fixture";
+}
+
+export function readFounderActorId(env: NodeJS.ProcessEnv): string {
+  const raw = env.CONTROL_CENTER_FOUNDER_ACTOR_ID;
+  if (!raw || raw.trim() === "") {
+    throw invalid("CONTROL_CENTER_FOUNDER_ACTOR_ID is required");
+  }
+  return sanitizeActorId(raw, "CONTROL_CENTER_FOUNDER_ACTOR_ID");
+}
+
+export function bootFromEnv(
+  env: NodeJS.ProcessEnv,
+  opts?: { logger?: Logger; clock?: Clock },
+): BootResult {
+  const founderActorId = readFounderActorId(env);
+  const defaultCompany = (env.CONTROL_CENTER_COMPANY ?? "confenge").trim() || "confenge";
+  const store = createStoreFromEnv(env);
+  const fixture = (env.CONTEXT_SERVICE_FIXTURE ?? "empty").trim() || "empty";
+  const clock =
+    opts?.clock ??
+    (fixture === "representative" ? frozenClock(REPRESENTATIVE_NOW) : systemClock);
+  if (fixture === "representative") {
+    seedRepresentative(store);
+  } else if (fixture !== "empty") {
+    throw invalid("CONTEXT_SERVICE_FIXTURE must be representative or empty");
+  }
+  const logger = opts?.logger ?? createLogger();
+  const service = createContextService({
+    store,
+    clock,
+    ids: cryptoIds,
+    founderActorId,
+    logger,
+    defaultCompany,
+  });
+  return { service, founderActorId, defaultCompany, fixture, storeName: "fixture" };
+}
+
+export function actorFromEnv(env: NodeJS.ProcessEnv): Actor {
+  return parseActor(env.CONTEXT_ACTOR_ID, env.CONTEXT_ACTOR_ROLE);
+}

--- a/control-center/services/context/src/canonical.ts
+++ b/control-center/services/context/src/canonical.ts
@@ -1,0 +1,26 @@
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortValue);
+  }
+  if (value !== null && typeof value === "object") {
+    const src = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(src).sort()) {
+      const item = src[key];
+      if (item === undefined) {
+        continue;
+      }
+      out[key] = sortValue(item);
+    }
+    return out;
+  }
+  return value;
+}
+
+export function canonicalStringify(value: unknown): string {
+  return `${JSON.stringify(sortValue(value))}\n`;
+}
+
+export function stableEqualJson(a: unknown, b: unknown): boolean {
+  return canonicalStringify(a) === canonicalStringify(b);
+}

--- a/control-center/services/context/src/cli.ts
+++ b/control-center/services/context/src/cli.ts
@@ -27,19 +27,22 @@ function parseArgs(argv: string[]): { command: Command; scope?: Scope } {
     flags[key] = value;
     i += 1;
   }
-  const extra = Object.keys(flags).filter((k) => k !== "company" && k !== "domain" && k !== "resource");
+  if (flags.company !== undefined || flags.domain !== undefined || flags.resource !== undefined) {
+    throw invalid("scope must be --scope <string>; --company/--domain/--resource are not accepted");
+  }
+  const extra = Object.keys(flags).filter((k) => k !== "scope");
   if (extra.length > 0) {
     throw invalid(`unknown flags: ${extra.sort().join(", ")}`);
   }
   if (command === "get_priorities" || command === "get_decisions") {
-    if (!flags.company && !flags.domain && !flags.resource) {
+    if (!flags.scope) {
       return { command };
     }
   }
-  if (!flags.company) {
-    throw invalid("--company is required");
+  if (!flags.scope) {
+    throw invalid("--scope is required");
   }
-  return { command: command as Command, scope: parseScope(flags) };
+  return { command: command as Command, scope: parseScope(flags.scope) };
 }
 
 export function runCli(argv: string[], env: NodeJS.ProcessEnv = process.env): string {
@@ -49,14 +52,11 @@ export function runCli(argv: string[], env: NodeJS.ProcessEnv = process.env): st
   let result: unknown;
   switch (parsed.command) {
     case "get_context":
-      result = boot.service.getContext(actor, parsed.scope ?? parseScope({ company: boot.defaultCompany }));
+      result = boot.service.getContext(actor, parsed.scope ?? boot.defaultScope);
       break;
     case "get_active_directives":
       result = {
-        items: boot.service.getActiveDirectives(
-          actor,
-          parsed.scope ?? parseScope({ company: boot.defaultCompany }),
-        ),
+        items: boot.service.getActiveDirectives(actor, parsed.scope ?? boot.defaultScope),
       };
       break;
     case "get_priorities":

--- a/control-center/services/context/src/cli.ts
+++ b/control-center/services/context/src/cli.ts
@@ -1,0 +1,92 @@
+import { actorFromEnv, bootFromEnv } from "./boot.ts";
+import { canonicalStringify } from "./canonical.ts";
+import { invalid, isServiceError } from "./errors.ts";
+import { silentLogger } from "./log.ts";
+import { parseScope } from "./scope.ts";
+import type { Scope } from "./types.ts";
+
+const COMMANDS = ["get_context", "get_active_directives", "get_priorities", "get_decisions"] as const;
+type Command = (typeof COMMANDS)[number];
+
+function parseArgs(argv: string[]): { command: Command; scope?: Scope } {
+  const [command, ...rest] = argv;
+  if (!command || !(COMMANDS as readonly string[]).includes(command)) {
+    throw invalid(`command must be one of: ${COMMANDS.join(", ")}`);
+  }
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (!token?.startsWith("--")) {
+      throw invalid(`unexpected argument: ${token ?? ""}`);
+    }
+    const key = token.slice(2);
+    const value = rest[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw invalid(`missing value for --${key}`);
+    }
+    flags[key] = value;
+    i += 1;
+  }
+  const extra = Object.keys(flags).filter((k) => k !== "company" && k !== "domain" && k !== "resource");
+  if (extra.length > 0) {
+    throw invalid(`unknown flags: ${extra.sort().join(", ")}`);
+  }
+  if (command === "get_priorities" || command === "get_decisions") {
+    if (!flags.company && !flags.domain && !flags.resource) {
+      return { command };
+    }
+  }
+  if (!flags.company) {
+    throw invalid("--company is required");
+  }
+  return { command: command as Command, scope: parseScope(flags) };
+}
+
+export function runCli(argv: string[], env: NodeJS.ProcessEnv = process.env): string {
+  const parsed = parseArgs(argv);
+  const boot = bootFromEnv(env, { logger: silentLogger });
+  const actor = actorFromEnv(env);
+  let result: unknown;
+  switch (parsed.command) {
+    case "get_context":
+      result = boot.service.getContext(actor, parsed.scope ?? parseScope({ company: boot.defaultCompany }));
+      break;
+    case "get_active_directives":
+      result = {
+        items: boot.service.getActiveDirectives(
+          actor,
+          parsed.scope ?? parseScope({ company: boot.defaultCompany }),
+        ),
+      };
+      break;
+    case "get_priorities":
+      result = { items: boot.service.getPriorities(actor, parsed.scope) };
+      break;
+    case "get_decisions":
+      result = { items: boot.service.getDecisions(actor, parsed.scope) };
+      break;
+  }
+  return canonicalStringify(result);
+}
+
+function isDirectEntry(): boolean {
+  const arg = process.argv[1];
+  if (!arg) {
+    return false;
+  }
+  const normalized = arg.replace(/\\/g, "/");
+  return normalized.endsWith("/cli.ts") || normalized.endsWith("/cli.js");
+}
+
+if (isDirectEntry()) {
+  try {
+    process.stdout.write(runCli(process.argv.slice(2)));
+  } catch (err) {
+    if (isServiceError(err)) {
+      process.stderr.write(canonicalStringify({ error: err.code, message: err.message }));
+      process.exit(err.httpStatus >= 500 ? 1 : 2);
+    }
+    process.stderr.write(canonicalStringify({ error: "internal", message: "cli failed" }));
+    process.exit(1);
+  }
+}

--- a/control-center/services/context/src/clock.ts
+++ b/control-center/services/context/src/clock.ts
@@ -1,0 +1,36 @@
+export interface Clock {
+  now(): Date;
+}
+
+export const systemClock: Clock = {
+  now(): Date {
+    return new Date();
+  },
+};
+
+export function frozenClock(isoUtc: string): Clock {
+  const fixed = new Date(isoUtc);
+  if (Number.isNaN(fixed.getTime())) {
+    throw new Error(`invalid frozen clock: ${isoUtc}`);
+  }
+  return {
+    now(): Date {
+      return new Date(fixed.getTime());
+    },
+  };
+}
+
+export function toUtcIso(date: Date): string {
+  return new Date(date.getTime()).toISOString();
+}
+
+export function parseUtcIso(value: string, field: string): Date {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/.test(value)) {
+    throw new Error(`${field} must be an ISO-8601 UTC timestamp ending in Z`);
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${field} is not a valid timestamp`);
+  }
+  return parsed;
+}

--- a/control-center/services/context/src/errors.ts
+++ b/control-center/services/context/src/errors.ts
@@ -1,0 +1,54 @@
+export type ErrorCode =
+  | "missing_actor"
+  | "unknown_actor"
+  | "unknown_actor_role"
+  | "invalid_actor_id"
+  | "agent_mutation_forbidden"
+  | "silent_replace_forbidden"
+  | "payload_too_large"
+  | "invalid_input"
+  | "directive_not_found"
+  | "proposal_not_found"
+  | "kind_immutable"
+  | "conflict"
+  | "store_misconfigured";
+
+export class ServiceError extends Error {
+  readonly code: ErrorCode;
+  readonly httpStatus: number;
+
+  constructor(code: ErrorCode, message: string, httpStatus: number) {
+    super(message);
+    this.name = "ServiceError";
+    this.code = code;
+    this.httpStatus = httpStatus;
+  }
+}
+
+export function authError(code: ErrorCode, message: string): ServiceError {
+  return new ServiceError(code, message, 401);
+}
+
+export function forbidden(code: ErrorCode, message: string): ServiceError {
+  return new ServiceError(code, message, 403);
+}
+
+export function invalid(message: string): ServiceError {
+  return new ServiceError("invalid_input", message, 400);
+}
+
+export function notFound(code: ErrorCode, message: string): ServiceError {
+  return new ServiceError(code, message, 404);
+}
+
+export function conflict(message: string): ServiceError {
+  return new ServiceError("conflict", message, 409);
+}
+
+export function payloadTooLarge(message: string): ServiceError {
+  return new ServiceError("payload_too_large", message, 413);
+}
+
+export function isServiceError(err: unknown): err is ServiceError {
+  return err instanceof ServiceError;
+}

--- a/control-center/services/context/src/http.ts
+++ b/control-center/services/context/src/http.ts
@@ -1,0 +1,211 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { parseActor } from "./actor.ts";
+import { canonicalStringify } from "./canonical.ts";
+import { invalid, isServiceError, payloadTooLarge } from "./errors.ts";
+import type { Logger } from "./log.ts";
+import { assertJsonSize } from "./sanitize.ts";
+import { parseScope } from "./scope.ts";
+import type { ContextService } from "./service.ts";
+import { LIMITS, type Actor, type Scope } from "./types.ts";
+
+export interface HttpDeps {
+  service: ContextService;
+  logger: Logger;
+}
+
+function header(req: IncomingMessage, name: string): string | undefined {
+  const raw = req.headers[name];
+  if (Array.isArray(raw)) {
+    return raw[0];
+  }
+  return raw;
+}
+
+function actorFromRequest(req: IncomingMessage): Actor {
+  return parseActor(header(req, "x-actor-id"), header(req, "x-actor-role"));
+}
+
+function send(res: ServerResponse, status: number, body: unknown): void {
+  const payload = canonicalStringify(body);
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.setHeader("cache-control", "no-store");
+  res.end(payload);
+}
+
+function sendError(res: ServerResponse, err: unknown, logger: Logger): void {
+  if (isServiceError(err)) {
+    send(res, err.httpStatus, { error: err.code, message: err.message });
+    return;
+  }
+  logger.error("unhandled", { kind: "internal" });
+  send(res, 500, { error: "internal", message: "internal error" });
+}
+
+async function readBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buf.length;
+    if (size > LIMITS.jsonBytes) {
+      throw payloadTooLarge(`JSON payload exceeds ${LIMITS.jsonBytes} bytes`);
+    }
+    chunks.push(buf);
+  }
+  if (chunks.length === 0) {
+    return {};
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (raw.trim() === "") {
+    return {};
+  }
+  assertJsonSize(raw);
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    throw invalid("body is not valid JSON");
+  }
+}
+
+function queryScope(url: URL, fallbackCompany: string): Scope {
+  const company = url.searchParams.get("company") ?? fallbackCompany;
+  const domain = url.searchParams.get("domain");
+  const resource = url.searchParams.get("resource");
+  const raw: Record<string, string> = { company };
+  if (domain) {
+    raw.domain = domain;
+  }
+  if (resource) {
+    raw.resource = resource;
+  }
+  return parseScope(raw);
+}
+
+function optionalQueryScope(url: URL): Scope | undefined {
+  const company = url.searchParams.get("company");
+  const domain = url.searchParams.get("domain");
+  const resource = url.searchParams.get("resource");
+  if (!company && !domain && !resource) {
+    return undefined;
+  }
+  if (!company) {
+    throw invalid("company is required when domain or resource is present");
+  }
+  const raw: Record<string, string> = { company };
+  if (domain) {
+    raw.domain = domain;
+  }
+  if (resource) {
+    raw.resource = resource;
+  }
+  return parseScope(raw);
+}
+
+export function createRequestListener(
+  deps: HttpDeps,
+  defaultCompany: string,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    void handle(deps, defaultCompany, req, res);
+  };
+}
+
+async function handle(
+  deps: HttpDeps,
+  defaultCompany: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  try {
+    const host = req.headers.host ?? "127.0.0.1";
+    const url = new URL(req.url ?? "/", `http://${host}`);
+    const method = req.method ?? "GET";
+    if (method === "GET" && url.pathname === "/healthz") {
+      send(res, 200, { ok: true, service: "control-center-context" });
+      return;
+    }
+    const actor = actorFromRequest(req);
+    const parts = url.pathname.split("/").filter(Boolean);
+
+    if (method === "GET" && url.pathname === "/v1/context") {
+      send(res, 200, deps.service.getContext(actor, queryScope(url, defaultCompany)));
+      return;
+    }
+    if (method === "GET" && url.pathname === "/v1/active-directives") {
+      send(res, 200, { items: deps.service.getActiveDirectives(actor, queryScope(url, defaultCompany)) });
+      return;
+    }
+    if (method === "GET" && url.pathname === "/v1/priorities") {
+      send(res, 200, { items: deps.service.getPriorities(actor, optionalQueryScope(url)) });
+      return;
+    }
+    if (method === "GET" && url.pathname === "/v1/decisions") {
+      send(res, 200, { items: deps.service.getDecisions(actor, optionalQueryScope(url)) });
+      return;
+    }
+    if (method === "GET" && url.pathname === "/v1/audit") {
+      send(res, 200, { items: deps.service.listAudit(actor) });
+      return;
+    }
+    if (method === "POST" && url.pathname === "/v1/directives") {
+      const body = await readBody(req);
+      send(res, 201, deps.service.createDirective(actor, body));
+      return;
+    }
+    if (method === "POST" && url.pathname === "/v1/proposals") {
+      const body = await readBody(req);
+      send(res, 201, deps.service.submitProposal(actor, body));
+      return;
+    }
+    if (method === "GET" && url.pathname === "/v1/proposals") {
+      send(res, 200, { items: deps.service.listProposals(actor) });
+      return;
+    }
+
+    if (parts[0] === "v1" && parts[1] === "directives" && parts[2] && !parts[3]) {
+      if (method === "GET") {
+        send(res, 200, deps.service.getDirective(actor, parts[2]));
+        return;
+      }
+    }
+    if (parts[0] === "v1" && parts[1] === "directives" && parts[2] && parts[3] === "revisions" && !parts[4]) {
+      if (method === "GET") {
+        send(res, 200, { items: deps.service.listRevisions(actor, parts[2]) });
+        return;
+      }
+    }
+    if (parts[0] === "v1" && parts[1] === "directives" && parts[2] && parts[3] && !parts[4] && method === "POST") {
+      const id = parts[2];
+      const action = parts[3];
+      if (action === "versions") {
+        send(res, 201, deps.service.createVersion(actor, id, await readBody(req)));
+        return;
+      }
+      if (action === "supersede") {
+        send(res, 201, deps.service.supersede(actor, id, await readBody(req)));
+        return;
+      }
+      if (action === "expire") {
+        send(res, 200, deps.service.expire(actor, id, await readBody(req)));
+        return;
+      }
+      if (action === "activate") {
+        send(res, 200, deps.service.activate(actor, id));
+        return;
+      }
+      if (action === "deactivate") {
+        send(res, 200, deps.service.deactivate(actor, id));
+        return;
+      }
+    }
+    if (parts[0] === "v1" && parts[1] === "proposals" && parts[2] && parts[3] === "reject" && method === "POST") {
+      send(res, 200, deps.service.rejectProposal(actor, parts[2]));
+      return;
+    }
+
+    send(res, 404, { error: "not_found", message: "route not found" });
+  } catch (err) {
+    sendError(res, err, deps.logger);
+  }
+}

--- a/control-center/services/context/src/http.ts
+++ b/control-center/services/context/src/http.ts
@@ -6,7 +6,7 @@ import type { Logger } from "./log.ts";
 import { assertJsonSize } from "./sanitize.ts";
 import { parseScope } from "./scope.ts";
 import type { ContextService } from "./service.ts";
-import { LIMITS, type Actor, type Scope } from "./types.ts";
+import { LIMITS, type ActorRef, type Scope } from "./types.ts";
 
 export interface HttpDeps {
   service: ContextService;
@@ -21,8 +21,8 @@ function header(req: IncomingMessage, name: string): string | undefined {
   return raw;
 }
 
-function actorFromRequest(req: IncomingMessage): Actor {
-  return parseActor(header(req, "x-actor-id"), header(req, "x-actor-role"));
+function actorFromRequest(req: IncomingMessage): ActorRef {
+  return parseActor(header(req, "x-actor-id"), header(req, "x-actor-kind"));
 }
 
 function send(res: ServerResponse, status: number, body: unknown): void {
@@ -68,52 +68,40 @@ async function readBody(req: IncomingMessage): Promise<unknown> {
   }
 }
 
-function queryScope(url: URL, fallbackCompany: string): Scope {
-  const company = url.searchParams.get("company") ?? fallbackCompany;
-  const domain = url.searchParams.get("domain");
-  const resource = url.searchParams.get("resource");
-  const raw: Record<string, string> = { company };
-  if (domain) {
-    raw.domain = domain;
+function rejectLegacyScopeParams(url: URL): void {
+  if (url.searchParams.has("company") || url.searchParams.has("domain") || url.searchParams.has("resource")) {
+    throw invalid("scope must be a single string parameter; company/domain/resource are not accepted");
   }
-  if (resource) {
-    raw.resource = resource;
+}
+
+function queryScope(url: URL): Scope {
+  rejectLegacyScopeParams(url);
+  const scope = url.searchParams.get("scope");
+  if (!scope) {
+    throw invalid("scope query parameter is required");
   }
-  return parseScope(raw);
+  return parseScope(scope);
 }
 
 function optionalQueryScope(url: URL): Scope | undefined {
-  const company = url.searchParams.get("company");
-  const domain = url.searchParams.get("domain");
-  const resource = url.searchParams.get("resource");
-  if (!company && !domain && !resource) {
+  rejectLegacyScopeParams(url);
+  const scope = url.searchParams.get("scope");
+  if (!scope) {
     return undefined;
   }
-  if (!company) {
-    throw invalid("company is required when domain or resource is present");
-  }
-  const raw: Record<string, string> = { company };
-  if (domain) {
-    raw.domain = domain;
-  }
-  if (resource) {
-    raw.resource = resource;
-  }
-  return parseScope(raw);
+  return parseScope(scope);
 }
 
 export function createRequestListener(
   deps: HttpDeps,
-  defaultCompany: string,
 ): (req: IncomingMessage, res: ServerResponse) => void {
   return (req, res) => {
-    void handle(deps, defaultCompany, req, res);
+    void handle(deps, req, res);
   };
 }
 
 async function handle(
   deps: HttpDeps,
-  defaultCompany: string,
   req: IncomingMessage,
   res: ServerResponse,
 ): Promise<void> {
@@ -129,11 +117,11 @@ async function handle(
     const parts = url.pathname.split("/").filter(Boolean);
 
     if (method === "GET" && url.pathname === "/v1/context") {
-      send(res, 200, deps.service.getContext(actor, queryScope(url, defaultCompany)));
+      send(res, 200, deps.service.getContext(actor, queryScope(url)));
       return;
     }
     if (method === "GET" && url.pathname === "/v1/active-directives") {
-      send(res, 200, { items: deps.service.getActiveDirectives(actor, queryScope(url, defaultCompany)) });
+      send(res, 200, { items: deps.service.getActiveDirectives(actor, queryScope(url)) });
       return;
     }
     if (method === "GET" && url.pathname === "/v1/priorities") {
@@ -194,8 +182,8 @@ async function handle(
         send(res, 200, deps.service.activate(actor, id));
         return;
       }
-      if (action === "deactivate") {
-        send(res, 200, deps.service.deactivate(actor, id));
+      if (action === "revoke") {
+        send(res, 200, deps.service.revoke(actor, id));
         return;
       }
     }

--- a/control-center/services/context/src/ids.ts
+++ b/control-center/services/context/src/ids.ts
@@ -1,21 +1,52 @@
 import { randomUUID } from "node:crypto";
+import { invalid } from "./errors.ts";
+import { ID_TYPE_PATTERN, RESOURCE_ID_PATTERN } from "./taxonomy.ts";
+import { LIMITS } from "./types.ts";
+
+const RESOURCE_ID_RE = new RegExp(RESOURCE_ID_PATTERN);
+const ID_TYPE_RE = new RegExp(ID_TYPE_PATTERN);
 
 export interface IdGenerator {
-  next(): string;
+  next(type: string): string;
+}
+
+export function isResourceId(value: unknown): value is string {
+  return typeof value === "string" && value.length <= LIMITS.resourceIdChars && RESOURCE_ID_RE.test(value);
+}
+
+export function assertResourceId(value: unknown, field: string): string {
+  if (!isResourceId(value)) {
+    throw invalid(`${field} must be a canonical resource id (cc:<type-kebab>:<ulid-or-slug>)`);
+  }
+  return value;
+}
+
+export function makeResourceId(type: string, slug: string): string {
+  if (!ID_TYPE_RE.test(type)) {
+    throw invalid(`resource id type must match ${ID_TYPE_PATTERN}`);
+  }
+  if (slug.length === 0 || !/^[A-Za-z0-9._~-]+$/.test(slug)) {
+    throw invalid("resource id slug is invalid");
+  }
+  const id = `cc:${type}:${slug}`;
+  if (!isResourceId(id)) {
+    throw invalid("resource id exceeds canonical constraints");
+  }
+  return id;
 }
 
 export const cryptoIds: IdGenerator = {
-  next(): string {
-    return randomUUID();
+  next(type: string): string {
+    return makeResourceId(type, randomUUID());
   },
 };
 
 export function sequentialIds(prefix: string): IdGenerator {
   let n = 0;
   return {
-    next(): string {
+    next(type: string): string {
       n += 1;
-      return `${prefix}-${String(n).padStart(4, "0")}`;
+      return makeResourceId(type, `${prefix}-${String(n).padStart(4, "0")}`);
     },
   };
 }

--- a/control-center/services/context/src/ids.ts
+++ b/control-center/services/context/src/ids.ts
@@ -1,0 +1,21 @@
+import { randomUUID } from "node:crypto";
+
+export interface IdGenerator {
+  next(): string;
+}
+
+export const cryptoIds: IdGenerator = {
+  next(): string {
+    return randomUUID();
+  },
+};
+
+export function sequentialIds(prefix: string): IdGenerator {
+  let n = 0;
+  return {
+    next(): string {
+      n += 1;
+      return `${prefix}-${String(n).padStart(4, "0")}`;
+    },
+  };
+}

--- a/control-center/services/context/src/index.ts
+++ b/control-center/services/context/src/index.ts
@@ -1,0 +1,42 @@
+export { parseActor, assertFounder, assertReadable } from "./actor.ts";
+export { canonicalStringify, stableEqualJson } from "./canonical.ts";
+export { frozenClock, systemClock, toUtcIso } from "./clock.ts";
+export { ServiceError, isServiceError } from "./errors.ts";
+export { cryptoIds, sequentialIds } from "./ids.ts";
+export { createLogger, silentLogger } from "./log.ts";
+export { isActiveAt, isProtectedKind, partitionByKind } from "./policy.ts";
+export { parseScope, scopeVisibleUnderQuery } from "./scope.ts";
+export { createContextService } from "./service.ts";
+export type { ContextService, ContextServiceDeps } from "./service.ts";
+export { createFixtureStore } from "./store/fixture.ts";
+export { createStoreFromEnv } from "./store/from-env.ts";
+export { ADAPTER_CONTRACT_VERSION } from "./store/adapter.ts";
+export type { PersistenceAdapter } from "./store/adapter.ts";
+export { bootFromEnv, actorFromEnv } from "./boot.ts";
+export { createRequestListener } from "./http.ts";
+export { startServer } from "./server.ts";
+export { runCli } from "./cli.ts";
+export {
+  REPRESENTATIVE_IDS,
+  REPRESENTATIVE_NOW,
+  REPRESENTATIVE_SCOPE,
+  SIBLING_SCOPE,
+  seedRepresentative,
+  representativeRecords,
+} from "./representative.ts";
+export {
+  DIRECTIVE_KINDS,
+  DIRECTIVE_STATUSES,
+  LIMITS,
+  PROTECTED_KINDS,
+} from "./types.ts";
+export type {
+  Actor,
+  AuditEvent,
+  ContextPayload,
+  DirectiveKind,
+  DirectiveRecord,
+  DirectiveView,
+  ProposalRecord,
+  Scope,
+} from "./types.ts";

--- a/control-center/services/context/src/index.ts
+++ b/control-center/services/context/src/index.ts
@@ -2,16 +2,16 @@ export { parseActor, assertFounder, assertReadable } from "./actor.ts";
 export { canonicalStringify, stableEqualJson } from "./canonical.ts";
 export { frozenClock, systemClock, toUtcIso } from "./clock.ts";
 export { ServiceError, isServiceError } from "./errors.ts";
-export { cryptoIds, sequentialIds } from "./ids.ts";
+export { cryptoIds, sequentialIds, isResourceId, makeResourceId } from "./ids.ts";
 export { createLogger, silentLogger } from "./log.ts";
 export { isActiveAt, isProtectedKind, partitionByKind } from "./policy.ts";
-export { parseScope, scopeVisibleUnderQuery } from "./scope.ts";
+export { parseScope, scopeVisibleUnderQuery, expandInheritedScopes, parseRepoDomainMap } from "./scope.ts";
 export { createContextService } from "./service.ts";
 export type { ContextService, ContextServiceDeps } from "./service.ts";
 export { createFixtureStore } from "./store/fixture.ts";
 export { createStoreFromEnv } from "./store/from-env.ts";
 export { ADAPTER_CONTRACT_VERSION } from "./store/adapter.ts";
-export type { PersistenceAdapter } from "./store/adapter.ts";
+export type { PersistencePort, PersistenceAdapter } from "./store/adapter.ts";
 export { bootFromEnv, actorFromEnv } from "./boot.ts";
 export { createRequestListener } from "./http.ts";
 export { startServer } from "./server.ts";
@@ -20,23 +20,32 @@ export {
   REPRESENTATIVE_IDS,
   REPRESENTATIVE_NOW,
   REPRESENTATIVE_SCOPE,
+  REPRESENTATIVE_REPO_DOMAINS,
   SIBLING_SCOPE,
+  CLIENT_SCOPE,
+  SIBLING_CLIENT_SCOPE,
   seedRepresentative,
   representativeRecords,
 } from "./representative.ts";
 export {
   DIRECTIVE_KINDS,
   DIRECTIVE_STATUSES,
+  FRESHNESS_STATUSES,
+  ACTOR_KINDS,
+  SCOPE_LITERALS,
   LIMITS,
   PROTECTED_KINDS,
 } from "./types.ts";
 export type {
   Actor,
+  ActorRef,
   AuditEvent,
   ContextPayload,
   DirectiveKind,
+  DirectiveProposal,
   DirectiveRecord,
   DirectiveView,
   ProposalRecord,
   Scope,
+  SourceRef,
 } from "./types.ts";

--- a/control-center/services/context/src/log.ts
+++ b/control-center/services/context/src/log.ts
@@ -1,0 +1,58 @@
+export type LogLevel = "info" | "warn" | "error";
+
+export interface Logger {
+  info(msg: string, fields?: Record<string, string | number | boolean | null>): void;
+  warn(msg: string, fields?: Record<string, string | number | boolean | null>): void;
+  error(msg: string, fields?: Record<string, string | number | boolean | null>): void;
+}
+
+const SECRET_KEY = /pass(word)?|secret|token|authorization|cookie|database_url|dsn|private[_-]?key|api[_-]?key/i;
+
+function assertSafeFields(fields: Record<string, string | number | boolean | null> | undefined): void {
+  if (!fields) {
+    return;
+  }
+  for (const key of Object.keys(fields)) {
+    if (SECRET_KEY.test(key)) {
+      throw new Error("refusing to log a secret-bearing field name");
+    }
+  }
+}
+
+export function createLogger(service = "control-center-context"): Logger {
+  const write = (
+    level: LogLevel,
+    msg: string,
+    fields?: Record<string, string | number | boolean | null>,
+  ): void => {
+    assertSafeFields(fields);
+    const rec: Record<string, string | number | boolean | null> = {
+      level,
+      msg,
+      service,
+      ts: new Date().toISOString(),
+    };
+    if (fields) {
+      for (const [k, v] of Object.entries(fields)) {
+        rec[k] = v;
+      }
+    }
+    const line = JSON.stringify(rec);
+    if (level === "error") {
+      process.stderr.write(`${line}\n`);
+    } else {
+      process.stdout.write(`${line}\n`);
+    }
+  };
+  return {
+    info: (msg, fields) => write("info", msg, fields),
+    warn: (msg, fields) => write("warn", msg, fields),
+    error: (msg, fields) => write("error", msg, fields),
+  };
+}
+
+export const silentLogger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+};

--- a/control-center/services/context/src/policy.ts
+++ b/control-center/services/context/src/policy.ts
@@ -92,5 +92,5 @@ export function partitionByKind(records: readonly DirectiveRecord[]): {
 }
 
 export function terminalStatus(status: DirectiveStatus): boolean {
-  return status === "superseded" || status === "expired";
+  return status === "superseded" || status === "expired" || status === "revoked";
 }

--- a/control-center/services/context/src/policy.ts
+++ b/control-center/services/context/src/policy.ts
@@ -1,0 +1,96 @@
+import type { DirectiveKind, DirectiveRecord, DirectiveStatus, ProtectedKind } from "./types.ts";
+import { PROTECTED_KINDS } from "./types.ts";
+import { parseUtcIso } from "./clock.ts";
+
+export function isProtectedKind(kind: DirectiveKind): kind is ProtectedKind {
+  return (PROTECTED_KINDS as readonly string[]).includes(kind);
+}
+
+export function isActiveAt(record: DirectiveRecord, now: Date): boolean {
+  if (record.status !== "active") {
+    return false;
+  }
+  const effective = parseUtcIso(record.effective_from, "effective_from");
+  if (effective.getTime() > now.getTime()) {
+    return false;
+  }
+  if (record.expires_at !== null) {
+    const expires = parseUtcIso(record.expires_at, "expires_at");
+    if (expires.getTime() <= now.getTime()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const KIND_ORDER: Record<DirectiveKind, number> = {
+  constraint: 0,
+  decision: 1,
+  directive: 2,
+  fact: 3,
+  priority: 4,
+  risk: 5,
+  hypothesis: 6,
+};
+
+export function compareDirectives(a: DirectiveRecord, b: DirectiveRecord): number {
+  const kind = KIND_ORDER[a.kind] - KIND_ORDER[b.kind];
+  if (kind !== 0) {
+    return kind;
+  }
+  const id = a.id.localeCompare(b.id);
+  if (id !== 0) {
+    return id;
+  }
+  return a.revision_id.localeCompare(b.revision_id);
+}
+
+export function partitionByKind(records: readonly DirectiveRecord[]): {
+  decisions: DirectiveRecord[];
+  facts: DirectiveRecord[];
+  constraints: DirectiveRecord[];
+  priorities: DirectiveRecord[];
+  risks: DirectiveRecord[];
+  directives: DirectiveRecord[];
+  hypotheses: DirectiveRecord[];
+} {
+  const out = {
+    decisions: [] as DirectiveRecord[],
+    facts: [] as DirectiveRecord[],
+    constraints: [] as DirectiveRecord[],
+    priorities: [] as DirectiveRecord[],
+    risks: [] as DirectiveRecord[],
+    directives: [] as DirectiveRecord[],
+    hypotheses: [] as DirectiveRecord[],
+  };
+  for (const rec of records) {
+    switch (rec.kind) {
+      case "decision":
+        out.decisions.push(rec);
+        break;
+      case "fact":
+        out.facts.push(rec);
+        break;
+      case "constraint":
+        out.constraints.push(rec);
+        break;
+      case "priority":
+        out.priorities.push(rec);
+        break;
+      case "risk":
+        out.risks.push(rec);
+        break;
+      case "directive":
+        out.directives.push(rec);
+        break;
+      case "hypothesis":
+        out.hypotheses.push(rec);
+        break;
+    }
+  }
+  return out;
+}
+
+export function terminalStatus(status: DirectiveStatus): boolean {
+  return status === "superseded" || status === "expired";
+}

--- a/control-center/services/context/src/representative.ts
+++ b/control-center/services/context/src/representative.ts
@@ -1,114 +1,128 @@
-import type { PersistenceAdapter } from "./store/adapter.ts";
-import type { DirectiveRecord, Scope } from "./types.ts";
+import type { RepoDomainMap } from "./scope.ts";
+import type { PersistencePort } from "./store/adapter.ts";
+import type { DirectiveRecord, Provenance, Scope, SourceRef } from "./types.ts";
 
 export const REPRESENTATIVE_NOW = "2026-08-20T12:00:00.000Z";
 
-export const REPRESENTATIVE_SCOPE: Scope = {
-  company: "confenge",
-  domain: "commercial",
-  resource: "offer:CFG-DIAG-EXP-v1",
-};
+export const REPRESENTATIVE_SCOPE: Scope = "repo:Governance";
+export const SIBLING_SCOPE: Scope = "repo:Warmbly";
+export const CLIENT_SCOPE: Scope = "client:acme";
+export const SIBLING_CLIENT_SCOPE: Scope = "client:other";
 
-export const SIBLING_SCOPE: Scope = {
-  company: "confenge",
-  domain: "commercial",
-  resource: "offer:OTHER-SKU",
+export const REPRESENTATIVE_REPO_DOMAINS: RepoDomainMap = {
+  Governance: "commercial",
+  Warmbly: "commercial",
 };
 
 const OBSERVED = "2026-08-20T00:00:00.000Z";
 const EFFECTIVE = "2026-01-01T00:00:00.000Z";
 const CREATED = "2026-08-19T12:00:00.000Z";
 
+const FOUNDER_SOURCE: SourceRef = {
+  system: "manual",
+  kind: "directive",
+  locator: "representative",
+};
+
 function rec(
-  partial: Omit<DirectiveRecord, "created_at" | "effective_from" | "provenance"> & {
-    provenance?: DirectiveRecord["provenance"];
+  partial: Omit<DirectiveRecord, "created_at" | "updated_at" | "effective_from" | "provenance"> & {
+    provenance?: Provenance;
     effective_from?: string;
     created_at?: string;
+    updated_at?: string;
   },
 ): DirectiveRecord {
   const provenance = partial.provenance ?? {
-    source: "founder",
+    source: FOUNDER_SOURCE,
     observed_at: OBSERVED,
-    freshness_status: "fresh",
+    freshness_status: "FRESH",
     confidence: 1,
   };
+  const created = partial.created_at ?? CREATED;
   return {
     ...partial,
     effective_from: partial.effective_from ?? EFFECTIVE,
-    created_at: partial.created_at ?? CREATED,
+    created_at: created,
+    updated_at: partial.updated_at ?? created,
     provenance,
   };
 }
 
 export const REPRESENTATIVE_IDS = {
-  companyPriority: "dir-company-priority",
-  companyDecision: "dir-company-decision",
-  domainDirective: "dir-domain-directive",
-  resourceFact: "dir-resource-fact",
-  expired: "dir-resource-expired",
-  supersededConstraint: "dir-constraint-old",
-  activeConstraint: "dir-constraint-now",
-  hypothesis: "dir-company-hypothesis",
-  siblingFact: "dir-sibling-fact",
+  companyPriority: "cc:directive:company-priority",
+  companyDecision: "cc:directive:company-decision",
+  domainDirective: "cc:directive:commercial-directive",
+  resourceFact: "cc:directive:repo-governance-fact",
+  expired: "cc:directive:repo-governance-expired",
+  supersededConstraint: "cc:directive:constraint-old",
+  activeConstraint: "cc:directive:constraint-now",
+  hypothesis: "cc:directive:company-hypothesis",
+  siblingFact: "cc:directive:sibling-repo-fact",
+  clientFact: "cc:directive:client-acme-fact",
+  siblingClientFact: "cc:directive:client-other-fact",
+  clientsDomain: "cc:directive:clients-domain",
+  collectionError: "cc:directive:collection-error",
 } as const;
+
+const FOUNDER = { kind: "human" as const, id: "founder-local" };
 
 export function representativeRecords(): DirectiveRecord[] {
   return [
     rec({
       id: REPRESENTATIVE_IDS.companyPriority,
-      revision_id: "rev-company-priority-1",
+      revision_id: "cc:directive-revision:company-priority-1",
       version: 1,
       kind: "priority",
       title: "Close Diagnostico limited production",
       body: "The three things that matter now start with Diagnostico limited production readiness.",
-      scope: { company: "confenge" },
+      scope: "company",
       status: "active",
       expires_at: null,
       supersedes: null,
-      created_by: "founder-local",
+      created_by: FOUNDER,
     }),
     rec({
       id: REPRESENTATIVE_IDS.companyDecision,
-      revision_id: "rev-company-decision-1",
+      revision_id: "cc:directive-revision:company-decision-1",
       version: 1,
       kind: "decision",
       title: "Governance is strategic authority",
       body: "Governance is the canonical strategic authority. Warmbly remains commercial CRM authority.",
-      scope: { company: "confenge" },
+      scope: "company",
       status: "active",
       expires_at: null,
       supersedes: null,
-      created_by: "founder-local",
+      created_by: FOUNDER,
     }),
     rec({
       id: REPRESENTATIVE_IDS.domainDirective,
-      revision_id: "rev-domain-directive-1",
+      revision_id: "cc:directive-revision:commercial-directive-1",
       version: 1,
       kind: "directive",
       title: "No financial-provider mutation from Control Center",
       body: "This wave does not charge, refund, cancel, or mutate Asaas.",
-      scope: { company: "confenge", domain: "commercial" },
+      scope: "commercial",
       status: "active",
       expires_at: null,
       supersedes: null,
-      created_by: "founder-local",
+      created_by: FOUNDER,
     }),
     rec({
       id: REPRESENTATIVE_IDS.resourceFact,
-      revision_id: "rev-resource-fact-1",
+      revision_id: "cc:directive-revision:repo-governance-fact-1",
       version: 1,
       kind: "fact",
-      title: "Diagnostico SKU list price",
-      body: "CFG-DIAG-EXP-v1 list price is 800000 BRL cents, one-time.",
+      title: "Governance repo is the strategic authority tree",
+      body: "tjsasakifln/Governance holds canonical strategic memory. List prices stay in catalog, 800000 BRL cents one-time for CFG-DIAG-EXP-v1.",
       scope: REPRESENTATIVE_SCOPE,
       status: "active",
       expires_at: null,
       supersedes: null,
-      created_by: "founder-local",
+      created_by: FOUNDER,
     }),
     rec({
       id: REPRESENTATIVE_IDS.expired,
-      revision_id: "rev-resource-expired-1",
+      revision_id: "cc:directive-revision:repo-governance-expired-1",
       version: 1,
       kind: "directive",
       title: "Temporary launch window",
@@ -118,70 +132,128 @@ export function representativeRecords(): DirectiveRecord[] {
       effective_from: "2025-12-01T00:00:00.000Z",
       expires_at: "2026-01-02T00:00:00.000Z",
       supersedes: null,
-      created_by: "founder-local",
+      created_by: FOUNDER,
     }),
     rec({
       id: REPRESENTATIVE_IDS.supersededConstraint,
-      revision_id: "rev-constraint-old-1",
+      revision_id: "cc:directive-revision:constraint-old-1",
       version: 1,
       kind: "constraint",
       title: "Do not publish Extra historical exception",
       body: "Superseded wording of the Extra non-publication constraint.",
-      scope: { company: "confenge", domain: "commercial" },
+      scope: "commercial",
       status: "superseded",
       expires_at: null,
       supersedes: null,
-      created_by: "founder-local",
+      created_by: FOUNDER,
     }),
     rec({
       id: REPRESENTATIVE_IDS.activeConstraint,
-      revision_id: "rev-constraint-now-1",
+      revision_id: "cc:directive-revision:constraint-now-1",
       version: 1,
       kind: "constraint",
       title: "Extra historical exception is not public",
       body: "Extra historical 1000000 cents/month remains non-public.",
-      scope: { company: "confenge", domain: "commercial" },
+      scope: "commercial",
       status: "active",
       expires_at: null,
-      supersedes: REPRESENTATIVE_IDS.supersededConstraint,
-      created_by: "founder-local",
+      supersedes: [REPRESENTATIVE_IDS.supersededConstraint],
+      created_by: FOUNDER,
     }),
     rec({
       id: REPRESENTATIVE_IDS.hypothesis,
-      revision_id: "rev-company-hypothesis-1",
+      revision_id: "cc:directive-revision:company-hypothesis-1",
       version: 1,
       kind: "hypothesis",
       title: "Extra could become a later SKU",
       body: "Hypothesis only: Extra historical demand might later become a priced SKU. Not a fact or decision.",
-      scope: { company: "confenge" },
+      scope: "company",
       status: "active",
       expires_at: null,
       supersedes: null,
-      created_by: "founder-local",
+      created_by: FOUNDER,
       provenance: {
-        source: "founder",
+        source: FOUNDER_SOURCE,
         observed_at: OBSERVED,
-        freshness_status: "fresh",
+        freshness_status: "FRESH",
         confidence: 0.4,
       },
     }),
     rec({
       id: REPRESENTATIVE_IDS.siblingFact,
-      revision_id: "rev-sibling-fact-1",
+      revision_id: "cc:directive-revision:sibling-repo-fact-1",
       version: 1,
       kind: "fact",
-      title: "Sibling SKU must not leak",
-      body: "This fact belongs to offer:OTHER-SKU and must not appear under CFG-DIAG-EXP-v1.",
+      title: "Sibling repo must not leak",
+      body: "This fact belongs to repo:Warmbly and must not appear under repo:Governance.",
       scope: SIBLING_SCOPE,
       status: "active",
       expires_at: null,
       supersedes: null,
-      created_by: "founder-local",
+      created_by: FOUNDER,
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.clientsDomain,
+      revision_id: "cc:directive-revision:clients-domain-1",
+      version: 1,
+      kind: "directive",
+      title: "Clients stay scoped",
+      body: "Client memory is queried per client slug plus the clients domain and company.",
+      scope: "clients",
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: FOUNDER,
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.clientFact,
+      revision_id: "cc:directive-revision:client-acme-fact-1",
+      version: 1,
+      kind: "fact",
+      title: "Acme is in discovery",
+      body: "client:acme is a discovery account. Sibling clients must not leak.",
+      scope: CLIENT_SCOPE,
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: FOUNDER,
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.siblingClientFact,
+      revision_id: "cc:directive-revision:client-other-fact-1",
+      version: 1,
+      kind: "fact",
+      title: "Other client must not leak",
+      body: "This fact belongs to client:other.",
+      scope: SIBLING_CLIENT_SCOPE,
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: FOUNDER,
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.collectionError,
+      revision_id: "cc:directive-revision:collection-error-1",
+      version: 1,
+      kind: "fact",
+      title: "Warmbly snapshot last collection failed",
+      body: "Last commercial collection failed. Freshness stays ERROR; it is not rewritten to UNKNOWN.",
+      scope: "commercial",
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: FOUNDER,
+      provenance: {
+        source: { system: "warmbly", kind: "snapshot", locator: "representative-error" },
+        observed_at: OBSERVED,
+        freshness_status: "ERROR",
+        confidence: 0.2,
+      },
     }),
   ];
 }
 
-export function seedRepresentative(store: PersistenceAdapter): void {
+export function seedRepresentative(store: PersistencePort): void {
   for (const record of representativeRecords()) {
     store.insertRevision(record);
     store.setCurrent(record.id, record.revision_id);

--- a/control-center/services/context/src/representative.ts
+++ b/control-center/services/context/src/representative.ts
@@ -1,0 +1,189 @@
+import type { PersistenceAdapter } from "./store/adapter.ts";
+import type { DirectiveRecord, Scope } from "./types.ts";
+
+export const REPRESENTATIVE_NOW = "2026-08-20T12:00:00.000Z";
+
+export const REPRESENTATIVE_SCOPE: Scope = {
+  company: "confenge",
+  domain: "commercial",
+  resource: "offer:CFG-DIAG-EXP-v1",
+};
+
+export const SIBLING_SCOPE: Scope = {
+  company: "confenge",
+  domain: "commercial",
+  resource: "offer:OTHER-SKU",
+};
+
+const OBSERVED = "2026-08-20T00:00:00.000Z";
+const EFFECTIVE = "2026-01-01T00:00:00.000Z";
+const CREATED = "2026-08-19T12:00:00.000Z";
+
+function rec(
+  partial: Omit<DirectiveRecord, "created_at" | "effective_from" | "provenance"> & {
+    provenance?: DirectiveRecord["provenance"];
+    effective_from?: string;
+    created_at?: string;
+  },
+): DirectiveRecord {
+  const provenance = partial.provenance ?? {
+    source: "founder",
+    observed_at: OBSERVED,
+    freshness_status: "fresh",
+    confidence: 1,
+  };
+  return {
+    ...partial,
+    effective_from: partial.effective_from ?? EFFECTIVE,
+    created_at: partial.created_at ?? CREATED,
+    provenance,
+  };
+}
+
+export const REPRESENTATIVE_IDS = {
+  companyPriority: "dir-company-priority",
+  companyDecision: "dir-company-decision",
+  domainDirective: "dir-domain-directive",
+  resourceFact: "dir-resource-fact",
+  expired: "dir-resource-expired",
+  supersededConstraint: "dir-constraint-old",
+  activeConstraint: "dir-constraint-now",
+  hypothesis: "dir-company-hypothesis",
+  siblingFact: "dir-sibling-fact",
+} as const;
+
+export function representativeRecords(): DirectiveRecord[] {
+  return [
+    rec({
+      id: REPRESENTATIVE_IDS.companyPriority,
+      revision_id: "rev-company-priority-1",
+      version: 1,
+      kind: "priority",
+      title: "Close Diagnostico limited production",
+      body: "The three things that matter now start with Diagnostico limited production readiness.",
+      scope: { company: "confenge" },
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: "founder-local",
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.companyDecision,
+      revision_id: "rev-company-decision-1",
+      version: 1,
+      kind: "decision",
+      title: "Governance is strategic authority",
+      body: "Governance is the canonical strategic authority. Warmbly remains commercial CRM authority.",
+      scope: { company: "confenge" },
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: "founder-local",
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.domainDirective,
+      revision_id: "rev-domain-directive-1",
+      version: 1,
+      kind: "directive",
+      title: "No financial-provider mutation from Control Center",
+      body: "This wave does not charge, refund, cancel, or mutate Asaas.",
+      scope: { company: "confenge", domain: "commercial" },
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: "founder-local",
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.resourceFact,
+      revision_id: "rev-resource-fact-1",
+      version: 1,
+      kind: "fact",
+      title: "Diagnostico SKU list price",
+      body: "CFG-DIAG-EXP-v1 list price is 800000 BRL cents, one-time.",
+      scope: REPRESENTATIVE_SCOPE,
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: "founder-local",
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.expired,
+      revision_id: "rev-resource-expired-1",
+      version: 1,
+      kind: "directive",
+      title: "Temporary launch window",
+      body: "This directive expired and must not appear in the active set.",
+      scope: REPRESENTATIVE_SCOPE,
+      status: "active",
+      effective_from: "2025-12-01T00:00:00.000Z",
+      expires_at: "2026-01-02T00:00:00.000Z",
+      supersedes: null,
+      created_by: "founder-local",
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.supersededConstraint,
+      revision_id: "rev-constraint-old-1",
+      version: 1,
+      kind: "constraint",
+      title: "Do not publish Extra historical exception",
+      body: "Superseded wording of the Extra non-publication constraint.",
+      scope: { company: "confenge", domain: "commercial" },
+      status: "superseded",
+      expires_at: null,
+      supersedes: null,
+      created_by: "founder-local",
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.activeConstraint,
+      revision_id: "rev-constraint-now-1",
+      version: 1,
+      kind: "constraint",
+      title: "Extra historical exception is not public",
+      body: "Extra historical 1000000 cents/month remains non-public.",
+      scope: { company: "confenge", domain: "commercial" },
+      status: "active",
+      expires_at: null,
+      supersedes: REPRESENTATIVE_IDS.supersededConstraint,
+      created_by: "founder-local",
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.hypothesis,
+      revision_id: "rev-company-hypothesis-1",
+      version: 1,
+      kind: "hypothesis",
+      title: "Extra could become a later SKU",
+      body: "Hypothesis only: Extra historical demand might later become a priced SKU. Not a fact or decision.",
+      scope: { company: "confenge" },
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: "founder-local",
+      provenance: {
+        source: "founder",
+        observed_at: OBSERVED,
+        freshness_status: "fresh",
+        confidence: 0.4,
+      },
+    }),
+    rec({
+      id: REPRESENTATIVE_IDS.siblingFact,
+      revision_id: "rev-sibling-fact-1",
+      version: 1,
+      kind: "fact",
+      title: "Sibling SKU must not leak",
+      body: "This fact belongs to offer:OTHER-SKU and must not appear under CFG-DIAG-EXP-v1.",
+      scope: SIBLING_SCOPE,
+      status: "active",
+      expires_at: null,
+      supersedes: null,
+      created_by: "founder-local",
+    }),
+  ];
+}
+
+export function seedRepresentative(store: PersistenceAdapter): void {
+  for (const record of representativeRecords()) {
+    store.insertRevision(record);
+    store.setCurrent(record.id, record.revision_id);
+  }
+}

--- a/control-center/services/context/src/sanitize.ts
+++ b/control-center/services/context/src/sanitize.ts
@@ -1,7 +1,9 @@
 import { invalid, payloadTooLarge } from "./errors.ts";
+import { ACTOR_ID_PATTERN } from "./taxonomy.ts";
 import { LIMITS } from "./types.ts";
 
 const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+const ACTOR_ID_RE = new RegExp(`^${ACTOR_ID_PATTERN.slice(1, -1)}$`);
 
 export function utf8Bytes(value: string): number {
   return Buffer.byteLength(value, "utf8");
@@ -49,23 +51,12 @@ export function sanitizeMultiline(value: unknown, field: string, maxChars: numbe
   return stripped;
 }
 
-export const ACTOR_ID_RE = /^[A-Za-z0-9:_-]{1,128}$/;
-export const SCOPE_PART_RE = /^[A-Za-z0-9:._-]{1,64}$/;
-
 export function sanitizeActorId(value: unknown, field = "actor_id"): string {
   const id = sanitizeLine(value, field, LIMITS.actorIdChars);
   if (!ACTOR_ID_RE.test(id) || id.includes("@")) {
     throw invalid(`${field} must be an opaque id (no email or whitespace)`);
   }
   return id;
-}
-
-export function sanitizeScopePart(value: unknown, field: string): string {
-  const part = sanitizeLine(value, field, LIMITS.scopePartChars);
-  if (!SCOPE_PART_RE.test(part)) {
-    throw invalid(`${field} contains unsupported characters`);
-  }
-  return part;
 }
 
 export function rejectUnknownKeys(obj: Record<string, unknown>, allowed: readonly string[], label: string): void {

--- a/control-center/services/context/src/sanitize.ts
+++ b/control-center/services/context/src/sanitize.ts
@@ -1,0 +1,76 @@
+import { invalid, payloadTooLarge } from "./errors.ts";
+import { LIMITS } from "./types.ts";
+
+const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+
+export function utf8Bytes(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+export function assertJsonSize(raw: string): void {
+  if (utf8Bytes(raw) > LIMITS.jsonBytes) {
+    throw payloadTooLarge(`JSON payload exceeds ${LIMITS.jsonBytes} bytes`);
+  }
+}
+
+export function sanitizeLine(value: unknown, field: string, maxChars: number): string {
+  if (typeof value !== "string") {
+    throw invalid(`${field} must be a string`);
+  }
+  const stripped = value.replace(CONTROL_CHARS, "").replace(/\s+/g, " ").trim();
+  if (stripped.length === 0) {
+    throw invalid(`${field} must not be empty`);
+  }
+  if (stripped.length > maxChars) {
+    throw invalid(`${field} exceeds ${maxChars} characters`);
+  }
+  if (stripped.includes("\u0000")) {
+    throw invalid(`${field} contains a NUL byte`);
+  }
+  return stripped;
+}
+
+export function sanitizeMultiline(value: unknown, field: string, maxChars: number): string {
+  if (typeof value !== "string") {
+    throw invalid(`${field} must be a string`);
+  }
+  const stripped = value
+    .replace(/\u0000/g, "")
+    .replace(/[\u0001-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .trim();
+  if (stripped.length === 0) {
+    throw invalid(`${field} must not be empty`);
+  }
+  if (stripped.length > maxChars) {
+    throw invalid(`${field} exceeds ${maxChars} characters`);
+  }
+  return stripped;
+}
+
+export const ACTOR_ID_RE = /^[A-Za-z0-9:_-]{1,128}$/;
+export const SCOPE_PART_RE = /^[A-Za-z0-9:._-]{1,64}$/;
+
+export function sanitizeActorId(value: unknown, field = "actor_id"): string {
+  const id = sanitizeLine(value, field, LIMITS.actorIdChars);
+  if (!ACTOR_ID_RE.test(id) || id.includes("@")) {
+    throw invalid(`${field} must be an opaque id (no email or whitespace)`);
+  }
+  return id;
+}
+
+export function sanitizeScopePart(value: unknown, field: string): string {
+  const part = sanitizeLine(value, field, LIMITS.scopePartChars);
+  if (!SCOPE_PART_RE.test(part)) {
+    throw invalid(`${field} contains unsupported characters`);
+  }
+  return part;
+}
+
+export function rejectUnknownKeys(obj: Record<string, unknown>, allowed: readonly string[], label: string): void {
+  const extra = Object.keys(obj).filter((k) => !allowed.includes(k));
+  if (extra.length > 0) {
+    throw invalid(`${label} has unknown fields: ${extra.sort().join(", ")}`);
+  }
+}

--- a/control-center/services/context/src/scope.ts
+++ b/control-center/services/context/src/scope.ts
@@ -1,73 +1,149 @@
 import { invalid } from "./errors.ts";
-import { sanitizeScopePart } from "./sanitize.ts";
-import type { Scope } from "./types.ts";
+import {
+  DOMAIN_LITERALS,
+  REPO_NAME_PATTERN,
+  SCOPE_LITERALS,
+  SCOPE_PATTERN,
+  type DomainLiteral,
+  type ScopeLiteral,
+} from "./taxonomy.ts";
+import { LIMITS, type Scope } from "./types.ts";
 
-const SCOPE_KEYS = ["company", "domain", "resource"] as const;
+const SCOPE_RE = new RegExp(SCOPE_PATTERN);
+const REPO_NAME_RE = new RegExp(`^${REPO_NAME_PATTERN.slice(1, -1)}$`);
+
+export type RepoDomainMap = Readonly<Record<string, DomainLiteral>>;
+
+export function isScope(value: unknown): value is Scope {
+  return (
+    typeof value === "string" &&
+    value.length >= 2 &&
+    value.length <= LIMITS.scopeChars &&
+    SCOPE_RE.test(value)
+  );
+}
 
 export function parseScope(raw: unknown): Scope {
-  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
-    throw invalid("scope must be an object");
+  if (raw !== null && typeof raw === "object") {
+    throw invalid("scope must be a string; object {company,domain,resource} is not accepted");
   }
-  const obj = raw as Record<string, unknown>;
-  const extra = Object.keys(obj).filter((k) => !SCOPE_KEYS.includes(k as (typeof SCOPE_KEYS)[number]));
-  if (extra.length > 0) {
-    throw invalid(`scope has unknown fields: ${extra.sort().join(", ")}`);
+  if (typeof raw !== "string") {
+    throw invalid("scope must be a string");
   }
-  if (typeof obj.company !== "string") {
-    throw invalid("scope.company is required");
+  if (raw.length < 2 || raw.length > LIMITS.scopeChars) {
+    throw invalid(`scope must be between 2 and ${LIMITS.scopeChars} characters`);
   }
-  const scope: Scope = { company: sanitizeScopePart(obj.company, "scope.company") };
-  if (obj.domain !== undefined) {
-    scope.domain = sanitizeScopePart(obj.domain, "scope.domain");
+  if (!SCOPE_RE.test(raw)) {
+    throw invalid("scope is not a v1 Control Center scope");
   }
-  if (obj.resource !== undefined) {
-    if (scope.domain === undefined) {
-      throw invalid("scope.resource requires scope.domain");
+  return raw;
+}
+
+export function isLiteralScope(value: string): value is ScopeLiteral {
+  return (SCOPE_LITERALS as readonly string[]).includes(value);
+}
+
+export function isDomainLiteral(value: string): value is DomainLiteral {
+  return (DOMAIN_LITERALS as readonly string[]).includes(value);
+}
+
+export function repoNameFromScope(scope: Scope): string | null {
+  if (!scope.startsWith("repo:")) {
+    return null;
+  }
+  const name = scope.slice("repo:".length);
+  return REPO_NAME_RE.test(name) ? name : null;
+}
+
+export function clientSlugFromScope(scope: Scope): string | null {
+  if (!scope.startsWith("client:")) {
+    return null;
+  }
+  return scope.slice("client:".length);
+}
+
+export function parseRepoDomainMap(raw: unknown): RepoDomainMap {
+  if (raw === undefined || raw === null) {
+    return {};
+  }
+  if (typeof raw === "string") {
+    const out: Record<string, DomainLiteral> = {};
+    const trimmed = raw.trim();
+    if (trimmed === "") {
+      return {};
     }
-    scope.resource = sanitizeScopePart(obj.resource, "scope.resource");
+    for (const part of trimmed.split(",")) {
+      const item = part.trim();
+      if (item === "") {
+        continue;
+      }
+      const sep = item.lastIndexOf(":");
+      if (sep <= 0 || sep === item.length - 1) {
+        throw invalid("CONTROL_CENTER_REPO_DOMAINS entries must be repo:domain");
+      }
+      const name = item.slice(0, sep);
+      const domain = item.slice(sep + 1);
+      assignRepoDomain(out, name, domain);
+    }
+    return out;
   }
-  return scope;
-}
-
-export function scopeKey(scope: Scope): string {
-  const parts = [scope.company];
-  if (scope.domain) {
-    parts.push(scope.domain);
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid("repo domain map must be an object or CSV string");
   }
-  if (scope.resource) {
-    parts.push(scope.resource);
-  }
-  return parts.join("/");
-}
-
-export function sortScope(scope: Scope): Scope {
-  const out: Scope = { company: scope.company };
-  if (scope.domain !== undefined) {
-    out.domain = scope.domain;
-  }
-  if (scope.resource !== undefined) {
-    out.resource = scope.resource;
+  const out: Record<string, DomainLiteral> = {};
+  for (const [name, domain] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof domain !== "string") {
+      throw invalid("repo domain map values must be domain literals");
+    }
+    assignRepoDomain(out, name, domain);
   }
   return out;
 }
 
+function assignRepoDomain(out: Record<string, DomainLiteral>, name: string, domain: string): void {
+  if (!REPO_NAME_RE.test(name)) {
+    throw invalid(`repo name is invalid: ${name}`);
+  }
+  if (!isDomainLiteral(domain)) {
+    throw invalid(`repo domain must be one of: ${DOMAIN_LITERALS.join(", ")}`);
+  }
+  out[name] = domain;
+}
+
 /**
- * Controlled inheritance: a directive is visible under a query when the
- * directive's scope is the query itself or an ancestor (company → domain →
- * resource). Descendants and siblings are never returned.
+ * Controlled inheritance: a query receives the query scope plus explicit
+ * ancestors. Never descendants, never siblings.
+ *
+ * - `company` → {company}
+ * - domain literal → {company, that domain}
+ * - `repo:x` → {company, configured domain for x, repo:x}
+ * - `client:y` → {company, clients, client:y}
  */
-export function scopeVisibleUnderQuery(directiveScope: Scope, query: Scope): boolean {
-  if (directiveScope.company !== query.company) {
-    return false;
+export function expandInheritedScopes(query: Scope, repoDomains: RepoDomainMap): readonly Scope[] {
+  if (query === "company") {
+    return ["company"];
   }
-  if (directiveScope.domain === undefined) {
-    return true;
+  if (isLiteralScope(query)) {
+    return ["company", query];
   }
-  if (query.domain !== directiveScope.domain) {
-    return false;
+  const repoName = repoNameFromScope(query);
+  if (repoName !== null) {
+    const domain = repoDomains[repoName];
+    if (domain) {
+      return ["company", domain, query];
+    }
+    return ["company", query];
   }
-  if (directiveScope.resource === undefined) {
-    return true;
+  if (clientSlugFromScope(query) !== null) {
+    return ["company", "clients", query];
   }
-  return query.resource === directiveScope.resource;
+  return ["company", query];
+}
+
+export function scopeVisibleUnderQuery(
+  directiveScope: Scope,
+  query: Scope,
+  repoDomains: RepoDomainMap,
+): boolean {
+  return expandInheritedScopes(query, repoDomains).includes(directiveScope);
 }

--- a/control-center/services/context/src/scope.ts
+++ b/control-center/services/context/src/scope.ts
@@ -1,0 +1,73 @@
+import { invalid } from "./errors.ts";
+import { sanitizeScopePart } from "./sanitize.ts";
+import type { Scope } from "./types.ts";
+
+const SCOPE_KEYS = ["company", "domain", "resource"] as const;
+
+export function parseScope(raw: unknown): Scope {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid("scope must be an object");
+  }
+  const obj = raw as Record<string, unknown>;
+  const extra = Object.keys(obj).filter((k) => !SCOPE_KEYS.includes(k as (typeof SCOPE_KEYS)[number]));
+  if (extra.length > 0) {
+    throw invalid(`scope has unknown fields: ${extra.sort().join(", ")}`);
+  }
+  if (typeof obj.company !== "string") {
+    throw invalid("scope.company is required");
+  }
+  const scope: Scope = { company: sanitizeScopePart(obj.company, "scope.company") };
+  if (obj.domain !== undefined) {
+    scope.domain = sanitizeScopePart(obj.domain, "scope.domain");
+  }
+  if (obj.resource !== undefined) {
+    if (scope.domain === undefined) {
+      throw invalid("scope.resource requires scope.domain");
+    }
+    scope.resource = sanitizeScopePart(obj.resource, "scope.resource");
+  }
+  return scope;
+}
+
+export function scopeKey(scope: Scope): string {
+  const parts = [scope.company];
+  if (scope.domain) {
+    parts.push(scope.domain);
+  }
+  if (scope.resource) {
+    parts.push(scope.resource);
+  }
+  return parts.join("/");
+}
+
+export function sortScope(scope: Scope): Scope {
+  const out: Scope = { company: scope.company };
+  if (scope.domain !== undefined) {
+    out.domain = scope.domain;
+  }
+  if (scope.resource !== undefined) {
+    out.resource = scope.resource;
+  }
+  return out;
+}
+
+/**
+ * Controlled inheritance: a directive is visible under a query when the
+ * directive's scope is the query itself or an ancestor (company → domain →
+ * resource). Descendants and siblings are never returned.
+ */
+export function scopeVisibleUnderQuery(directiveScope: Scope, query: Scope): boolean {
+  if (directiveScope.company !== query.company) {
+    return false;
+  }
+  if (directiveScope.domain === undefined) {
+    return true;
+  }
+  if (query.domain !== directiveScope.domain) {
+    return false;
+  }
+  if (directiveScope.resource === undefined) {
+    return true;
+  }
+  return query.resource === directiveScope.resource;
+}

--- a/control-center/services/context/src/server.ts
+++ b/control-center/services/context/src/server.ts
@@ -29,10 +29,7 @@ export function startServer(
   const boot = bootFromEnv(env, { logger });
   const host = listenHost(env);
   const port = listenPort(env);
-  const listener = createRequestListener(
-    { service: boot.service, logger },
-    boot.defaultCompany,
-  );
+  const listener = createRequestListener({ service: boot.service, logger });
   const server = createServer(listener);
   return new Promise((resolve, reject) => {
     server.once("error", reject);

--- a/control-center/services/context/src/server.ts
+++ b/control-center/services/context/src/server.ts
@@ -1,0 +1,71 @@
+import { createServer } from "node:http";
+import { bootFromEnv } from "./boot.ts";
+import { createRequestListener } from "./http.ts";
+import { createLogger, type Logger } from "./log.ts";
+import { isServiceError } from "./errors.ts";
+
+function listenPort(env: NodeJS.ProcessEnv): number {
+  const raw = env.PORT ?? "8787";
+  const port = Number.parseInt(raw, 10);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error("PORT must be an integer 0-65535");
+  }
+  return port;
+}
+
+function listenHost(env: NodeJS.ProcessEnv): string {
+  const host = (env.HOST ?? "127.0.0.1").trim();
+  if (!host) {
+    throw new Error("HOST must not be empty");
+  }
+  return host;
+}
+
+export function startServer(
+  env: NodeJS.ProcessEnv = process.env,
+  opts?: { logger?: Logger },
+): Promise<{ server: ReturnType<typeof createServer>; host: string; port: number }> {
+  const logger = opts?.logger ?? createLogger();
+  const boot = bootFromEnv(env, { logger });
+  const host = listenHost(env);
+  const port = listenPort(env);
+  const listener = createRequestListener(
+    { service: boot.service, logger },
+    boot.defaultCompany,
+  );
+  const server = createServer(listener);
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      const addr = server.address();
+      const bound = addr && typeof addr === "object" ? addr.port : port;
+      logger.info("listen", {
+        host,
+        port: bound,
+        fixture: boot.fixture,
+        store: boot.storeName,
+      });
+      resolve({ server, host, port: bound });
+    });
+  });
+}
+
+function isDirectEntry(): boolean {
+  const arg = process.argv[1];
+  if (!arg) {
+    return false;
+  }
+  const normalized = arg.replace(/\\/g, "/");
+  return normalized.endsWith("/server.ts") || normalized.endsWith("/server.js");
+}
+
+if (isDirectEntry()) {
+  startServer().catch((err: unknown) => {
+    if (isServiceError(err)) {
+      process.stderr.write(`${JSON.stringify({ level: "error", msg: err.message, code: err.code })}\n`);
+    } else {
+      process.stderr.write(`${JSON.stringify({ level: "error", msg: "boot_failed" })}\n`);
+    }
+    process.exit(1);
+  });
+}

--- a/control-center/services/context/src/service.ts
+++ b/control-center/services/context/src/service.ts
@@ -1,0 +1,470 @@
+import { assertAgent, assertFounder, assertReadable } from "./actor.ts";
+import { toUtcIso, type Clock } from "./clock.ts";
+import { conflict, invalid, notFound } from "./errors.ts";
+import type { IdGenerator } from "./ids.ts";
+import type { Logger } from "./log.ts";
+import { compareDirectives, isActiveAt, isProtectedKind, partitionByKind, terminalStatus } from "./policy.ts";
+import { parseScope, scopeVisibleUnderQuery, sortScope } from "./scope.ts";
+import type { PersistenceAdapter } from "./store/adapter.ts";
+import type {
+  Actor,
+  AuditEvent,
+  ContextPayload,
+  CreateDirectiveInput,
+  DirectiveRecord,
+  DirectiveView,
+  ProposalRecord,
+  Provenance,
+  Scope,
+} from "./types.ts";
+import { parseCreateInput, parsePathId, parseProposalInput, parseVersionInput } from "./validate.ts";
+
+export interface ContextServiceDeps {
+  store: PersistenceAdapter;
+  clock: Clock;
+  ids: IdGenerator;
+  founderActorId: string;
+  logger: Logger;
+  defaultCompany: string;
+}
+
+export interface ContextService {
+  createDirective(actor: Actor, raw: unknown): DirectiveRecord;
+  getDirective(actor: Actor, id: string): DirectiveRecord;
+  listRevisions(actor: Actor, id: string): DirectiveRecord[];
+  createVersion(actor: Actor, id: string, raw: unknown): DirectiveRecord;
+  supersede(actor: Actor, id: string, raw: unknown): DirectiveRecord;
+  expire(actor: Actor, id: string, raw?: unknown): DirectiveRecord;
+  activate(actor: Actor, id: string): DirectiveRecord;
+  deactivate(actor: Actor, id: string): DirectiveRecord;
+  submitProposal(actor: Actor, raw: unknown): ProposalRecord;
+  listProposals(actor: Actor): ProposalRecord[];
+  rejectProposal(actor: Actor, id: string): ProposalRecord;
+  getContext(actor: Actor, scope: Scope): ContextPayload;
+  getActiveDirectives(actor: Actor, scope: Scope): DirectiveView[];
+  getPriorities(actor: Actor, scope?: Scope): DirectiveView[];
+  getDecisions(actor: Actor, scope?: Scope): DirectiveView[];
+  listAudit(actor: Actor): AuditEvent[];
+}
+
+function provenanceFromInput(input: {
+  source: string;
+  observed_at?: string;
+  freshness_status?: Provenance["freshness_status"];
+  confidence?: number;
+}): Provenance {
+  if (!input.observed_at || !input.freshness_status) {
+    throw invalid("provenance is incomplete");
+  }
+  const provenance: Provenance = {
+    source: input.source,
+    observed_at: input.observed_at,
+    freshness_status: input.freshness_status,
+  };
+  if (input.confidence !== undefined) {
+    provenance.confidence = input.confidence;
+  }
+  return provenance;
+}
+
+function toView(record: DirectiveRecord): DirectiveView {
+  const view: DirectiveView = {
+    id: record.id,
+    revision_id: record.revision_id,
+    version: record.version,
+    kind: record.kind,
+    title: record.title,
+    body: record.body,
+    scope: sortScope(record.scope),
+    status: record.status,
+    effective_from: record.effective_from,
+    expires_at: record.expires_at,
+    supersedes: record.supersedes,
+    created_by: record.created_by,
+    source: record.provenance.source,
+    observed_at: record.provenance.observed_at,
+    freshness_status: record.provenance.freshness_status,
+  };
+  if (record.provenance.confidence !== undefined) {
+    view.confidence = record.provenance.confidence;
+  }
+  return view;
+}
+
+function viewsOf(records: readonly DirectiveRecord[]): DirectiveView[] {
+  return [...records].sort(compareDirectives).map(toView);
+}
+
+export function createContextService(deps: ContextServiceDeps): ContextService {
+  const founderActorId = deps.founderActorId.trim();
+  if (!founderActorId) {
+    throw invalid("CONTROL_CENTER_FOUNDER_ACTOR_ID is required");
+  }
+
+  const mustCurrent = (id: string): DirectiveRecord => {
+    const current = deps.store.getCurrent(id);
+    if (!current) {
+      throw notFound("directive_not_found", "directive not found");
+    }
+    return current;
+  };
+
+  const writeAudit = (
+    actor: Actor,
+    action: string,
+    entityType: AuditEvent["entity_type"],
+    entityId: string,
+    revisionId: string | null,
+    metadata: AuditEvent["metadata"],
+  ): void => {
+    const event: AuditEvent = {
+      id: deps.ids.next(),
+      at: toUtcIso(deps.clock.now()),
+      actor_id: actor.id,
+      actor_role: actor.role,
+      action,
+      entity_type: entityType,
+      entity_id: entityId,
+      revision_id: revisionId,
+      metadata,
+    };
+    deps.store.appendAudit(event);
+    deps.logger.info(action, {
+      entity_type: entityType,
+      entity_id: entityId,
+      actor_role: actor.role,
+      kind: typeof metadata.kind === "string" ? metadata.kind : null,
+    });
+  };
+
+  const insertCurrent = (record: DirectiveRecord): void => {
+    deps.store.insertRevision(record);
+    deps.store.setCurrent(record.id, record.revision_id);
+  };
+
+  const buildFromCreate = (actor: Actor, input: CreateDirectiveInput, id: string, version: number): DirectiveRecord => {
+    const now = toUtcIso(deps.clock.now());
+    return {
+      id,
+      revision_id: deps.ids.next(),
+      version,
+      kind: input.kind,
+      title: input.title,
+      body: input.body,
+      scope: sortScope(input.scope),
+      status: input.status ?? "active",
+      effective_from: input.effective_from ?? now,
+      expires_at: input.expires_at ?? null,
+      supersedes: input.supersedes ?? null,
+      created_by: actor.id,
+      created_at: now,
+      provenance: provenanceFromInput(input),
+    };
+  };
+
+  const snapshot = (
+    actor: Actor,
+    current: DirectiveRecord,
+    patch: Partial<Pick<DirectiveRecord, "title" | "body" | "status" | "effective_from" | "expires_at" | "supersedes">> & {
+      provenance?: Provenance;
+    },
+  ): DirectiveRecord => {
+    const now = toUtcIso(deps.clock.now());
+    return {
+      id: current.id,
+      revision_id: deps.ids.next(),
+      version: current.version + 1,
+      kind: current.kind,
+      title: patch.title ?? current.title,
+      body: patch.body ?? current.body,
+      scope: sortScope(current.scope),
+      status: patch.status ?? current.status,
+      effective_from: patch.effective_from ?? current.effective_from,
+      expires_at: patch.expires_at !== undefined ? patch.expires_at : current.expires_at,
+      supersedes: patch.supersedes !== undefined ? patch.supersedes : current.supersedes,
+      created_by: actor.id,
+      created_at: now,
+      provenance: patch.provenance ?? current.provenance,
+    };
+  };
+
+  const visibleActive = (scope: Scope): DirectiveRecord[] => {
+    const now = deps.clock.now();
+    return deps.store
+      .listCurrent()
+      .filter((rec) => isActiveAt(rec, now) && scopeVisibleUnderQuery(rec.scope, scope))
+      .sort(compareDirectives);
+  };
+
+  const resolveScope = (scope?: Scope): Scope => {
+    if (scope) {
+      return parseScope(scope);
+    }
+    return parseScope({ company: deps.defaultCompany });
+  };
+
+  return {
+    createDirective(actor: Actor, raw: unknown): DirectiveRecord {
+      assertFounder(actor, founderActorId);
+      const input = parseCreateInput(raw, deps.clock);
+      const record = buildFromCreate(actor, input, deps.ids.next(), 1);
+      insertCurrent(record);
+      writeAudit(actor, "directive.create", "directive", record.id, record.revision_id, {
+        kind: record.kind,
+        version: record.version,
+        scope: `${record.scope.company}/${record.scope.domain ?? ""}/${record.scope.resource ?? ""}`,
+      });
+      return record;
+    },
+
+    getDirective(actor: Actor, id: string): DirectiveRecord {
+      assertReadable(actor, founderActorId);
+      return mustCurrent(parsePathId(id, "id"));
+    },
+
+    listRevisions(actor: Actor, id: string): DirectiveRecord[] {
+      assertReadable(actor, founderActorId);
+      const parsed = parsePathId(id, "id");
+      const revs = deps.store.listRevisions(parsed);
+      if (revs.length === 0) {
+        throw notFound("directive_not_found", "directive not found");
+      }
+      return revs;
+    },
+
+    createVersion(actor: Actor, id: string, raw: unknown): DirectiveRecord {
+      assertFounder(actor, founderActorId);
+      const current = mustCurrent(parsePathId(id, "id"));
+      if (current.status === "superseded") {
+        throw conflict("cannot version a superseded directive; create a successor via supersede");
+      }
+      const input = parseVersionInput(raw, deps.clock);
+      const provenance: Provenance = {
+        source: input.source ?? current.provenance.source,
+        observed_at: input.observed_at ?? toUtcIso(deps.clock.now()),
+        freshness_status: input.freshness_status ?? current.provenance.freshness_status,
+      };
+      if (input.confidence !== undefined && input.confidence !== null) {
+        provenance.confidence = input.confidence;
+      } else if (input.confidence !== null && current.provenance.confidence !== undefined) {
+        provenance.confidence = current.provenance.confidence;
+      }
+      const patch: Partial<
+        Pick<DirectiveRecord, "title" | "body" | "status" | "effective_from" | "expires_at" | "supersedes">
+      > & { provenance?: Provenance } = { provenance };
+      if (input.title !== undefined) {
+        patch.title = input.title;
+      }
+      if (input.body !== undefined) {
+        patch.body = input.body;
+      }
+      if (input.effective_from !== undefined) {
+        patch.effective_from = input.effective_from;
+      }
+      if (input.expires_at !== undefined) {
+        patch.expires_at = input.expires_at;
+      }
+      const next = snapshot(actor, current, patch);
+      insertCurrent(next);
+      writeAudit(actor, "directive.version", "directive", next.id, next.revision_id, {
+        kind: next.kind,
+        version: next.version,
+      });
+      return next;
+    },
+
+    supersede(actor: Actor, id: string, raw: unknown): DirectiveRecord {
+      assertFounder(actor, founderActorId);
+      const current = mustCurrent(parsePathId(id, "id"));
+      if (current.status === "superseded") {
+        throw conflict("directive is already superseded");
+      }
+      const input = parseCreateInput(raw, deps.clock);
+      const closed = snapshot(actor, current, { status: "superseded" });
+      insertCurrent(closed);
+      writeAudit(actor, "directive.supersede", "directive", closed.id, closed.revision_id, {
+        kind: closed.kind,
+        version: closed.version,
+        successor_pending: true,
+      });
+      const successorInput: CreateDirectiveInput = {
+        ...input,
+        supersedes: current.id,
+      };
+      const successor = buildFromCreate(actor, successorInput, deps.ids.next(), 1);
+      insertCurrent(successor);
+      writeAudit(actor, "directive.create", "directive", successor.id, successor.revision_id, {
+        kind: successor.kind,
+        version: successor.version,
+        supersedes: current.id,
+      });
+      return successor;
+    },
+
+    expire(actor: Actor, id: string, raw?: unknown): DirectiveRecord {
+      assertFounder(actor, founderActorId);
+      const current = mustCurrent(parsePathId(id, "id"));
+      if (current.status === "superseded") {
+        throw conflict("cannot expire a superseded directive");
+      }
+      let expiresAt = toUtcIso(deps.clock.now());
+      if (raw !== undefined && raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+        const obj = raw as Record<string, unknown>;
+        if (obj.expires_at !== undefined && obj.expires_at !== null) {
+          if (typeof obj.expires_at !== "string") {
+            throw invalid("expires_at must be an ISO-8601 UTC timestamp");
+          }
+          expiresAt = toUtcIso(new Date(obj.expires_at));
+        }
+      }
+      const next = snapshot(actor, current, { status: "expired", expires_at: expiresAt });
+      insertCurrent(next);
+      writeAudit(actor, "directive.expire", "directive", next.id, next.revision_id, {
+        kind: next.kind,
+        version: next.version,
+      });
+      return next;
+    },
+
+    activate(actor: Actor, id: string): DirectiveRecord {
+      assertFounder(actor, founderActorId);
+      const current = mustCurrent(parsePathId(id, "id"));
+      if (terminalStatus(current.status)) {
+        throw conflict("cannot activate a superseded or expired directive");
+      }
+      const next = snapshot(actor, current, { status: "active" });
+      insertCurrent(next);
+      writeAudit(actor, "directive.activate", "directive", next.id, next.revision_id, {
+        kind: next.kind,
+        version: next.version,
+      });
+      return next;
+    },
+
+    deactivate(actor: Actor, id: string): DirectiveRecord {
+      assertFounder(actor, founderActorId);
+      const current = mustCurrent(parsePathId(id, "id"));
+      if (terminalStatus(current.status)) {
+        throw conflict("cannot deactivate a superseded or expired directive");
+      }
+      const next = snapshot(actor, current, { status: "inactive" });
+      insertCurrent(next);
+      writeAudit(actor, "directive.deactivate", "directive", next.id, next.revision_id, {
+        kind: next.kind,
+        version: next.version,
+      });
+      return next;
+    },
+
+    submitProposal(actor: Actor, raw: unknown): ProposalRecord {
+      assertAgent(actor, founderActorId);
+      const input = parseProposalInput(raw, deps.clock);
+      if (input.target_directive_id) {
+        const target = deps.store.getCurrent(input.target_directive_id);
+        if (!target) {
+          throw notFound("directive_not_found", "target directive not found");
+        }
+        if (isProtectedKind(target.kind) && input.action !== "create") {
+          deps.logger.warn("proposal.protected_target", {
+            actor_role: actor.role,
+            kind: target.kind,
+            action: input.action,
+          });
+        }
+      }
+      if (isProtectedKind(input.kind) && (input.action === "supersede" || input.action === "expire" || input.action === "deactivate" || input.action === "version")) {
+        // Accepted as a suggestion only; never applied here.
+        deps.logger.warn("proposal.protected_kind", {
+          actor_role: actor.role,
+          kind: input.kind,
+          action: input.action,
+        });
+      }
+      const record: ProposalRecord = {
+        id: deps.ids.next(),
+        status: "pending",
+        action: input.action,
+        kind: input.kind,
+        title: input.title,
+        body: input.body,
+        scope: sortScope(input.scope),
+        target_directive_id: input.target_directive_id ?? null,
+        rationale: input.rationale,
+        created_by: actor.id,
+        created_at: toUtcIso(deps.clock.now()),
+        provenance: provenanceFromInput(input),
+      };
+      deps.store.insertProposal(record);
+      writeAudit(actor, "proposal.submit", "proposal", record.id, null, {
+        kind: record.kind,
+        action: record.action,
+        target: record.target_directive_id,
+      });
+      return record;
+    },
+
+    listProposals(actor: Actor): ProposalRecord[] {
+      assertReadable(actor, founderActorId);
+      const all = deps.store.listProposals();
+      if (actor.role === "agent") {
+        return all.filter((p) => p.created_by === actor.id);
+      }
+      return all;
+    },
+
+    rejectProposal(actor: Actor, id: string): ProposalRecord {
+      assertFounder(actor, founderActorId);
+      const current = deps.store.getProposal(parsePathId(id, "id"));
+      if (!current) {
+        throw notFound("proposal_not_found", "proposal not found");
+      }
+      const next: ProposalRecord = { ...current, status: "rejected" };
+      deps.store.updateProposal(next);
+      writeAudit(actor, "proposal.reject", "proposal", next.id, null, {
+        kind: next.kind,
+        action: next.action,
+      });
+      return next;
+    },
+
+    getContext(actor: Actor, scope: Scope): ContextPayload {
+      assertReadable(actor, founderActorId);
+      const query = parseScope(scope);
+      const active = visibleActive(query);
+      const parts = partitionByKind(active);
+      return {
+        scope: sortScope(query),
+        active_directives: viewsOf(active),
+        decisions: viewsOf(parts.decisions),
+        facts: viewsOf(parts.facts),
+        constraints: viewsOf(parts.constraints),
+        priorities: viewsOf(parts.priorities),
+        risks: viewsOf(parts.risks),
+        directives: viewsOf(parts.directives),
+        hypotheses: viewsOf(parts.hypotheses),
+      };
+    },
+
+    getActiveDirectives(actor: Actor, scope: Scope): DirectiveView[] {
+      assertReadable(actor, founderActorId);
+      return viewsOf(visibleActive(parseScope(scope)));
+    },
+
+    getPriorities(actor: Actor, scope?: Scope): DirectiveView[] {
+      assertReadable(actor, founderActorId);
+      const query = resolveScope(scope);
+      return viewsOf(visibleActive(query).filter((r) => r.kind === "priority"));
+    },
+
+    getDecisions(actor: Actor, scope?: Scope): DirectiveView[] {
+      assertReadable(actor, founderActorId);
+      const query = resolveScope(scope);
+      return viewsOf(visibleActive(query).filter((r) => r.kind === "decision"));
+    },
+
+    listAudit(actor: Actor): AuditEvent[] {
+      assertFounder(actor, founderActorId);
+      return deps.store.listAudit();
+    },
+  };
+}

--- a/control-center/services/context/src/service.ts
+++ b/control-center/services/context/src/service.ts
@@ -1,81 +1,80 @@
-import { assertAgent, assertFounder, assertReadable } from "./actor.ts";
+import { assertAgent, assertFounder, assertReadable, sameActor } from "./actor.ts";
 import { toUtcIso, type Clock } from "./clock.ts";
 import { conflict, invalid, notFound } from "./errors.ts";
 import type { IdGenerator } from "./ids.ts";
 import type { Logger } from "./log.ts";
 import { compareDirectives, isActiveAt, isProtectedKind, partitionByKind, terminalStatus } from "./policy.ts";
-import { parseScope, scopeVisibleUnderQuery, sortScope } from "./scope.ts";
-import type { PersistenceAdapter } from "./store/adapter.ts";
+import { parseScope, scopeVisibleUnderQuery, type RepoDomainMap } from "./scope.ts";
+import type { PersistencePort } from "./store/adapter.ts";
 import type {
-  Actor,
+  ActorRef,
   AuditEvent,
   ContextPayload,
   CreateDirectiveInput,
+  DirectiveProposal,
   DirectiveRecord,
   DirectiveView,
-  ProposalRecord,
   Provenance,
+  ResourceId,
   Scope,
 } from "./types.ts";
 import { parseCreateInput, parsePathId, parseProposalInput, parseVersionInput } from "./validate.ts";
 
 export interface ContextServiceDeps {
-  store: PersistenceAdapter;
+  store: PersistencePort;
   clock: Clock;
   ids: IdGenerator;
   founderActorId: string;
   logger: Logger;
-  defaultCompany: string;
+  defaultScope: Scope;
+  repoDomains: RepoDomainMap;
 }
 
 export interface ContextService {
-  createDirective(actor: Actor, raw: unknown): DirectiveRecord;
-  getDirective(actor: Actor, id: string): DirectiveRecord;
-  listRevisions(actor: Actor, id: string): DirectiveRecord[];
-  createVersion(actor: Actor, id: string, raw: unknown): DirectiveRecord;
-  supersede(actor: Actor, id: string, raw: unknown): DirectiveRecord;
-  expire(actor: Actor, id: string, raw?: unknown): DirectiveRecord;
-  activate(actor: Actor, id: string): DirectiveRecord;
-  deactivate(actor: Actor, id: string): DirectiveRecord;
-  submitProposal(actor: Actor, raw: unknown): ProposalRecord;
-  listProposals(actor: Actor): ProposalRecord[];
-  rejectProposal(actor: Actor, id: string): ProposalRecord;
-  getContext(actor: Actor, scope: Scope): ContextPayload;
-  getActiveDirectives(actor: Actor, scope: Scope): DirectiveView[];
-  getPriorities(actor: Actor, scope?: Scope): DirectiveView[];
-  getDecisions(actor: Actor, scope?: Scope): DirectiveView[];
-  listAudit(actor: Actor): AuditEvent[];
+  createDirective(actor: ActorRef, raw: unknown): DirectiveRecord;
+  getDirective(actor: ActorRef, id: string): DirectiveRecord;
+  listRevisions(actor: ActorRef, id: string): DirectiveRecord[];
+  createVersion(actor: ActorRef, id: string, raw: unknown): DirectiveRecord;
+  supersede(actor: ActorRef, id: string, raw: unknown): DirectiveRecord;
+  expire(actor: ActorRef, id: string, raw?: unknown): DirectiveRecord;
+  activate(actor: ActorRef, id: string): DirectiveRecord;
+  revoke(actor: ActorRef, id: string): DirectiveRecord;
+  submitProposal(actor: ActorRef, raw: unknown): DirectiveProposal;
+  listProposals(actor: ActorRef): DirectiveProposal[];
+  rejectProposal(actor: ActorRef, id: string): DirectiveProposal;
+  getContext(actor: ActorRef, scope: Scope): ContextPayload;
+  getActiveDirectives(actor: ActorRef, scope: Scope): DirectiveView[];
+  getPriorities(actor: ActorRef, scope?: Scope): DirectiveView[];
+  getDecisions(actor: ActorRef, scope?: Scope): DirectiveView[];
+  listAudit(actor: ActorRef): AuditEvent[];
 }
 
 function provenanceFromInput(input: {
-  source: string;
+  source: Provenance["source"];
   observed_at?: string;
   freshness_status?: Provenance["freshness_status"];
-  confidence?: number;
+  confidence: number;
 }): Provenance {
   if (!input.observed_at || !input.freshness_status) {
     throw invalid("provenance is incomplete");
   }
-  const provenance: Provenance = {
+  return {
     source: input.source,
     observed_at: input.observed_at,
     freshness_status: input.freshness_status,
+    confidence: input.confidence,
   };
-  if (input.confidence !== undefined) {
-    provenance.confidence = input.confidence;
-  }
-  return provenance;
 }
 
 function toView(record: DirectiveRecord): DirectiveView {
-  const view: DirectiveView = {
+  return {
     id: record.id,
     revision_id: record.revision_id,
     version: record.version,
     kind: record.kind,
     title: record.title,
     body: record.body,
-    scope: sortScope(record.scope),
+    scope: record.scope,
     status: record.status,
     effective_from: record.effective_from,
     expires_at: record.expires_at,
@@ -84,15 +83,24 @@ function toView(record: DirectiveRecord): DirectiveView {
     source: record.provenance.source,
     observed_at: record.provenance.observed_at,
     freshness_status: record.provenance.freshness_status,
+    confidence: record.provenance.confidence,
   };
-  if (record.provenance.confidence !== undefined) {
-    view.confidence = record.provenance.confidence;
-  }
-  return view;
 }
 
 function viewsOf(records: readonly DirectiveRecord[]): DirectiveView[] {
   return [...records].sort(compareDirectives).map(toView);
+}
+
+function uniqueIds(ids: readonly ResourceId[]): ResourceId[] {
+  const seen = new Set<ResourceId>();
+  const out: ResourceId[] = [];
+  for (const id of ids) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  return out;
 }
 
 export function createContextService(deps: ContextServiceDeps): ContextService {
@@ -110,18 +118,17 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
   };
 
   const writeAudit = (
-    actor: Actor,
+    actor: ActorRef,
     action: string,
     entityType: AuditEvent["entity_type"],
-    entityId: string,
-    revisionId: string | null,
+    entityId: ResourceId,
+    revisionId: ResourceId | null,
     metadata: AuditEvent["metadata"],
   ): void => {
     const event: AuditEvent = {
-      id: deps.ids.next(),
+      id: deps.ids.next("audit-event"),
       at: toUtcIso(deps.clock.now()),
-      actor_id: actor.id,
-      actor_role: actor.role,
+      actor: { kind: actor.kind, id: actor.id },
       action,
       entity_type: entityType,
       entity_id: entityId,
@@ -132,7 +139,7 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
     deps.logger.info(action, {
       entity_type: entityType,
       entity_id: entityId,
-      actor_role: actor.role,
+      actor_kind: actor.kind,
       kind: typeof metadata.kind === "string" ? metadata.kind : null,
     });
   };
@@ -142,28 +149,34 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
     deps.store.setCurrent(record.id, record.revision_id);
   };
 
-  const buildFromCreate = (actor: Actor, input: CreateDirectiveInput, id: string, version: number): DirectiveRecord => {
+  const buildFromCreate = (
+    actor: ActorRef,
+    input: CreateDirectiveInput,
+    id: ResourceId,
+    version: number,
+  ): DirectiveRecord => {
     const now = toUtcIso(deps.clock.now());
     return {
       id,
-      revision_id: deps.ids.next(),
+      revision_id: deps.ids.next("directive-revision"),
       version,
       kind: input.kind,
       title: input.title,
       body: input.body,
-      scope: sortScope(input.scope),
+      scope: input.scope,
       status: input.status ?? "active",
       effective_from: input.effective_from ?? now,
       expires_at: input.expires_at ?? null,
       supersedes: input.supersedes ?? null,
-      created_by: actor.id,
+      created_by: { kind: actor.kind, id: actor.id },
       created_at: now,
+      updated_at: now,
       provenance: provenanceFromInput(input),
     };
   };
 
   const snapshot = (
-    actor: Actor,
+    actor: ActorRef,
     current: DirectiveRecord,
     patch: Partial<Pick<DirectiveRecord, "title" | "body" | "status" | "effective_from" | "expires_at" | "supersedes">> & {
       provenance?: Provenance;
@@ -172,27 +185,47 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
     const now = toUtcIso(deps.clock.now());
     return {
       id: current.id,
-      revision_id: deps.ids.next(),
+      revision_id: deps.ids.next("directive-revision"),
       version: current.version + 1,
       kind: current.kind,
       title: patch.title ?? current.title,
       body: patch.body ?? current.body,
-      scope: sortScope(current.scope),
+      scope: current.scope,
       status: patch.status ?? current.status,
       effective_from: patch.effective_from ?? current.effective_from,
       expires_at: patch.expires_at !== undefined ? patch.expires_at : current.expires_at,
       supersedes: patch.supersedes !== undefined ? patch.supersedes : current.supersedes,
-      created_by: actor.id,
-      created_at: now,
+      created_by: { kind: actor.kind, id: actor.id },
+      created_at: current.created_at,
+      updated_at: now,
       provenance: patch.provenance ?? current.provenance,
     };
+  };
+
+  const closeAsSuperseded = (actor: ActorRef, ids: readonly ResourceId[]): void => {
+    for (const predecessorId of ids) {
+      const current = mustCurrent(predecessorId);
+      if (current.status === "superseded") {
+        throw conflict(`directive ${predecessorId} is already superseded`);
+      }
+      if (terminalStatus(current.status)) {
+        throw conflict(`cannot supersede a ${current.status} directive`);
+      }
+      const closed = snapshot(actor, current, { status: "superseded" });
+      insertCurrent(closed);
+      writeAudit(actor, "directive.supersede", "directive", closed.id, closed.revision_id, {
+        kind: closed.kind,
+        version: closed.version,
+        successor_pending: true,
+      });
+    }
   };
 
   const visibleActive = (scope: Scope): DirectiveRecord[] => {
     const now = deps.clock.now();
     return deps.store
       .listCurrent()
-      .filter((rec) => isActiveAt(rec, now) && scopeVisibleUnderQuery(rec.scope, scope))
+      .filter((rec) => isActiveAt(rec, now) && scopeVisibleUnderQuery(rec.scope, scope, deps.repoDomains))
       .sort(compareDirectives);
   };
 
@@ -200,29 +233,33 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
     if (scope) {
       return parseScope(scope);
     }
-    return parseScope({ company: deps.defaultCompany });
+    return parseScope(deps.defaultScope);
   };
 
   return {
-    createDirective(actor: Actor, raw: unknown): DirectiveRecord {
+    createDirective(actor: ActorRef, raw: unknown): DirectiveRecord {
       assertFounder(actor, founderActorId);
       const input = parseCreateInput(raw, deps.clock);
-      const record = buildFromCreate(actor, input, deps.ids.next(), 1);
+      const predecessors = input.supersedes ?? [];
+      if (predecessors.length > 0) {
+        closeAsSuperseded(actor, predecessors);
+      }
+      const record = buildFromCreate(actor, input, deps.ids.next("directive"), 1);
       insertCurrent(record);
       writeAudit(actor, "directive.create", "directive", record.id, record.revision_id, {
         kind: record.kind,
         version: record.version,
-        scope: `${record.scope.company}/${record.scope.domain ?? ""}/${record.scope.resource ?? ""}`,
+        scope: record.scope,
       });
       return record;
     },
 
-    getDirective(actor: Actor, id: string): DirectiveRecord {
+    getDirective(actor: ActorRef, id: string): DirectiveRecord {
       assertReadable(actor, founderActorId);
       return mustCurrent(parsePathId(id, "id"));
     },
 
-    listRevisions(actor: Actor, id: string): DirectiveRecord[] {
+    listRevisions(actor: ActorRef, id: string): DirectiveRecord[] {
       assertReadable(actor, founderActorId);
       const parsed = parsePathId(id, "id");
       const revs = deps.store.listRevisions(parsed);
@@ -232,22 +269,24 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
       return revs;
     },
 
-    createVersion(actor: Actor, id: string, raw: unknown): DirectiveRecord {
+    createVersion(actor: ActorRef, id: string, raw: unknown): DirectiveRecord {
       assertFounder(actor, founderActorId);
       const current = mustCurrent(parsePathId(id, "id"));
       if (current.status === "superseded") {
         throw conflict("cannot version a superseded directive; create a successor via supersede");
+      }
+      if (current.status === "revoked" || current.status === "expired") {
+        throw conflict(`cannot version a ${current.status} directive`);
       }
       const input = parseVersionInput(raw, deps.clock);
       const provenance: Provenance = {
         source: input.source ?? current.provenance.source,
         observed_at: input.observed_at ?? toUtcIso(deps.clock.now()),
         freshness_status: input.freshness_status ?? current.provenance.freshness_status,
+        confidence: current.provenance.confidence,
       };
       if (input.confidence !== undefined && input.confidence !== null) {
         provenance.confidence = input.confidence;
-      } else if (input.confidence !== null && current.provenance.confidence !== undefined) {
-        provenance.confidence = current.provenance.confidence;
       }
       const patch: Partial<
         Pick<DirectiveRecord, "title" | "body" | "status" | "effective_from" | "expires_at" | "supersedes">
@@ -273,39 +312,31 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
       return next;
     },
 
-    supersede(actor: Actor, id: string, raw: unknown): DirectiveRecord {
+    supersede(actor: ActorRef, id: string, raw: unknown): DirectiveRecord {
       assertFounder(actor, founderActorId);
-      const current = mustCurrent(parsePathId(id, "id"));
-      if (current.status === "superseded") {
-        throw conflict("directive is already superseded");
-      }
+      const currentId = parsePathId(id, "id");
       const input = parseCreateInput(raw, deps.clock);
-      const closed = snapshot(actor, current, { status: "superseded" });
-      insertCurrent(closed);
-      writeAudit(actor, "directive.supersede", "directive", closed.id, closed.revision_id, {
-        kind: closed.kind,
-        version: closed.version,
-        successor_pending: true,
-      });
+      const predecessors = uniqueIds([currentId, ...(input.supersedes ?? [])]);
+      closeAsSuperseded(actor, predecessors);
       const successorInput: CreateDirectiveInput = {
         ...input,
-        supersedes: current.id,
+        supersedes: predecessors,
       };
-      const successor = buildFromCreate(actor, successorInput, deps.ids.next(), 1);
+      const successor = buildFromCreate(actor, successorInput, deps.ids.next("directive"), 1);
       insertCurrent(successor);
       writeAudit(actor, "directive.create", "directive", successor.id, successor.revision_id, {
         kind: successor.kind,
         version: successor.version,
-        supersedes: current.id,
+        supersedes: predecessors.join(","),
       });
       return successor;
     },
 
-    expire(actor: Actor, id: string, raw?: unknown): DirectiveRecord {
+    expire(actor: ActorRef, id: string, raw?: unknown): DirectiveRecord {
       assertFounder(actor, founderActorId);
       const current = mustCurrent(parsePathId(id, "id"));
-      if (current.status === "superseded") {
-        throw conflict("cannot expire a superseded directive");
+      if (terminalStatus(current.status)) {
+        throw conflict(`cannot expire a ${current.status} directive`);
       }
       let expiresAt = toUtcIso(deps.clock.now());
       if (raw !== undefined && raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
@@ -326,11 +357,11 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
       return next;
     },
 
-    activate(actor: Actor, id: string): DirectiveRecord {
+    activate(actor: ActorRef, id: string): DirectiveRecord {
       assertFounder(actor, founderActorId);
       const current = mustCurrent(parsePathId(id, "id"));
       if (terminalStatus(current.status)) {
-        throw conflict("cannot activate a superseded or expired directive");
+        throw conflict("cannot activate a superseded, revoked, or expired directive");
       }
       const next = snapshot(actor, current, { status: "active" });
       insertCurrent(next);
@@ -341,22 +372,22 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
       return next;
     },
 
-    deactivate(actor: Actor, id: string): DirectiveRecord {
+    revoke(actor: ActorRef, id: string): DirectiveRecord {
       assertFounder(actor, founderActorId);
       const current = mustCurrent(parsePathId(id, "id"));
       if (terminalStatus(current.status)) {
-        throw conflict("cannot deactivate a superseded or expired directive");
+        throw conflict("cannot revoke a superseded, revoked, or expired directive");
       }
-      const next = snapshot(actor, current, { status: "inactive" });
+      const next = snapshot(actor, current, { status: "revoked" });
       insertCurrent(next);
-      writeAudit(actor, "directive.deactivate", "directive", next.id, next.revision_id, {
+      writeAudit(actor, "directive.revoke", "directive", next.id, next.revision_id, {
         kind: next.kind,
         version: next.version,
       });
       return next;
     },
 
-    submitProposal(actor: Actor, raw: unknown): ProposalRecord {
+    submitProposal(actor: ActorRef, raw: unknown): DirectiveProposal {
       assertAgent(actor, founderActorId);
       const input = parseProposalInput(raw, deps.clock);
       if (input.target_directive_id) {
@@ -366,31 +397,36 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
         }
         if (isProtectedKind(target.kind) && input.action !== "create") {
           deps.logger.warn("proposal.protected_target", {
-            actor_role: actor.role,
+            actor_kind: actor.kind,
             kind: target.kind,
             action: input.action,
           });
         }
       }
-      if (isProtectedKind(input.kind) && (input.action === "supersede" || input.action === "expire" || input.action === "deactivate" || input.action === "version")) {
-        // Accepted as a suggestion only; never applied here.
+      if (
+        isProtectedKind(input.kind) &&
+        (input.action === "supersede" ||
+          input.action === "expire" ||
+          input.action === "revoke" ||
+          input.action === "version")
+      ) {
         deps.logger.warn("proposal.protected_kind", {
-          actor_role: actor.role,
+          actor_kind: actor.kind,
           kind: input.kind,
           action: input.action,
         });
       }
-      const record: ProposalRecord = {
-        id: deps.ids.next(),
+      const record: DirectiveProposal = {
+        id: deps.ids.next("directive-proposal"),
         status: "pending",
         action: input.action,
         kind: input.kind,
         title: input.title,
         body: input.body,
-        scope: sortScope(input.scope),
+        scope: input.scope,
         target_directive_id: input.target_directive_id ?? null,
         rationale: input.rationale,
-        created_by: actor.id,
+        created_by: { kind: actor.kind, id: actor.id },
         created_at: toUtcIso(deps.clock.now()),
         provenance: provenanceFromInput(input),
       };
@@ -403,22 +439,22 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
       return record;
     },
 
-    listProposals(actor: Actor): ProposalRecord[] {
+    listProposals(actor: ActorRef): DirectiveProposal[] {
       assertReadable(actor, founderActorId);
       const all = deps.store.listProposals();
-      if (actor.role === "agent") {
-        return all.filter((p) => p.created_by === actor.id);
+      if (actor.kind === "agent") {
+        return all.filter((p) => sameActor(p.created_by, actor));
       }
       return all;
     },
 
-    rejectProposal(actor: Actor, id: string): ProposalRecord {
+    rejectProposal(actor: ActorRef, id: string): DirectiveProposal {
       assertFounder(actor, founderActorId);
       const current = deps.store.getProposal(parsePathId(id, "id"));
       if (!current) {
         throw notFound("proposal_not_found", "proposal not found");
       }
-      const next: ProposalRecord = { ...current, status: "rejected" };
+      const next: DirectiveProposal = { ...current, status: "rejected" };
       deps.store.updateProposal(next);
       writeAudit(actor, "proposal.reject", "proposal", next.id, null, {
         kind: next.kind,
@@ -427,13 +463,13 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
       return next;
     },
 
-    getContext(actor: Actor, scope: Scope): ContextPayload {
+    getContext(actor: ActorRef, scope: Scope): ContextPayload {
       assertReadable(actor, founderActorId);
       const query = parseScope(scope);
       const active = visibleActive(query);
       const parts = partitionByKind(active);
       return {
-        scope: sortScope(query),
+        scope: query,
         active_directives: viewsOf(active),
         decisions: viewsOf(parts.decisions),
         facts: viewsOf(parts.facts),
@@ -445,24 +481,24 @@ export function createContextService(deps: ContextServiceDeps): ContextService {
       };
     },
 
-    getActiveDirectives(actor: Actor, scope: Scope): DirectiveView[] {
+    getActiveDirectives(actor: ActorRef, scope: Scope): DirectiveView[] {
       assertReadable(actor, founderActorId);
       return viewsOf(visibleActive(parseScope(scope)));
     },
 
-    getPriorities(actor: Actor, scope?: Scope): DirectiveView[] {
+    getPriorities(actor: ActorRef, scope?: Scope): DirectiveView[] {
       assertReadable(actor, founderActorId);
       const query = resolveScope(scope);
       return viewsOf(visibleActive(query).filter((r) => r.kind === "priority"));
     },
 
-    getDecisions(actor: Actor, scope?: Scope): DirectiveView[] {
+    getDecisions(actor: ActorRef, scope?: Scope): DirectiveView[] {
       assertReadable(actor, founderActorId);
       const query = resolveScope(scope);
       return viewsOf(visibleActive(query).filter((r) => r.kind === "decision"));
     },
 
-    listAudit(actor: Actor): AuditEvent[] {
+    listAudit(actor: ActorRef): AuditEvent[] {
       assertFounder(actor, founderActorId);
       return deps.store.listAudit();
     },

--- a/control-center/services/context/src/store/adapter.ts
+++ b/control-center/services/context/src/store/adapter.ts
@@ -1,14 +1,17 @@
-import type { AuditEvent, DirectiveRecord, ProposalRecord } from "../types.ts";
+import type { AuditEvent, DirectiveProposal, DirectiveRecord } from "../types.ts";
 
 /**
- * Persistence contract expected from control-center/persistence at
- * convergence. This workstream ships a fixture implementation only.
+ * Persistence port expected from control-center/persistence at convergence.
+ * This workstream ships an in-memory fixture implementation only.
  *
  * All methods are synchronous on the fixture store so policy tests can
  * run without I/O. A PostgreSQL adapter MUST provide the same semantics
  * and MUST write the audit event in the same commit as the mutation.
+ *
+ * `src/store/expected-schema.sql` is a test-only contract snapshot of
+ * these records. The service MUST NOT load or apply that file.
  */
-export interface PersistenceAdapter {
+export interface PersistencePort {
   insertRevision(record: DirectiveRecord): void;
   getRevision(revisionId: string): DirectiveRecord | undefined;
   getCurrent(id: string): DirectiveRecord | undefined;
@@ -17,10 +20,13 @@ export interface PersistenceAdapter {
   setCurrent(id: string, revisionId: string): void;
   appendAudit(event: AuditEvent): void;
   listAudit(): AuditEvent[];
-  insertProposal(record: ProposalRecord): void;
-  getProposal(id: string): ProposalRecord | undefined;
-  listProposals(): ProposalRecord[];
-  updateProposal(record: ProposalRecord): void;
+  insertProposal(record: DirectiveProposal): void;
+  getProposal(id: string): DirectiveProposal | undefined;
+  listProposals(): DirectiveProposal[];
+  updateProposal(record: DirectiveProposal): void;
 }
+
+/** @deprecated Use PersistencePort. */
+export type PersistenceAdapter = PersistencePort;
 
 export const ADAPTER_CONTRACT_VERSION = "control-center.context.persistence.v1";

--- a/control-center/services/context/src/store/adapter.ts
+++ b/control-center/services/context/src/store/adapter.ts
@@ -1,0 +1,26 @@
+import type { AuditEvent, DirectiveRecord, ProposalRecord } from "../types.ts";
+
+/**
+ * Persistence contract expected from control-center/persistence at
+ * convergence. This workstream ships a fixture implementation only.
+ *
+ * All methods are synchronous on the fixture store so policy tests can
+ * run without I/O. A PostgreSQL adapter MUST provide the same semantics
+ * and MUST write the audit event in the same commit as the mutation.
+ */
+export interface PersistenceAdapter {
+  insertRevision(record: DirectiveRecord): void;
+  getRevision(revisionId: string): DirectiveRecord | undefined;
+  getCurrent(id: string): DirectiveRecord | undefined;
+  listCurrent(): DirectiveRecord[];
+  listRevisions(id: string): DirectiveRecord[];
+  setCurrent(id: string, revisionId: string): void;
+  appendAudit(event: AuditEvent): void;
+  listAudit(): AuditEvent[];
+  insertProposal(record: ProposalRecord): void;
+  getProposal(id: string): ProposalRecord | undefined;
+  listProposals(): ProposalRecord[];
+  updateProposal(record: ProposalRecord): void;
+}
+
+export const ADAPTER_CONTRACT_VERSION = "control-center.context.persistence.v1";

--- a/control-center/services/context/src/store/expected-schema.sql
+++ b/control-center/services/context/src/store/expected-schema.sql
@@ -1,0 +1,68 @@
+-- Expected PostgreSQL surface for control-center/persistence (convergence).
+-- This file is a contract, not a live migration. Do not apply it from this
+-- workstream. Timestamps are timestamptz (UTC). Money is not stored here.
+
+CREATE TABLE IF NOT EXISTS cc_directive_revisions (
+  revision_id TEXT PRIMARY KEY,
+  id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN (
+    'decision', 'directive', 'fact', 'constraint', 'priority', 'risk', 'hypothesis'
+  )),
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  scope_company TEXT NOT NULL,
+  scope_domain TEXT,
+  scope_resource TEXT,
+  status TEXT NOT NULL CHECK (status IN ('active', 'inactive', 'expired', 'superseded')),
+  effective_from TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ,
+  supersedes TEXT,
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  source TEXT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL,
+  freshness_status TEXT NOT NULL CHECK (freshness_status IN ('fresh', 'stale', 'unknown')),
+  confidence DOUBLE PRECISION,
+  UNIQUE (id, version)
+);
+
+CREATE TABLE IF NOT EXISTS cc_directive_current (
+  id TEXT PRIMARY KEY REFERENCES cc_directive_revisions (id),
+  revision_id TEXT NOT NULL REFERENCES cc_directive_revisions (revision_id)
+);
+
+CREATE TABLE IF NOT EXISTS cc_audit_events (
+  id TEXT PRIMARY KEY,
+  at TIMESTAMPTZ NOT NULL,
+  actor_id TEXT NOT NULL,
+  actor_role TEXT NOT NULL CHECK (actor_role IN ('founder', 'agent')),
+  action TEXT NOT NULL,
+  entity_type TEXT NOT NULL CHECK (entity_type IN ('directive', 'proposal')),
+  entity_id TEXT NOT NULL,
+  revision_id TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS cc_proposals (
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'rejected')),
+  action TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  scope_company TEXT NOT NULL,
+  scope_domain TEXT,
+  scope_resource TEXT,
+  target_directive_id TEXT,
+  rationale TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  source TEXT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL,
+  freshness_status TEXT NOT NULL,
+  confidence DOUBLE PRECISION
+);
+
+-- Persistence MUST insert the audit row in the same transaction as the
+-- directive/proposal mutation.

--- a/control-center/services/context/src/store/expected-schema.sql
+++ b/control-center/services/context/src/store/expected-schema.sql
@@ -1,6 +1,7 @@
--- Expected PostgreSQL surface for control-center/persistence (convergence).
--- This file is a contract, not a live migration. Do not apply it from this
--- workstream. Timestamps are timestamptz (UTC). Money is not stored here.
+-- TEST CONTRACT ONLY of PersistencePort records.
+-- This file is a snapshot for tests. The service MUST NOT load, parse, or
+-- apply it at runtime. Do not treat it as a second authority or a live
+-- migration. Timestamps are timestamptz (UTC). Money is not stored here.
 
 CREATE TABLE IF NOT EXISTS cc_directive_revisions (
   revision_id TEXT PRIMARY KEY,
@@ -11,32 +12,35 @@ CREATE TABLE IF NOT EXISTS cc_directive_revisions (
   )),
   title TEXT NOT NULL,
   body TEXT NOT NULL,
-  scope_company TEXT NOT NULL,
-  scope_domain TEXT,
-  scope_resource TEXT,
-  status TEXT NOT NULL CHECK (status IN ('active', 'inactive', 'expired', 'superseded')),
+  scope TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('draft', 'active', 'superseded', 'revoked', 'expired')),
   effective_from TIMESTAMPTZ NOT NULL,
   expires_at TIMESTAMPTZ,
-  supersedes TEXT,
-  created_by TEXT NOT NULL,
+  supersedes TEXT[],
+  created_by_kind TEXT NOT NULL CHECK (created_by_kind IN ('human', 'agent', 'system')),
+  created_by_id TEXT NOT NULL,
   created_at TIMESTAMPTZ NOT NULL,
-  source TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  source_system TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  source_locator TEXT NOT NULL,
+  source_label TEXT,
   observed_at TIMESTAMPTZ NOT NULL,
-  freshness_status TEXT NOT NULL CHECK (freshness_status IN ('fresh', 'stale', 'unknown')),
-  confidence DOUBLE PRECISION,
+  freshness_status TEXT NOT NULL CHECK (freshness_status IN ('FRESH', 'STALE', 'UNKNOWN', 'ERROR')),
+  confidence DOUBLE PRECISION NOT NULL,
   UNIQUE (id, version)
 );
 
 CREATE TABLE IF NOT EXISTS cc_directive_current (
-  id TEXT PRIMARY KEY REFERENCES cc_directive_revisions (id),
+  id TEXT PRIMARY KEY,
   revision_id TEXT NOT NULL REFERENCES cc_directive_revisions (revision_id)
 );
 
 CREATE TABLE IF NOT EXISTS cc_audit_events (
   id TEXT PRIMARY KEY,
   at TIMESTAMPTZ NOT NULL,
+  actor_kind TEXT NOT NULL CHECK (actor_kind IN ('human', 'agent', 'system')),
   actor_id TEXT NOT NULL,
-  actor_role TEXT NOT NULL CHECK (actor_role IN ('founder', 'agent')),
   action TEXT NOT NULL,
   entity_type TEXT NOT NULL CHECK (entity_type IN ('directive', 'proposal')),
   entity_id TEXT NOT NULL,
@@ -51,17 +55,18 @@ CREATE TABLE IF NOT EXISTS cc_proposals (
   kind TEXT NOT NULL,
   title TEXT NOT NULL,
   body TEXT NOT NULL,
-  scope_company TEXT NOT NULL,
-  scope_domain TEXT,
-  scope_resource TEXT,
+  scope TEXT NOT NULL,
   target_directive_id TEXT,
   rationale TEXT NOT NULL,
-  created_by TEXT NOT NULL,
+  created_by_kind TEXT NOT NULL CHECK (created_by_kind IN ('human', 'agent', 'system')),
+  created_by_id TEXT NOT NULL,
   created_at TIMESTAMPTZ NOT NULL,
-  source TEXT NOT NULL,
+  source_system TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  source_locator TEXT NOT NULL,
   observed_at TIMESTAMPTZ NOT NULL,
-  freshness_status TEXT NOT NULL,
-  confidence DOUBLE PRECISION
+  freshness_status TEXT NOT NULL CHECK (freshness_status IN ('FRESH', 'STALE', 'UNKNOWN', 'ERROR')),
+  confidence DOUBLE PRECISION NOT NULL
 );
 
 -- Persistence MUST insert the audit row in the same transaction as the

--- a/control-center/services/context/src/store/fixture.ts
+++ b/control-center/services/context/src/store/fixture.ts
@@ -1,31 +1,45 @@
-import type { AuditEvent, DirectiveRecord, ProposalRecord } from "../types.ts";
-import type { PersistenceAdapter } from "./adapter.ts";
+import type { AuditEvent, DirectiveProposal, DirectiveRecord, Provenance } from "../types.ts";
+import type { PersistencePort } from "./adapter.ts";
+
+function cloneProvenance(provenance: Provenance): Provenance {
+  const cloned: Provenance = {
+    source: { ...provenance.source },
+    observed_at: provenance.observed_at,
+    freshness_status: provenance.freshness_status,
+    confidence: provenance.confidence,
+  };
+  if (provenance.freshness_window_seconds !== undefined) {
+    cloned.freshness_window_seconds = provenance.freshness_window_seconds;
+  }
+  return cloned;
+}
 
 function cloneDirective(record: DirectiveRecord): DirectiveRecord {
   return {
     ...record,
-    scope: { ...record.scope },
-    provenance: { ...record.provenance },
+    supersedes: record.supersedes ? [...record.supersedes] : null,
+    created_by: { ...record.created_by },
+    provenance: cloneProvenance(record.provenance),
   };
 }
 
 function cloneAudit(event: AuditEvent): AuditEvent {
-  return { ...event, metadata: { ...event.metadata } };
+  return { ...event, actor: { ...event.actor }, metadata: { ...event.metadata } };
 }
 
-function cloneProposal(record: ProposalRecord): ProposalRecord {
+function cloneProposal(record: DirectiveProposal): DirectiveProposal {
   return {
     ...record,
-    scope: { ...record.scope },
-    provenance: { ...record.provenance },
+    created_by: { ...record.created_by },
+    provenance: cloneProvenance(record.provenance),
   };
 }
 
-export function createFixtureStore(): PersistenceAdapter {
+export function createFixtureStore(): PersistencePort {
   const revisions = new Map<string, DirectiveRecord>();
   const current = new Map<string, string>();
   const audits: AuditEvent[] = [];
-  const proposals = new Map<string, ProposalRecord>();
+  const proposals = new Map<string, DirectiveProposal>();
 
   return {
     insertRevision(record: DirectiveRecord): void {
@@ -78,20 +92,20 @@ export function createFixtureStore(): PersistenceAdapter {
     listAudit(): AuditEvent[] {
       return audits.map(cloneAudit);
     },
-    insertProposal(record: ProposalRecord): void {
+    insertProposal(record: DirectiveProposal): void {
       if (proposals.has(record.id)) {
         throw new Error(`duplicate proposal id ${record.id}`);
       }
       proposals.set(record.id, cloneProposal(record));
     },
-    getProposal(id: string): ProposalRecord | undefined {
+    getProposal(id: string): DirectiveProposal | undefined {
       const found = proposals.get(id);
       return found ? cloneProposal(found) : undefined;
     },
-    listProposals(): ProposalRecord[] {
+    listProposals(): DirectiveProposal[] {
       return [...proposals.values()].map(cloneProposal);
     },
-    updateProposal(record: ProposalRecord): void {
+    updateProposal(record: DirectiveProposal): void {
       if (!proposals.has(record.id)) {
         throw new Error(`unknown proposal ${record.id}`);
       }

--- a/control-center/services/context/src/store/fixture.ts
+++ b/control-center/services/context/src/store/fixture.ts
@@ -1,0 +1,101 @@
+import type { AuditEvent, DirectiveRecord, ProposalRecord } from "../types.ts";
+import type { PersistenceAdapter } from "./adapter.ts";
+
+function cloneDirective(record: DirectiveRecord): DirectiveRecord {
+  return {
+    ...record,
+    scope: { ...record.scope },
+    provenance: { ...record.provenance },
+  };
+}
+
+function cloneAudit(event: AuditEvent): AuditEvent {
+  return { ...event, metadata: { ...event.metadata } };
+}
+
+function cloneProposal(record: ProposalRecord): ProposalRecord {
+  return {
+    ...record,
+    scope: { ...record.scope },
+    provenance: { ...record.provenance },
+  };
+}
+
+export function createFixtureStore(): PersistenceAdapter {
+  const revisions = new Map<string, DirectiveRecord>();
+  const current = new Map<string, string>();
+  const audits: AuditEvent[] = [];
+  const proposals = new Map<string, ProposalRecord>();
+
+  return {
+    insertRevision(record: DirectiveRecord): void {
+      if (revisions.has(record.revision_id)) {
+        throw new Error(`duplicate revision_id ${record.revision_id}`);
+      }
+      revisions.set(record.revision_id, cloneDirective(record));
+    },
+    getRevision(revisionId: string): DirectiveRecord | undefined {
+      const found = revisions.get(revisionId);
+      return found ? cloneDirective(found) : undefined;
+    },
+    getCurrent(id: string): DirectiveRecord | undefined {
+      const revisionId = current.get(id);
+      if (!revisionId) {
+        return undefined;
+      }
+      const found = revisions.get(revisionId);
+      return found ? cloneDirective(found) : undefined;
+    },
+    listCurrent(): DirectiveRecord[] {
+      const out: DirectiveRecord[] = [];
+      for (const revisionId of current.values()) {
+        const found = revisions.get(revisionId);
+        if (found) {
+          out.push(cloneDirective(found));
+        }
+      }
+      return out;
+    },
+    listRevisions(id: string): DirectiveRecord[] {
+      const out: DirectiveRecord[] = [];
+      for (const rec of revisions.values()) {
+        if (rec.id === id) {
+          out.push(cloneDirective(rec));
+        }
+      }
+      out.sort((a, b) => a.version - b.version);
+      return out;
+    },
+    setCurrent(id: string, revisionId: string): void {
+      if (!revisions.has(revisionId)) {
+        throw new Error(`unknown revision_id ${revisionId}`);
+      }
+      current.set(id, revisionId);
+    },
+    appendAudit(event: AuditEvent): void {
+      audits.push(cloneAudit(event));
+    },
+    listAudit(): AuditEvent[] {
+      return audits.map(cloneAudit);
+    },
+    insertProposal(record: ProposalRecord): void {
+      if (proposals.has(record.id)) {
+        throw new Error(`duplicate proposal id ${record.id}`);
+      }
+      proposals.set(record.id, cloneProposal(record));
+    },
+    getProposal(id: string): ProposalRecord | undefined {
+      const found = proposals.get(id);
+      return found ? cloneProposal(found) : undefined;
+    },
+    listProposals(): ProposalRecord[] {
+      return [...proposals.values()].map(cloneProposal);
+    },
+    updateProposal(record: ProposalRecord): void {
+      if (!proposals.has(record.id)) {
+        throw new Error(`unknown proposal ${record.id}`);
+      }
+      proposals.set(record.id, cloneProposal(record));
+    },
+  };
+}

--- a/control-center/services/context/src/store/from-env.ts
+++ b/control-center/services/context/src/store/from-env.ts
@@ -1,13 +1,13 @@
 import { ServiceError } from "../errors.ts";
 import { createFixtureStore } from "./fixture.ts";
-import type { PersistenceAdapter } from "./adapter.ts";
+import type { PersistencePort } from "./adapter.ts";
 
 /**
  * DATABASE_URL, if present, means the operator expects PostgreSQL.
  * This workstream does not own that database. Fail closed rather than
  * silently serving the in-memory fixture.
  */
-export function createStoreFromEnv(env: NodeJS.ProcessEnv): PersistenceAdapter {
+export function createStoreFromEnv(env: NodeJS.ProcessEnv): PersistencePort {
   if (env.DATABASE_URL && env.DATABASE_URL.trim() !== "") {
     throw new ServiceError(
       "store_misconfigured",

--- a/control-center/services/context/src/store/from-env.ts
+++ b/control-center/services/context/src/store/from-env.ts
@@ -1,0 +1,19 @@
+import { ServiceError } from "../errors.ts";
+import { createFixtureStore } from "./fixture.ts";
+import type { PersistenceAdapter } from "./adapter.ts";
+
+/**
+ * DATABASE_URL, if present, means the operator expects PostgreSQL.
+ * This workstream does not own that database. Fail closed rather than
+ * silently serving the in-memory fixture.
+ */
+export function createStoreFromEnv(env: NodeJS.ProcessEnv): PersistenceAdapter {
+  if (env.DATABASE_URL && env.DATABASE_URL.trim() !== "") {
+    throw new ServiceError(
+      "store_misconfigured",
+      "DATABASE_URL is set; wire control-center/persistence at convergence. Refusing fixture fallback.",
+      500,
+    );
+  }
+  return createFixtureStore();
+}

--- a/control-center/services/context/src/taxonomy.ts
+++ b/control-center/services/context/src/taxonomy.ts
@@ -1,0 +1,77 @@
+/**
+ * Canonical Control Center taxonomies, duplicated in lockstep with
+ * control-center/contracts (cc/01). This package must not import that
+ * worktree; exclusive path is this service.
+ */
+
+export const UTC_DATETIME_PATTERN =
+  "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$";
+
+export const RESOURCE_ID_PATTERN = "^cc:[a-z][a-z0-9-]*:[A-Za-z0-9._~-]+$";
+
+export const CLIENT_SLUG_PATTERN = "^[a-z0-9]+(?:-[a-z0-9]+)*$";
+
+export const REPO_NAME_PATTERN = "^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$";
+
+export const SCOPE_LITERALS = [
+  "company",
+  "commercial",
+  "finance",
+  "clients",
+  "infrastructure",
+  "inbound",
+] as const;
+
+export type ScopeLiteral = (typeof SCOPE_LITERALS)[number];
+
+export const DOMAIN_LITERALS = [
+  "commercial",
+  "finance",
+  "clients",
+  "infrastructure",
+  "inbound",
+] as const;
+
+export type DomainLiteral = (typeof DOMAIN_LITERALS)[number];
+
+export const SCOPE_CORE =
+  "(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)";
+
+export const SCOPE_PATTERN = `^${SCOPE_CORE}$`;
+
+export const FRESHNESS_STATUSES = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const CONFIDENCE_MIN = 0;
+export const CONFIDENCE_MAX = 1;
+
+export const DIRECTIVE_KINDS = [
+  "decision",
+  "directive",
+  "fact",
+  "constraint",
+  "priority",
+  "risk",
+  "hypothesis",
+] as const;
+export type DirectiveKind = (typeof DIRECTIVE_KINDS)[number];
+
+export const DIRECTIVE_STATUSES = [
+  "draft",
+  "active",
+  "superseded",
+  "revoked",
+  "expired",
+] as const;
+export type DirectiveStatus = (typeof DIRECTIVE_STATUSES)[number];
+
+export const ACTOR_KINDS = ["human", "agent", "system"] as const;
+export type ActorKind = (typeof ACTOR_KINDS)[number];
+
+export const SOURCE_SYSTEM_PATTERN = "^[a-z][a-z0-9-]*$";
+export const SOURCE_KIND_PATTERN = "^[a-z][a-z0-9._-]*$";
+export const ACTOR_ID_PATTERN = "^[A-Za-z0-9._:-]+$";
+export const ID_TYPE_PATTERN = "^[a-z][a-z0-9-]*$";
+
+export const CREATE_STATUSES = ["draft", "active"] as const;
+export type CreateStatus = (typeof CREATE_STATUSES)[number];

--- a/control-center/services/context/src/types.ts
+++ b/control-center/services/context/src/types.ts
@@ -1,0 +1,186 @@
+export const DIRECTIVE_KINDS = [
+  "decision",
+  "directive",
+  "fact",
+  "constraint",
+  "priority",
+  "risk",
+  "hypothesis",
+] as const;
+
+export type DirectiveKind = (typeof DIRECTIVE_KINDS)[number];
+
+export const PROTECTED_KINDS = ["constraint", "decision"] as const;
+export type ProtectedKind = (typeof PROTECTED_KINDS)[number];
+
+export const DIRECTIVE_STATUSES = [
+  "active",
+  "inactive",
+  "expired",
+  "superseded",
+] as const;
+
+export type DirectiveStatus = (typeof DIRECTIVE_STATUSES)[number];
+
+export const FRESHNESS_STATUSES = ["fresh", "stale", "unknown"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const ACTOR_ROLES = ["founder", "agent"] as const;
+export type ActorRole = (typeof ACTOR_ROLES)[number];
+
+export const PROPOSAL_ACTIONS = [
+  "create",
+  "version",
+  "supersede",
+  "expire",
+  "activate",
+  "deactivate",
+] as const;
+export type ProposalAction = (typeof PROPOSAL_ACTIONS)[number];
+
+export const PROPOSAL_STATUSES = ["pending", "rejected"] as const;
+export type ProposalStatus = (typeof PROPOSAL_STATUSES)[number];
+
+export interface Scope {
+  company: string;
+  domain?: string;
+  resource?: string;
+}
+
+export interface Actor {
+  id: string;
+  role: ActorRole;
+}
+
+export interface Provenance {
+  source: string;
+  observed_at: string;
+  freshness_status: FreshnessStatus;
+  confidence?: number;
+}
+
+export interface DirectiveRecord {
+  id: string;
+  revision_id: string;
+  version: number;
+  kind: DirectiveKind;
+  title: string;
+  body: string;
+  scope: Scope;
+  status: DirectiveStatus;
+  effective_from: string;
+  expires_at: string | null;
+  supersedes: string | null;
+  created_by: string;
+  created_at: string;
+  provenance: Provenance;
+}
+
+export interface DirectiveView {
+  id: string;
+  revision_id: string;
+  version: number;
+  kind: DirectiveKind;
+  title: string;
+  body: string;
+  scope: Scope;
+  status: DirectiveStatus;
+  effective_from: string;
+  expires_at: string | null;
+  supersedes: string | null;
+  created_by: string;
+  source: string;
+  observed_at: string;
+  freshness_status: FreshnessStatus;
+  confidence?: number;
+}
+
+export interface ContextPayload {
+  scope: Scope;
+  active_directives: DirectiveView[];
+  decisions: DirectiveView[];
+  facts: DirectiveView[];
+  constraints: DirectiveView[];
+  priorities: DirectiveView[];
+  risks: DirectiveView[];
+  directives: DirectiveView[];
+  hypotheses: DirectiveView[];
+}
+
+export interface AuditEvent {
+  id: string;
+  at: string;
+  actor_id: string;
+  actor_role: ActorRole;
+  action: string;
+  entity_type: "directive" | "proposal";
+  entity_id: string;
+  revision_id: string | null;
+  metadata: Record<string, string | number | boolean | null>;
+}
+
+export interface ProposalRecord {
+  id: string;
+  status: ProposalStatus;
+  action: ProposalAction;
+  kind: DirectiveKind;
+  title: string;
+  body: string;
+  scope: Scope;
+  target_directive_id: string | null;
+  rationale: string;
+  created_by: string;
+  created_at: string;
+  provenance: Provenance;
+}
+
+export interface CreateDirectiveInput {
+  kind: DirectiveKind;
+  title: string;
+  body: string;
+  scope: Scope;
+  status?: "active" | "inactive";
+  effective_from?: string;
+  expires_at?: string | null;
+  supersedes?: string | null;
+  source: string;
+  observed_at?: string;
+  freshness_status?: FreshnessStatus;
+  confidence?: number;
+}
+
+export interface VersionDirectiveInput {
+  title?: string;
+  body?: string;
+  effective_from?: string;
+  expires_at?: string | null;
+  source?: string;
+  observed_at?: string;
+  freshness_status?: FreshnessStatus;
+  confidence?: number | null;
+}
+
+export interface SubmitProposalInput {
+  action: ProposalAction;
+  kind: DirectiveKind;
+  title: string;
+  body: string;
+  scope: Scope;
+  target_directive_id?: string | null;
+  rationale: string;
+  source: string;
+  observed_at?: string;
+  freshness_status?: FreshnessStatus;
+  confidence?: number;
+}
+
+export const LIMITS = {
+  jsonBytes: 32 * 1024,
+  titleChars: 200,
+  bodyChars: 8000,
+  sourceChars: 128,
+  scopePartChars: 64,
+  actorIdChars: 128,
+  rationaleChars: 4000,
+  companyChars: 64,
+} as const;

--- a/control-center/services/context/src/types.ts
+++ b/control-center/services/context/src/types.ts
@@ -1,32 +1,33 @@
-export const DIRECTIVE_KINDS = [
-  "decision",
-  "directive",
-  "fact",
-  "constraint",
-  "priority",
-  "risk",
-  "hypothesis",
-] as const;
+import type {
+  ActorKind,
+  CreateStatus,
+  DirectiveKind,
+  DirectiveStatus,
+  FreshnessStatus,
+} from "./taxonomy.ts";
 
-export type DirectiveKind = (typeof DIRECTIVE_KINDS)[number];
+export type {
+  ActorKind,
+  CreateStatus,
+  DirectiveKind,
+  DirectiveStatus,
+  DomainLiteral,
+  FreshnessStatus,
+  ScopeLiteral,
+} from "./taxonomy.ts";
+
+export {
+  ACTOR_KINDS,
+  CREATE_STATUSES,
+  DIRECTIVE_KINDS,
+  DIRECTIVE_STATUSES,
+  DOMAIN_LITERALS,
+  FRESHNESS_STATUSES,
+  SCOPE_LITERALS,
+} from "./taxonomy.ts";
 
 export const PROTECTED_KINDS = ["constraint", "decision"] as const;
 export type ProtectedKind = (typeof PROTECTED_KINDS)[number];
-
-export const DIRECTIVE_STATUSES = [
-  "active",
-  "inactive",
-  "expired",
-  "superseded",
-] as const;
-
-export type DirectiveStatus = (typeof DIRECTIVE_STATUSES)[number];
-
-export const FRESHNESS_STATUSES = ["fresh", "stale", "unknown"] as const;
-export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
-
-export const ACTOR_ROLES = ["founder", "agent"] as const;
-export type ActorRole = (typeof ACTOR_ROLES)[number];
 
 export const PROPOSAL_ACTIONS = [
   "create",
@@ -34,34 +35,45 @@ export const PROPOSAL_ACTIONS = [
   "supersede",
   "expire",
   "activate",
-  "deactivate",
+  "revoke",
 ] as const;
 export type ProposalAction = (typeof PROPOSAL_ACTIONS)[number];
 
 export const PROPOSAL_STATUSES = ["pending", "rejected"] as const;
 export type ProposalStatus = (typeof PROPOSAL_STATUSES)[number];
 
-export interface Scope {
-  company: string;
-  domain?: string;
-  resource?: string;
+/** v1 scope: literal, `repo:<name>`, `client:<slug>`, or future prefix:id. */
+export type Scope = string;
+
+export type ResourceId = string;
+
+export interface SourceRef {
+  system: string;
+  kind: string;
+  locator: string;
+  label?: string;
 }
 
-export interface Actor {
+export interface ActorRef {
+  kind: ActorKind;
   id: string;
-  role: ActorRole;
+  display_name?: string;
 }
+
+/** @deprecated Use ActorRef. Alias so existing call sites compile during this PR. */
+export type Actor = ActorRef;
 
 export interface Provenance {
-  source: string;
+  source: SourceRef;
   observed_at: string;
   freshness_status: FreshnessStatus;
-  confidence?: number;
+  confidence: number;
+  freshness_window_seconds?: number;
 }
 
 export interface DirectiveRecord {
-  id: string;
-  revision_id: string;
+  id: ResourceId;
+  revision_id: ResourceId;
   version: number;
   kind: DirectiveKind;
   title: string;
@@ -70,15 +82,16 @@ export interface DirectiveRecord {
   status: DirectiveStatus;
   effective_from: string;
   expires_at: string | null;
-  supersedes: string | null;
-  created_by: string;
+  supersedes: ResourceId[] | null;
+  created_by: ActorRef;
   created_at: string;
+  updated_at: string;
   provenance: Provenance;
 }
 
 export interface DirectiveView {
-  id: string;
-  revision_id: string;
+  id: ResourceId;
+  revision_id: ResourceId;
   version: number;
   kind: DirectiveKind;
   title: string;
@@ -87,12 +100,12 @@ export interface DirectiveView {
   status: DirectiveStatus;
   effective_from: string;
   expires_at: string | null;
-  supersedes: string | null;
-  created_by: string;
-  source: string;
+  supersedes: ResourceId[] | null;
+  created_by: ActorRef;
+  source: SourceRef;
   observed_at: string;
   freshness_status: FreshnessStatus;
-  confidence?: number;
+  confidence: number;
 }
 
 export interface ContextPayload {
@@ -108,45 +121,46 @@ export interface ContextPayload {
 }
 
 export interface AuditEvent {
-  id: string;
+  id: ResourceId;
   at: string;
-  actor_id: string;
-  actor_role: ActorRole;
+  actor: ActorRef;
   action: string;
   entity_type: "directive" | "proposal";
-  entity_id: string;
-  revision_id: string | null;
+  entity_id: ResourceId;
+  revision_id: ResourceId | null;
   metadata: Record<string, string | number | boolean | null>;
 }
 
-export interface ProposalRecord {
-  id: string;
+export interface DirectiveProposal {
+  id: ResourceId;
   status: ProposalStatus;
   action: ProposalAction;
   kind: DirectiveKind;
   title: string;
   body: string;
   scope: Scope;
-  target_directive_id: string | null;
+  target_directive_id: ResourceId | null;
   rationale: string;
-  created_by: string;
+  created_by: ActorRef;
   created_at: string;
   provenance: Provenance;
 }
+
+export type ProposalRecord = DirectiveProposal;
 
 export interface CreateDirectiveInput {
   kind: DirectiveKind;
   title: string;
   body: string;
   scope: Scope;
-  status?: "active" | "inactive";
+  status?: CreateStatus;
   effective_from?: string;
   expires_at?: string | null;
-  supersedes?: string | null;
-  source: string;
+  supersedes?: ResourceId[] | null;
+  source: SourceRef;
   observed_at?: string;
   freshness_status?: FreshnessStatus;
-  confidence?: number;
+  confidence: number;
 }
 
 export interface VersionDirectiveInput {
@@ -154,7 +168,7 @@ export interface VersionDirectiveInput {
   body?: string;
   effective_from?: string;
   expires_at?: string | null;
-  source?: string;
+  source?: SourceRef;
   observed_at?: string;
   freshness_status?: FreshnessStatus;
   confidence?: number | null;
@@ -166,21 +180,25 @@ export interface SubmitProposalInput {
   title: string;
   body: string;
   scope: Scope;
-  target_directive_id?: string | null;
+  target_directive_id?: ResourceId | null;
   rationale: string;
-  source: string;
+  source: SourceRef;
   observed_at?: string;
   freshness_status?: FreshnessStatus;
-  confidence?: number;
+  confidence: number;
 }
 
 export const LIMITS = {
   jsonBytes: 32 * 1024,
   titleChars: 200,
   bodyChars: 8000,
-  sourceChars: 128,
-  scopePartChars: 64,
+  sourceSystemChars: 64,
+  sourceKindChars: 64,
+  sourceLocatorChars: 512,
+  sourceLabelChars: 128,
+  scopeChars: 128,
   actorIdChars: 128,
   rationaleChars: 4000,
-  companyChars: 64,
+  resourceIdChars: 128,
+  supersedesMax: 32,
 } as const;

--- a/control-center/services/context/src/validate.ts
+++ b/control-center/services/context/src/validate.ts
@@ -1,16 +1,25 @@
 import { parseUtcIso, toUtcIso, type Clock } from "./clock.ts";
 import { invalid } from "./errors.ts";
+import { assertResourceId } from "./ids.ts";
 import { rejectUnknownKeys, sanitizeLine, sanitizeMultiline } from "./sanitize.ts";
 import { parseScope } from "./scope.ts";
 import {
+  SOURCE_KIND_PATTERN,
+  SOURCE_SYSTEM_PATTERN,
+} from "./taxonomy.ts";
+import {
+  CREATE_STATUSES,
   DIRECTIVE_KINDS,
   FRESHNESS_STATUSES,
   LIMITS,
   PROPOSAL_ACTIONS,
   type CreateDirectiveInput,
+  type CreateStatus,
   type DirectiveKind,
   type FreshnessStatus,
   type Provenance,
+  type ResourceId,
+  type SourceRef,
   type SubmitProposalInput,
   type VersionDirectiveInput,
 } from "./types.ts";
@@ -55,6 +64,12 @@ const PROPOSAL_KEYS = [
   "confidence",
 ] as const;
 
+const SOURCE_KEYS = ["system", "kind", "locator", "label"] as const;
+const SOURCE_SYSTEM_RE = new RegExp(SOURCE_SYSTEM_PATTERN);
+const SOURCE_KIND_RE = new RegExp(SOURCE_KIND_PATTERN);
+
+const FRESHNESS_WINDOW_MS = 24 * 60 * 60 * 1000;
+
 export function parseKind(value: unknown): DirectiveKind {
   if (typeof value !== "string" || !(DIRECTIVE_KINDS as readonly string[]).includes(value)) {
     throw invalid(`kind must be one of: ${DIRECTIVE_KINDS.join(", ")}`);
@@ -62,7 +77,7 @@ export function parseKind(value: unknown): DirectiveKind {
   return value as DirectiveKind;
 }
 
-function parseFreshness(value: unknown): FreshnessStatus {
+export function parseFreshness(value: unknown): FreshnessStatus {
   if (typeof value !== "string" || !(FRESHNESS_STATUSES as readonly string[]).includes(value)) {
     throw invalid(`freshness_status must be one of: ${FRESHNESS_STATUSES.join(", ")}`);
   }
@@ -87,31 +102,78 @@ function parseOptionalUtc(value: unknown, field: string): string | undefined {
   return toUtcIso(new Date(value));
 }
 
+/**
+ * Age-based classification for omitted freshness. Never returns UNKNOWN or
+ * ERROR: those statuses are explicit. Future observed_at is invalid, not
+ * coerced to UNKNOWN. ERROR is never produced or rewritten here.
+ */
 function computeFreshness(observedAt: string, now: Date): FreshnessStatus {
   const observed = parseUtcIso(observedAt, "observed_at");
   const ageMs = now.getTime() - observed.getTime();
   if (ageMs < 0) {
-    return "unknown";
+    throw invalid("observed_at must not be in the future");
   }
-  const day = 24 * 60 * 60 * 1000;
-  return ageMs <= day ? "fresh" : "stale";
+  return ageMs <= FRESHNESS_WINDOW_MS ? "FRESH" : "STALE";
 }
 
-export function parseProvenance(
-  raw: Record<string, unknown>,
-  clock: Clock,
-): Provenance {
-  const source = sanitizeLine(raw.source, "source", LIMITS.sourceChars);
+export function parseSourceRef(raw: unknown, field = "source"): SourceRef {
+  if (typeof raw === "string") {
+    throw invalid(`${field} must be a SourceRef object; a bare string is not accepted`);
+  }
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid(`${field} must be a SourceRef object`);
+  }
+  const obj = raw as Record<string, unknown>;
+  rejectUnknownKeys(obj, SOURCE_KEYS, field);
+  const system = sanitizeLine(obj.system, `${field}.system`, LIMITS.sourceSystemChars);
+  if (!SOURCE_SYSTEM_RE.test(system)) {
+    throw invalid(`${field}.system must be a lowercase kebab source system`);
+  }
+  const kind = sanitizeLine(obj.kind, `${field}.kind`, LIMITS.sourceKindChars);
+  if (!SOURCE_KIND_RE.test(kind)) {
+    throw invalid(`${field}.kind must be a lowercase source kind`);
+  }
+  const locator = sanitizeLine(obj.locator, `${field}.locator`, LIMITS.sourceLocatorChars);
+  const ref: SourceRef = { system, kind, locator };
+  if (obj.label !== undefined) {
+    ref.label = sanitizeLine(obj.label, `${field}.label`, LIMITS.sourceLabelChars);
+  }
+  return ref;
+}
+
+export function parseSupersedes(raw: unknown): ResourceId[] | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  if (typeof raw === "string") {
+    throw invalid("supersedes must be an array of canonical resource ids; a scalar string is not accepted");
+  }
+  if (!Array.isArray(raw)) {
+    throw invalid("supersedes must be an array of canonical resource ids or null");
+  }
+  if (raw.length > LIMITS.supersedesMax) {
+    throw invalid(`supersedes exceeds ${LIMITS.supersedesMax} ids`);
+  }
+  const ids = raw.map((item, i) => assertResourceId(item, `supersedes[${i}]`));
+  const unique = new Set(ids);
+  if (unique.size !== ids.length) {
+    throw invalid("supersedes ids must be unique");
+  }
+  return ids.length === 0 ? null : ids;
+}
+
+export function parseProvenance(raw: Record<string, unknown>, clock: Clock, confidenceRequired: boolean): Provenance {
+  const source = parseSourceRef(raw.source);
   const observed_at = parseOptionalUtc(raw.observed_at, "observed_at") ?? toUtcIso(clock.now());
   const freshness_status =
     raw.freshness_status === undefined
       ? computeFreshness(observed_at, clock.now())
       : parseFreshness(raw.freshness_status);
-  const provenance: Provenance = { source, observed_at, freshness_status };
-  if (raw.confidence !== undefined) {
-    provenance.confidence = parseConfidence(raw.confidence);
+  if (confidenceRequired && raw.confidence === undefined) {
+    throw invalid("confidence is required on aggregated provenance");
   }
-  return provenance;
+  const confidence = raw.confidence === undefined ? 1 : parseConfidence(raw.confidence);
+  return { source, observed_at, freshness_status, confidence };
 }
 
 export function parseCreateInput(raw: unknown, clock: Clock): CreateDirectiveInput {
@@ -127,12 +189,12 @@ export function parseCreateInput(raw: unknown, clock: Clock): CreateDirectiveInp
   const title = sanitizeLine(obj.title, "title", LIMITS.titleChars);
   const body = sanitizeMultiline(obj.body, "body", LIMITS.bodyChars);
   const scope = parseScope(obj.scope);
-  let status: "active" | "inactive" = "active";
+  let status: CreateStatus = "active";
   if (obj.status !== undefined) {
-    if (obj.status !== "active" && obj.status !== "inactive") {
-      throw invalid("status on create must be active or inactive");
+    if (typeof obj.status !== "string" || !(CREATE_STATUSES as readonly string[]).includes(obj.status)) {
+      throw invalid("status on create must be draft or active");
     }
-    status = obj.status;
+    status = obj.status as CreateStatus;
   }
   const effective_from = parseOptionalUtc(obj.effective_from, "effective_from") ?? toUtcIso(clock.now());
   let expires_at: string | null = null;
@@ -142,12 +204,9 @@ export function parseCreateInput(raw: unknown, clock: Clock): CreateDirectiveInp
   if (expires_at !== null && parseUtcIso(expires_at, "expires_at").getTime() <= parseUtcIso(effective_from, "effective_from").getTime()) {
     throw invalid("expires_at must be after effective_from");
   }
-  let supersedes: string | null = null;
-  if (obj.supersedes !== undefined && obj.supersedes !== null) {
-    supersedes = sanitizeLine(obj.supersedes, "supersedes", 128);
-  }
-  const provenance = parseProvenance(obj, clock);
-  const input: CreateDirectiveInput = {
+  const supersedes = parseSupersedes(obj.supersedes);
+  const provenance = parseProvenance(obj, clock, true);
+  return {
     kind,
     title,
     body,
@@ -159,11 +218,8 @@ export function parseCreateInput(raw: unknown, clock: Clock): CreateDirectiveInp
     source: provenance.source,
     observed_at: provenance.observed_at,
     freshness_status: provenance.freshness_status,
+    confidence: provenance.confidence,
   };
-  if (provenance.confidence !== undefined) {
-    input.confidence = provenance.confidence;
-  }
-  return input;
 }
 
 export function parseVersionInput(raw: unknown, clock: Clock): VersionDirectiveInput {
@@ -192,28 +248,23 @@ export function parseVersionInput(raw: unknown, clock: Clock): VersionDirectiveI
   if (obj.expires_at !== undefined) {
     input.expires_at = obj.expires_at === null ? null : parseOptionalUtc(obj.expires_at, "expires_at") ?? null;
   }
-  if (obj.source !== undefined || obj.observed_at !== undefined || obj.freshness_status !== undefined || obj.confidence !== undefined) {
-    const provenance = parseProvenance(
-      {
-        source: obj.source ?? "founder",
-        observed_at: obj.observed_at,
-        freshness_status: obj.freshness_status,
-        confidence: obj.confidence,
-      },
-      clock,
-    );
-    if (obj.source !== undefined) {
-      input.source = provenance.source;
+  if (obj.source !== undefined) {
+    input.source = parseSourceRef(obj.source);
+  }
+  if (obj.observed_at !== undefined) {
+    const observed = parseOptionalUtc(obj.observed_at, "observed_at");
+    if (observed !== undefined) {
+      input.observed_at = observed;
     }
-    if (obj.observed_at !== undefined) {
-      input.observed_at = provenance.observed_at;
-    }
-    if (obj.freshness_status !== undefined) {
-      input.freshness_status = provenance.freshness_status;
-    }
-    if (obj.confidence !== undefined && provenance.confidence !== undefined) {
-      input.confidence = provenance.confidence;
-    }
+  }
+  if (obj.freshness_status !== undefined) {
+    input.freshness_status = parseFreshness(obj.freshness_status);
+  }
+  if (obj.confidence !== undefined) {
+    input.confidence = obj.confidence === null ? null : parseConfidence(obj.confidence);
+  }
+  if (obj.observed_at !== undefined && obj.freshness_status === undefined && input.observed_at) {
+    input.freshness_status = computeFreshness(input.observed_at, clock.now());
   }
   if (Object.keys(input).length === 0) {
     throw invalid("version requires at least one field");
@@ -230,15 +281,15 @@ export function parseProposalInput(raw: unknown, clock: Clock): SubmitProposalIn
   if (typeof obj.action !== "string" || !(PROPOSAL_ACTIONS as readonly string[]).includes(obj.action)) {
     throw invalid(`action must be one of: ${PROPOSAL_ACTIONS.join(", ")}`);
   }
-  const provenance = parseProvenance(obj, clock);
-  let target: string | null = null;
+  const provenance = parseProvenance(obj, clock, true);
+  let target: ResourceId | null = null;
   if (obj.target_directive_id !== undefined && obj.target_directive_id !== null) {
-    target = sanitizeLine(obj.target_directive_id, "target_directive_id", 128);
+    target = assertResourceId(obj.target_directive_id, "target_directive_id");
   }
   if (obj.action !== "create" && target === null) {
     throw invalid("target_directive_id is required unless action is create");
   }
-  const input: SubmitProposalInput = {
+  return {
     action: obj.action as SubmitProposalInput["action"],
     kind: parseKind(obj.kind),
     title: sanitizeLine(obj.title, "title", LIMITS.titleChars),
@@ -249,13 +300,10 @@ export function parseProposalInput(raw: unknown, clock: Clock): SubmitProposalIn
     source: provenance.source,
     observed_at: provenance.observed_at,
     freshness_status: provenance.freshness_status,
+    confidence: provenance.confidence,
   };
-  if (provenance.confidence !== undefined) {
-    input.confidence = provenance.confidence;
-  }
-  return input;
 }
 
-export function parsePathId(value: string, field: string): string {
-  return sanitizeLine(value, field, 128);
+export function parsePathId(value: string, field: string): ResourceId {
+  return assertResourceId(value, field);
 }

--- a/control-center/services/context/src/validate.ts
+++ b/control-center/services/context/src/validate.ts
@@ -1,0 +1,261 @@
+import { parseUtcIso, toUtcIso, type Clock } from "./clock.ts";
+import { invalid } from "./errors.ts";
+import { rejectUnknownKeys, sanitizeLine, sanitizeMultiline } from "./sanitize.ts";
+import { parseScope } from "./scope.ts";
+import {
+  DIRECTIVE_KINDS,
+  FRESHNESS_STATUSES,
+  LIMITS,
+  PROPOSAL_ACTIONS,
+  type CreateDirectiveInput,
+  type DirectiveKind,
+  type FreshnessStatus,
+  type Provenance,
+  type SubmitProposalInput,
+  type VersionDirectiveInput,
+} from "./types.ts";
+
+const CREATE_KEYS = [
+  "kind",
+  "title",
+  "body",
+  "scope",
+  "status",
+  "effective_from",
+  "expires_at",
+  "supersedes",
+  "source",
+  "observed_at",
+  "freshness_status",
+  "confidence",
+] as const;
+
+const VERSION_KEYS = [
+  "title",
+  "body",
+  "effective_from",
+  "expires_at",
+  "source",
+  "observed_at",
+  "freshness_status",
+  "confidence",
+] as const;
+
+const PROPOSAL_KEYS = [
+  "action",
+  "kind",
+  "title",
+  "body",
+  "scope",
+  "target_directive_id",
+  "rationale",
+  "source",
+  "observed_at",
+  "freshness_status",
+  "confidence",
+] as const;
+
+export function parseKind(value: unknown): DirectiveKind {
+  if (typeof value !== "string" || !(DIRECTIVE_KINDS as readonly string[]).includes(value)) {
+    throw invalid(`kind must be one of: ${DIRECTIVE_KINDS.join(", ")}`);
+  }
+  return value as DirectiveKind;
+}
+
+function parseFreshness(value: unknown): FreshnessStatus {
+  if (typeof value !== "string" || !(FRESHNESS_STATUSES as readonly string[]).includes(value)) {
+    throw invalid(`freshness_status must be one of: ${FRESHNESS_STATUSES.join(", ")}`);
+  }
+  return value as FreshnessStatus;
+}
+
+function parseConfidence(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw invalid("confidence must be a finite number in [0, 1]");
+  }
+  return value;
+}
+
+function parseOptionalUtc(value: unknown, field: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw invalid(`${field} must be an ISO-8601 UTC timestamp`);
+  }
+  parseUtcIso(value, field);
+  return toUtcIso(new Date(value));
+}
+
+function computeFreshness(observedAt: string, now: Date): FreshnessStatus {
+  const observed = parseUtcIso(observedAt, "observed_at");
+  const ageMs = now.getTime() - observed.getTime();
+  if (ageMs < 0) {
+    return "unknown";
+  }
+  const day = 24 * 60 * 60 * 1000;
+  return ageMs <= day ? "fresh" : "stale";
+}
+
+export function parseProvenance(
+  raw: Record<string, unknown>,
+  clock: Clock,
+): Provenance {
+  const source = sanitizeLine(raw.source, "source", LIMITS.sourceChars);
+  const observed_at = parseOptionalUtc(raw.observed_at, "observed_at") ?? toUtcIso(clock.now());
+  const freshness_status =
+    raw.freshness_status === undefined
+      ? computeFreshness(observed_at, clock.now())
+      : parseFreshness(raw.freshness_status);
+  const provenance: Provenance = { source, observed_at, freshness_status };
+  if (raw.confidence !== undefined) {
+    provenance.confidence = parseConfidence(raw.confidence);
+  }
+  return provenance;
+}
+
+export function parseCreateInput(raw: unknown, clock: Clock): CreateDirectiveInput {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid("body must be an object");
+  }
+  const obj = raw as Record<string, unknown>;
+  rejectUnknownKeys(obj, CREATE_KEYS, "directive");
+  if (obj.created_by !== undefined) {
+    throw invalid("created_by is server-assigned from the actor");
+  }
+  const kind = parseKind(obj.kind);
+  const title = sanitizeLine(obj.title, "title", LIMITS.titleChars);
+  const body = sanitizeMultiline(obj.body, "body", LIMITS.bodyChars);
+  const scope = parseScope(obj.scope);
+  let status: "active" | "inactive" = "active";
+  if (obj.status !== undefined) {
+    if (obj.status !== "active" && obj.status !== "inactive") {
+      throw invalid("status on create must be active or inactive");
+    }
+    status = obj.status;
+  }
+  const effective_from = parseOptionalUtc(obj.effective_from, "effective_from") ?? toUtcIso(clock.now());
+  let expires_at: string | null = null;
+  if (obj.expires_at !== undefined && obj.expires_at !== null) {
+    expires_at = parseOptionalUtc(obj.expires_at, "expires_at") ?? null;
+  }
+  if (expires_at !== null && parseUtcIso(expires_at, "expires_at").getTime() <= parseUtcIso(effective_from, "effective_from").getTime()) {
+    throw invalid("expires_at must be after effective_from");
+  }
+  let supersedes: string | null = null;
+  if (obj.supersedes !== undefined && obj.supersedes !== null) {
+    supersedes = sanitizeLine(obj.supersedes, "supersedes", 128);
+  }
+  const provenance = parseProvenance(obj, clock);
+  const input: CreateDirectiveInput = {
+    kind,
+    title,
+    body,
+    scope,
+    status,
+    effective_from,
+    expires_at,
+    supersedes,
+    source: provenance.source,
+    observed_at: provenance.observed_at,
+    freshness_status: provenance.freshness_status,
+  };
+  if (provenance.confidence !== undefined) {
+    input.confidence = provenance.confidence;
+  }
+  return input;
+}
+
+export function parseVersionInput(raw: unknown, clock: Clock): VersionDirectiveInput {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid("body must be an object");
+  }
+  const obj = raw as Record<string, unknown>;
+  rejectUnknownKeys(obj, VERSION_KEYS, "version");
+  if (obj.kind !== undefined) {
+    throw invalid("kind is immutable across versions; supersede to change kind");
+  }
+  if (obj.created_by !== undefined) {
+    throw invalid("created_by is server-assigned from the actor");
+  }
+  const input: VersionDirectiveInput = {};
+  if (obj.title !== undefined) {
+    input.title = sanitizeLine(obj.title, "title", LIMITS.titleChars);
+  }
+  if (obj.body !== undefined) {
+    input.body = sanitizeMultiline(obj.body, "body", LIMITS.bodyChars);
+  }
+  const effective = parseOptionalUtc(obj.effective_from, "effective_from");
+  if (effective !== undefined) {
+    input.effective_from = effective;
+  }
+  if (obj.expires_at !== undefined) {
+    input.expires_at = obj.expires_at === null ? null : parseOptionalUtc(obj.expires_at, "expires_at") ?? null;
+  }
+  if (obj.source !== undefined || obj.observed_at !== undefined || obj.freshness_status !== undefined || obj.confidence !== undefined) {
+    const provenance = parseProvenance(
+      {
+        source: obj.source ?? "founder",
+        observed_at: obj.observed_at,
+        freshness_status: obj.freshness_status,
+        confidence: obj.confidence,
+      },
+      clock,
+    );
+    if (obj.source !== undefined) {
+      input.source = provenance.source;
+    }
+    if (obj.observed_at !== undefined) {
+      input.observed_at = provenance.observed_at;
+    }
+    if (obj.freshness_status !== undefined) {
+      input.freshness_status = provenance.freshness_status;
+    }
+    if (obj.confidence !== undefined && provenance.confidence !== undefined) {
+      input.confidence = provenance.confidence;
+    }
+  }
+  if (Object.keys(input).length === 0) {
+    throw invalid("version requires at least one field");
+  }
+  return input;
+}
+
+export function parseProposalInput(raw: unknown, clock: Clock): SubmitProposalInput {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw invalid("body must be an object");
+  }
+  const obj = raw as Record<string, unknown>;
+  rejectUnknownKeys(obj, PROPOSAL_KEYS, "proposal");
+  if (typeof obj.action !== "string" || !(PROPOSAL_ACTIONS as readonly string[]).includes(obj.action)) {
+    throw invalid(`action must be one of: ${PROPOSAL_ACTIONS.join(", ")}`);
+  }
+  const provenance = parseProvenance(obj, clock);
+  let target: string | null = null;
+  if (obj.target_directive_id !== undefined && obj.target_directive_id !== null) {
+    target = sanitizeLine(obj.target_directive_id, "target_directive_id", 128);
+  }
+  if (obj.action !== "create" && target === null) {
+    throw invalid("target_directive_id is required unless action is create");
+  }
+  const input: SubmitProposalInput = {
+    action: obj.action as SubmitProposalInput["action"],
+    kind: parseKind(obj.kind),
+    title: sanitizeLine(obj.title, "title", LIMITS.titleChars),
+    body: sanitizeMultiline(obj.body, "body", LIMITS.bodyChars),
+    scope: parseScope(obj.scope),
+    target_directive_id: target,
+    rationale: sanitizeMultiline(obj.rationale, "rationale", LIMITS.rationaleChars),
+    source: provenance.source,
+    observed_at: provenance.observed_at,
+    freshness_status: provenance.freshness_status,
+  };
+  if (provenance.confidence !== undefined) {
+    input.confidence = provenance.confidence;
+  }
+  return input;
+}
+
+export function parsePathId(value: string, field: string): string {
+  return sanitizeLine(value, field, 128);
+}

--- a/control-center/services/context/test/actor-policy.test.ts
+++ b/control-center/services/context/test/actor-policy.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ServiceError, parseActor } from "../src/index.ts";
+import { AGENT, FOUNDER, createInput, makeService } from "./helpers.ts";
+
+test("missing or unknown actor identity is rejected fail-closed", () => {
+  assert.throws(() => parseActor(undefined, "founder"), (err: unknown) => {
+    return err instanceof ServiceError && err.code === "missing_actor" && err.httpStatus === 401;
+  });
+  assert.throws(() => parseActor("founder-test", undefined), (err: unknown) => {
+    return err instanceof ServiceError && err.code === "missing_actor";
+  });
+  assert.throws(() => parseActor("founder-test", "admin"), (err: unknown) => {
+    return err instanceof ServiceError && err.code === "unknown_actor_role";
+  });
+  assert.throws(() => parseActor("user@example.com", "founder"), (err: unknown) => {
+    return err instanceof ServiceError && err.code === "invalid_actor_id";
+  });
+  const { service } = makeService();
+  assert.throws(
+    () => service.createDirective({ id: "someone-else", role: "founder" }, createInput("fact", "Nope")),
+    (err: unknown) => err instanceof ServiceError && err.code === "unknown_actor" && err.httpStatus === 401,
+  );
+});
+
+test("agent cannot mutate directives", () => {
+  const { service } = makeService();
+  const rec = service.createDirective(FOUNDER, createInput("constraint", "Do not ship Extra"));
+  const attempts: Array<() => void> = [
+    () => service.createDirective(AGENT, createInput("fact", "Agent fact")),
+    () => service.createVersion(AGENT, rec.id, { title: "silent rewrite" }),
+    () => service.expire(AGENT, rec.id),
+    () => service.deactivate(AGENT, rec.id),
+    () =>
+      service.supersede(
+        AGENT,
+        rec.id,
+        createInput("constraint", "Replacement", { body: "agent replacement" }),
+      ),
+    () => service.activate(AGENT, rec.id),
+  ];
+  for (const attempt of attempts) {
+    assert.throws(
+      attempt,
+      (err: unknown) =>
+        err instanceof ServiceError && err.code === "agent_mutation_forbidden" && err.httpStatus === 403,
+    );
+  }
+  const still = service.getDirective(FOUNDER, rec.id);
+  assert.equal(still.title, "Do not ship Extra");
+  assert.equal(still.version, 1);
+  assert.equal(still.status, "active");
+});
+
+test("agent cannot silently replace an active constraint or decision; proposals do not change the active set", () => {
+  const { service } = makeService();
+  const constraint = service.createDirective(FOUNDER, createInput("constraint", "Keep Extra private"));
+  const decision = service.createDirective(FOUNDER, createInput("decision", "Governance is authority"));
+  const before = service.getActiveDirectives(FOUNDER, { company: "confenge" });
+  const beforeContext = service.getContext(FOUNDER, { company: "confenge" });
+
+  const proposal = service.submitProposal(AGENT, {
+    action: "supersede",
+    kind: "constraint",
+    title: "Agent wants to replace constraint",
+    body: "This must remain a suggestion.",
+    scope: { company: "confenge" },
+    target_directive_id: constraint.id,
+    rationale: "Agent suggestion only",
+    source: "agent",
+  });
+  assert.equal(proposal.status, "pending");
+  assert.equal(proposal.action, "supersede");
+
+  service.submitProposal(AGENT, {
+    action: "expire",
+    kind: "decision",
+    title: "Agent wants to expire a decision",
+    body: "Must not apply.",
+    scope: { company: "confenge" },
+    target_directive_id: decision.id,
+    rationale: "Suggestion",
+    source: "agent",
+  });
+
+  const after = service.getActiveDirectives(FOUNDER, { company: "confenge" });
+  assert.deepEqual(
+    after.map((d) => d.revision_id),
+    before.map((d) => d.revision_id),
+  );
+  assert.equal(service.getDirective(FOUNDER, constraint.id).status, "active");
+  assert.equal(service.getDirective(FOUNDER, decision.id).status, "active");
+  const afterContext = service.getContext(FOUNDER, { company: "confenge" });
+  assert.deepEqual(afterContext, beforeContext);
+  const proposalAudits = service.listAudit(FOUNDER).filter((a) => a.action === "proposal.submit");
+  assert.equal(proposalAudits.length, 2);
+});
+
+test("identity is injected, not hardcoded as a password", () => {
+  const { service } = makeService();
+  const rec = service.createDirective(FOUNDER, createInput("fact", "Injected founder"));
+  assert.equal(rec.created_by, "founder-test");
+  assert.notEqual(rec.created_by, "password");
+  assert.notEqual(FOUNDER.id, "admin");
+});

--- a/control-center/services/context/test/actor-policy.test.ts
+++ b/control-center/services/context/test/actor-policy.test.ts
@@ -4,7 +4,7 @@ import { ServiceError, parseActor } from "../src/index.ts";
 import { AGENT, FOUNDER, createInput, makeService } from "./helpers.ts";
 
 test("missing or unknown actor identity is rejected fail-closed", () => {
-  assert.throws(() => parseActor(undefined, "founder"), (err: unknown) => {
+  assert.throws(() => parseActor(undefined, "human"), (err: unknown) => {
     return err instanceof ServiceError && err.code === "missing_actor" && err.httpStatus === 401;
   });
   assert.throws(() => parseActor("founder-test", undefined), (err: unknown) => {
@@ -13,12 +13,15 @@ test("missing or unknown actor identity is rejected fail-closed", () => {
   assert.throws(() => parseActor("founder-test", "admin"), (err: unknown) => {
     return err instanceof ServiceError && err.code === "unknown_actor_role";
   });
-  assert.throws(() => parseActor("user@example.com", "founder"), (err: unknown) => {
+  assert.throws(() => parseActor("founder-test", "founder"), (err: unknown) => {
+    return err instanceof ServiceError && err.code === "unknown_actor_role";
+  });
+  assert.throws(() => parseActor("user@example.com", "human"), (err: unknown) => {
     return err instanceof ServiceError && err.code === "invalid_actor_id";
   });
   const { service } = makeService();
   assert.throws(
-    () => service.createDirective({ id: "someone-else", role: "founder" }, createInput("fact", "Nope")),
+    () => service.createDirective({ id: "someone-else", kind: "human" }, createInput("fact", "Nope")),
     (err: unknown) => err instanceof ServiceError && err.code === "unknown_actor" && err.httpStatus === 401,
   );
 });
@@ -30,7 +33,7 @@ test("agent cannot mutate directives", () => {
     () => service.createDirective(AGENT, createInput("fact", "Agent fact")),
     () => service.createVersion(AGENT, rec.id, { title: "silent rewrite" }),
     () => service.expire(AGENT, rec.id),
-    () => service.deactivate(AGENT, rec.id),
+    () => service.revoke(AGENT, rec.id),
     () =>
       service.supersede(
         AGENT,
@@ -56,41 +59,44 @@ test("agent cannot silently replace an active constraint or decision; proposals 
   const { service } = makeService();
   const constraint = service.createDirective(FOUNDER, createInput("constraint", "Keep Extra private"));
   const decision = service.createDirective(FOUNDER, createInput("decision", "Governance is authority"));
-  const before = service.getActiveDirectives(FOUNDER, { company: "confenge" });
-  const beforeContext = service.getContext(FOUNDER, { company: "confenge" });
+  const before = service.getActiveDirectives(FOUNDER, "company");
+  const beforeContext = service.getContext(FOUNDER, "company");
 
   const proposal = service.submitProposal(AGENT, {
     action: "supersede",
     kind: "constraint",
     title: "Agent wants to replace constraint",
     body: "This must remain a suggestion.",
-    scope: { company: "confenge" },
+    scope: "company",
     target_directive_id: constraint.id,
     rationale: "Agent suggestion only",
-    source: "agent",
+    source: { system: "collector", kind: "agent-report", locator: "session-1" },
+    confidence: 0.5,
   });
   assert.equal(proposal.status, "pending");
   assert.equal(proposal.action, "supersede");
+  assert.equal(proposal.created_by.kind, "agent");
 
   service.submitProposal(AGENT, {
     action: "expire",
     kind: "decision",
     title: "Agent wants to expire a decision",
     body: "Must not apply.",
-    scope: { company: "confenge" },
+    scope: "company",
     target_directive_id: decision.id,
     rationale: "Suggestion",
-    source: "agent",
+    source: { system: "collector", kind: "agent-report", locator: "session-1" },
+    confidence: 0.5,
   });
 
-  const after = service.getActiveDirectives(FOUNDER, { company: "confenge" });
+  const after = service.getActiveDirectives(FOUNDER, "company");
   assert.deepEqual(
     after.map((d) => d.revision_id),
     before.map((d) => d.revision_id),
   );
   assert.equal(service.getDirective(FOUNDER, constraint.id).status, "active");
   assert.equal(service.getDirective(FOUNDER, decision.id).status, "active");
-  const afterContext = service.getContext(FOUNDER, { company: "confenge" });
+  const afterContext = service.getContext(FOUNDER, "company");
   assert.deepEqual(afterContext, beforeContext);
   const proposalAudits = service.listAudit(FOUNDER).filter((a) => a.action === "proposal.submit");
   assert.equal(proposalAudits.length, 2);
@@ -99,7 +105,33 @@ test("agent cannot silently replace an active constraint or decision; proposals 
 test("identity is injected, not hardcoded as a password", () => {
   const { service } = makeService();
   const rec = service.createDirective(FOUNDER, createInput("fact", "Injected founder"));
-  assert.equal(rec.created_by, "founder-test");
-  assert.notEqual(rec.created_by, "password");
+  assert.equal(rec.created_by.kind, "human");
+  assert.equal(rec.created_by.id, "founder-test");
+  assert.notEqual(rec.created_by.id, "password");
   assert.notEqual(FOUNDER.id, "admin");
+});
+
+test("system actor cannot mutate or submit proposals", () => {
+  const { service } = makeService();
+  const rec = service.createDirective(FOUNDER, createInput("decision", "Locked"));
+  const system = { kind: "system" as const, id: "cc-context" };
+  assert.throws(
+    () => service.createDirective(system, createInput("fact", "nope")),
+    (err: unknown) => err instanceof ServiceError && err.code === "agent_mutation_forbidden",
+  );
+  assert.throws(
+    () =>
+      service.submitProposal(system, {
+        action: "create",
+        kind: "fact",
+        title: "system proposal",
+        body: "nope",
+        scope: "company",
+        rationale: "nope",
+        source: { system: "collector", kind: "system", locator: "x" },
+        confidence: 1,
+      }),
+    (err: unknown) => err instanceof ServiceError && err.code === "agent_mutation_forbidden",
+  );
+  assert.equal(service.getDirective(system, rec.id).id, rec.id);
 });

--- a/control-center/services/context/test/adversarial.test.ts
+++ b/control-center/services/context/test/adversarial.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ServiceError } from "../src/index.ts";
+import { AGENT, FOUNDER, createInput, makeService } from "./helpers.ts";
+
+test("adversarial: scope leak across repo, client, domain, and company dump", () => {
+  const { service } = makeService();
+  const company = service.createDirective(FOUNDER, createInput("priority", "Company", { scope: "company" }));
+  const commercial = service.createDirective(FOUNDER, createInput("directive", "Commercial", { scope: "commercial" }));
+  const finance = service.createDirective(FOUNDER, createInput("risk", "Finance", { scope: "finance" }));
+  const gov = service.createDirective(FOUNDER, createInput("fact", "Gov repo", { scope: "repo:Governance" }));
+  const warmbly = service.createDirective(FOUNDER, createInput("fact", "Warmbly repo", { scope: "repo:Warmbly" }));
+  const clients = service.createDirective(FOUNDER, createInput("directive", "Clients", { scope: "clients" }));
+  const acme = service.createDirective(FOUNDER, createInput("fact", "Acme", { scope: "client:acme" }));
+  const other = service.createDirective(FOUNDER, createInput("fact", "Other", { scope: "client:other" }));
+
+  const repoIds = service.getContext(FOUNDER, "repo:Governance").active_directives.map((d) => d.id);
+  assert.deepEqual(
+    new Set(repoIds),
+    new Set([company.id, commercial.id, gov.id]),
+  );
+
+  const clientIds = service.getContext(FOUNDER, "client:acme").active_directives.map((d) => d.id);
+  assert.deepEqual(
+    new Set(clientIds),
+    new Set([company.id, clients.id, acme.id]),
+  );
+
+  const companyIds = service.getContext(FOUNDER, "company").active_directives.map((d) => d.id);
+  assert.deepEqual(companyIds, [company.id]);
+
+  const commercialIds = service.getContext(FOUNDER, "commercial").active_directives.map((d) => d.id);
+  assert.equal(commercialIds.includes(gov.id), false);
+  assert.equal(commercialIds.includes(warmbly.id), false);
+  assert.equal(commercialIds.includes(finance.id), false);
+  assert.equal(commercialIds.includes(acme.id), false);
+  assert.ok(commercialIds.includes(company.id));
+  assert.ok(commercialIds.includes(commercial.id));
+
+  assert.equal(clientIds.includes(other.id), false);
+  assert.equal(repoIds.includes(warmbly.id), false);
+});
+
+test("adversarial: agent overwrite of decision and constraint is denied and leaves the active set unchanged", () => {
+  const { service } = makeService();
+  const decision = service.createDirective(FOUNDER, createInput("decision", "Canonical decision"));
+  const constraint = service.createDirective(FOUNDER, createInput("constraint", "Canonical constraint"));
+  const before = service.getContext(FOUNDER, "company");
+
+  for (const target of [decision, constraint]) {
+    assert.throws(
+      () => service.createVersion(AGENT, target.id, { body: "overwrite" }),
+      (err: unknown) => err instanceof ServiceError && err.code === "agent_mutation_forbidden",
+    );
+    assert.throws(
+      () => service.supersede(AGENT, target.id, createInput(target.kind, "Replacement")),
+      (err: unknown) => err instanceof ServiceError && err.code === "agent_mutation_forbidden",
+    );
+    assert.throws(
+      () => service.revoke(AGENT, target.id),
+      (err: unknown) => err instanceof ServiceError && err.code === "agent_mutation_forbidden",
+    );
+    assert.throws(
+      () => service.expire(AGENT, target.id),
+      (err: unknown) => err instanceof ServiceError && err.code === "agent_mutation_forbidden",
+    );
+    const proposal = service.submitProposal(AGENT, {
+      action: "supersede",
+      kind: target.kind,
+      title: "Agent replacement",
+      body: "Must not apply.",
+      scope: "company",
+      target_directive_id: target.id,
+      rationale: "report only",
+      source: { system: "collector", kind: "agent-report", locator: "adv" },
+      confidence: 0.1,
+    });
+    assert.equal(proposal.status, "pending");
+  }
+
+  const after = service.getContext(FOUNDER, "company");
+  assert.deepEqual(after, before);
+  assert.equal(service.getDirective(FOUNDER, decision.id).status, "active");
+  assert.equal(service.getDirective(FOUNDER, constraint.id).status, "active");
+  assert.equal(service.getDirective(FOUNDER, decision.id).body, "Canonical decision body");
+});
+
+test("adversarial: multi-supersede, revoke, expire drop from the active set but remain readable", () => {
+  const { service } = makeService();
+  const a = service.createDirective(FOUNDER, createInput("constraint", "A"));
+  const b = service.createDirective(FOUNDER, createInput("constraint", "B"));
+  const toRevoke = service.createDirective(FOUNDER, createInput("directive", "Revoke me"));
+  const toExpire = service.createDirective(FOUNDER, createInput("risk", "Expire me"));
+
+  const successor = service.supersede(
+    FOUNDER,
+    a.id,
+    createInput("constraint", "Merged", { supersedes: [b.id] }),
+  );
+  assert.deepEqual(successor.supersedes, [a.id, b.id]);
+  service.revoke(FOUNDER, toRevoke.id);
+  service.expire(FOUNDER, toExpire.id);
+
+  const activeIds = service.getActiveDirectives(FOUNDER, "company").map((d) => d.id);
+  assert.equal(activeIds.includes(a.id), false);
+  assert.equal(activeIds.includes(b.id), false);
+  assert.equal(activeIds.includes(toRevoke.id), false);
+  assert.equal(activeIds.includes(toExpire.id), false);
+  assert.ok(activeIds.includes(successor.id));
+
+  assert.equal(service.getDirective(FOUNDER, a.id).status, "superseded");
+  assert.equal(service.getDirective(FOUNDER, b.id).status, "superseded");
+  assert.equal(service.getDirective(FOUNDER, toRevoke.id).status, "revoked");
+  assert.equal(service.getDirective(FOUNDER, toExpire.id).status, "expired");
+});
+
+test("adversarial: ERROR freshness is stored and returned as ERROR, never UNKNOWN", () => {
+  const { service } = makeService();
+  const rec = service.createDirective(
+    FOUNDER,
+    createInput("fact", "Broken collector", {
+      freshness_status: "ERROR",
+      confidence: 0.15,
+      source: { system: "warmbly", kind: "snapshot", locator: "fail-1" },
+    }),
+  );
+  assert.equal(rec.provenance.freshness_status, "ERROR");
+  const loaded = service.getDirective(FOUNDER, rec.id);
+  assert.equal(loaded.provenance.freshness_status, "ERROR");
+  const view = service.getContext(FOUNDER, "company").active_directives.find((d) => d.id === rec.id);
+  assert.ok(view);
+  assert.equal(view.freshness_status, "ERROR");
+  assert.notEqual(view.freshness_status, "UNKNOWN");
+  assert.equal(view.confidence, 0.15);
+
+  const versioned = service.createVersion(FOUNDER, rec.id, { freshness_status: "ERROR", title: "Still broken" });
+  assert.equal(versioned.provenance.freshness_status, "ERROR");
+  assert.equal(service.getDirective(FOUNDER, rec.id).provenance.freshness_status, "ERROR");
+});

--- a/control-center/services/context/test/cli-entry.test.ts
+++ b/control-center/services/context/test/cli-entry.test.ts
@@ -6,14 +6,14 @@ import { ServiceError } from "../src/errors.ts";
 import {
   REPRESENTATIVE_IDS,
   REPRESENTATIVE_SCOPE,
+  SIBLING_SCOPE,
 } from "../src/representative.ts";
 
 const ENV: NodeJS.ProcessEnv = {
   CONTROL_CENTER_FOUNDER_ACTOR_ID: "founder-local",
   CONTEXT_ACTOR_ID: "agent-session-launch",
-  CONTEXT_ACTOR_ROLE: "agent",
+  CONTEXT_ACTOR_KIND: "agent",
   CONTEXT_SERVICE_FIXTURE: "representative",
-  CONTROL_CENTER_COMPANY: "confenge",
 };
 
 function parse(json: string): Record<string, unknown> {
@@ -21,27 +21,21 @@ function parse(json: string): Record<string, unknown> {
 }
 
 test("shipped CLI get_context is deterministic and minimum-sufficient for the representative scope", () => {
-  const args = [
-    "get_context",
-    "--company",
-    REPRESENTATIVE_SCOPE.company,
-    "--domain",
-    REPRESENTATIVE_SCOPE.domain ?? "",
-    "--resource",
-    REPRESENTATIVE_SCOPE.resource ?? "",
-  ];
+  const args = ["get_context", "--scope", REPRESENTATIVE_SCOPE];
   const first = runCli(args, ENV);
   const second = runCli(args, ENV);
   assert.equal(first, second);
 
   const ctx = parse(first) as {
-    scope: { company: string; domain: string; resource: string };
+    scope: string;
     active_directives: Array<{
       id: string;
       kind: string;
-      source: string;
+      source: { system: string; kind: string; locator: string };
       observed_at: string;
       freshness_status: string;
+      confidence: number;
+      created_by: { kind: string; id: string };
     }>;
     decisions: Array<{ id: string; kind: string }>;
     facts: Array<{ id: string; kind: string }>;
@@ -51,15 +45,20 @@ test("shipped CLI get_context is deterministic and minimum-sufficient for the re
     directives: Array<{ id: string }>;
   };
 
+  assert.equal(typeof ctx.scope, "string");
+  assert.equal(ctx.scope, REPRESENTATIVE_SCOPE);
+
   const ids = ctx.active_directives.map((d) => d.id);
   assert.ok(ids.includes(REPRESENTATIVE_IDS.companyPriority));
   assert.ok(ids.includes(REPRESENTATIVE_IDS.companyDecision));
   assert.ok(ids.includes(REPRESENTATIVE_IDS.domainDirective));
   assert.ok(ids.includes(REPRESENTATIVE_IDS.resourceFact));
   assert.ok(ids.includes(REPRESENTATIVE_IDS.activeConstraint));
+  assert.ok(ids.includes(REPRESENTATIVE_IDS.collectionError));
   assert.equal(ids.includes(REPRESENTATIVE_IDS.expired), false);
   assert.equal(ids.includes(REPRESENTATIVE_IDS.supersededConstraint), false);
   assert.equal(ids.includes(REPRESENTATIVE_IDS.siblingFact), false);
+  assert.equal(ids.includes(REPRESENTATIVE_IDS.clientFact), false);
   assert.ok(ids.includes(REPRESENTATIVE_IDS.hypothesis));
 
   assert.ok(ctx.hypotheses.every((d) => d.kind === "hypothesis"));
@@ -77,26 +76,27 @@ test("shipped CLI get_context is deterministic and minimum-sufficient for the re
   assert.ok(ctx.priorities.some((d) => d.id === REPRESENTATIVE_IDS.companyPriority));
 
   for (const item of ctx.active_directives) {
-    assert.equal(typeof item.source, "string");
+    assert.match(item.id, /^cc:/);
+    assert.equal(typeof item.source, "object");
+    assert.equal(typeof item.source.system, "string");
     assert.match(item.observed_at, /Z$/);
-    assert.ok(["fresh", "stale", "unknown"].includes(item.freshness_status));
+    assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(item.freshness_status));
+    assert.equal(typeof item.confidence, "number");
+    assert.ok(["human", "agent", "system"].includes(item.created_by.kind));
   }
+  const errorItem = ctx.active_directives.find((d) => d.id === REPRESENTATIVE_IDS.collectionError);
+  assert.equal(errorItem?.freshness_status, "ERROR");
 });
 
 test("shipped CLI get_active_directives, get_priorities and get_decisions match policy", () => {
-  const scopeArgs = [
-    "--company",
-    "confenge",
-    "--domain",
-    "commercial",
-    "--resource",
-    "offer:CFG-DIAG-EXP-v1",
-  ];
-  const active = parse(runCli(["get_active_directives", ...scopeArgs], ENV)) as {
+  const active = parse(runCli(["get_active_directives", "--scope", REPRESENTATIVE_SCOPE], ENV)) as {
     items: Array<{ id: string; kind: string }>;
   };
   const priorities = parse(runCli(["get_priorities"], ENV)) as { items: Array<{ id: string; kind: string }> };
   const decisions = parse(runCli(["get_decisions"], ENV)) as { items: Array<{ id: string; kind: string }> };
+  const sibling = parse(runCli(["get_active_directives", "--scope", SIBLING_SCOPE], ENV)) as {
+    items: Array<{ id: string }>;
+  };
 
   assert.ok(active.items.some((d) => d.id === REPRESENTATIVE_IDS.resourceFact));
   assert.equal(
@@ -111,6 +111,11 @@ test("shipped CLI get_active_directives, get_priorities and get_decisions match 
     active.items.some((d) => d.id === REPRESENTATIVE_IDS.supersededConstraint),
     false,
   );
+  assert.ok(sibling.items.some((d) => d.id === REPRESENTATIVE_IDS.siblingFact));
+  assert.equal(
+    sibling.items.some((d) => d.id === REPRESENTATIVE_IDS.resourceFact),
+    false,
+  );
   assert.ok(priorities.items.every((d) => d.kind === "priority"));
   assert.ok(priorities.items.some((d) => d.id === REPRESENTATIVE_IDS.companyPriority));
   assert.ok(decisions.items.every((d) => d.kind === "decision"));
@@ -118,6 +123,13 @@ test("shipped CLI get_active_directives, get_priorities and get_decisions match 
   assert.equal(
     decisions.items.some((d) => d.id === REPRESENTATIVE_IDS.hypothesis),
     false,
+  );
+});
+
+test("CLI rejects legacy company/domain/resource flags", () => {
+  assert.throws(
+    () => runCli(["get_context", "--company", "confenge", "--domain", "commercial"], ENV),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
   );
 });
 

--- a/control-center/services/context/test/cli-entry.test.ts
+++ b/control-center/services/context/test/cli-entry.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { runCli } from "../src/cli.ts";
+import { createStoreFromEnv } from "../src/store/from-env.ts";
+import { ServiceError } from "../src/errors.ts";
+import {
+  REPRESENTATIVE_IDS,
+  REPRESENTATIVE_SCOPE,
+} from "../src/representative.ts";
+
+const ENV: NodeJS.ProcessEnv = {
+  CONTROL_CENTER_FOUNDER_ACTOR_ID: "founder-local",
+  CONTEXT_ACTOR_ID: "agent-session-launch",
+  CONTEXT_ACTOR_ROLE: "agent",
+  CONTEXT_SERVICE_FIXTURE: "representative",
+  CONTROL_CENTER_COMPANY: "confenge",
+};
+
+function parse(json: string): Record<string, unknown> {
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+test("shipped CLI get_context is deterministic and minimum-sufficient for the representative scope", () => {
+  const args = [
+    "get_context",
+    "--company",
+    REPRESENTATIVE_SCOPE.company,
+    "--domain",
+    REPRESENTATIVE_SCOPE.domain ?? "",
+    "--resource",
+    REPRESENTATIVE_SCOPE.resource ?? "",
+  ];
+  const first = runCli(args, ENV);
+  const second = runCli(args, ENV);
+  assert.equal(first, second);
+
+  const ctx = parse(first) as {
+    scope: { company: string; domain: string; resource: string };
+    active_directives: Array<{
+      id: string;
+      kind: string;
+      source: string;
+      observed_at: string;
+      freshness_status: string;
+    }>;
+    decisions: Array<{ id: string; kind: string }>;
+    facts: Array<{ id: string; kind: string }>;
+    hypotheses: Array<{ id: string; kind: string }>;
+    constraints: Array<{ id: string; kind: string }>;
+    priorities: Array<{ id: string; kind: string }>;
+    directives: Array<{ id: string }>;
+  };
+
+  const ids = ctx.active_directives.map((d) => d.id);
+  assert.ok(ids.includes(REPRESENTATIVE_IDS.companyPriority));
+  assert.ok(ids.includes(REPRESENTATIVE_IDS.companyDecision));
+  assert.ok(ids.includes(REPRESENTATIVE_IDS.domainDirective));
+  assert.ok(ids.includes(REPRESENTATIVE_IDS.resourceFact));
+  assert.ok(ids.includes(REPRESENTATIVE_IDS.activeConstraint));
+  assert.equal(ids.includes(REPRESENTATIVE_IDS.expired), false);
+  assert.equal(ids.includes(REPRESENTATIVE_IDS.supersededConstraint), false);
+  assert.equal(ids.includes(REPRESENTATIVE_IDS.siblingFact), false);
+  assert.ok(ids.includes(REPRESENTATIVE_IDS.hypothesis));
+
+  assert.ok(ctx.hypotheses.every((d) => d.kind === "hypothesis"));
+  assert.ok(ctx.decisions.every((d) => d.kind === "decision"));
+  assert.ok(ctx.facts.every((d) => d.kind === "fact"));
+  assert.equal(
+    ctx.decisions.some((d) => d.id === REPRESENTATIVE_IDS.hypothesis),
+    false,
+  );
+  assert.equal(
+    ctx.facts.some((d) => d.id === REPRESENTATIVE_IDS.hypothesis),
+    false,
+  );
+  assert.ok(ctx.constraints.some((d) => d.id === REPRESENTATIVE_IDS.activeConstraint));
+  assert.ok(ctx.priorities.some((d) => d.id === REPRESENTATIVE_IDS.companyPriority));
+
+  for (const item of ctx.active_directives) {
+    assert.equal(typeof item.source, "string");
+    assert.match(item.observed_at, /Z$/);
+    assert.ok(["fresh", "stale", "unknown"].includes(item.freshness_status));
+  }
+});
+
+test("shipped CLI get_active_directives, get_priorities and get_decisions match policy", () => {
+  const scopeArgs = [
+    "--company",
+    "confenge",
+    "--domain",
+    "commercial",
+    "--resource",
+    "offer:CFG-DIAG-EXP-v1",
+  ];
+  const active = parse(runCli(["get_active_directives", ...scopeArgs], ENV)) as {
+    items: Array<{ id: string; kind: string }>;
+  };
+  const priorities = parse(runCli(["get_priorities"], ENV)) as { items: Array<{ id: string; kind: string }> };
+  const decisions = parse(runCli(["get_decisions"], ENV)) as { items: Array<{ id: string; kind: string }> };
+
+  assert.ok(active.items.some((d) => d.id === REPRESENTATIVE_IDS.resourceFact));
+  assert.equal(
+    active.items.some((d) => d.id === REPRESENTATIVE_IDS.siblingFact),
+    false,
+  );
+  assert.equal(
+    active.items.some((d) => d.id === REPRESENTATIVE_IDS.expired),
+    false,
+  );
+  assert.equal(
+    active.items.some((d) => d.id === REPRESENTATIVE_IDS.supersededConstraint),
+    false,
+  );
+  assert.ok(priorities.items.every((d) => d.kind === "priority"));
+  assert.ok(priorities.items.some((d) => d.id === REPRESENTATIVE_IDS.companyPriority));
+  assert.ok(decisions.items.every((d) => d.kind === "decision"));
+  assert.ok(decisions.items.some((d) => d.id === REPRESENTATIVE_IDS.companyDecision));
+  assert.equal(
+    decisions.items.some((d) => d.id === REPRESENTATIVE_IDS.hypothesis),
+    false,
+  );
+});
+
+test("DATABASE_URL refuses fixture fallback", () => {
+  assert.throws(
+    () => createStoreFromEnv({ DATABASE_URL: "postgresql://localhost/control_center" }),
+    (err: unknown) => err instanceof ServiceError && err.code === "store_misconfigured",
+  );
+});

--- a/control-center/services/context/test/helpers.ts
+++ b/control-center/services/context/test/helpers.ts
@@ -1,0 +1,65 @@
+import { frozenClock } from "../src/clock.ts";
+import { sequentialIds } from "../src/ids.ts";
+import { silentLogger } from "../src/log.ts";
+import { createContextService, type ContextService } from "../src/service.ts";
+import { createFixtureStore } from "../src/store/fixture.ts";
+import type { Actor } from "../src/types.ts";
+import type { CreateDirectiveInput } from "../src/types.ts";
+import type { PersistenceAdapter } from "../src/store/adapter.ts";
+
+export const NOW = "2026-08-20T12:00:00.000Z";
+
+export const FOUNDER: Actor = { id: "founder-test", role: "founder" };
+export const AGENT: Actor = { id: "agent-session-1", role: "agent" };
+
+export function makeService(): { service: ContextService; store: PersistenceAdapter } {
+  const store = createFixtureStore();
+  const service = createContextService({
+    store,
+    clock: frozenClock(NOW),
+    ids: sequentialIds("id"),
+    founderActorId: FOUNDER.id,
+    logger: silentLogger,
+    defaultCompany: "confenge",
+  });
+  return { service, store };
+}
+
+export function createInput(
+  kind: CreateDirectiveInput["kind"],
+  title: string,
+  extras: Partial<CreateDirectiveInput> = {},
+): CreateDirectiveInput {
+  const input: CreateDirectiveInput = {
+    kind,
+    title,
+    body: extras.body ?? `${title} body`,
+    scope: extras.scope ?? { company: "confenge" },
+    source: extras.source ?? "founder",
+  };
+  if (extras.status !== undefined) {
+    input.status = extras.status;
+  }
+  if (extras.effective_from !== undefined) {
+    input.effective_from = extras.effective_from;
+  }
+  if (extras.expires_at !== undefined) {
+    input.expires_at = extras.expires_at;
+  }
+  if (extras.supersedes !== undefined) {
+    input.supersedes = extras.supersedes;
+  }
+  if (extras.observed_at !== undefined) {
+    input.observed_at = extras.observed_at;
+  }
+  if (extras.freshness_status !== undefined) {
+    input.freshness_status = extras.freshness_status;
+  }
+  if (extras.confidence !== undefined) {
+    input.confidence = extras.confidence;
+  }
+  if (extras.body !== undefined) {
+    input.body = extras.body;
+  }
+  return input;
+}

--- a/control-center/services/context/test/helpers.ts
+++ b/control-center/services/context/test/helpers.ts
@@ -1,18 +1,24 @@
 import { frozenClock } from "../src/clock.ts";
 import { sequentialIds } from "../src/ids.ts";
 import { silentLogger } from "../src/log.ts";
+import { REPRESENTATIVE_REPO_DOMAINS } from "../src/representative.ts";
 import { createContextService, type ContextService } from "../src/service.ts";
 import { createFixtureStore } from "../src/store/fixture.ts";
-import type { Actor } from "../src/types.ts";
-import type { CreateDirectiveInput } from "../src/types.ts";
-import type { PersistenceAdapter } from "../src/store/adapter.ts";
+import type { ActorRef, CreateDirectiveInput, SourceRef } from "../src/types.ts";
+import type { PersistencePort } from "../src/store/adapter.ts";
 
 export const NOW = "2026-08-20T12:00:00.000Z";
 
-export const FOUNDER: Actor = { id: "founder-test", role: "founder" };
-export const AGENT: Actor = { id: "agent-session-1", role: "agent" };
+export const FOUNDER: ActorRef = { id: "founder-test", kind: "human" };
+export const AGENT: ActorRef = { id: "agent-session-1", kind: "agent" };
 
-export function makeService(): { service: ContextService; store: PersistenceAdapter } {
+export const DEFAULT_SOURCE: SourceRef = {
+  system: "manual",
+  kind: "founder-entry",
+  locator: "test",
+};
+
+export function makeService(): { service: ContextService; store: PersistencePort } {
   const store = createFixtureStore();
   const service = createContextService({
     store,
@@ -20,7 +26,8 @@ export function makeService(): { service: ContextService; store: PersistenceAdap
     ids: sequentialIds("id"),
     founderActorId: FOUNDER.id,
     logger: silentLogger,
-    defaultCompany: "confenge",
+    defaultScope: "company",
+    repoDomains: REPRESENTATIVE_REPO_DOMAINS,
   });
   return { service, store };
 }
@@ -34,8 +41,9 @@ export function createInput(
     kind,
     title,
     body: extras.body ?? `${title} body`,
-    scope: extras.scope ?? { company: "confenge" },
-    source: extras.source ?? "founder",
+    scope: extras.scope ?? "company",
+    source: extras.source ?? DEFAULT_SOURCE,
+    confidence: extras.confidence ?? 1,
   };
   if (extras.status !== undefined) {
     input.status = extras.status;
@@ -54,9 +62,6 @@ export function createInput(
   }
   if (extras.freshness_status !== undefined) {
     input.freshness_status = extras.freshness_status;
-  }
-  if (extras.confidence !== undefined) {
-    input.confidence = extras.confidence;
   }
   if (extras.body !== undefined) {
     input.body = extras.body;

--- a/control-center/services/context/test/http-entry.test.ts
+++ b/control-center/services/context/test/http-entry.test.ts
@@ -6,12 +6,13 @@ import { silentLogger } from "../src/log.ts";
 import { startServer } from "../src/server.ts";
 import { LIMITS } from "../src/types.ts";
 import { AGENT, FOUNDER, makeService } from "./helpers.ts";
+import { REPRESENTATIVE_IDS, REPRESENTATIVE_SCOPE } from "../src/representative.ts";
 
 async function withServer(
   fn: (base: string) => Promise<void>,
 ): Promise<void> {
   const { service } = makeService();
-  const server = createServer(createRequestListener({ service, logger: silentLogger }, "confenge"));
+  const server = createServer(createRequestListener({ service, logger: silentLogger }));
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", () => resolve());
   });
@@ -34,22 +35,24 @@ test("HTTP entry drives shipped get_context and rejects agent mutation plus over
       headers: {
         "content-type": "application/json",
         "x-actor-id": FOUNDER.id,
-        "x-actor-role": FOUNDER.role,
+        "x-actor-kind": FOUNDER.kind,
       },
       body: JSON.stringify({
         kind: "priority",
         title: "Now",
         body: "Do the important thing.",
-        scope: { company: "confenge" },
-        source: "founder",
+        scope: "company",
+        source: { system: "manual", kind: "founder-entry", locator: "http-test" },
         confidence: 1,
       }),
     });
     assert.equal(created.status, 201);
-    const rec = (await created.json()) as { id: string; kind: string };
+    const rec = (await created.json()) as { id: string; kind: string; created_by: { kind: string } };
     assert.equal(rec.kind, "priority");
+    assert.match(rec.id, /^cc:directive:/);
+    assert.equal(rec.created_by.kind, "human");
 
-    const missing = await fetch(`${base}/v1/context?company=confenge`);
+    const missing = await fetch(`${base}/v1/context?scope=company`);
     assert.equal(missing.status, 401);
     const missingBody = (await missing.json()) as { error: string };
     assert.equal(missingBody.error, "missing_actor");
@@ -59,14 +62,15 @@ test("HTTP entry drives shipped get_context and rejects agent mutation plus over
       headers: {
         "content-type": "application/json",
         "x-actor-id": AGENT.id,
-        "x-actor-role": AGENT.role,
+        "x-actor-kind": AGENT.kind,
       },
       body: JSON.stringify({
         kind: "decision",
         title: "Agent decision",
         body: "Should fail.",
-        scope: { company: "confenge" },
-        source: "agent",
+        scope: "company",
+        source: { system: "collector", kind: "agent-report", locator: "http" },
+        confidence: 1,
       }),
     });
     assert.equal(agentWrite.status, 403);
@@ -78,59 +82,96 @@ test("HTTP entry drives shipped get_context and rejects agent mutation plus over
       headers: {
         "content-type": "application/json",
         "x-actor-id": FOUNDER.id,
-        "x-actor-role": FOUNDER.role,
+        "x-actor-kind": FOUNDER.kind,
       },
       body: "x".repeat(LIMITS.jsonBytes + 8),
     });
     assert.equal(oversized.status, 413);
 
-    const ctx = await fetch(`${base}/v1/context?company=confenge`, {
-      headers: { "x-actor-id": AGENT.id, "x-actor-role": AGENT.role },
+    const legacy = await fetch(`${base}/v1/context?company=confenge&domain=commercial`, {
+      headers: { "x-actor-id": AGENT.id, "x-actor-kind": AGENT.kind },
+    });
+    assert.equal(legacy.status, 400);
+
+    const ctx = await fetch(`${base}/v1/context?scope=company`, {
+      headers: { "x-actor-id": AGENT.id, "x-actor-kind": AGENT.kind },
     });
     assert.equal(ctx.status, 200);
     const ctxText = await ctx.text();
     const payload = JSON.parse(ctxText) as {
-      active_directives: Array<{ id: string; source: string; observed_at: string; freshness_status: string }>;
+      scope: string;
+      active_directives: Array<{
+        id: string;
+        source: { system: string };
+        observed_at: string;
+        freshness_status: string;
+        confidence: number;
+      }>;
       priorities: Array<{ id: string }>;
+      hypotheses: Array<{ kind: string }>;
+      decisions: Array<{ kind: string }>;
     };
+    assert.equal(typeof payload.scope, "string");
     assert.ok(payload.active_directives.some((d) => d.id === rec.id));
     assert.ok(payload.priorities.some((d) => d.id === rec.id));
     const first = payload.active_directives[0];
-    assert.ok(first?.source);
+    assert.ok(first?.source?.system);
     assert.ok(first?.observed_at);
-    assert.ok(first?.freshness_status);
+    assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(first?.freshness_status ?? ""));
+    assert.equal(typeof first?.confidence, "number");
+    assert.ok(payload.hypotheses.every((d) => d.kind === "hypothesis"));
+    assert.ok(payload.decisions.every((d) => d.kind === "decision"));
 
-    const ctx2 = await fetch(`${base}/v1/context?company=confenge`, {
-      headers: { "x-actor-id": AGENT.id, "x-actor-role": AGENT.role },
+    const ctx2 = await fetch(`${base}/v1/context?scope=company`, {
+      headers: { "x-actor-id": AGENT.id, "x-actor-kind": AGENT.kind },
     });
     assert.equal(ctxText, await ctx2.text());
   });
 });
 
-test("shipped startServer binds HTTP and serves representative get_context", async () => {
-  const { server, host, port } = await startServer(
-    {
-      CONTROL_CENTER_FOUNDER_ACTOR_ID: "founder-local",
-      CONTEXT_SERVICE_FIXTURE: "representative",
-      CONTROL_CENTER_COMPANY: "confenge",
-      HOST: "127.0.0.1",
-      PORT: "0",
-    },
-    { logger: silentLogger },
-  );
+test("shipped startServer binds HTTP and serves representative get_context twice", async () => {
+  const env = {
+    CONTROL_CENTER_FOUNDER_ACTOR_ID: "founder-local",
+    CONTEXT_SERVICE_FIXTURE: "representative",
+    HOST: "127.0.0.1",
+    PORT: "0",
+  };
+  const { server, host, port } = await startServer(env, { logger: silentLogger });
   try {
-    const url = `http://${host}:${port}/v1/context?company=confenge&domain=commercial&resource=offer:CFG-DIAG-EXP-v1`;
-    const res = await fetch(url, {
-      headers: { "x-actor-id": "agent-session-launch", "x-actor-role": "agent" },
-    });
-    assert.equal(res.status, 200);
-    const body = (await res.json()) as { active_directives: Array<{ id: string; kind: string }>; hypotheses: Array<{ id: string }> };
+    const url = `http://${host}:${port}/v1/context?scope=${encodeURIComponent(REPRESENTATIVE_SCOPE)}`;
+    const headers = { "x-actor-id": "agent-session-launch", "x-actor-kind": "agent" };
+    const res1 = await fetch(url, { headers });
+    const res2 = await fetch(url, { headers });
+    assert.equal(res1.status, 200);
+    assert.equal(res2.status, 200);
+    const text1 = await res1.text();
+    const text2 = await res2.text();
+    assert.equal(text1, text2);
+    const body = JSON.parse(text1) as {
+      scope: string;
+      active_directives: Array<{ id: string; kind: string; freshness_status: string }>;
+      hypotheses: Array<{ id: string; kind: string }>;
+      decisions: Array<{ kind: string }>;
+      facts: Array<{ kind: string }>;
+    };
+    assert.equal(typeof body.scope, "string");
+    assert.equal(body.scope, REPRESENTATIVE_SCOPE);
     const ids = body.active_directives.map((d) => d.id);
-    assert.ok(ids.includes("dir-company-priority"));
-    assert.ok(ids.includes("dir-resource-fact"));
-    assert.equal(ids.includes("dir-sibling-fact"), false);
-    assert.equal(ids.includes("dir-resource-expired"), false);
-    assert.ok(body.hypotheses.some((d) => d.id === "dir-company-hypothesis"));
+    assert.ok(ids.includes(REPRESENTATIVE_IDS.companyPriority));
+    assert.ok(ids.includes(REPRESENTATIVE_IDS.resourceFact));
+    assert.equal(ids.includes(REPRESENTATIVE_IDS.siblingFact), false);
+    assert.equal(ids.includes(REPRESENTATIVE_IDS.expired), false);
+    assert.equal(ids.includes(REPRESENTATIVE_IDS.clientFact), false);
+    assert.ok(body.hypotheses.some((d) => d.id === REPRESENTATIVE_IDS.hypothesis));
+    assert.ok(body.hypotheses.every((d) => d.kind === "hypothesis"));
+    assert.ok(body.decisions.every((d) => d.kind === "decision"));
+    assert.ok(body.facts.every((d) => d.kind === "fact"));
+    const errorItem = body.active_directives.find((d) => d.id === REPRESENTATIVE_IDS.collectionError);
+    assert.equal(errorItem?.freshness_status, "ERROR");
+    for (const item of body.active_directives) {
+      assert.match(item.id, /^cc:/);
+      assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(item.freshness_status));
+    }
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));

--- a/control-center/services/context/test/http-entry.test.ts
+++ b/control-center/services/context/test/http-entry.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { test } from "node:test";
+import { createRequestListener } from "../src/http.ts";
+import { silentLogger } from "../src/log.ts";
+import { startServer } from "../src/server.ts";
+import { LIMITS } from "../src/types.ts";
+import { AGENT, FOUNDER, makeService } from "./helpers.ts";
+
+async function withServer(
+  fn: (base: string) => Promise<void>,
+): Promise<void> {
+  const { service } = makeService();
+  const server = createServer(createRequestListener({ service, logger: silentLogger }, "confenge"));
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object");
+  const base = `http://127.0.0.1:${addr.port}`;
+  try {
+    await fn(base);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+test("HTTP entry drives shipped get_context and rejects agent mutation plus oversized payload", async () => {
+  await withServer(async (base) => {
+    const created = await fetch(`${base}/v1/directives`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-actor-id": FOUNDER.id,
+        "x-actor-role": FOUNDER.role,
+      },
+      body: JSON.stringify({
+        kind: "priority",
+        title: "Now",
+        body: "Do the important thing.",
+        scope: { company: "confenge" },
+        source: "founder",
+        confidence: 1,
+      }),
+    });
+    assert.equal(created.status, 201);
+    const rec = (await created.json()) as { id: string; kind: string };
+    assert.equal(rec.kind, "priority");
+
+    const missing = await fetch(`${base}/v1/context?company=confenge`);
+    assert.equal(missing.status, 401);
+    const missingBody = (await missing.json()) as { error: string };
+    assert.equal(missingBody.error, "missing_actor");
+
+    const agentWrite = await fetch(`${base}/v1/directives`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-actor-id": AGENT.id,
+        "x-actor-role": AGENT.role,
+      },
+      body: JSON.stringify({
+        kind: "decision",
+        title: "Agent decision",
+        body: "Should fail.",
+        scope: { company: "confenge" },
+        source: "agent",
+      }),
+    });
+    assert.equal(agentWrite.status, 403);
+    const agentBody = (await agentWrite.json()) as { error: string };
+    assert.equal(agentBody.error, "agent_mutation_forbidden");
+
+    const oversized = await fetch(`${base}/v1/directives`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-actor-id": FOUNDER.id,
+        "x-actor-role": FOUNDER.role,
+      },
+      body: "x".repeat(LIMITS.jsonBytes + 8),
+    });
+    assert.equal(oversized.status, 413);
+
+    const ctx = await fetch(`${base}/v1/context?company=confenge`, {
+      headers: { "x-actor-id": AGENT.id, "x-actor-role": AGENT.role },
+    });
+    assert.equal(ctx.status, 200);
+    const ctxText = await ctx.text();
+    const payload = JSON.parse(ctxText) as {
+      active_directives: Array<{ id: string; source: string; observed_at: string; freshness_status: string }>;
+      priorities: Array<{ id: string }>;
+    };
+    assert.ok(payload.active_directives.some((d) => d.id === rec.id));
+    assert.ok(payload.priorities.some((d) => d.id === rec.id));
+    const first = payload.active_directives[0];
+    assert.ok(first?.source);
+    assert.ok(first?.observed_at);
+    assert.ok(first?.freshness_status);
+
+    const ctx2 = await fetch(`${base}/v1/context?company=confenge`, {
+      headers: { "x-actor-id": AGENT.id, "x-actor-role": AGENT.role },
+    });
+    assert.equal(ctxText, await ctx2.text());
+  });
+});
+
+test("shipped startServer binds HTTP and serves representative get_context", async () => {
+  const { server, host, port } = await startServer(
+    {
+      CONTROL_CENTER_FOUNDER_ACTOR_ID: "founder-local",
+      CONTEXT_SERVICE_FIXTURE: "representative",
+      CONTROL_CENTER_COMPANY: "confenge",
+      HOST: "127.0.0.1",
+      PORT: "0",
+    },
+    { logger: silentLogger },
+  );
+  try {
+    const url = `http://${host}:${port}/v1/context?company=confenge&domain=commercial&resource=offer:CFG-DIAG-EXP-v1`;
+    const res = await fetch(url, {
+      headers: { "x-actor-id": "agent-session-launch", "x-actor-role": "agent" },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { active_directives: Array<{ id: string; kind: string }>; hypotheses: Array<{ id: string }> };
+    const ids = body.active_directives.map((d) => d.id);
+    assert.ok(ids.includes("dir-company-priority"));
+    assert.ok(ids.includes("dir-resource-fact"));
+    assert.equal(ids.includes("dir-sibling-fact"), false);
+    assert.equal(ids.includes("dir-resource-expired"), false);
+    assert.ok(body.hypotheses.some((d) => d.id === "dir-company-hypothesis"));
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+});

--- a/control-center/services/context/test/lifecycle.test.ts
+++ b/control-center/services/context/test/lifecycle.test.ts
@@ -12,20 +12,25 @@ test("creates all seven kinds with required fields and one audit per create", ()
     );
     assert.equal(rec.kind, kind);
     assert.equal(rec.status, "active");
-    assert.ok(rec.scope);
+    assert.equal(rec.scope, "company");
+    assert.match(rec.id, /^cc:directive:/);
+    assert.match(rec.revision_id, /^cc:directive-revision:/);
     assert.ok(rec.effective_from.endsWith("Z"));
     assert.equal(rec.expires_at, null);
     assert.equal(rec.supersedes, null);
-    assert.equal(rec.created_by, FOUNDER.id);
+    assert.equal(rec.created_by.kind, "human");
+    assert.equal(rec.created_by.id, FOUNDER.id);
     assert.equal(rec.created_at, NOW);
-    assert.equal(rec.provenance.source, "founder");
+    assert.equal(rec.provenance.source.system, "manual");
     assert.ok(rec.provenance.observed_at.endsWith("Z"));
-    assert.ok(rec.provenance.freshness_status);
+    assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(rec.provenance.freshness_status));
+    assert.equal(typeof rec.provenance.confidence, "number");
   }
   const audits = service.listAudit(FOUNDER);
   assert.equal(audits.length, DIRECTIVE_KINDS.length);
   assert.ok(audits.every((a) => a.action === "directive.create"));
   assert.ok(audits.every((a) => a.at.endsWith("Z")));
+  assert.ok(audits.every((a) => a.actor.kind === "human"));
 });
 
 test("versioning is non-destructive and audited", () => {
@@ -54,7 +59,7 @@ test("supersede closes the predecessor and creates a successor", () => {
     original.id,
     createInput("constraint", "New constraint", { body: "Replacement text" }),
   );
-  assert.equal(successor.supersedes, original.id);
+  assert.deepEqual(successor.supersedes, [original.id]);
   assert.equal(successor.status, "active");
   const closed = service.getDirective(FOUNDER, original.id);
   assert.equal(closed.status, "superseded");
@@ -65,11 +70,30 @@ test("supersede closes the predecessor and creates a successor", () => {
   assert.ok(history.length >= 2);
   assert.ok(history.some((r) => r.status === "active"));
   assert.ok(history.some((r) => r.status === "superseded"));
-  const active = service.getActiveDirectives(FOUNDER, { company: "confenge" });
+  const active = service.getActiveDirectives(FOUNDER, "company");
   assert.ok(active.every((d) => d.id !== original.id));
   assert.ok(active.some((d) => d.id === successor.id));
   const actions = service.listAudit(FOUNDER).map((a) => a.action);
   assert.deepEqual(actions, ["directive.create", "directive.supersede", "directive.create"]);
+});
+
+test("one successor can supersede multiple canonical predecessors", () => {
+  const { service } = makeService();
+  const a = service.createDirective(FOUNDER, createInput("constraint", "Constraint A"));
+  const b = service.createDirective(FOUNDER, createInput("constraint", "Constraint B"));
+  const successor = service.createDirective(
+    FOUNDER,
+    createInput("constraint", "Merged constraint", { supersedes: [a.id, b.id] }),
+  );
+  assert.deepEqual(successor.supersedes, [a.id, b.id]);
+  assert.equal(service.getDirective(FOUNDER, a.id).status, "superseded");
+  assert.equal(service.getDirective(FOUNDER, b.id).status, "superseded");
+  const active = service.getActiveDirectives(FOUNDER, "company");
+  assert.equal(active.some((d) => d.id === a.id), false);
+  assert.equal(active.some((d) => d.id === b.id), false);
+  assert.ok(active.some((d) => d.id === successor.id));
+  assert.ok(service.getDirective(FOUNDER, a.id).id, a.id);
+  assert.ok(service.listRevisions(FOUNDER, a.id).length >= 2);
 });
 
 test("expire removes from active set and keeps history", () => {
@@ -78,31 +102,34 @@ test("expire removes from active set and keeps history", () => {
   const expired = service.expire(FOUNDER, rec.id);
   assert.equal(expired.status, "expired");
   assert.equal(expired.expires_at, NOW);
-  const active = service.getActiveDirectives(FOUNDER, { company: "confenge" });
+  const active = service.getActiveDirectives(FOUNDER, "company");
   assert.ok(active.every((d) => d.id !== rec.id));
   const history = service.listRevisions(FOUNDER, rec.id);
   assert.equal(history.length, 2);
   assert.equal(service.listAudit(FOUNDER).filter((a) => a.action === "directive.expire").length, 1);
+  assert.equal(service.getDirective(FOUNDER, rec.id).status, "expired");
 });
 
-test("activate and deactivate toggle membership of the active set", () => {
+test("draft then activate then revoke toggles membership of the active set", () => {
   const { service } = makeService();
-  const rec = service.createDirective(FOUNDER, createInput("directive", "Draft", { status: "inactive" }));
+  const rec = service.createDirective(FOUNDER, createInput("directive", "Draft", { status: "draft" }));
+  assert.equal(rec.status, "draft");
   assert.equal(
-    service.getActiveDirectives(FOUNDER, { company: "confenge" }).some((d) => d.id === rec.id),
+    service.getActiveDirectives(FOUNDER, "company").some((d) => d.id === rec.id),
     false,
   );
   const activated = service.activate(FOUNDER, rec.id);
   assert.equal(activated.status, "active");
-  assert.ok(service.getActiveDirectives(FOUNDER, { company: "confenge" }).some((d) => d.id === rec.id));
-  const deactivated = service.deactivate(FOUNDER, rec.id);
-  assert.equal(deactivated.status, "inactive");
+  assert.ok(service.getActiveDirectives(FOUNDER, "company").some((d) => d.id === rec.id));
+  const revoked = service.revoke(FOUNDER, rec.id);
+  assert.equal(revoked.status, "revoked");
   assert.equal(
-    service.getActiveDirectives(FOUNDER, { company: "confenge" }).some((d) => d.id === rec.id),
+    service.getActiveDirectives(FOUNDER, "company").some((d) => d.id === rec.id),
     false,
   );
+  assert.equal(service.getDirective(FOUNDER, rec.id).status, "revoked");
   const actions = service.listAudit(FOUNDER).map((a) => a.action);
-  assert.deepEqual(actions, ["directive.create", "directive.activate", "directive.deactivate"]);
+  assert.deepEqual(actions, ["directive.create", "directive.activate", "directive.revoke"]);
 });
 
 test("items past expires_at are absent from the active set even if status is still active", () => {
@@ -115,7 +142,7 @@ test("items past expires_at are absent from the active set even if status is sti
     }),
   );
   assert.equal(rec.status, "active");
-  const active = service.getActiveDirectives(FOUNDER, { company: "confenge" });
+  const active = service.getActiveDirectives(FOUNDER, "company");
   assert.ok(active.every((d) => d.id !== rec.id));
   assert.equal(service.getDirective(FOUNDER, rec.id).id, rec.id);
 });

--- a/control-center/services/context/test/lifecycle.test.ts
+++ b/control-center/services/context/test/lifecycle.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DIRECTIVE_KINDS, isActiveAt, frozenClock } from "../src/index.ts";
+import { NOW, FOUNDER, createInput, makeService } from "./helpers.ts";
+
+test("creates all seven kinds with required fields and one audit per create", () => {
+  const { service } = makeService();
+  for (const kind of DIRECTIVE_KINDS) {
+    const rec = service.createDirective(
+      FOUNDER,
+      createInput(kind, `Kind ${kind}`, { confidence: kind === "hypothesis" ? 0.3 : 1 }),
+    );
+    assert.equal(rec.kind, kind);
+    assert.equal(rec.status, "active");
+    assert.ok(rec.scope);
+    assert.ok(rec.effective_from.endsWith("Z"));
+    assert.equal(rec.expires_at, null);
+    assert.equal(rec.supersedes, null);
+    assert.equal(rec.created_by, FOUNDER.id);
+    assert.equal(rec.created_at, NOW);
+    assert.equal(rec.provenance.source, "founder");
+    assert.ok(rec.provenance.observed_at.endsWith("Z"));
+    assert.ok(rec.provenance.freshness_status);
+  }
+  const audits = service.listAudit(FOUNDER);
+  assert.equal(audits.length, DIRECTIVE_KINDS.length);
+  assert.ok(audits.every((a) => a.action === "directive.create"));
+  assert.ok(audits.every((a) => a.at.endsWith("Z")));
+});
+
+test("versioning is non-destructive and audited", () => {
+  const { service } = makeService();
+  const created = service.createDirective(FOUNDER, createInput("directive", "V1 title"));
+  const v2 = service.createVersion(FOUNDER, created.id, { title: "V2 title", body: "V2 body" });
+  assert.equal(v2.id, created.id);
+  assert.equal(v2.version, 2);
+  assert.notEqual(v2.revision_id, created.revision_id);
+  assert.equal(v2.title, "V2 title");
+  const current = service.getDirective(FOUNDER, created.id);
+  assert.equal(current.revision_id, v2.revision_id);
+  const revs = service.listRevisions(FOUNDER, created.id);
+  assert.equal(revs.length, 2);
+  assert.equal(revs[0]?.title, "V1 title");
+  assert.equal(revs[1]?.title, "V2 title");
+  const actions = service.listAudit(FOUNDER).map((a) => a.action);
+  assert.deepEqual(actions, ["directive.create", "directive.version"]);
+});
+
+test("supersede closes the predecessor and creates a successor", () => {
+  const { service } = makeService();
+  const original = service.createDirective(FOUNDER, createInput("constraint", "Old constraint"));
+  const successor = service.supersede(
+    FOUNDER,
+    original.id,
+    createInput("constraint", "New constraint", { body: "Replacement text" }),
+  );
+  assert.equal(successor.supersedes, original.id);
+  assert.equal(successor.status, "active");
+  const closed = service.getDirective(FOUNDER, original.id);
+  assert.equal(closed.status, "superseded");
+  const now = frozenClock(NOW).now();
+  assert.equal(isActiveAt(closed, now), false);
+  assert.equal(isActiveAt(successor, now), true);
+  const history = service.listRevisions(FOUNDER, original.id);
+  assert.ok(history.length >= 2);
+  assert.ok(history.some((r) => r.status === "active"));
+  assert.ok(history.some((r) => r.status === "superseded"));
+  const active = service.getActiveDirectives(FOUNDER, { company: "confenge" });
+  assert.ok(active.every((d) => d.id !== original.id));
+  assert.ok(active.some((d) => d.id === successor.id));
+  const actions = service.listAudit(FOUNDER).map((a) => a.action);
+  assert.deepEqual(actions, ["directive.create", "directive.supersede", "directive.create"]);
+});
+
+test("expire removes from active set and keeps history", () => {
+  const { service } = makeService();
+  const rec = service.createDirective(FOUNDER, createInput("risk", "A risk"));
+  const expired = service.expire(FOUNDER, rec.id);
+  assert.equal(expired.status, "expired");
+  assert.equal(expired.expires_at, NOW);
+  const active = service.getActiveDirectives(FOUNDER, { company: "confenge" });
+  assert.ok(active.every((d) => d.id !== rec.id));
+  const history = service.listRevisions(FOUNDER, rec.id);
+  assert.equal(history.length, 2);
+  assert.equal(service.listAudit(FOUNDER).filter((a) => a.action === "directive.expire").length, 1);
+});
+
+test("activate and deactivate toggle membership of the active set", () => {
+  const { service } = makeService();
+  const rec = service.createDirective(FOUNDER, createInput("directive", "Draft", { status: "inactive" }));
+  assert.equal(
+    service.getActiveDirectives(FOUNDER, { company: "confenge" }).some((d) => d.id === rec.id),
+    false,
+  );
+  const activated = service.activate(FOUNDER, rec.id);
+  assert.equal(activated.status, "active");
+  assert.ok(service.getActiveDirectives(FOUNDER, { company: "confenge" }).some((d) => d.id === rec.id));
+  const deactivated = service.deactivate(FOUNDER, rec.id);
+  assert.equal(deactivated.status, "inactive");
+  assert.equal(
+    service.getActiveDirectives(FOUNDER, { company: "confenge" }).some((d) => d.id === rec.id),
+    false,
+  );
+  const actions = service.listAudit(FOUNDER).map((a) => a.action);
+  assert.deepEqual(actions, ["directive.create", "directive.activate", "directive.deactivate"]);
+});
+
+test("items past expires_at are absent from the active set even if status is still active", () => {
+  const { service } = makeService();
+  const rec = service.createDirective(
+    FOUNDER,
+    createInput("directive", "Time boxed", {
+      effective_from: "2026-01-01T00:00:00.000Z",
+      expires_at: "2026-01-02T00:00:00.000Z",
+    }),
+  );
+  assert.equal(rec.status, "active");
+  const active = service.getActiveDirectives(FOUNDER, { company: "confenge" });
+  assert.ok(active.every((d) => d.id !== rec.id));
+  assert.equal(service.getDirective(FOUNDER, rec.id).id, rec.id);
+});

--- a/control-center/services/context/test/payload.test.ts
+++ b/control-center/services/context/test/payload.test.ts
@@ -41,17 +41,9 @@ test("oversized and unsanitized inputs are rejected", () => {
       }),
     (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
   );
-  assert.throws(
-    () =>
-      service.createDirective(
-        FOUNDER,
-        createInput("fact", "ok", { scope: { company: "confenge", resource: "no-domain" } }),
-      ),
-    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
-  );
   const created = service.createDirective(FOUNDER, createInput("fact", "Sanitized   title"));
   assert.equal(created.title, "Sanitized title");
-  assert.equal(created.created_by, FOUNDER.id);
+  assert.equal(created.created_by.id, FOUNDER.id);
 });
 
 test("kind cannot change across versions", () => {
@@ -59,6 +51,43 @@ test("kind cannot change across versions", () => {
   const rec = service.createDirective(FOUNDER, createInput("fact", "A fact"));
   assert.throws(
     () => service.createVersion(FOUNDER, rec.id, { kind: "hypothesis", title: "now a guess" }),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+});
+
+test("parallel ontology payloads are rejected", () => {
+  const { service } = makeService();
+  assert.throws(
+    () =>
+      service.createDirective(FOUNDER, {
+        ...createInput("fact", "ok"),
+        scope: { company: "confenge", domain: "commercial", resource: "offer:x" },
+      }),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () => service.createDirective(FOUNDER, createInput("fact", "ok", { status: "inactive" as never })),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () =>
+      service.createDirective(FOUNDER, createInput("fact", "ok", { freshness_status: "fresh" as never })),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () =>
+      service.createDirective(FOUNDER, {
+        ...createInput("fact", "ok"),
+        source: "founder",
+      }),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () =>
+      service.createDirective(FOUNDER, {
+        ...createInput("fact", "ok"),
+        supersedes: "cc:directive:other",
+      }),
     (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
   );
 });

--- a/control-center/services/context/test/payload.test.ts
+++ b/control-center/services/context/test/payload.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { LIMITS, ServiceError } from "../src/index.ts";
+import { FOUNDER, createInput, makeService } from "./helpers.ts";
+
+test("oversized and unsanitized inputs are rejected", () => {
+  const { service } = makeService();
+  assert.throws(
+    () => service.createDirective(FOUNDER, createInput("fact", "x".repeat(LIMITS.titleChars + 1))),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () =>
+      service.createDirective(
+        FOUNDER,
+        createInput("fact", "ok", { body: "b".repeat(LIMITS.bodyChars + 1) }),
+      ),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () => service.createDirective(FOUNDER, { ...createInput("fact", "ok"), extra: true }),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () => service.createDirective(FOUNDER, createInput("fact", "   ")),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () =>
+      service.createDirective(FOUNDER, {
+        ...createInput("fact", "ok"),
+        kind: "note",
+      }),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () =>
+      service.createDirective(FOUNDER, {
+        ...createInput("fact", "ok"),
+        created_by: "spoof",
+      }),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  assert.throws(
+    () =>
+      service.createDirective(
+        FOUNDER,
+        createInput("fact", "ok", { scope: { company: "confenge", resource: "no-domain" } }),
+      ),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+  const created = service.createDirective(FOUNDER, createInput("fact", "Sanitized   title"));
+  assert.equal(created.title, "Sanitized title");
+  assert.equal(created.created_by, FOUNDER.id);
+});
+
+test("kind cannot change across versions", () => {
+  const { service } = makeService();
+  const rec = service.createDirective(FOUNDER, createInput("fact", "A fact"));
+  assert.throws(
+    () => service.createVersion(FOUNDER, rec.id, { kind: "hypothesis", title: "now a guess" }),
+    (err: unknown) => err instanceof ServiceError && err.code === "invalid_input",
+  );
+});

--- a/control-center/services/context/test/schema-contract.test.ts
+++ b/control-center/services/context/test/schema-contract.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { createStoreFromEnv } from "../src/store/from-env.ts";
+import { ServiceError } from "../src/errors.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcRoot = join(here, "..", "src");
+const sqlPath = join(srcRoot, "store", "expected-schema.sql");
+
+function walkTs(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkTs(full));
+    } else if (entry.name.endsWith(".ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test("expected-schema.sql is a test-only contract of canonical PersistencePort records", () => {
+  const sql = readFileSync(sqlPath, "utf8");
+  assert.match(sql, /TEST CONTRACT ONLY/);
+  assert.match(sql, /MUST NOT load/);
+  assert.match(sql, /at runtime/);
+  assert.match(sql, /scope TEXT NOT NULL/);
+  assert.doesNotMatch(sql, /scope_company/);
+  assert.doesNotMatch(sql, /scope_domain/);
+  assert.doesNotMatch(sql, /scope_resource/);
+  assert.match(sql, /status TEXT NOT NULL CHECK \(status IN \('draft', 'active', 'superseded', 'revoked', 'expired'\)\)/);
+  assert.doesNotMatch(sql, /'inactive'/);
+  assert.match(sql, /freshness_status TEXT NOT NULL CHECK \(freshness_status IN \('FRESH', 'STALE', 'UNKNOWN', 'ERROR'\)\)/);
+  assert.doesNotMatch(sql, /'fresh'| 'stale'| 'unknown'/);
+  assert.match(sql, /supersedes TEXT\[\]/);
+  assert.match(sql, /created_by_kind TEXT NOT NULL CHECK \(created_by_kind IN \('human', 'agent', 'system'\)\)/);
+  assert.match(sql, /source_system TEXT NOT NULL/);
+  assert.match(sql, /source_kind TEXT NOT NULL/);
+  assert.match(sql, /source_locator TEXT NOT NULL/);
+  assert.match(sql, /confidence DOUBLE PRECISION NOT NULL/);
+
+  for (const file of walkTs(srcRoot)) {
+    const body = readFileSync(file, "utf8");
+    assert.equal(body.includes("readFile") && body.includes("expected-schema.sql"), false);
+    assert.doesNotMatch(body, /from ["'].*expected-schema/);
+    if (file.endsWith("from-env.ts") || file.endsWith("boot.ts") || file.endsWith("server.ts")) {
+      assert.doesNotMatch(body, /expected-schema\.sql/);
+    }
+  }
+});
+
+test("package has no postgres production dependency and DATABASE_URL still fail-closes", () => {
+  const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8")) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+  for (const name of Object.keys(deps)) {
+    assert.equal(["pg", "postgres", "postgresql"].includes(name), false);
+  }
+  assert.throws(
+    () => createStoreFromEnv({ DATABASE_URL: "postgresql://127.0.0.1/control_center" }),
+    (err: unknown) => err instanceof ServiceError && err.code === "store_misconfigured",
+  );
+});

--- a/control-center/services/context/test/scope-context.test.ts
+++ b/control-center/services/context/test/scope-context.test.ts
@@ -3,51 +3,70 @@ import { test } from "node:test";
 import { canonicalStringify } from "../src/index.ts";
 import { AGENT, FOUNDER, createInput, makeService } from "./helpers.ts";
 
-const RESOURCE = {
-  company: "confenge",
-  domain: "commercial",
-  resource: "offer:CFG-DIAG-EXP-v1",
-};
-const SIBLING = {
-  company: "confenge",
-  domain: "commercial",
-  resource: "offer:OTHER-SKU",
-};
-const DOMAIN = { company: "confenge", domain: "commercial" };
-const COMPANY = { company: "confenge" };
-
-test("scope inheritance is company + domain + resource and does not leak siblings or descendants", () => {
+test("repo query inherits company + configured domain + repo and does not leak siblings or descendants", () => {
   const { service } = makeService();
-  const company = service.createDirective(FOUNDER, createInput("priority", "Company priority", { scope: COMPANY }));
-  const domain = service.createDirective(FOUNDER, createInput("directive", "Domain directive", { scope: DOMAIN }));
-  const resource = service.createDirective(FOUNDER, createInput("fact", "Resource fact", { scope: RESOURCE }));
-  const sibling = service.createDirective(FOUNDER, createInput("fact", "Sibling fact", { scope: SIBLING }));
+  const company = service.createDirective(FOUNDER, createInput("priority", "Company priority", { scope: "company" }));
+  const domain = service.createDirective(FOUNDER, createInput("directive", "Domain directive", { scope: "commercial" }));
+  const resource = service.createDirective(
+    FOUNDER,
+    createInput("fact", "Repo fact", { scope: "repo:Governance" }),
+  );
+  const sibling = service.createDirective(FOUNDER, createInput("fact", "Sibling fact", { scope: "repo:Warmbly" }));
   const otherDomain = service.createDirective(
     FOUNDER,
-    createInput("risk", "Finance risk", { scope: { company: "confenge", domain: "finance" } }),
+    createInput("risk", "Finance risk", { scope: "finance" }),
   );
+  const client = service.createDirective(FOUNDER, createInput("fact", "Client fact", { scope: "client:acme" }));
 
-  const ctx = service.getContext(FOUNDER, RESOURCE);
+  const ctx = service.getContext(FOUNDER, "repo:Governance");
+  assert.equal(ctx.scope, "repo:Governance");
   const ids = ctx.active_directives.map((d) => d.id);
   assert.ok(ids.includes(company.id));
   assert.ok(ids.includes(domain.id));
   assert.ok(ids.includes(resource.id));
   assert.equal(ids.includes(sibling.id), false);
   assert.equal(ids.includes(otherDomain.id), false);
+  assert.equal(ids.includes(client.id), false);
 
-  const companyCtx = service.getContext(FOUNDER, COMPANY);
+  const companyCtx = service.getContext(FOUNDER, "company");
   const companyIds = companyCtx.active_directives.map((d) => d.id);
   assert.ok(companyIds.includes(company.id));
   assert.equal(companyIds.includes(domain.id), false);
   assert.equal(companyIds.includes(resource.id), false);
   assert.equal(companyIds.includes(sibling.id), false);
 
-  const siblingCtx = service.getContext(AGENT, SIBLING);
+  const siblingCtx = service.getContext(AGENT, "repo:Warmbly");
   assert.ok(siblingCtx.active_directives.some((d) => d.id === sibling.id));
   assert.equal(
     siblingCtx.active_directives.some((d) => d.id === resource.id),
     false,
   );
+});
+
+test("client query inherits company + clients + client and does not leak siblings", () => {
+  const { service } = makeService();
+  const company = service.createDirective(FOUNDER, createInput("decision", "Company decision", { scope: "company" }));
+  const clients = service.createDirective(FOUNDER, createInput("directive", "Clients domain", { scope: "clients" }));
+  const acme = service.createDirective(FOUNDER, createInput("fact", "Acme fact", { scope: "client:acme" }));
+  const other = service.createDirective(FOUNDER, createInput("fact", "Other client", { scope: "client:other" }));
+  const commercial = service.createDirective(FOUNDER, createInput("fact", "Commercial fact", { scope: "commercial" }));
+  const repo = service.createDirective(FOUNDER, createInput("fact", "Repo fact", { scope: "repo:Governance" }));
+
+  const ctx = service.getContext(FOUNDER, "client:acme");
+  const ids = ctx.active_directives.map((d) => d.id);
+  assert.ok(ids.includes(company.id));
+  assert.ok(ids.includes(clients.id));
+  assert.ok(ids.includes(acme.id));
+  assert.equal(ids.includes(other.id), false);
+  assert.equal(ids.includes(commercial.id), false);
+  assert.equal(ids.includes(repo.id), false);
+
+  const clientsOnly = service.getContext(FOUNDER, "clients");
+  const clientsIds = clientsOnly.active_directives.map((d) => d.id);
+  assert.ok(clientsIds.includes(company.id));
+  assert.ok(clientsIds.includes(clients.id));
+  assert.equal(clientsIds.includes(acme.id), false);
+  assert.equal(clientsIds.includes(other.id), false);
 });
 
 test("hypothesis is separated from fact and decision; provenance is present; get_context is deterministic", () => {
@@ -60,8 +79,8 @@ test("hypothesis is separated from fact and decision; provenance is present; get
   );
   service.createDirective(FOUNDER, createInput("priority", "A priority"));
 
-  const ctx1 = service.getContext(FOUNDER, COMPANY);
-  const ctx2 = service.getContext(FOUNDER, COMPANY);
+  const ctx1 = service.getContext(FOUNDER, "company");
+  const ctx2 = service.getContext(FOUNDER, "company");
   assert.equal(canonicalStringify(ctx1), canonicalStringify(ctx2));
 
   assert.ok(ctx1.hypotheses.length === 1);
@@ -80,9 +99,14 @@ test("hypothesis is separated from fact and decision; provenance is present; get
   assert.equal(ctx1.facts[0]?.kind, "fact");
 
   for (const item of ctx1.active_directives) {
-    assert.equal(typeof item.source, "string");
+    assert.equal(typeof item.source, "object");
+    assert.equal(typeof item.source.system, "string");
+    assert.equal(typeof item.source.kind, "string");
+    assert.equal(typeof item.source.locator, "string");
     assert.ok(item.observed_at.endsWith("Z"));
-    assert.ok(item.freshness_status === "fresh" || item.freshness_status === "stale" || item.freshness_status === "unknown");
+    assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(item.freshness_status));
+    assert.equal(typeof item.confidence, "number");
+    assert.equal(item.created_by.kind, "human");
   }
   assert.equal(ctx1.hypotheses[0]?.confidence, 0.2);
 
@@ -105,7 +129,7 @@ test("expired and superseded items stay out of get_context and remain readable a
   service.expire(FOUNDER, expiring.id);
   const successor = service.supersede(FOUNDER, old.id, createInput("constraint", "New constraint"));
 
-  const ctx = service.getContext(FOUNDER, COMPANY);
+  const ctx = service.getContext(FOUNDER, "company");
   const ids = ctx.active_directives.map((d) => d.id);
   assert.ok(ids.includes(live.id));
   assert.ok(ids.includes(successor.id));

--- a/control-center/services/context/test/scope-context.test.ts
+++ b/control-center/services/context/test/scope-context.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { canonicalStringify } from "../src/index.ts";
+import { AGENT, FOUNDER, createInput, makeService } from "./helpers.ts";
+
+const RESOURCE = {
+  company: "confenge",
+  domain: "commercial",
+  resource: "offer:CFG-DIAG-EXP-v1",
+};
+const SIBLING = {
+  company: "confenge",
+  domain: "commercial",
+  resource: "offer:OTHER-SKU",
+};
+const DOMAIN = { company: "confenge", domain: "commercial" };
+const COMPANY = { company: "confenge" };
+
+test("scope inheritance is company + domain + resource and does not leak siblings or descendants", () => {
+  const { service } = makeService();
+  const company = service.createDirective(FOUNDER, createInput("priority", "Company priority", { scope: COMPANY }));
+  const domain = service.createDirective(FOUNDER, createInput("directive", "Domain directive", { scope: DOMAIN }));
+  const resource = service.createDirective(FOUNDER, createInput("fact", "Resource fact", { scope: RESOURCE }));
+  const sibling = service.createDirective(FOUNDER, createInput("fact", "Sibling fact", { scope: SIBLING }));
+  const otherDomain = service.createDirective(
+    FOUNDER,
+    createInput("risk", "Finance risk", { scope: { company: "confenge", domain: "finance" } }),
+  );
+
+  const ctx = service.getContext(FOUNDER, RESOURCE);
+  const ids = ctx.active_directives.map((d) => d.id);
+  assert.ok(ids.includes(company.id));
+  assert.ok(ids.includes(domain.id));
+  assert.ok(ids.includes(resource.id));
+  assert.equal(ids.includes(sibling.id), false);
+  assert.equal(ids.includes(otherDomain.id), false);
+
+  const companyCtx = service.getContext(FOUNDER, COMPANY);
+  const companyIds = companyCtx.active_directives.map((d) => d.id);
+  assert.ok(companyIds.includes(company.id));
+  assert.equal(companyIds.includes(domain.id), false);
+  assert.equal(companyIds.includes(resource.id), false);
+  assert.equal(companyIds.includes(sibling.id), false);
+
+  const siblingCtx = service.getContext(AGENT, SIBLING);
+  assert.ok(siblingCtx.active_directives.some((d) => d.id === sibling.id));
+  assert.equal(
+    siblingCtx.active_directives.some((d) => d.id === resource.id),
+    false,
+  );
+});
+
+test("hypothesis is separated from fact and decision; provenance is present; get_context is deterministic", () => {
+  const { service } = makeService();
+  service.createDirective(FOUNDER, createInput("decision", "A decision", { confidence: 1 }));
+  service.createDirective(FOUNDER, createInput("fact", "A fact", { confidence: 0.9 }));
+  service.createDirective(
+    FOUNDER,
+    createInput("hypothesis", "A hypothesis", { confidence: 0.2, body: "Not a fact." }),
+  );
+  service.createDirective(FOUNDER, createInput("priority", "A priority"));
+
+  const ctx1 = service.getContext(FOUNDER, COMPANY);
+  const ctx2 = service.getContext(FOUNDER, COMPANY);
+  assert.equal(canonicalStringify(ctx1), canonicalStringify(ctx2));
+
+  assert.ok(ctx1.hypotheses.length === 1);
+  assert.ok(ctx1.decisions.length === 1);
+  assert.ok(ctx1.facts.length === 1);
+  assert.equal(
+    ctx1.decisions.some((d) => d.kind === "hypothesis"),
+    false,
+  );
+  assert.equal(
+    ctx1.facts.some((d) => d.kind === "hypothesis"),
+    false,
+  );
+  assert.equal(ctx1.hypotheses[0]?.kind, "hypothesis");
+  assert.equal(ctx1.decisions[0]?.kind, "decision");
+  assert.equal(ctx1.facts[0]?.kind, "fact");
+
+  for (const item of ctx1.active_directives) {
+    assert.equal(typeof item.source, "string");
+    assert.ok(item.observed_at.endsWith("Z"));
+    assert.ok(item.freshness_status === "fresh" || item.freshness_status === "stale" || item.freshness_status === "unknown");
+  }
+  assert.equal(ctx1.hypotheses[0]?.confidence, 0.2);
+
+  const decisions = service.getDecisions(FOUNDER);
+  assert.ok(decisions.every((d) => d.kind === "decision"));
+  assert.equal(
+    decisions.some((d) => d.kind === "hypothesis"),
+    false,
+  );
+  const priorities = service.getPriorities(FOUNDER);
+  assert.ok(priorities.every((d) => d.kind === "priority"));
+  assert.ok(priorities.some((d) => d.title === "A priority"));
+});
+
+test("expired and superseded items stay out of get_context and remain readable as history", () => {
+  const { service } = makeService();
+  const live = service.createDirective(FOUNDER, createInput("fact", "Live fact"));
+  const expiring = service.createDirective(FOUNDER, createInput("directive", "Will expire"));
+  const old = service.createDirective(FOUNDER, createInput("constraint", "Old constraint"));
+  service.expire(FOUNDER, expiring.id);
+  const successor = service.supersede(FOUNDER, old.id, createInput("constraint", "New constraint"));
+
+  const ctx = service.getContext(FOUNDER, COMPANY);
+  const ids = ctx.active_directives.map((d) => d.id);
+  assert.ok(ids.includes(live.id));
+  assert.ok(ids.includes(successor.id));
+  assert.equal(ids.includes(expiring.id), false);
+  assert.equal(ids.includes(old.id), false);
+  assert.equal(service.getDirective(FOUNDER, expiring.id).status, "expired");
+  assert.equal(service.getDirective(FOUNDER, old.id).status, "superseded");
+  assert.ok(service.listRevisions(FOUNDER, old.id).length >= 2);
+});

--- a/control-center/services/context/tsconfig.json
+++ b/control-center/services/context/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "useUnknownInCatchVariables": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Aligns the Control Center **context service** (`control-center/services/context/`) with the canonical ontology from `cc/01` **without weakening authority policy**.

This remains **not** UI, **not** MCP, **not** ERP, and **not** a Warmbly replacement. It returns minimum sufficient, deterministic context for one agent session **by string scope**.

## Canonical ontology (this update)

- `scope` is a **string**: v1 literals `company|commercial|finance|clients|infrastructure|inbound` plus `repo:NAME` and `client:SLUG`.
- Statuses are exactly `draft|active|superseded|revoked|expired`. `inactive` is rejected.
- Freshness is exactly `FRESH|STALE|UNKNOWN|ERROR`. `ERROR` is never coerced to `UNKNOWN`.
- `supersedes` is a list of canonical `cc:*` IDs (or null).
- Actors are `ActorRef` (`kind` `human|agent|system` plus opaque `id`). Sources are `SourceRef` (`system`, `kind`, `locator`).
- Resource IDs match `cc:type-kebab:ulid-or-slug`.
- Aggregated items carry provenance `source`, `observed_at`, `freshness_status`, and `confidence`.
- Object `{company,domain,resource}`, status `inactive`, lowercase `fresh|stale|unknown`, a bare string `source`, and a scalar `supersedes` are rejected.

## Authority policy (preserved)

- Only the configured founder/`human` ActorRef may mutate directives (including `decision`/`constraint`).
- An agent may only submit a `DirectiveProposal` that does **not** change the active set, status, or supersession.
- Missing/unknown actor fails closed. No admin bypass.

## Inheritance

- Query `repo:x` returns `company` + the **explicitly configured** domain for that repo + `repo:x`.
- Query `client:y` returns `company` + `clients` + `client:y`.
- Siblings and descendants do not leak. A `company` query does not dump descendants.
- `hypothesis` stays partitioned from `fact`/`decision`. `get_decisions()` never returns hypothesis.

## Persistence

- In-memory `PersistencePort` only. No live Postgres client or applied migration.
- `DATABASE_URL` fails closed (no silent fixture fallback).
- `expected-schema.sql` is a **test-only contract** of the port, not a second runtime authority.

## Out of scope

- Real PostgreSQL adapter, UI / cockpit / MCP, `commercial/`, Governance PR #8, Asaas / Warmbly mutations.
- Merge to `main`.

## Tests

```bash
cd control-center/services/context && npm test
```

31 tests covering ontology rejection, repo/client inheritance, agent overwrite, multi-supersede, revoke, expire, and ERROR freshness. HTTP and CLI representative launches are deterministic across two runs.

Draft PR. Do not merge automatically.
