### PR TITLE
feat(control-center): commercial executive read model

### DIFF
--- a/control-center/domains/commercial/.gitignore
+++ b/control-center/domains/commercial/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/control-center/domains/commercial/README.md
+++ b/control-center/domains/commercial/README.md
@@ -1,0 +1,81 @@
+# Control Center — commercial executive read model
+
+Ownership path: `control-center/domains/commercial/`.
+
+This package projects **Warmbly-shaped commercial observations** plus a **read-only Governance offer pin** into a one-screen executive summary: funnel counts, pipeline money, exceptions, and at most three `now` attention items.
+
+It is not chat, not an ERP, not a second catalog, and not a Warmbly or Asaas client. It never mutates Warmbly, Asaas, checkout, refund, cancel, or commercial send.
+
+## Decisions
+
+1. **Governance is catalog/terms authority. Warmbly is commercial runtime.** This document is a read model (`authority.this_document = read_model`).
+2. **Offer pin is identity only.** The pin carries `authority_id`, `catalog_id`, `offer_id` + `offer_version` pairs, and the Extra historical marker (`1000000` cents / `CFG-EXC-EXTRA-HISTORICAL-v1`). It does **not** copy `commercial/offers/catalog.v1.json` (no names, prices, terms, copy). Extra is **not an offer**.
+3. **Provenance on every aggregate.** `source`, `observed_at`, `freshness_status`, and `confidence` when applicable.
+4. **Local freshness set:** `FRESH` | `STALE` | `UNKNOWN` | `ERROR` (contracts workstream). Persistence currently uses `fresh` | `stale` | `unknown` | `expired`. Map at the persistence boundary later; do not rewrite persistence from here.
+5. **Money is integer cents + ISO currency.** Warmbly major-unit floats convert fail-closed (no silent rounding). `10.001` is not cents.
+6. **Nominal pipeline** is the sum of known open-pipeline cents. **Weighted pipeline** is emitted only when every open item has a known amount **and** a `probability` in `[0, 1]` marked `probability_reliable: true`. Otherwise `insufficient_data`. Warmbly CRM deals have no win-probability field today — weighted `insufficient_data` is correct, not a gap to fill by invention.
+7. **Funnel keys (fixed):** `novos_leads`, `qualificados`, `oportunidades`, `propostas`, `clientes`. Unclassifiable / `UNKNOWN` records do not inflate those counts.
+8. **Attention is action, not a KPI wall.** Exceptions include aging, missing next action, stalled stages, conversion-window gaps, unknown `offer_id`, version drift, and Extra-as-offer. Homepage-shaped slice: horizon `now`, max 3, one item per record, highest-rank first.
+9. **Fail closed.** Incomplete fixtures yield zeros, `UNKNOWN`, or `insufficient_data`. The projection does not throw into invented counts.
+10. **Single-user later, no hardcoded identity/password.** No secrets in git, logs, URLs, or a client bundle. Logs are structured JSON on stderr with secret/PII keys redacted.
+11. **Read-only.** No HTTP client. Convergence with the Warmbly connector is a later campaign.
+
+## Layout
+
+```
+src/contracts.ts    local observation + summary types; sibling interfaces
+src/normalize.ts    coerce incomplete input; classify funnel; money convert
+src/project.ts      shipped projection (funnel, pipeline, exceptions, attention)
+src/cli.ts          fixture → JSON summary
+src/money.ts        fail-closed cents
+fixtures/           complete, exceptions, incomplete, discrepancies, probabilities
+tests/              drive projectCommercialSummary / runFixture / CLI
+```
+
+## Run
+
+Requires Node ≥ 20.
+
+```bash
+cd control-center/domains/commercial
+npm install
+npm test
+npm run typecheck
+npm run summary -- --fixture fixtures/representative.json --now 2026-08-20T12:00:00Z
+```
+
+Two consecutive `summary` runs with the same fixture and `--now` (or the fixture's `observed_at`) print identical JSON.
+
+## Env vars
+
+See `env.example`. This package reads only:
+
+| Variable | Role |
+|---|---|
+| `COMMERCIAL_READMODEL_NOW` | Optional RFC3339 UTC clock pin for the CLI |
+| `COMMERCIAL_READMODEL_FIXTURE` | Optional default fixture path |
+
+It does **not** read `WARMBLY_*` or Asaas credentials. Those belong to the connector workstream.
+
+## Expected convergence
+
+Do not import sibling trees from this package. Later:
+
+| Workstream | Expected wiring |
+|---|---|
+| `control-center/connectors/warmbly` | Emit `CommercialObservationSet` (records + provenance) from read-only Warmbly fetches. This projection consumes that shape. |
+| `control-center/contracts` | Today's `CommercialSnapshot` v1 is thin (`pipeline_open_count`, …). An additive revision should carry funnel + pipeline money + attention, or wrap this summary. |
+| `control-center/persistence` | Store the summary as an operational snapshot scoped `commercial`. Translate freshness enums at the boundary. |
+| `control-center/services/context` + MCP | Agents query by scope `commercial`. They do not receive whole-company memory. |
+| Governance `commercial/` | Remain the writable catalog authority. This path only **pins** `offer_id` / `offer_version`. |
+
+Financial/provider mutation stays forbidden.
+
+## Thresholds (UTC)
+
+| Signal | Window |
+|---|---|
+| Fresh vs stale | 24 hours from `observed_at` |
+| Aging | 14 days without activity |
+| Stalled stage | 14 days in the same stage |
+| Conversion window | `expected_close_at` in the past, or 30 days in `oportunidades` / `propostas` |

--- a/control-center/domains/commercial/env.example
+++ b/control-center/domains/commercial/env.example
@@ -1,0 +1,13 @@
+# Pure projection. No network, no Warmbly/Asaas credentials.
+#
+# Optional clock pin for the CLI (RFC3339 UTC, Z suffix).
+# When unset, the CLI uses the fixture's observed_at so two runs agree.
+# COMMERCIAL_READMODEL_NOW=2026-08-20T12:00:00Z
+#
+# Optional default fixture path (otherwise pass --fixture).
+# COMMERCIAL_READMODEL_FIXTURE=fixtures/representative.json
+#
+# Later convergence (NOT read by this package today):
+# WARMBLY_BASE_URL=
+# WARMBLY_API_TOKEN=
+# CONTROL_CENTER_DATABASE_URL=

--- a/control-center/domains/commercial/fixtures/complete-funnel.json
+++ b/control-center/domains/commercial/fixtures/complete-funnel.json
@@ -1,0 +1,181 @@
+{
+  "schema_version": "control-center.commercial-observations.v1",
+  "observed_at": "2026-08-20T12:00:00Z",
+  "source": {
+    "system": "warmbly",
+    "kind": "commercial-observation",
+    "locator": "fixture:complete-funnel"
+  },
+  "freshness_status": "FRESH",
+  "confidence": 1,
+  "offer_pin": {
+    "authority_id": "CFG-OFFER-AUTHORITY-v1",
+    "catalog_id": "CFG-OFFER-CATALOG-v1",
+    "catalog_authority": "governance",
+    "known_offers": [
+      { "offer_id": "CFG-DIAG-EXP-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-FLEX-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-180-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-365-v1", "offer_version": "v1" }
+    ],
+    "not_an_offer": [
+      {
+        "kind": "extra_historical",
+        "exception_id": "CFG-EXC-EXTRA-HISTORICAL-v1",
+        "amount_cents": 1000000,
+        "currency": "BRL"
+      }
+    ],
+    "observed_at": "2026-08-17T00:00:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 1
+  },
+  "records": [
+    {
+      "id": "lead-new-1",
+      "entity": "inbound_lead",
+      "status": "new",
+      "funnel_stage": "novos_leads",
+      "created_at": "2026-08-19T10:00:00Z",
+      "last_activity_at": "2026-08-20T09:00:00Z",
+      "next_action": "qualify_call",
+      "next_action_at": "2026-08-21T14:00:00Z"
+    },
+    {
+      "id": "lead-new-2",
+      "entity": "inbound_lead",
+      "status": "new",
+      "funnel_stage": "novos_leads",
+      "created_at": "2026-08-18T10:00:00Z",
+      "last_activity_at": "2026-08-20T08:00:00Z",
+      "next_action": "send_intro",
+      "next_action_at": "2026-08-20T16:00:00Z"
+    },
+    {
+      "id": "deal-qual-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "qualificados",
+      "stage_name": "qualified",
+      "stage_entered_at": "2026-08-12T00:00:00Z",
+      "value": 8000,
+      "currency": "BRL",
+      "created_at": "2026-08-10T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "discovery",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-qual-2",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "qualificados",
+      "stage_name": "qualified",
+      "stage_entered_at": "2026-08-14T00:00:00Z",
+      "value": 8000,
+      "currency": "BRL",
+      "created_at": "2026-08-11T00:00:00Z",
+      "updated_at": "2026-08-19T12:00:00Z",
+      "last_activity_at": "2026-08-19T12:00:00Z",
+      "next_action": "scope_check",
+      "next_action_at": "2026-08-22T00:00:00Z"
+    },
+    {
+      "id": "deal-opp-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "oportunidades",
+      "stage_name": "opportunity",
+      "stage_entered_at": "2026-08-08T00:00:00Z",
+      "value": 15000,
+      "currency": "BRL",
+      "created_at": "2026-08-01T00:00:00Z",
+      "updated_at": "2026-08-18T00:00:00Z",
+      "last_activity_at": "2026-08-18T00:00:00Z",
+      "next_action": "proposal_draft",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "expected_close_at": "2026-09-01T00:00:00Z",
+      "offer_id": "CFG-DIRB2G-FLEX-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-opp-2",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "oportunidades",
+      "stage_name": "opportunity",
+      "stage_entered_at": "2026-08-09T00:00:00Z",
+      "amount_cents": 1800000,
+      "currency": "BRL",
+      "created_at": "2026-08-02T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "stakeholder_map",
+      "next_action_at": "2026-08-22T00:00:00Z",
+      "expected_close_at": "2026-09-15T00:00:00Z",
+      "offer_id": "CFG-DIRB2G-180-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-prop-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "propostas",
+      "stage_name": "proposal",
+      "stage_entered_at": "2026-08-15T00:00:00Z",
+      "value": 8000,
+      "currency": "BRL",
+      "created_at": "2026-08-05T00:00:00Z",
+      "updated_at": "2026-08-19T18:00:00Z",
+      "last_activity_at": "2026-08-19T18:00:00Z",
+      "next_action": "follow_up_proposal",
+      "next_action_at": "2026-08-21T12:00:00Z",
+      "expected_close_at": "2026-08-28T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-prop-2",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "propostas",
+      "stage_name": "proposal",
+      "stage_entered_at": "2026-08-16T00:00:00Z",
+      "amount_cents": 3650000,
+      "currency": "BRL",
+      "created_at": "2026-08-06T00:00:00Z",
+      "updated_at": "2026-08-20T08:00:00Z",
+      "last_activity_at": "2026-08-20T08:00:00Z",
+      "next_action": "legal_review",
+      "next_action_at": "2026-08-23T00:00:00Z",
+      "expected_close_at": "2026-09-10T00:00:00Z",
+      "offer_id": "CFG-DIRB2G-365-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-won-1",
+      "entity": "deal",
+      "status": "won",
+      "funnel_stage": "clientes",
+      "stage_name": "won",
+      "amount_cents": 800000,
+      "currency": "BRL",
+      "created_at": "2026-07-01T00:00:00Z",
+      "updated_at": "2026-08-01T00:00:00Z",
+      "last_activity_at": "2026-08-18T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "contact-client-1",
+      "entity": "contact",
+      "status": "client",
+      "funnel_stage": "clientes",
+      "created_at": "2026-06-01T00:00:00Z",
+      "last_activity_at": "2026-08-17T00:00:00Z"
+    }
+  ]
+}

--- a/control-center/domains/commercial/fixtures/exceptions-gaps.json
+++ b/control-center/domains/commercial/fixtures/exceptions-gaps.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "control-center.commercial-observations.v1",
+  "observed_at": "2026-08-20T12:00:00Z",
+  "source": {
+    "system": "warmbly",
+    "kind": "commercial-observation",
+    "locator": "fixture:exceptions-gaps"
+  },
+  "freshness_status": "FRESH",
+  "confidence": 1,
+  "offer_pin": {
+    "authority_id": "CFG-OFFER-AUTHORITY-v1",
+    "catalog_id": "CFG-OFFER-CATALOG-v1",
+    "catalog_authority": "governance",
+    "known_offers": [
+      { "offer_id": "CFG-DIAG-EXP-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-FLEX-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-180-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-365-v1", "offer_version": "v1" }
+    ],
+    "not_an_offer": [
+      {
+        "kind": "extra_historical",
+        "exception_id": "CFG-EXC-EXTRA-HISTORICAL-v1",
+        "amount_cents": 1000000,
+        "currency": "BRL"
+      }
+    ],
+    "observed_at": "2026-08-17T00:00:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 1
+  },
+  "records": [
+    {
+      "id": "deal-missing-next",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "oportunidades",
+      "stage_name": "opportunity",
+      "stage_entered_at": "2026-08-18T00:00:00Z",
+      "value": 8000,
+      "currency": "BRL",
+      "created_at": "2026-08-18T00:00:00Z",
+      "updated_at": "2026-08-18T00:00:00Z",
+      "last_activity_at": "2026-08-18T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-stalled",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "propostas",
+      "stage_name": "proposal",
+      "stage_entered_at": "2026-07-01T00:00:00Z",
+      "value": 15000,
+      "currency": "BRL",
+      "created_at": "2026-06-01T00:00:00Z",
+      "updated_at": "2026-07-01T00:00:00Z",
+      "last_activity_at": "2026-07-01T00:00:00Z",
+      "next_action": "chase",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "expected_close_at": "2026-09-01T00:00:00Z",
+      "offer_id": "CFG-DIRB2G-FLEX-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-aging",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "qualificados",
+      "stage_name": "qualified",
+      "stage_entered_at": "2026-08-10T00:00:00Z",
+      "value": 8000,
+      "currency": "BRL",
+      "created_at": "2026-08-01T00:00:00Z",
+      "updated_at": "2026-07-30T00:00:00Z",
+      "last_activity_at": "2026-07-30T00:00:00Z",
+      "next_action": "nurture",
+      "next_action_at": "2026-08-22T00:00:00Z"
+    },
+    {
+      "id": "deal-conversion-gap",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "propostas",
+      "stage_name": "proposal",
+      "stage_entered_at": "2026-08-18T00:00:00Z",
+      "value": 8000,
+      "currency": "BRL",
+      "created_at": "2026-08-18T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "close_call",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "expected_close_at": "2026-08-01T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    }
+  ]
+}

--- a/control-center/domains/commercial/fixtures/incomplete-unknown.json
+++ b/control-center/domains/commercial/fixtures/incomplete-unknown.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "control-center.commercial-observations.v1",
+  "observed_at": null,
+  "source": {
+    "system": "warmbly",
+    "kind": "commercial-observation",
+    "locator": "fixture:incomplete-unknown"
+  },
+  "freshness_status": "UNKNOWN",
+  "records": [
+    {
+      "id": "deal-partial-1",
+      "entity": "deal",
+      "status": "UNKNOWN",
+      "funnel_stage": "UNKNOWN",
+      "value": 10.001,
+      "currency": "BRL"
+    },
+    {
+      "id": "deal-partial-2",
+      "entity": "deal",
+      "stage_name": "mystery-board-column",
+      "probability": 0.4
+    },
+    {
+      "id": "not-a-record"
+    },
+    {
+      "id": "deal-lost-1",
+      "entity": "deal",
+      "status": "lost",
+      "funnel_stage": "oportunidades",
+      "value": 999,
+      "currency": "BRL"
+    }
+  ]
+}

--- a/control-center/domains/commercial/fixtures/offer-discrepancy.json
+++ b/control-center/domains/commercial/fixtures/offer-discrepancy.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": "control-center.commercial-observations.v1",
+  "observed_at": "2026-08-20T12:00:00Z",
+  "source": {
+    "system": "warmbly",
+    "kind": "commercial-observation",
+    "locator": "fixture:offer-discrepancy"
+  },
+  "freshness_status": "FRESH",
+  "confidence": 1,
+  "offer_pin": {
+    "authority_id": "CFG-OFFER-AUTHORITY-v1",
+    "catalog_id": "CFG-OFFER-CATALOG-v1",
+    "catalog_authority": "governance",
+    "known_offers": [
+      { "offer_id": "CFG-DIAG-EXP-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-FLEX-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-180-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-365-v1", "offer_version": "v1" }
+    ],
+    "not_an_offer": [
+      {
+        "kind": "extra_historical",
+        "exception_id": "CFG-EXC-EXTRA-HISTORICAL-v1",
+        "amount_cents": 1000000,
+        "currency": "BRL"
+      }
+    ],
+    "observed_at": "2026-08-17T00:00:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 1
+  },
+  "records": [
+    {
+      "id": "deal-unknown-offer",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "propostas",
+      "stage_entered_at": "2026-08-18T00:00:00Z",
+      "value": 5000,
+      "currency": "BRL",
+      "created_at": "2026-08-18T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "clarify_sku",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "offer_id": "CFG-NOT-IN-CATALOG-v9",
+      "offer_version": "v9",
+      "treated_as_catalog_offer": true
+    },
+    {
+      "id": "deal-version-drift",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "propostas",
+      "stage_entered_at": "2026-08-18T00:00:00Z",
+      "amount_cents": 800000,
+      "currency": "BRL",
+      "created_at": "2026-08-18T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "re_pin",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v0"
+    },
+    {
+      "id": "deal-extra-as-offer",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "clientes",
+      "stage_name": "won",
+      "amount_cents": 1000000,
+      "currency": "BRL",
+      "created_at": "2026-02-01T00:00:00Z",
+      "updated_at": "2026-08-01T00:00:00Z",
+      "last_activity_at": "2026-08-01T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1",
+      "treated_as_catalog_offer": true
+    },
+    {
+      "id": "deal-extra-id",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "oportunidades",
+      "stage_entered_at": "2026-08-18T00:00:00Z",
+      "amount_cents": 1000000,
+      "currency": "BRL",
+      "created_at": "2026-08-18T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "do_not_catalog",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "offer_id": "CFG-EXC-EXTRA-HISTORICAL-v1",
+      "treated_as_catalog_offer": true
+    }
+  ]
+}

--- a/control-center/domains/commercial/fixtures/offer-pin.json
+++ b/control-center/domains/commercial/fixtures/offer-pin.json
@@ -1,0 +1,22 @@
+{
+  "authority_id": "CFG-OFFER-AUTHORITY-v1",
+  "catalog_id": "CFG-OFFER-CATALOG-v1",
+  "catalog_authority": "governance",
+  "known_offers": [
+    { "offer_id": "CFG-DIAG-EXP-v1", "offer_version": "v1" },
+    { "offer_id": "CFG-DIRB2G-FLEX-v1", "offer_version": "v1" },
+    { "offer_id": "CFG-DIRB2G-180-v1", "offer_version": "v1" },
+    { "offer_id": "CFG-DIRB2G-365-v1", "offer_version": "v1" }
+  ],
+  "not_an_offer": [
+    {
+      "kind": "extra_historical",
+      "exception_id": "CFG-EXC-EXTRA-HISTORICAL-v1",
+      "amount_cents": 1000000,
+      "currency": "BRL"
+    }
+  ],
+  "observed_at": "2026-08-17T00:00:00Z",
+  "freshness_status": "FRESH",
+  "confidence": 1
+}

--- a/control-center/domains/commercial/fixtures/probabilities-absent.json
+++ b/control-center/domains/commercial/fixtures/probabilities-absent.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "control-center.commercial-observations.v1",
+  "observed_at": "2026-08-20T12:00:00Z",
+  "source": {
+    "system": "warmbly",
+    "kind": "commercial-observation",
+    "locator": "fixture:probabilities-absent"
+  },
+  "freshness_status": "FRESH",
+  "confidence": 1,
+  "offer_pin": {
+    "authority_id": "CFG-OFFER-AUTHORITY-v1",
+    "catalog_id": "CFG-OFFER-CATALOG-v1",
+    "catalog_authority": "governance",
+    "known_offers": [
+      { "offer_id": "CFG-DIAG-EXP-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-FLEX-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-180-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-365-v1", "offer_version": "v1" }
+    ],
+    "not_an_offer": [
+      {
+        "kind": "extra_historical",
+        "exception_id": "CFG-EXC-EXTRA-HISTORICAL-v1",
+        "amount_cents": 1000000,
+        "currency": "BRL"
+      }
+    ],
+    "observed_at": "2026-08-17T00:00:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 1
+  },
+  "records": [
+    {
+      "id": "deal-qual-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "qualificados",
+      "amount_cents": 800000,
+      "currency": "BRL",
+      "created_at": "2026-08-10T00:00:00Z",
+      "stage_entered_at": "2026-08-12T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "discovery",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-opp-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "oportunidades",
+      "amount_cents": 1800000,
+      "currency": "BRL",
+      "probability": 0.5,
+      "probability_reliable": false,
+      "created_at": "2026-08-01T00:00:00Z",
+      "stage_entered_at": "2026-08-08T00:00:00Z",
+      "updated_at": "2026-08-18T00:00:00Z",
+      "last_activity_at": "2026-08-18T00:00:00Z",
+      "next_action": "proposal_draft",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "offer_id": "CFG-DIRB2G-180-v1",
+      "offer_version": "v1"
+    }
+  ]
+}

--- a/control-center/domains/commercial/fixtures/probabilities-reliable.json
+++ b/control-center/domains/commercial/fixtures/probabilities-reliable.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": "control-center.commercial-observations.v1",
+  "observed_at": "2026-08-20T12:00:00Z",
+  "source": {
+    "system": "warmbly",
+    "kind": "commercial-observation",
+    "locator": "fixture:probabilities-reliable"
+  },
+  "freshness_status": "FRESH",
+  "confidence": 1,
+  "offer_pin": {
+    "authority_id": "CFG-OFFER-AUTHORITY-v1",
+    "catalog_id": "CFG-OFFER-CATALOG-v1",
+    "catalog_authority": "governance",
+    "known_offers": [
+      { "offer_id": "CFG-DIAG-EXP-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-FLEX-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-180-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-365-v1", "offer_version": "v1" }
+    ],
+    "not_an_offer": [
+      {
+        "kind": "extra_historical",
+        "exception_id": "CFG-EXC-EXTRA-HISTORICAL-v1",
+        "amount_cents": 1000000,
+        "currency": "BRL"
+      }
+    ],
+    "observed_at": "2026-08-17T00:00:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 1
+  },
+  "records": [
+    {
+      "id": "lead-new-1",
+      "entity": "inbound_lead",
+      "status": "new",
+      "funnel_stage": "novos_leads",
+      "amount_cents": 0,
+      "currency": "BRL",
+      "probability": 0.25,
+      "probability_reliable": true,
+      "created_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-20T00:00:00Z",
+      "next_action": "qualify",
+      "next_action_at": "2026-08-21T00:00:00Z"
+    },
+    {
+      "id": "deal-qual-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "qualificados",
+      "amount_cents": 800000,
+      "currency": "BRL",
+      "probability": 0.5,
+      "probability_reliable": true,
+      "created_at": "2026-08-10T00:00:00Z",
+      "stage_entered_at": "2026-08-12T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "discovery",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-opp-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "oportunidades",
+      "amount_cents": 1800000,
+      "currency": "BRL",
+      "probability": 0.5,
+      "probability_reliable": true,
+      "created_at": "2026-08-01T00:00:00Z",
+      "stage_entered_at": "2026-08-08T00:00:00Z",
+      "updated_at": "2026-08-18T00:00:00Z",
+      "last_activity_at": "2026-08-18T00:00:00Z",
+      "next_action": "proposal_draft",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "expected_close_at": "2026-09-01T00:00:00Z",
+      "offer_id": "CFG-DIRB2G-180-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-prop-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "propostas",
+      "amount_cents": 3650000,
+      "currency": "BRL",
+      "probability": 1,
+      "probability_reliable": true,
+      "created_at": "2026-08-05T00:00:00Z",
+      "stage_entered_at": "2026-08-15T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "close",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "expected_close_at": "2026-08-28T00:00:00Z",
+      "offer_id": "CFG-DIRB2G-365-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-won-1",
+      "entity": "deal",
+      "status": "won",
+      "funnel_stage": "clientes",
+      "amount_cents": 800000,
+      "currency": "BRL",
+      "probability": 1,
+      "probability_reliable": true,
+      "created_at": "2026-07-01T00:00:00Z",
+      "updated_at": "2026-08-01T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    }
+  ]
+}

--- a/control-center/domains/commercial/fixtures/representative.json
+++ b/control-center/domains/commercial/fixtures/representative.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "control-center.commercial-observations.v1",
+  "observed_at": "2026-08-20T12:00:00Z",
+  "source": {
+    "system": "warmbly",
+    "kind": "commercial-observation",
+    "locator": "fixture:representative"
+  },
+  "freshness_status": "FRESH",
+  "confidence": 1,
+  "offer_pin": {
+    "authority_id": "CFG-OFFER-AUTHORITY-v1",
+    "catalog_id": "CFG-OFFER-CATALOG-v1",
+    "catalog_authority": "governance",
+    "known_offers": [
+      { "offer_id": "CFG-DIAG-EXP-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-FLEX-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-180-v1", "offer_version": "v1" },
+      { "offer_id": "CFG-DIRB2G-365-v1", "offer_version": "v1" }
+    ],
+    "not_an_offer": [
+      {
+        "kind": "extra_historical",
+        "exception_id": "CFG-EXC-EXTRA-HISTORICAL-v1",
+        "amount_cents": 1000000,
+        "currency": "BRL"
+      }
+    ],
+    "observed_at": "2026-08-17T00:00:00Z",
+    "freshness_status": "FRESH",
+    "confidence": 1
+  },
+  "records": [
+    {
+      "id": "lead-new-1",
+      "entity": "inbound_lead",
+      "status": "new",
+      "funnel_stage": "novos_leads",
+      "created_at": "2026-08-19T10:00:00Z",
+      "last_activity_at": "2026-08-20T09:00:00Z",
+      "next_action": "qualify_call",
+      "next_action_at": "2026-08-21T14:00:00Z"
+    },
+    {
+      "id": "lead-new-2",
+      "entity": "inbound_lead",
+      "status": "new",
+      "funnel_stage": "novos_leads",
+      "created_at": "2026-08-18T10:00:00Z",
+      "last_activity_at": "2026-08-20T08:00:00Z"
+    },
+    {
+      "id": "deal-qual-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "qualificados",
+      "stage_name": "qualified",
+      "stage_entered_at": "2026-08-12T00:00:00Z",
+      "value": 8000,
+      "currency": "BRL",
+      "created_at": "2026-08-10T00:00:00Z",
+      "updated_at": "2026-08-19T00:00:00Z",
+      "last_activity_at": "2026-08-19T00:00:00Z",
+      "next_action": "discovery",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-opp-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "oportunidades",
+      "stage_name": "opportunity",
+      "stage_entered_at": "2026-07-01T00:00:00Z",
+      "value": 15000,
+      "currency": "BRL",
+      "created_at": "2026-06-15T00:00:00Z",
+      "updated_at": "2026-07-01T00:00:00Z",
+      "last_activity_at": "2026-07-01T00:00:00Z",
+      "next_action": "unstick",
+      "next_action_at": "2026-08-21T00:00:00Z",
+      "expected_close_at": "2026-08-01T00:00:00Z",
+      "offer_id": "CFG-DIRB2G-FLEX-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-prop-1",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "propostas",
+      "stage_name": "proposal",
+      "stage_entered_at": "2026-08-15T00:00:00Z",
+      "amount_cents": 800000,
+      "currency": "BRL",
+      "created_at": "2026-08-05T00:00:00Z",
+      "updated_at": "2026-08-19T18:00:00Z",
+      "last_activity_at": "2026-08-19T18:00:00Z",
+      "next_action": "follow_up_proposal",
+      "next_action_at": "2026-08-21T12:00:00Z",
+      "expected_close_at": "2026-08-28T00:00:00Z",
+      "offer_id": "CFG-NOT-IN-CATALOG-v9",
+      "offer_version": "v9",
+      "treated_as_catalog_offer": true
+    },
+    {
+      "id": "deal-won-1",
+      "entity": "deal",
+      "status": "won",
+      "funnel_stage": "clientes",
+      "amount_cents": 800000,
+      "currency": "BRL",
+      "created_at": "2026-07-01T00:00:00Z",
+      "updated_at": "2026-08-01T00:00:00Z",
+      "last_activity_at": "2026-08-18T00:00:00Z",
+      "offer_id": "CFG-DIAG-EXP-v1",
+      "offer_version": "v1"
+    },
+    {
+      "id": "deal-extra-as-offer",
+      "entity": "deal",
+      "status": "open",
+      "funnel_stage": "clientes",
+      "amount_cents": 1000000,
+      "currency": "BRL",
+      "created_at": "2026-02-01T00:00:00Z",
+      "updated_at": "2026-08-01T00:00:00Z",
+      "offer_id": "1000000",
+      "treated_as_catalog_offer": true
+    }
+  ]
+}

--- a/control-center/domains/commercial/package-lock.json
+++ b/control-center/domains/commercial/package-lock.json
@@ -1,0 +1,572 @@
+{
+  "name": "@confenge/control-center-commercial-readmodel",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-commercial-readmodel",
+      "version": "0.1.0",
+      "bin": {
+        "cc-commercial-summary": "src/cli.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^22.18.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/control-center/domains/commercial/package.json
+++ b/control-center/domains/commercial/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@confenge/control-center-commercial-readmodel",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Executive commercial read model for Confenge Control Center. Warmbly-shaped observations + Governance offer pin in; one-screen summary out. Read-only. Never mutates Warmbly or Asaas.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "cc-commercial-summary": "./src/cli.ts"
+  },
+  "scripts": {
+    "test": "tsx --test tests/*.test.ts",
+    "summary": "tsx src/cli.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/domains/commercial/src/cli.ts
+++ b/control-center/domains/commercial/src/cli.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import { parseUtc } from "./clock.ts";
+import { logStructured } from "./log.ts";
+import { runFixture } from "./load-fixture.ts";
+
+function argValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx === -1) {
+    return undefined;
+  }
+  return args[idx + 1];
+}
+
+function defaultFixture(): string {
+  return (
+    process.env.COMMERCIAL_READMODEL_FIXTURE ??
+    fileURLToPath(new URL("../fixtures/representative.json", import.meta.url))
+  );
+}
+
+function parseNow(raw: string | undefined) {
+  if (!raw) {
+    return undefined;
+  }
+  const d = parseUtc(raw);
+  if (!d) {
+    throw new Error(`invalid --now: ${raw}`);
+  }
+  return d;
+}
+
+async function main(argv: string[]): Promise<void> {
+  const args = argv.slice(2);
+  const fixture = argValue(args, "--fixture") ?? defaultFixture();
+  const now = parseNow(
+    argValue(args, "--now") ?? process.env.COMMERCIAL_READMODEL_NOW,
+  );
+  logStructured("info", "commercial.summary.start", {
+    fixture,
+    now_pinned: Boolean(now),
+  });
+  const summary = runFixture(fixture, { now });
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  logStructured("info", "commercial.summary.done", {
+    funnel_keys: Object.keys(summary.funnel),
+    attention: summary.attention.items.length,
+    exceptions: summary.exceptions.length,
+    nominal: summary.pipeline.nominal.treatment,
+    weighted: summary.pipeline.weighted.treatment,
+  });
+}
+
+main(process.argv).catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : "cli failed";
+  logStructured("error", "commercial.summary.fail", { error: message });
+  process.exitCode = 1;
+});

--- a/control-center/domains/commercial/src/clock.ts
+++ b/control-center/domains/commercial/src/clock.ts
@@ -1,0 +1,28 @@
+const UTC_RE =
+  /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,9})?Z$/;
+
+export function isUtcDateTime(value: unknown): value is string {
+  return typeof value === "string" && UTC_RE.test(value);
+}
+
+export function toUtcIso(date: Date): string {
+  return date.toISOString();
+}
+
+export function parseUtc(value: string | null | undefined): Date | null {
+  if (!value || typeof value !== "string") {
+    return null;
+  }
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) {
+    return null;
+  }
+  return d;
+}
+
+export function parseUtcOrNull(value: unknown): Date | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  return parseUtc(value);
+}

--- a/control-center/domains/commercial/src/contracts.ts
+++ b/control-center/domains/commercial/src/contracts.ts
@@ -1,0 +1,266 @@
+/**
+ * Local contracts for the commercial executive read model.
+ *
+ * Canonical JSON Schema for CommercialSnapshot lives in
+ * `control-center/contracts/` (parallel workstream). Persistence taxonomies
+ * live in `control-center/persistence/`. The Warmbly HTTP collector lives in
+ * `control-center/connectors/warmbly/`. This package MUST NOT import those
+ * trees; it ships a local adapter until the convergence campaign.
+ *
+ * Freshness closed set here matches the contracts workstream
+ * (`FRESH` | `STALE` | `UNKNOWN` | `ERROR`), not persistence
+ * (`fresh` | `stale` | `unknown` | `expired`). Do not rewrite persistence.
+ */
+
+export const SUMMARY_SCHEMA_VERSION =
+  "control-center.commercial-summary.v1" as const;
+
+export const OBSERVATION_SCHEMA_VERSION =
+  "control-center.commercial-observations.v1" as const;
+
+export const FRESHNESS_STATUSES = [
+  "FRESH",
+  "STALE",
+  "UNKNOWN",
+  "ERROR",
+] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const FUNNEL_KEYS = [
+  "novos_leads",
+  "qualificados",
+  "oportunidades",
+  "propostas",
+  "clientes",
+] as const;
+export type FunnelKey = (typeof FUNNEL_KEYS)[number];
+
+export const ATTENTION_KINDS = [
+  "extra_historical_as_offer",
+  "unknown_offer_id",
+  "offer_version_drift",
+  "missing_next_action",
+  "stalled_stage",
+  "conversion_window_gap",
+  "aging",
+] as const;
+export type AttentionKind = (typeof ATTENTION_KINDS)[number];
+
+export const ATTENTION_SEVERITIES = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+] as const;
+export type AttentionSeverity = (typeof ATTENTION_SEVERITIES)[number];
+
+export const PIPELINE_TREATMENTS = ["present", "insufficient_data"] as const;
+export type PipelineTreatment = (typeof PIPELINE_TREATMENTS)[number];
+
+export const DEFAULT_CURRENCY = "BRL";
+export const EXTRA_HISTORICAL_AMOUNT_CENTS = 1_000_000;
+export const EXTRA_HISTORICAL_EXCEPTION_ID = "CFG-EXC-EXTRA-HISTORICAL-v1";
+export const ATTENTION_NOW_LIMIT = 3;
+export const FRESHNESS_WINDOW_SECONDS = 86_400;
+export const AGING_MS = 14 * 24 * 60 * 60 * 1000;
+export const STALL_MS = 14 * 24 * 60 * 60 * 1000;
+export const CONVERSION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Pin identity only. Never a copied catalog (no names, prices, terms, copy). */
+export type KnownOfferPin = {
+  offer_id: string;
+  offer_version: string;
+};
+
+export type ExtraHistoricalMarker = {
+  kind: "extra_historical";
+  exception_id: string;
+  amount_cents: number;
+  currency: string;
+};
+
+export type GovernanceOfferPin = {
+  authority_id: string;
+  catalog_id: string;
+  catalog_authority: "governance";
+  known_offers: KnownOfferPin[];
+  not_an_offer: ExtraHistoricalMarker[];
+  observed_at?: string;
+  freshness_status?: FreshnessStatus;
+  confidence?: number;
+};
+
+export type SourceRef = {
+  system: string;
+  kind: string;
+  locator: string;
+  label?: string;
+};
+
+export type Provenance = {
+  source: SourceRef;
+  observed_at: string;
+  freshness_status: FreshnessStatus;
+  confidence?: number;
+  freshness_window_seconds?: number;
+};
+
+export type Money = {
+  amount_cents: number;
+  currency: string;
+};
+
+/**
+ * Warmbly-shaped commercial record. Later the Warmbly connector can emit this
+ * without this package calling Warmbly itself.
+ *
+ * `value` is Warmbly major-unit money (float). Conversion to cents is
+ * fail-closed: not silently rounded.
+ * `probability` is a closed unit interval. Warmbly CRM deals currently have
+ * no win-probability field; weighted pipeline stays insufficient_data unless
+ * the input explicitly marks probabilities reliable.
+ */
+export type WarmblyCommercialRecord = {
+  id: string;
+  entity: "deal" | "inbound_lead" | "contact" | "task";
+  status?: string | null;
+  funnel_stage?: FunnelKey | "UNKNOWN" | string | null;
+  stage_id?: string | null;
+  stage_name?: string | null;
+  stage_entered_at?: string | null;
+  value?: number | null;
+  amount_cents?: number | null;
+  currency?: string | null;
+  probability?: number | null;
+  probability_reliable?: boolean | null;
+  offer_id?: string | null;
+  offer_version?: string | null;
+  treated_as_catalog_offer?: boolean | null;
+  next_action?: string | null;
+  next_action_at?: string | null;
+  last_activity_at?: string | null;
+  expected_close_at?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  observed_at?: string | null;
+  freshness_status?: FreshnessStatus | string | null;
+  confidence?: number | null;
+  deal_id?: string | null;
+  inbound_lead_id?: string | null;
+  due_date?: string | null;
+};
+
+export type StageMap = Record<string, FunnelKey>;
+
+export type CommercialObservationSet = {
+  schema_version: typeof OBSERVATION_SCHEMA_VERSION | string;
+  observed_at?: string | null;
+  source?: Partial<SourceRef> | string | null;
+  freshness_status?: FreshnessStatus | string | null;
+  confidence?: number | null;
+  records?: WarmblyCommercialRecord[] | null;
+  stage_map?: StageMap | null;
+  offer_pin?: GovernanceOfferPin | null;
+};
+
+export type AggregatedFigure = {
+  key: string;
+  value: number;
+  source: SourceRef;
+  observed_at: string;
+  freshness_status: FreshnessStatus;
+  confidence?: number;
+};
+
+export type PipelineMoney = {
+  treatment: PipelineTreatment;
+  amount_cents?: number;
+  currency?: string;
+  reason?: string;
+  provenance: Provenance;
+};
+
+export type ExceptionRow = {
+  id: string;
+  kind: AttentionKind;
+  record_id: string;
+  severity: AttentionSeverity;
+  title: string;
+  summary: string;
+  recommended_action: string;
+  provenance: Provenance;
+};
+
+export type AttentionItem = {
+  id: string;
+  kind: AttentionKind;
+  record_id: string;
+  severity: AttentionSeverity;
+  horizon: "now";
+  title: string;
+  summary: string;
+  recommended_action: string;
+  provenance: Provenance;
+};
+
+export type CommercialSummary = {
+  schema_version: typeof SUMMARY_SCHEMA_VERSION;
+  scope: "commercial";
+  generated_at: string;
+  authority: {
+    catalog_authority: "governance";
+    commercial_runtime: "warmbly";
+    this_document: "read_model";
+    offer_pin: {
+      authority_id: string;
+      catalog_id: string;
+      pin_observed_at: string;
+    };
+  };
+  provenance: Provenance;
+  funnel: Record<FunnelKey, AggregatedFigure>;
+  pipeline: {
+    nominal: PipelineMoney;
+    weighted: PipelineMoney;
+  };
+  exceptions: ExceptionRow[];
+  attention: {
+    horizon: "now";
+    items: AttentionItem[];
+  };
+  unclassified: AggregatedFigure;
+};
+
+export type ProjectOptions = {
+  now?: Date;
+};
+
+/**
+ * Sibling interfaces expected at convergence. Documented here; not imported.
+ *
+ * control-center/connectors/warmbly:
+ *   collectFromWarmblyPayload(payload) → Warmbly-shaped records compatible
+ *   with CommercialObservationSet.records (read-only GET/POST search).
+ *
+ * control-center/contracts:
+ *   CommercialSnapshot v1 is currently a thin cockpit document
+ *   (pipeline_open_count, inbound_unread_count, at_risk_client_count).
+ *   This executive summary is a richer local projection. A later additive
+ *   schema revision should carry funnel + pipeline money + attention.
+ *
+ * control-center/persistence:
+ *   Store the summary payload as an operational snapshot scoped `commercial`.
+ *   Map local FRESHNESS_STATUSES to persistence casing at the boundary;
+ *   do not change persistence enums from this workstream.
+ *
+ * control-center/services/context + MCP:
+ *   Agents query by scope `commercial`. They do not receive this whole
+ *   document unless that scope is granted.
+ */
+export const EXPECTED_CONVERGENCE = {
+  warmbly_connector: "control-center/connectors/warmbly",
+  contracts: "control-center/contracts",
+  persistence: "control-center/persistence",
+  context_service: "control-center/services/context",
+  mcp: "control-center/mcp",
+} as const;

--- a/control-center/domains/commercial/src/freshness.ts
+++ b/control-center/domains/commercial/src/freshness.ts
@@ -1,0 +1,88 @@
+import {
+  FRESHNESS_STATUSES,
+  FRESHNESS_WINDOW_SECONDS,
+  type FreshnessStatus,
+} from "./contracts.ts";
+
+export function isFreshnessStatus(value: unknown): value is FreshnessStatus {
+  return (
+    typeof value === "string" &&
+    (FRESHNESS_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+export function parseFreshness(value: unknown): FreshnessStatus {
+  if (isFreshnessStatus(value)) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return "UNKNOWN";
+  }
+  const key = value.trim().toUpperCase();
+  if (isFreshnessStatus(key)) {
+    return key;
+  }
+  // Persistence workstream uses lowercase / `expired`. Map locally; do not
+  // rewrite persistence. `expired` is recency-failure → STALE, not a new enum.
+  if (key === "EXPIRED") {
+    return "STALE";
+  }
+  return "UNKNOWN";
+}
+
+export function clampConfidence(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+}
+
+export function classifyFreshness(
+  observedAt: Date | null,
+  now: Date,
+  declared: FreshnessStatus,
+  windowSeconds: number = FRESHNESS_WINDOW_SECONDS,
+): FreshnessStatus {
+  if (declared === "ERROR" || declared === "UNKNOWN") {
+    return declared;
+  }
+  if (!observedAt) {
+    return "UNKNOWN";
+  }
+  const ageMs = now.getTime() - observedAt.getTime();
+  if (!Number.isFinite(ageMs)) {
+    return "UNKNOWN";
+  }
+  if (ageMs > windowSeconds * 1000) {
+    return "STALE";
+  }
+  return declared;
+}
+
+export function rollupFreshness(statuses: FreshnessStatus[]): FreshnessStatus {
+  if (statuses.length === 0) {
+    return "UNKNOWN";
+  }
+  if (statuses.includes("ERROR")) {
+    return "ERROR";
+  }
+  const hasFresh = statuses.includes("FRESH");
+  const hasStale = statuses.includes("STALE");
+  const hasUnknown = statuses.includes("UNKNOWN");
+  if (hasUnknown && !hasFresh && !hasStale) {
+    return "UNKNOWN";
+  }
+  if (hasStale) {
+    return "STALE";
+  }
+  if (hasFresh) {
+    return "FRESH";
+  }
+  return "UNKNOWN";
+}

--- a/control-center/domains/commercial/src/index.ts
+++ b/control-center/domains/commercial/src/index.ts
@@ -1,0 +1,29 @@
+export {
+  ATTENTION_NOW_LIMIT,
+  EXPECTED_CONVERGENCE,
+  EXTRA_HISTORICAL_AMOUNT_CENTS,
+  EXTRA_HISTORICAL_EXCEPTION_ID,
+  FRESHNESS_STATUSES,
+  FUNNEL_KEYS,
+  OBSERVATION_SCHEMA_VERSION,
+  SUMMARY_SCHEMA_VERSION,
+} from "./contracts.ts";
+export type {
+  AggregatedFigure,
+  AttentionItem,
+  AttentionKind,
+  CommercialObservationSet,
+  CommercialSummary,
+  ExceptionRow,
+  FreshnessStatus,
+  FunnelKey,
+  GovernanceOfferPin,
+  PipelineMoney,
+  ProjectOptions,
+  Provenance,
+  WarmblyCommercialRecord,
+} from "./contracts.ts";
+export { projectCommercialSummary, attentionSlice } from "./project.ts";
+export { loadObservationFile, runFixture } from "./load-fixture.ts";
+export { majorUnitsToCentsExact, weightedCentsExact } from "./money.ts";
+export { coerceObservationSet, normalizeInput } from "./normalize.ts";

--- a/control-center/domains/commercial/src/load-fixture.ts
+++ b/control-center/domains/commercial/src/load-fixture.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { CommercialObservationSet, CommercialSummary, ProjectOptions } from "./contracts.ts";
+import { coerceObservationSet } from "./normalize.ts";
+import { projectCommercialSummary } from "./project.ts";
+
+export function loadObservationFile(path: string): CommercialObservationSet {
+  const text = readFileSync(resolve(path), "utf8");
+  const parsed: unknown = JSON.parse(text);
+  return coerceObservationSet(parsed);
+}
+
+export function runFixture(path: string, opts: ProjectOptions = {}): CommercialSummary {
+  const input = loadObservationFile(path);
+  return projectCommercialSummary(input, opts);
+}

--- a/control-center/domains/commercial/src/log.ts
+++ b/control-center/domains/commercial/src/log.ts
@@ -1,0 +1,55 @@
+const SECRET_KEY =
+  /^(.*[_-])?(api[_-]?key|access[_-]?token|authorization|password|secret|token|cookie|credential|private[_-]?key)$/i;
+
+const PII_KEY = /^(email|phone|first_name|last_name|full_name|person|contact_name)$/i;
+
+export type LogSink = (record: Record<string, unknown>) => void;
+
+function redact(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
+    return value;
+  }
+  if (value === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    return value.map(redact);
+  }
+  if (typeof value === "object") {
+    const rec = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(rec)) {
+      if (SECRET_KEY.test(k) || PII_KEY.test(k)) {
+        out[k] = "[redacted]";
+        continue;
+      }
+      out[k] = redact(v);
+    }
+    return out;
+  }
+  return String(value);
+}
+
+export function logStructured(
+  level: "info" | "warn" | "error",
+  event: string,
+  fields: Record<string, unknown> = {},
+  sink: LogSink = (record) => {
+    process.stderr.write(`${JSON.stringify(record)}\n`);
+  },
+): void {
+  const rec = redact({
+    level,
+    event,
+    ts: new Date().toISOString(),
+    ...fields,
+  }) as Record<string, unknown>;
+  sink(rec);
+}

--- a/control-center/domains/commercial/src/money.ts
+++ b/control-center/domains/commercial/src/money.ts
@@ -1,0 +1,88 @@
+import { DEFAULT_CURRENCY, type Money } from "./contracts.ts";
+
+const CURRENCY_RE = /^[A-Z]{3}$/;
+
+/**
+ * Convert Warmbly major-unit money to integer cents without silent rounding.
+ * Exact 2-decimal amounts (including IEEE noise around 0.01) succeed.
+ * 10.001, NaN, Infinity, and unsafe integers fail closed as null.
+ */
+export function majorUnitsToCentsExact(value: number): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  if (value < 0) {
+    return null;
+  }
+  const scaled = value * 100;
+  const nearest = Math.round(scaled);
+  if (Math.abs(scaled - nearest) > 1e-6) {
+    return null;
+  }
+  if (!Number.isSafeInteger(nearest) || nearest < 0) {
+    return null;
+  }
+  return nearest;
+}
+
+export function integerCents(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return null;
+  }
+  if (!Number.isSafeInteger(value)) {
+    return null;
+  }
+  return value;
+}
+
+export function normalizeCurrency(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim().toUpperCase();
+  if (!CURRENCY_RE.test(trimmed)) {
+    return null;
+  }
+  return trimmed;
+}
+
+export function moneyOrNull(
+  amountCents: number | null,
+  currency: string | null,
+): Money | null {
+  if (amountCents === null) {
+    return null;
+  }
+  return {
+    amount_cents: amountCents,
+    currency: currency ?? DEFAULT_CURRENCY,
+  };
+}
+
+/**
+ * Weighted cents = amount_cents × probability. Fail closed unless the product
+ * is an integer number of cents (fixtures use 0.25 / 0.5 / 1 so this is exact).
+ */
+export function weightedCentsExact(
+  amountCents: number,
+  probability: number,
+): number | null {
+  if (
+    !Number.isInteger(amountCents) ||
+    amountCents < 0 ||
+    !Number.isFinite(probability) ||
+    probability < 0 ||
+    probability > 1
+  ) {
+    return null;
+  }
+  const product = amountCents * probability;
+  const nearest = Math.round(product);
+  if (Math.abs(product - nearest) > 1e-8) {
+    return null;
+  }
+  if (!Number.isSafeInteger(nearest) || nearest < 0) {
+    return null;
+  }
+  return nearest;
+}

--- a/control-center/domains/commercial/src/normalize.ts
+++ b/control-center/domains/commercial/src/normalize.ts
@@ -1,0 +1,521 @@
+import { parseUtc } from "./clock.ts";
+import {
+  DEFAULT_CURRENCY,
+  EXTRA_HISTORICAL_AMOUNT_CENTS,
+  EXTRA_HISTORICAL_EXCEPTION_ID,
+  FUNNEL_KEYS,
+  OBSERVATION_SCHEMA_VERSION,
+  type CommercialObservationSet,
+  type ExtraHistoricalMarker,
+  type FreshnessStatus,
+  type FunnelKey,
+  type GovernanceOfferPin,
+  type KnownOfferPin,
+  type SourceRef,
+  type StageMap,
+  type WarmblyCommercialRecord,
+} from "./contracts.ts";
+import { clampConfidence, parseFreshness } from "./freshness.ts";
+import {
+  integerCents,
+  majorUnitsToCentsExact,
+  normalizeCurrency,
+} from "./money.ts";
+
+export type FunnelBucket = FunnelKey | "unclassified" | "lost";
+
+export type NormalizedRecord = {
+  id: string;
+  entity: WarmblyCommercialRecord["entity"];
+  funnel: FunnelBucket;
+  status: string;
+  amount_cents: number | null;
+  currency: string | null;
+  probability: number | null;
+  probability_reliable: boolean;
+  offer_id: string | null;
+  offer_version: string | null;
+  treated_as_catalog_offer: boolean;
+  next_action: string | null;
+  next_action_at: Date | null;
+  last_activity_at: Date | null;
+  stage_entered_at: Date | null;
+  expected_close_at: Date | null;
+  created_at: Date | null;
+  updated_at: Date | null;
+  observed_at: Date | null;
+  freshness_status: FreshnessStatus;
+  confidence: number | undefined;
+  stage_name: string | null;
+  extra_historical_cents: boolean;
+};
+
+export type NormalizedInput = {
+  observed_at: Date | null;
+  observed_at_iso: string;
+  source: SourceRef;
+  freshness_status: FreshnessStatus;
+  confidence: number | undefined;
+  records: NormalizedRecord[];
+  offer_pin: GovernanceOfferPin;
+  extra_historical: ExtraHistoricalMarker;
+};
+
+const DEFAULT_STAGE_MAP: Record<string, FunnelKey> = {
+  new: "novos_leads",
+  lead: "novos_leads",
+  novos: "novos_leads",
+  novo: "novos_leads",
+  novos_leads: "novos_leads",
+  inbound: "novos_leads",
+  inbound_lead: "novos_leads",
+  qualified: "qualificados",
+  qualificad: "qualificados",
+  qualificado: "qualificados",
+  qualificados: "qualificados",
+  mql: "qualificados",
+  sql: "qualificados",
+  opportunity: "oportunidades",
+  oportunidade: "oportunidades",
+  oportunidades: "oportunidades",
+  deal: "oportunidades",
+  proposal: "propostas",
+  proposta: "propostas",
+  propostas: "propostas",
+  quote: "propostas",
+  sent: "propostas",
+  client: "clientes",
+  cliente: "clientes",
+  clientes: "clientes",
+  won: "clientes",
+  customer: "clientes",
+  "closed-won": "clientes",
+  closed_won: "clientes",
+  closedwon: "clientes",
+};
+
+const LOST = new Set(["lost", "closed-lost", "closed_lost", "discarded", "churned"]);
+const WON = new Set(["won", "client", "customer", "closed-won", "closed_won", "active_client"]);
+const TERMINAL_TASK = new Set(["completed", "cancelled", "canceled", "done"]);
+
+function isFunnelKey(value: string): value is FunnelKey {
+  return (FUNNEL_KEYS as readonly string[]).includes(value);
+}
+
+function normKey(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+function lookupStage(
+  raw: string | null | undefined,
+  stageMap: StageMap,
+): FunnelKey | null {
+  if (!raw) {
+    return null;
+  }
+  const key = normKey(raw);
+  const mapped = stageMap[key] ?? stageMap[raw] ?? DEFAULT_STAGE_MAP[key];
+  return mapped ?? null;
+}
+
+function classifyFunnel(
+  record: WarmblyCommercialRecord,
+  stageMap: StageMap,
+): FunnelBucket {
+  const status = normKey(record.status ?? "");
+  if (LOST.has(status)) {
+    return "lost";
+  }
+  if (typeof record.funnel_stage === "string" && isFunnelKey(record.funnel_stage)) {
+    return record.funnel_stage;
+  }
+  if (typeof record.funnel_stage === "string") {
+    const key = normKey(record.funnel_stage);
+    if (key === "unknown" || key === "") {
+      // fall through to other signals
+    } else if (isFunnelKey(key)) {
+      return key;
+    } else {
+      const mapped = lookupStage(record.funnel_stage, stageMap);
+      if (mapped) {
+        return mapped;
+      }
+    }
+  }
+  if (WON.has(status) || record.entity === "contact" && status === "client") {
+    return "clientes";
+  }
+  const fromStage =
+    lookupStage(record.stage_name, stageMap) ??
+    lookupStage(record.stage_id, stageMap);
+  if (fromStage) {
+    return fromStage;
+  }
+  if (record.entity === "inbound_lead") {
+    if (status === "qualified" || status === "qualificado") {
+      return "qualificados";
+    }
+    if (status === "proposal" || status === "proposta") {
+      return "propostas";
+    }
+    if (status === "client" || status === "won") {
+      return "clientes";
+    }
+    if (status === "opportunity" || status === "oportunidade") {
+      return "oportunidades";
+    }
+    return "novos_leads";
+  }
+  if (record.entity === "contact") {
+    if (status === "qualified") {
+      return "qualificados";
+    }
+    if (status === "client" || status === "customer") {
+      return "clientes";
+    }
+    if (status === "lead" || status === "new" || status === "") {
+      return "novos_leads";
+    }
+  }
+  return "unclassified";
+}
+
+function resolveAmount(record: WarmblyCommercialRecord): {
+  amount_cents: number | null;
+  currency: string | null;
+} {
+  const currency =
+    normalizeCurrency(record.currency) ??
+    (record.amount_cents != null || record.value != null
+      ? DEFAULT_CURRENCY
+      : null);
+  const fromCents = integerCents(record.amount_cents ?? null);
+  if (fromCents !== null) {
+    if (typeof record.value === "number" && Number.isFinite(record.value)) {
+      const fromMajor = majorUnitsToCentsExact(record.value);
+      if (fromMajor !== null && fromMajor !== fromCents) {
+        return { amount_cents: null, currency };
+      }
+    }
+    return { amount_cents: fromCents, currency };
+  }
+  if (typeof record.value === "number") {
+    return {
+      amount_cents: majorUnitsToCentsExact(record.value),
+      currency,
+    };
+  }
+  return { amount_cents: null, currency };
+}
+
+function resolveProbability(record: WarmblyCommercialRecord): {
+  probability: number | null;
+  probability_reliable: boolean;
+} {
+  const raw = record.probability;
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0 || raw > 1) {
+    return { probability: null, probability_reliable: false };
+  }
+  return {
+    probability: raw,
+    probability_reliable: record.probability_reliable === true,
+  };
+}
+
+function asRecordArray(value: unknown): WarmblyCommercialRecord[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const out: WarmblyCommercialRecord[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const rec = item as Partial<WarmblyCommercialRecord>;
+    if (typeof rec.id !== "string" || rec.id.length === 0) {
+      continue;
+    }
+    const entity = rec.entity;
+    if (
+      entity !== "deal" &&
+      entity !== "inbound_lead" &&
+      entity !== "contact" &&
+      entity !== "task"
+    ) {
+      continue;
+    }
+    out.push(rec as WarmblyCommercialRecord);
+  }
+  return out;
+}
+
+function defaultPin(): GovernanceOfferPin {
+  return {
+    authority_id: "UNKNOWN",
+    catalog_id: "UNKNOWN",
+    catalog_authority: "governance",
+    known_offers: [],
+    not_an_offer: [
+      {
+        kind: "extra_historical",
+        exception_id: EXTRA_HISTORICAL_EXCEPTION_ID,
+        amount_cents: EXTRA_HISTORICAL_AMOUNT_CENTS,
+        currency: DEFAULT_CURRENCY,
+      },
+    ],
+  };
+}
+
+function coercePin(raw: unknown): GovernanceOfferPin {
+  const base = defaultPin();
+  if (!raw || typeof raw !== "object") {
+    return base;
+  }
+  const p = raw as Partial<GovernanceOfferPin>;
+  const known: KnownOfferPin[] = [];
+  if (Array.isArray(p.known_offers)) {
+    for (const row of p.known_offers) {
+      if (
+        row &&
+        typeof row.offer_id === "string" &&
+        row.offer_id.length > 0 &&
+        typeof row.offer_version === "string" &&
+        row.offer_version.length > 0
+      ) {
+        known.push({
+          offer_id: row.offer_id,
+          offer_version: row.offer_version,
+        });
+      }
+    }
+  }
+  const extras: ExtraHistoricalMarker[] = [];
+  if (Array.isArray(p.not_an_offer)) {
+    for (const row of p.not_an_offer) {
+      if (
+        row &&
+        row.kind === "extra_historical" &&
+        typeof row.exception_id === "string" &&
+        typeof row.amount_cents === "number" &&
+        Number.isInteger(row.amount_cents)
+      ) {
+        extras.push({
+          kind: "extra_historical",
+          exception_id: row.exception_id,
+          amount_cents: row.amount_cents,
+          currency: normalizeCurrency(row.currency) ?? DEFAULT_CURRENCY,
+        });
+      }
+    }
+  }
+  return {
+    authority_id:
+      typeof p.authority_id === "string" && p.authority_id.length > 0
+        ? p.authority_id
+        : base.authority_id,
+    catalog_id:
+      typeof p.catalog_id === "string" && p.catalog_id.length > 0
+        ? p.catalog_id
+        : base.catalog_id,
+    catalog_authority: "governance",
+    known_offers: known,
+    not_an_offer: extras.length > 0 ? extras : base.not_an_offer,
+    observed_at: typeof p.observed_at === "string" ? p.observed_at : undefined,
+    freshness_status: p.freshness_status
+      ? parseFreshness(p.freshness_status)
+      : undefined,
+    confidence: clampConfidence(p.confidence),
+  };
+}
+
+function coerceSource(raw: unknown, fallbackLocator: string): SourceRef {
+  if (typeof raw === "string" && raw.length > 0) {
+    return { system: raw, kind: "commercial-observation", locator: fallbackLocator };
+  }
+  if (raw && typeof raw === "object") {
+    const s = raw as Partial<SourceRef>;
+    return {
+      system:
+        typeof s.system === "string" && s.system.length > 0
+          ? s.system
+          : "warmbly",
+      kind:
+        typeof s.kind === "string" && s.kind.length > 0
+          ? s.kind
+          : "commercial-observation",
+      locator:
+        typeof s.locator === "string" && s.locator.length > 0
+          ? s.locator
+          : fallbackLocator,
+      label: typeof s.label === "string" ? s.label : undefined,
+    };
+  }
+  return {
+    system: "warmbly",
+    kind: "commercial-observation",
+    locator: fallbackLocator,
+  };
+}
+
+function extraMarker(pin: GovernanceOfferPin): ExtraHistoricalMarker {
+  const found = pin.not_an_offer.find((row) => row.kind === "extra_historical");
+  return (
+    found ?? {
+      kind: "extra_historical",
+      exception_id: EXTRA_HISTORICAL_EXCEPTION_ID,
+      amount_cents: EXTRA_HISTORICAL_AMOUNT_CENTS,
+      currency: DEFAULT_CURRENCY,
+    }
+  );
+}
+
+function attachTaskNextActions(
+  records: NormalizedRecord[],
+  tasks: WarmblyCommercialRecord[],
+): void {
+  const byDeal = new Map<string, WarmblyCommercialRecord[]>();
+  const byLead = new Map<string, WarmblyCommercialRecord[]>();
+  for (const task of tasks) {
+    const status = (task.status ?? "").toLowerCase();
+    if (TERMINAL_TASK.has(status)) {
+      continue;
+    }
+    if (task.deal_id) {
+      const list = byDeal.get(task.deal_id) ?? [];
+      list.push(task);
+      byDeal.set(task.deal_id, list);
+    }
+    if (task.inbound_lead_id) {
+      const list = byLead.get(task.inbound_lead_id) ?? [];
+      list.push(task);
+      byLead.set(task.inbound_lead_id, list);
+    }
+  }
+  for (const rec of records) {
+    if (rec.next_action || rec.next_action_at) {
+      continue;
+    }
+    const linked =
+      (rec.entity === "deal" ? byDeal.get(rec.id) : undefined) ??
+      (rec.entity === "inbound_lead" ? byLead.get(rec.id) : undefined) ??
+      [];
+    const open = linked[0];
+    if (!open) {
+      continue;
+    }
+    rec.next_action = typeof open.next_action === "string" ? open.next_action : "open_task";
+    rec.next_action_at = parseUtc(open.next_action_at ?? open.due_date ?? null);
+  }
+}
+
+export function coerceObservationSet(raw: unknown): CommercialObservationSet {
+  if (!raw || typeof raw !== "object") {
+    return {
+      schema_version: OBSERVATION_SCHEMA_VERSION,
+      records: [],
+      offer_pin: defaultPin(),
+    };
+  }
+  const input = raw as CommercialObservationSet;
+  return {
+    schema_version:
+      typeof input.schema_version === "string"
+        ? input.schema_version
+        : OBSERVATION_SCHEMA_VERSION,
+    observed_at: input.observed_at,
+    source: input.source,
+    freshness_status: input.freshness_status,
+    confidence: input.confidence,
+    records: asRecordArray(input.records),
+    stage_map: input.stage_map ?? undefined,
+    offer_pin: coercePin(input.offer_pin),
+  };
+}
+
+export function normalizeInput(
+  raw: unknown,
+  fallbackLocator: string,
+): NormalizedInput {
+  const input = coerceObservationSet(raw);
+  const offer_pin = coercePin(input.offer_pin);
+  const extra_historical = extraMarker(offer_pin);
+  const observed_at = parseUtc(input.observed_at ?? null);
+  const observed_at_iso =
+    input.observed_at && observed_at
+      ? input.observed_at
+      : "1970-01-01T00:00:00Z";
+  const source = coerceSource(input.source, fallbackLocator);
+  const freshness_status = parseFreshness(input.freshness_status ?? "FRESH");
+  const confidence = clampConfidence(input.confidence);
+  const stageMap: StageMap = { ...DEFAULT_STAGE_MAP, ...(input.stage_map ?? {}) };
+  const all = asRecordArray(input.records);
+  const tasks = all.filter((r) => r.entity === "task");
+  const commercial = all.filter((r) => r.entity !== "task");
+
+  const records: NormalizedRecord[] = commercial
+    .map((record) => {
+      const amount = resolveAmount(record);
+      const prob = resolveProbability(record);
+      const extra =
+        amount.amount_cents === extra_historical.amount_cents &&
+        (amount.currency ?? DEFAULT_CURRENCY) === extra_historical.currency;
+      return {
+        id: record.id,
+        entity: record.entity,
+        funnel: classifyFunnel(record, stageMap),
+        status: (record.status ?? "").toLowerCase(),
+        amount_cents: amount.amount_cents,
+        currency: amount.currency,
+        probability: prob.probability,
+        probability_reliable: prob.probability_reliable,
+        offer_id: typeof record.offer_id === "string" ? record.offer_id : null,
+        offer_version:
+          typeof record.offer_version === "string" ? record.offer_version : null,
+        treated_as_catalog_offer: record.treated_as_catalog_offer === true,
+        next_action:
+          typeof record.next_action === "string" && record.next_action.length > 0
+            ? record.next_action
+            : null,
+        next_action_at: parseUtc(record.next_action_at ?? record.due_date ?? null),
+        last_activity_at: parseUtc(record.last_activity_at ?? record.updated_at ?? null),
+        stage_entered_at: parseUtc(record.stage_entered_at ?? null),
+        expected_close_at: parseUtc(record.expected_close_at ?? null),
+        created_at: parseUtc(record.created_at ?? null),
+        updated_at: parseUtc(record.updated_at ?? null),
+        observed_at: parseUtc(record.observed_at ?? input.observed_at ?? null),
+        freshness_status: parseFreshness(
+          record.freshness_status ?? input.freshness_status ?? "FRESH",
+        ),
+        confidence: clampConfidence(record.confidence ?? input.confidence),
+        stage_name: record.stage_name ?? record.stage_id ?? null,
+        extra_historical_cents: extra,
+      };
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  attachTaskNextActions(records, tasks);
+
+  return {
+    observed_at,
+    observed_at_iso,
+    source,
+    freshness_status,
+    confidence,
+    records,
+    offer_pin,
+    extra_historical,
+  };
+}
+
+export function isOpenPipeline(record: NormalizedRecord): boolean {
+  if (record.funnel === "lost" || record.funnel === "clientes") {
+    return false;
+  }
+  if (record.funnel === "unclassified") {
+    return false;
+  }
+  if (record.status === "won" || LOST.has(record.status)) {
+    return false;
+  }
+  return true;
+}

--- a/control-center/domains/commercial/src/project.ts
+++ b/control-center/domains/commercial/src/project.ts
@@ -1,0 +1,614 @@
+import { toUtcIso } from "./clock.ts";
+import {
+  AGING_MS,
+  ATTENTION_NOW_LIMIT,
+  CONVERSION_WINDOW_MS,
+  DEFAULT_CURRENCY,
+  FRESHNESS_WINDOW_SECONDS,
+  FUNNEL_KEYS,
+  STALL_MS,
+  SUMMARY_SCHEMA_VERSION,
+  type AggregatedFigure,
+  type AttentionItem,
+  type AttentionKind,
+  type AttentionSeverity,
+  type CommercialObservationSet,
+  type CommercialSummary,
+  type ExceptionRow,
+  type FreshnessStatus,
+  type FunnelKey,
+  type PipelineMoney,
+  type ProjectOptions,
+  type Provenance,
+  type SourceRef,
+} from "./contracts.ts";
+import {
+  classifyFreshness,
+  rollupFreshness,
+} from "./freshness.ts";
+import { weightedCentsExact } from "./money.ts";
+import {
+  isOpenPipeline,
+  normalizeInput,
+  type NormalizedInput,
+  type NormalizedRecord,
+} from "./normalize.ts";
+
+const KIND_RANK: Record<AttentionKind, number> = {
+  extra_historical_as_offer: 0,
+  unknown_offer_id: 1,
+  offer_version_drift: 2,
+  missing_next_action: 3,
+  stalled_stage: 4,
+  conversion_window_gap: 5,
+  aging: 6,
+};
+
+const SEVERITY_RANK: Record<AttentionSeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+function attentionId(kind: AttentionKind, recordId: string): string {
+  const slug = `${kind}-${recordId}`.replace(/[^A-Za-z0-9._~-]+/g, "-");
+  return `cc:attention-item:${slug}`;
+}
+
+function provenanceFor(
+  source: SourceRef,
+  observedAtIso: string,
+  freshness: FreshnessStatus,
+  confidence: number | undefined,
+): Provenance {
+  const p: Provenance = {
+    source,
+    observed_at: observedAtIso,
+    freshness_status: freshness,
+  };
+  if (confidence !== undefined) {
+    p.confidence = confidence;
+  }
+  p.freshness_window_seconds = FRESHNESS_WINDOW_SECONDS;
+  return p;
+}
+
+function figure(
+  key: string,
+  value: number,
+  source: SourceRef,
+  observedAtIso: string,
+  freshness: FreshnessStatus,
+  confidence: number | undefined,
+): AggregatedFigure {
+  const f: AggregatedFigure = {
+    key,
+    value,
+    source,
+    observed_at: observedAtIso,
+    freshness_status: freshness,
+  };
+  if (confidence !== undefined) {
+    f.confidence = confidence;
+  }
+  return f;
+}
+
+function buildFunnel(
+  records: NormalizedRecord[],
+  source: SourceRef,
+  observedAtIso: string,
+  freshness: FreshnessStatus,
+  confidence: number | undefined,
+): { funnel: Record<FunnelKey, AggregatedFigure>; unclassified: AggregatedFigure } {
+  const counts: Record<FunnelKey, number> = {
+    novos_leads: 0,
+    qualificados: 0,
+    oportunidades: 0,
+    propostas: 0,
+    clientes: 0,
+  };
+  let unclassified = 0;
+  for (const rec of records) {
+    if (rec.funnel === "lost") {
+      continue;
+    }
+    if (rec.funnel === "unclassified") {
+      unclassified += 1;
+      continue;
+    }
+    counts[rec.funnel] += 1;
+  }
+  const funnel = {} as Record<FunnelKey, AggregatedFigure>;
+  for (const key of FUNNEL_KEYS) {
+    funnel[key] = figure(
+      key,
+      counts[key],
+      source,
+      observedAtIso,
+      freshness,
+      confidence,
+    );
+  }
+  return {
+    funnel,
+    unclassified: figure(
+      "unclassified",
+      unclassified,
+      source,
+      observedAtIso,
+      freshness,
+      confidence,
+    ),
+  };
+}
+
+function buildPipeline(
+  records: NormalizedRecord[],
+  source: SourceRef,
+  observedAtIso: string,
+  freshness: FreshnessStatus,
+  confidence: number | undefined,
+): { nominal: PipelineMoney; weighted: PipelineMoney } {
+  const open = records.filter(isOpenPipeline);
+  const baseProv = provenanceFor(source, observedAtIso, freshness, confidence);
+
+  if (open.length === 0) {
+    return {
+      nominal: {
+        treatment: "present",
+        amount_cents: 0,
+        currency: DEFAULT_CURRENCY,
+        provenance: baseProv,
+      },
+      weighted: {
+        treatment: "insufficient_data",
+        reason: "no_open_pipeline_probabilities",
+        provenance: baseProv,
+      },
+    };
+  }
+
+  const known = open.filter((r) => r.amount_cents !== null);
+  const currencies = new Set(
+    known.map((r) => r.currency ?? DEFAULT_CURRENCY),
+  );
+
+  let nominal: PipelineMoney;
+  if (known.length === 0 || currencies.size !== 1) {
+    nominal = {
+      treatment: "insufficient_data",
+      reason: known.length === 0 ? "no_known_amounts" : "mixed_currency",
+      provenance: baseProv,
+    };
+  } else {
+    const currency = [...currencies][0] ?? DEFAULT_CURRENCY;
+    let cents = 0;
+    for (const r of known) {
+      cents += r.amount_cents as number;
+    }
+    const conf =
+      known.length === open.length
+        ? confidence
+        : Math.min(confidence ?? 1, 0.5);
+    nominal = {
+      treatment: "present",
+      amount_cents: cents,
+      currency,
+      provenance: provenanceFor(source, observedAtIso, freshness, conf),
+    };
+  }
+
+  const allReliable =
+    open.length > 0 &&
+    open.every(
+      (r) =>
+        r.amount_cents !== null &&
+        r.probability_reliable &&
+        r.probability !== null,
+    );
+
+  let weighted: PipelineMoney;
+  if (!allReliable) {
+    weighted = {
+      treatment: "insufficient_data",
+      reason: "probabilities_missing_or_unreliable",
+      provenance: baseProv,
+    };
+  } else if (currencies.size !== 1) {
+    weighted = {
+      treatment: "insufficient_data",
+      reason: "mixed_currency",
+      provenance: baseProv,
+    };
+  } else {
+    const currency = [...currencies][0] ?? DEFAULT_CURRENCY;
+    let cents = 0;
+    let exact = true;
+    for (const r of open) {
+      const w = weightedCentsExact(r.amount_cents as number, r.probability as number);
+      if (w === null) {
+        exact = false;
+        break;
+      }
+      cents += w;
+    }
+    if (!exact) {
+      weighted = {
+        treatment: "insufficient_data",
+        reason: "weighted_cents_not_integer",
+        provenance: baseProv,
+      };
+    } else {
+      weighted = {
+        treatment: "present",
+        amount_cents: cents,
+        currency,
+        provenance: baseProv,
+      };
+    }
+  }
+
+  return { nominal, weighted };
+}
+
+function offerExceptions(
+  rec: NormalizedRecord,
+  input: NormalizedInput,
+  nowIso: string,
+  freshness: FreshnessStatus,
+): ExceptionRow[] {
+  const rows: ExceptionRow[] = [];
+  const pin = input.offer_pin;
+  const extra = input.extra_historical;
+  const source: SourceRef = {
+    system: "warmbly",
+    kind: "offer-discrepancy",
+    locator: rec.id,
+  };
+  const prov = provenanceFor(source, rec.observed_at ? toUtcIso(rec.observed_at) : nowIso, freshness, rec.confidence);
+
+  const offerId = rec.offer_id;
+  const known = offerId
+    ? pin.known_offers.find((o) => o.offer_id === offerId)
+    : undefined;
+  const extraAsOfferId =
+    offerId === extra.exception_id ||
+    offerId === String(extra.amount_cents) ||
+    offerId === "1000000";
+
+  if (rec.extra_historical_cents && (rec.treated_as_catalog_offer || extraAsOfferId || Boolean(known))) {
+    rows.push({
+      id: attentionId("extra_historical_as_offer", rec.id),
+      kind: "extra_historical_as_offer",
+      record_id: rec.id,
+      severity: "critical",
+      title: "Extra historical amount treated as catalog offer",
+      summary:
+        "Amount 1000000 cents is the private Extra historical contract, not a Governance catalog offer.",
+      recommended_action:
+        "Remove catalog offer_id from this record; keep Extra as a private exception.",
+      provenance: prov,
+    });
+  } else if (extraAsOfferId) {
+    rows.push({
+      id: attentionId("extra_historical_as_offer", rec.id),
+      kind: "extra_historical_as_offer",
+      record_id: rec.id,
+      severity: "critical",
+      title: "Extra historical identifier used as offer_id",
+      summary:
+        "CFG-EXC-EXTRA-HISTORICAL-v1 / 1000000 is not an offer. Governance pin lists it under not_an_offer.",
+      recommended_action: "Stop treating Extra historical as a catalog SKU.",
+      provenance: prov,
+    });
+  }
+
+  if (offerId && !extraAsOfferId && !known && rec.treated_as_catalog_offer) {
+    rows.push({
+      id: attentionId("unknown_offer_id", rec.id),
+      kind: "unknown_offer_id",
+      record_id: rec.id,
+      severity: "high",
+      title: `Unknown offer_id ${offerId}`,
+      summary:
+        "Warmbly record references an offer_id that is not on the Governance pin.",
+      recommended_action: "Align Warmbly offer_id with the Governance pin or clear it.",
+      provenance: prov,
+    });
+  } else if (offerId && !extraAsOfferId && !known && offerId.startsWith("CFG-")) {
+    rows.push({
+      id: attentionId("unknown_offer_id", rec.id),
+      kind: "unknown_offer_id",
+      record_id: rec.id,
+      severity: "high",
+      title: `Unknown offer_id ${offerId}`,
+      summary:
+        "Warmbly record references an offer_id that is not on the Governance pin.",
+      recommended_action: "Align Warmbly offer_id with the Governance pin or clear it.",
+      provenance: prov,
+    });
+  }
+
+  if (known) {
+    if (!rec.offer_version || rec.offer_version !== known.offer_version) {
+      rows.push({
+        id: attentionId("offer_version_drift", rec.id),
+        kind: "offer_version_drift",
+        record_id: rec.id,
+        severity: "high",
+        title: `Offer version drift on ${offerId}`,
+        summary: `Pin version ${known.offer_version}; Warmbly has ${rec.offer_version ?? "UNKNOWN"}.`,
+        recommended_action: "Re-pin Warmbly to the Governance offer_version.",
+        provenance: prov,
+      });
+    }
+  }
+
+  return rows;
+}
+
+function operationalExceptions(
+  rec: NormalizedRecord,
+  now: Date,
+  nowIso: string,
+  freshness: FreshnessStatus,
+): ExceptionRow[] {
+  if (!isOpenPipeline(rec)) {
+    return [];
+  }
+  const rows: ExceptionRow[] = [];
+  const source: SourceRef = {
+    system: "warmbly",
+    kind: "commercial-record",
+    locator: rec.id,
+  };
+  const prov = provenanceFor(
+    source,
+    rec.observed_at ? toUtcIso(rec.observed_at) : nowIso,
+    freshness,
+    rec.confidence,
+  );
+
+  if (!rec.next_action && !rec.next_action_at) {
+    rows.push({
+      id: attentionId("missing_next_action", rec.id),
+      kind: "missing_next_action",
+      record_id: rec.id,
+      severity: "high",
+      title: `Missing next action on ${rec.id}`,
+      summary: "Open commercial record has no next_action and no next_action_at.",
+      recommended_action: "Set a next action before the record ages further.",
+      provenance: prov,
+    });
+  }
+
+  const stageAnchor = rec.stage_entered_at ?? rec.updated_at ?? rec.last_activity_at;
+  if (stageAnchor && now.getTime() - stageAnchor.getTime() >= STALL_MS) {
+    rows.push({
+      id: attentionId("stalled_stage", rec.id),
+      kind: "stalled_stage",
+      record_id: rec.id,
+      severity: "high",
+      title: `Stalled stage on ${rec.id}`,
+      summary: "Open record has not changed stage within the stall window (14 days).",
+      recommended_action: "Move the stage or close the record.",
+      provenance: prov,
+    });
+  }
+
+  const conversionAnchor = rec.expected_close_at;
+  const ageAnchor = rec.stage_entered_at ?? rec.created_at;
+  const pastClose = Boolean(conversionAnchor && conversionAnchor.getTime() < now.getTime());
+  const overWindow =
+    Boolean(ageAnchor && now.getTime() - ageAnchor.getTime() >= CONVERSION_WINDOW_MS) &&
+    (rec.funnel === "propostas" || rec.funnel === "oportunidades");
+  if (pastClose || overWindow) {
+    rows.push({
+      id: attentionId("conversion_window_gap", rec.id),
+      kind: "conversion_window_gap",
+      record_id: rec.id,
+      severity: "medium",
+      title: `Conversion window gap on ${rec.id}`,
+      summary: pastClose
+        ? "expected_close_at is in the past while the record is still open."
+        : "Open opportunity/proposal exceeded the 30-day conversion window.",
+      recommended_action: "Re-forecast the close date or close the record.",
+      provenance: prov,
+    });
+  }
+
+  const activity = rec.last_activity_at ?? rec.updated_at;
+  if (activity && now.getTime() - activity.getTime() >= AGING_MS) {
+    rows.push({
+      id: attentionId("aging", rec.id),
+      kind: "aging",
+      record_id: rec.id,
+      severity: "medium",
+      title: `Aging record ${rec.id}`,
+      summary: "No commercial activity within 14 days.",
+      recommended_action: "Touch the record or park it.",
+      provenance: prov,
+    });
+  }
+
+  return rows;
+}
+
+function collectExceptions(
+  input: NormalizedInput,
+  now: Date,
+  nowIso: string,
+  freshness: FreshnessStatus,
+): ExceptionRow[] {
+  const rows: ExceptionRow[] = [];
+  for (const rec of input.records) {
+    rows.push(...offerExceptions(rec, input, nowIso, freshness));
+    rows.push(...operationalExceptions(rec, now, nowIso, freshness));
+  }
+  rows.sort((a, b) => {
+    const k = KIND_RANK[a.kind] - KIND_RANK[b.kind];
+    if (k !== 0) {
+      return k;
+    }
+    const s = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (s !== 0) {
+      return s;
+    }
+    return a.id.localeCompare(b.id);
+  });
+  return rows;
+}
+
+function selectAttention(exceptions: ExceptionRow[]): AttentionItem[] {
+  const byRecord = new Map<string, ExceptionRow>();
+  for (const row of exceptions) {
+    const existing = byRecord.get(row.record_id);
+    if (!existing) {
+      byRecord.set(row.record_id, row);
+      continue;
+    }
+    const better =
+      KIND_RANK[row.kind] < KIND_RANK[existing.kind] ||
+      (KIND_RANK[row.kind] === KIND_RANK[existing.kind] &&
+        SEVERITY_RANK[row.severity] < SEVERITY_RANK[existing.severity]);
+    if (better) {
+      byRecord.set(row.record_id, row);
+    }
+  }
+  const ranked = [...byRecord.values()].sort((a, b) => {
+    const k = KIND_RANK[a.kind] - KIND_RANK[b.kind];
+    if (k !== 0) {
+      return k;
+    }
+    const s = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (s !== 0) {
+      return s;
+    }
+    return a.id.localeCompare(b.id);
+  });
+  return ranked.slice(0, ATTENTION_NOW_LIMIT).map((row) => ({
+    id: row.id,
+    kind: row.kind,
+    record_id: row.record_id,
+    severity: row.severity,
+    horizon: "now",
+    title: row.title,
+    summary: row.summary,
+    recommended_action: row.recommended_action,
+    provenance: row.provenance,
+  }));
+}
+
+function aggregateConfidence(
+  input: NormalizedInput,
+  unclassifiedCount: number,
+): number | undefined {
+  if (input.records.length === 0) {
+    return 0;
+  }
+  if (input.confidence !== undefined) {
+    return unclassifiedCount > 0
+      ? Math.min(input.confidence, 0.5)
+      : input.confidence;
+  }
+  const classified = input.records.length - unclassifiedCount;
+  return classified / input.records.length;
+}
+
+/**
+ * Shipped projection: Warmbly-shaped observations + Governance offer pin
+ * → one-screen commercial summary. Pure. Never mutates Warmbly or Asaas.
+ */
+export function projectCommercialSummary(
+  raw: CommercialObservationSet | unknown,
+  opts: ProjectOptions = {},
+): CommercialSummary {
+  const input = normalizeInput(raw, "fixture");
+  const now =
+    opts.now ??
+    input.observed_at ??
+    new Date("1970-01-01T00:00:00Z");
+  const generated_at = toUtcIso(now);
+  const observedIso = input.observed_at
+    ? toUtcIso(input.observed_at)
+    : input.observed_at_iso;
+
+  const recordFreshness = input.records.map((r) =>
+    classifyFreshness(r.observed_at, now, r.freshness_status),
+  );
+  recordFreshness.push(
+    classifyFreshness(input.observed_at, now, input.freshness_status),
+  );
+  const freshness = rollupFreshness(recordFreshness);
+
+  const { funnel, unclassified } = buildFunnel(
+    input.records,
+    input.source,
+    observedIso,
+    freshness,
+    undefined,
+  );
+  const confidence = aggregateConfidence(input, unclassified.value);
+  for (const key of FUNNEL_KEYS) {
+    const current = funnel[key];
+    funnel[key] = {
+      ...current,
+      ...(confidence !== undefined ? { confidence } : {}),
+    };
+  }
+  if (confidence !== undefined) {
+    unclassified.confidence = confidence;
+  }
+
+  const pipeline = buildPipeline(
+    input.records,
+    input.source,
+    observedIso,
+    freshness,
+    confidence,
+  );
+  const exceptions = collectExceptions(input, now, observedIso, freshness);
+  const attentionItems = selectAttention(exceptions);
+
+  const pinObserved =
+    input.offer_pin.observed_at ?? observedIso;
+
+  return {
+    schema_version: SUMMARY_SCHEMA_VERSION,
+    scope: "commercial",
+    generated_at,
+    authority: {
+      catalog_authority: "governance",
+      commercial_runtime: "warmbly",
+      this_document: "read_model",
+      offer_pin: {
+        authority_id: input.offer_pin.authority_id,
+        catalog_id: input.offer_pin.catalog_id,
+        pin_observed_at: pinObserved,
+      },
+    },
+    provenance: provenanceFor(input.source, observedIso, freshness, confidence),
+    funnel,
+    pipeline,
+    exceptions,
+    attention: {
+      horizon: "now",
+      items: attentionItems,
+    },
+    unclassified,
+  };
+}
+
+export function attentionSlice(summary: CommercialSummary): Array<{
+  id: string;
+  kind: AttentionKind;
+  record_id: string;
+}> {
+  return summary.attention.items.map((item) => ({
+    id: item.id,
+    kind: item.kind,
+    record_id: item.record_id,
+  }));
+}

--- a/control-center/domains/commercial/tests/cli.test.ts
+++ b/control-center/domains/commercial/tests/cli.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { FUNNEL_KEYS } from "../src/contracts.ts";
+import { runFixture } from "../src/load-fixture.ts";
+import { fixturePath, NOW } from "./helpers.ts";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CLI = join(ROOT, "src", "cli.ts");
+
+describe("launchable fixture runner", () => {
+  it("runFixture drives the shipped projection on the representative fixture", () => {
+    const summary = runFixture(fixturePath("representative.json"), { now: NOW });
+    for (const key of FUNNEL_KEYS) {
+      assert.ok(key in summary.funnel);
+    }
+    assert.ok(summary.attention.items.length <= 3);
+    assert.equal(summary.pipeline.nominal.treatment, "present");
+  });
+
+  it("CLI prints JSON twice with identical commercial content", () => {
+    const args = [
+      CLI,
+      "--fixture",
+      fixturePath("representative.json"),
+      "--now",
+      "2026-08-20T12:00:00Z",
+    ];
+    const tsxBin = join(ROOT, "node_modules", "tsx", "dist", "cli.mjs");
+    const first = spawnSync(process.execPath, [tsxBin, ...args], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+    const second = spawnSync(process.execPath, [tsxBin, ...args], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(second.status, 0, second.stderr);
+    const a = JSON.parse(first.stdout) as { funnel: unknown; attention: unknown; pipeline: unknown };
+    const b = JSON.parse(second.stdout) as { funnel: unknown; attention: unknown; pipeline: unknown };
+    assert.deepEqual(a.funnel, b.funnel);
+    assert.deepEqual(a.attention, b.attention);
+    assert.deepEqual(a.pipeline, b.pipeline);
+    assert.equal(first.stdout, second.stdout);
+  });
+});

--- a/control-center/domains/commercial/tests/helpers.ts
+++ b/control-center/domains/commercial/tests/helpers.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  FUNNEL_KEYS,
+  type CommercialObservationSet,
+  type FunnelKey,
+  type WarmblyCommercialRecord,
+} from "../src/contracts.ts";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+export const NOW = new Date("2026-08-20T12:00:00Z");
+
+export function fixturePath(name: string): string {
+  return join(ROOT, "fixtures", name);
+}
+
+export function loadJson(name: string): CommercialObservationSet {
+  const text = readFileSync(fixturePath(name), "utf8");
+  return JSON.parse(text) as CommercialObservationSet;
+}
+
+export function declaredFunnelCount(
+  records: WarmblyCommercialRecord[] | null | undefined,
+  key: FunnelKey,
+): number {
+  return (records ?? []).filter((row) => row.funnel_stage === key).length;
+}
+
+export function declaredOpenPipeline(records: WarmblyCommercialRecord[] | null | undefined): WarmblyCommercialRecord[] {
+  return (records ?? []).filter((row) => {
+    if (row.entity === "task") {
+      return false;
+    }
+    const stage = row.funnel_stage;
+    if (typeof stage !== "string" || !(FUNNEL_KEYS as readonly string[]).includes(stage)) {
+      return false;
+    }
+    if (stage === "clientes") {
+      return false;
+    }
+    const status = (row.status ?? "").toLowerCase();
+    return status !== "won" && status !== "lost";
+  });
+}
+
+export function provenanceFields(value: {
+  source: unknown;
+  observed_at: unknown;
+  freshness_status: unknown;
+}): string[] {
+  const missing: string[] = [];
+  if (!value.source || typeof value.source !== "object") {
+    missing.push("source");
+  }
+  if (typeof value.observed_at !== "string") {
+    missing.push("observed_at");
+  }
+  if (typeof value.freshness_status !== "string") {
+    missing.push("freshness_status");
+  }
+  return missing;
+}

--- a/control-center/domains/commercial/tests/money.test.ts
+++ b/control-center/domains/commercial/tests/money.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { majorUnitsToCentsExact, weightedCentsExact } from "../src/money.ts";
+import { projectCommercialSummary } from "../src/project.ts";
+import { NOW } from "./helpers.ts";
+
+describe("majorUnitsToCentsExact", () => {
+  it("converts exact major units without inventing cents", () => {
+    assert.equal(majorUnitsToCentsExact(0), 0);
+    assert.equal(majorUnitsToCentsExact(8000), 800_000);
+    assert.equal(majorUnitsToCentsExact(1500.5), 150_050);
+    assert.equal(majorUnitsToCentsExact(10.01), 1001);
+  });
+
+  it("fail-closes amounts that are not exact cents", () => {
+    assert.equal(majorUnitsToCentsExact(10.001), null);
+    assert.equal(majorUnitsToCentsExact(Number.NaN), null);
+    assert.equal(majorUnitsToCentsExact(Number.POSITIVE_INFINITY), null);
+    assert.equal(majorUnitsToCentsExact(-1), null);
+  });
+});
+
+describe("projection money fail-closed", () => {
+  it("does not include inexact Warmbly floats in nominal pipeline", () => {
+    const summary = projectCommercialSummary(
+      {
+        schema_version: "control-center.commercial-observations.v1",
+        observed_at: "2026-08-20T12:00:00Z",
+        freshness_status: "FRESH",
+        records: [
+          {
+            id: "deal-bad-float",
+            entity: "deal",
+            status: "open",
+            funnel_stage: "oportunidades",
+            value: 10.001,
+            currency: "BRL",
+            next_action: "fix_amount",
+            next_action_at: "2026-08-21T00:00:00Z",
+            last_activity_at: "2026-08-19T00:00:00Z",
+            stage_entered_at: "2026-08-18T00:00:00Z",
+          },
+          {
+            id: "deal-good",
+            entity: "deal",
+            status: "open",
+            funnel_stage: "propostas",
+            amount_cents: 800000,
+            currency: "BRL",
+            next_action: "send",
+            next_action_at: "2026-08-21T00:00:00Z",
+            last_activity_at: "2026-08-19T00:00:00Z",
+            stage_entered_at: "2026-08-18T00:00:00Z",
+          },
+        ],
+      },
+      { now: NOW },
+    );
+    assert.equal(summary.pipeline.nominal.treatment, "present");
+    assert.equal(summary.pipeline.nominal.amount_cents, 800000);
+    assert.equal(summary.funnel.oportunidades.value, 1);
+    assert.equal(summary.funnel.propostas.value, 1);
+  });
+});
+
+describe("weightedCentsExact", () => {
+  it("keeps cents × probability as integer cents when exact", () => {
+    assert.equal(weightedCentsExact(800000, 0.5), 400000);
+    assert.equal(weightedCentsExact(800000, 0.25), 200000);
+    assert.equal(weightedCentsExact(100, 1), 100);
+  });
+
+  it("rejects out-of-range probability", () => {
+    assert.equal(weightedCentsExact(800000, 1.5), null);
+    assert.equal(weightedCentsExact(800000, -0.1), null);
+  });
+});

--- a/control-center/domains/commercial/tests/mutation-surface.test.ts
+++ b/control-center/domains/commercial/tests/mutation-surface.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (full.endsWith(".ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("read-only mutation surface", () => {
+  const files = walk(SRC);
+  const joined = files.map((f) => readFileSync(f, "utf8")).join("\n");
+
+  it("does not ship an HTTP mutation client", () => {
+    assert.equal(/new\s+WarmblyClient/.test(joined), false);
+    assert.equal(/asaas\.com/i.test(joined), false);
+    assert.equal(/\bfetch\s*\(/.test(joined), false);
+    assert.equal(/http\.request/.test(joined), false);
+    assert.equal(/https\.request/.test(joined), false);
+    assert.equal(/method:\s*["'](POST|PUT|PATCH|DELETE)["']/.test(joined), false);
+  });
+
+  it("does not reference checkout, refund, or send-commercial actions as callable APIs", () => {
+    assert.equal(/createPayment|refundPayment|cancelSubscription/.test(joined), false);
+    assert.equal(/auto_send|sendCampaign/.test(joined), false);
+  });
+
+  it("ships the projection and CLI entrypoints", () => {
+    assert.equal(files.some((f) => f.endsWith("project.ts")), true);
+    assert.equal(files.some((f) => f.endsWith("cli.ts")), true);
+    assert.equal(joined.includes("export function projectCommercialSummary"), true);
+  });
+});

--- a/control-center/domains/commercial/tests/projection.test.ts
+++ b/control-center/domains/commercial/tests/projection.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  ATTENTION_NOW_LIMIT,
+  FUNNEL_KEYS,
+  SUMMARY_SCHEMA_VERSION,
+} from "../src/contracts.ts";
+import { projectCommercialSummary } from "../src/project.ts";
+import {
+  NOW,
+  declaredFunnelCount,
+  declaredOpenPipeline,
+  loadJson,
+  provenanceFields,
+} from "./helpers.ts";
+
+describe("projectCommercialSummary — complete funnel", () => {
+  const input = loadJson("complete-funnel.json");
+  const summary = projectCommercialSummary(input, { now: NOW });
+
+  it("emits the executive schema with all funnel keys", () => {
+    assert.equal(summary.schema_version, SUMMARY_SCHEMA_VERSION);
+    assert.equal(summary.scope, "commercial");
+    assert.equal(summary.authority.catalog_authority, "governance");
+    assert.equal(summary.authority.commercial_runtime, "warmbly");
+    assert.equal(summary.authority.this_document, "read_model");
+    for (const key of FUNNEL_KEYS) {
+      assert.ok(key in summary.funnel, `missing funnel key ${key}`);
+      const fig = summary.funnel[key];
+      assert.equal(fig.key, key);
+      assert.equal(fig.value, declaredFunnelCount(input.records, key));
+      assert.deepEqual(provenanceFields(fig), []);
+    }
+    assert.deepEqual(provenanceFields(summary.provenance), []);
+  });
+
+  it("emits nominal pipeline in integer cents when amounts are known", () => {
+    assert.equal(summary.pipeline.nominal.treatment, "present");
+    assert.equal(typeof summary.pipeline.nominal.amount_cents, "number");
+    assert.equal(Number.isInteger(summary.pipeline.nominal.amount_cents), true);
+    assert.equal(summary.pipeline.nominal.currency, "BRL");
+    const open = declaredOpenPipeline(input.records);
+    let expected = 0;
+    for (const row of open) {
+      if (typeof row.amount_cents === "number") {
+        expected += row.amount_cents;
+      } else if (typeof row.value === "number") {
+        expected += row.value * 100;
+      }
+    }
+    assert.equal(summary.pipeline.nominal.amount_cents, expected);
+  });
+
+  it("does not invent weighted pipeline when probabilities are absent", () => {
+    assert.equal(summary.pipeline.weighted.treatment, "insufficient_data");
+    assert.equal(summary.pipeline.weighted.amount_cents, undefined);
+  });
+
+  it("pins Governance identity without copying a catalog", () => {
+    assert.equal(summary.authority.offer_pin.authority_id, "CFG-OFFER-AUTHORITY-v1");
+    assert.equal(summary.authority.offer_pin.catalog_id, "CFG-OFFER-CATALOG-v1");
+    const blob = JSON.stringify(summary);
+    assert.equal(blob.includes("Diagnóstico B2G"), false);
+    assert.equal(blob.includes("description_short"), false);
+    assert.equal(blob.includes("catalog.v1.json"), false);
+  });
+});
+
+describe("projectCommercialSummary — exceptions and attention", () => {
+  const input = loadJson("exceptions-gaps.json");
+  const summary = projectCommercialSummary(input, { now: NOW });
+
+  it("emits checkable rows for aging, missing next action, stalled stages, conversion windows", () => {
+    const kinds = new Set(summary.exceptions.map((row) => row.kind));
+    assert.equal(kinds.has("missing_next_action"), true);
+    assert.equal(kinds.has("stalled_stage"), true);
+    assert.equal(kinds.has("aging"), true);
+    assert.equal(kinds.has("conversion_window_gap"), true);
+    const missing = summary.exceptions.find((row) => row.record_id === "deal-missing-next");
+    assert.equal(missing?.kind, "missing_next_action");
+  });
+
+  it("caps commercial attention at 3 now-horizon items and is non-empty when exceptions exist", () => {
+    assert.ok(summary.exceptions.length > 0);
+    assert.ok(summary.attention.items.length > 0);
+    assert.ok(summary.attention.items.length <= ATTENTION_NOW_LIMIT);
+    assert.equal(summary.attention.horizon, "now");
+    for (const item of summary.attention.items) {
+      assert.equal(item.horizon, "now");
+      assert.equal(typeof item.recommended_action, "string");
+      assert.ok(item.recommended_action.length > 0);
+      assert.deepEqual(provenanceFields(item.provenance), []);
+    }
+  });
+});
+
+describe("projectCommercialSummary — incomplete / UNKNOWN", () => {
+  const input = loadJson("incomplete-unknown.json");
+  const summary = projectCommercialSummary(input, { now: NOW });
+
+  it("fail-closes to zeros / UNKNOWN / insufficient_data and does not invent counts", () => {
+    for (const key of FUNNEL_KEYS) {
+      assert.equal(summary.funnel[key].value, 0);
+      assert.deepEqual(provenanceFields(summary.funnel[key]), []);
+    }
+    assert.ok(summary.unclassified.value >= 1);
+    assert.equal(summary.provenance.freshness_status, "UNKNOWN");
+    assert.equal(
+      summary.pipeline.nominal.treatment === "insufficient_data" ||
+        summary.pipeline.nominal.amount_cents === 0,
+      true,
+    );
+    assert.equal(summary.pipeline.weighted.treatment, "insufficient_data");
+  });
+
+  it("does not throw on empty, null, or partial input", () => {
+    assert.doesNotThrow(() => projectCommercialSummary(null, { now: NOW }));
+    assert.doesNotThrow(() => projectCommercialSummary({}, { now: NOW }));
+    assert.doesNotThrow(() =>
+      projectCommercialSummary({ records: [] }, { now: NOW }),
+    );
+    const empty = projectCommercialSummary({ records: [] }, { now: NOW });
+    for (const key of FUNNEL_KEYS) {
+      assert.equal(empty.funnel[key].value, 0);
+    }
+  });
+});
+
+describe("projectCommercialSummary — offer pin mismatch and Extra leak", () => {
+  const input = loadJson("offer-discrepancy.json");
+  const summary = projectCommercialSummary(input, { now: NOW });
+
+  it("flags unknown offer_id, version drift, and Extra 1000000 treated as an offer", () => {
+    const kinds = new Set(summary.exceptions.map((row) => row.kind));
+    assert.equal(kinds.has("unknown_offer_id"), true);
+    assert.equal(kinds.has("offer_version_drift"), true);
+    assert.equal(kinds.has("extra_historical_as_offer"), true);
+    const extra = summary.exceptions.filter((row) => row.kind === "extra_historical_as_offer");
+    assert.ok(extra.length >= 1);
+    assert.equal(
+      extra.some((row) => row.summary.toLowerCase().includes("not a") || row.summary.includes("not an offer")),
+      true,
+    );
+    assert.equal(
+      summary.attention.items.some((item) => item.kind === "extra_historical_as_offer"),
+      true,
+    );
+  });
+});
+
+describe("projectCommercialSummary — probabilities", () => {
+  it("emits weighted pipeline as cents × probability when every open item is reliable", () => {
+    const input = loadJson("probabilities-reliable.json");
+    const summary = projectCommercialSummary(input, { now: NOW });
+    assert.equal(summary.pipeline.weighted.treatment, "present");
+    const open = declaredOpenPipeline(input.records);
+    let expected = 0;
+    for (const row of open) {
+      assert.equal(row.probability_reliable, true);
+      assert.equal(typeof row.amount_cents, "number");
+      assert.equal(typeof row.probability, "number");
+      expected += (row.amount_cents as number) * (row.probability as number);
+    }
+    assert.equal(summary.pipeline.weighted.amount_cents, expected);
+    assert.equal(summary.pipeline.nominal.treatment, "present");
+  });
+
+  it("marks weighted insufficient_data when probabilities are absent or unreliable", () => {
+    const input = loadJson("probabilities-absent.json");
+    const summary = projectCommercialSummary(input, { now: NOW });
+    assert.equal(summary.pipeline.nominal.treatment, "present");
+    assert.equal(summary.pipeline.weighted.treatment, "insufficient_data");
+    assert.equal(summary.pipeline.weighted.amount_cents, undefined);
+    assert.equal(summary.pipeline.weighted.reason, "probabilities_missing_or_unreliable");
+  });
+});
+
+describe("projectCommercialSummary — representative one-screen summary", () => {
+  it("fits an action-first view: five funnel figures, pipeline, ≤3 attention", () => {
+    const input = loadJson("representative.json");
+    const summary = projectCommercialSummary(input, { now: NOW });
+    assert.equal(Object.keys(summary.funnel).length, FUNNEL_KEYS.length);
+    for (const key of FUNNEL_KEYS) {
+      assert.equal(typeof summary.funnel[key].value, "number");
+    }
+    assert.ok(summary.attention.items.length <= ATTENTION_NOW_LIMIT);
+    assert.ok(summary.attention.items.length >= 1);
+    assert.equal(summary.pipeline.weighted.treatment, "insufficient_data");
+    assert.equal(summary.pipeline.nominal.treatment, "present");
+    const kinds = new Set(summary.exceptions.map((row) => row.kind));
+    assert.equal(kinds.has("extra_historical_as_offer"), true);
+    assert.equal(kinds.has("unknown_offer_id"), true);
+    assert.equal(kinds.has("missing_next_action"), true);
+  });
+
+  it("is deterministic for the same observations and clock", () => {
+    const input = loadJson("representative.json");
+    const a = projectCommercialSummary(input, { now: NOW });
+    const b = projectCommercialSummary(input, { now: NOW });
+    assert.equal(JSON.stringify(a), JSON.stringify(b));
+  });
+});

--- a/control-center/domains/commercial/tsconfig.json
+++ b/control-center/domains/commercial/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds the Control Center **commercial executive read model** under `control-center/domains/commercial/` only.

Warmbly-shaped observations + a read-only Governance offer pin (`offer_id` / `offer_version` / authority identity, never a copied catalog) project into a one-screen summary:

- Funnel: `novos_leads`, `qualificados`, `oportunidades`, `propostas`, `clientes`
- Every aggregate carries `source`, `observed_at`, `freshness_status`, and `confidence` when applicable
- Pipeline money as integer cents + ISO currency; nominal when amounts are known; weighted only when every open item has a reliable probability
- Exceptions: aging, missing next action, stalled stages, conversion-window gaps, unknown `offer_id`, version drift, Extra historical `1000000` treated as a catalog offer
- Commercial attention: horizon `now`, max 3, action-first
- Incomplete / UNKNOWN input fail-closes to zeros / `UNKNOWN` / `insufficient_data`
- Zero Warmbly/Asaas mutation clients

## Branch / SHA

- Branch: `cc/11-commercial-readmodel`
- SHA: `df8e086a1e1d982abefedf604baca65b4c55dc56`
- Base: `origin/main` at/after `39da6ad` (`e2b0498`)
- Worktree: `../Governance-cc-11-commercial-readmodel`

## Tests

From `control-center/domains/commercial`:

- `npm test` — 23 passed (`tsx --test`)
- `npx tsc --noEmit` — clean
- CLI launched twice on `fixtures/representative.json` — identical JSON, exit 0
- `git diff --check` — clean

## Contracts exposed (local until convergence)

- Input: `control-center.commercial-observations.v1` (Warmbly-shaped records + Governance offer pin)
- Output: `control-center.commercial-summary.v1` via `projectCommercialSummary` / `cc-commercial-summary`
- Freshness closed set: `FRESH | STALE | UNKNOWN | ERROR` (contracts workstream casing; persistence uses lowercase/`expired` — map at the boundary, do not rewrite persistence)

## Convergence dependencies (do not import sibling trees from this PR)

- `control-center/connectors/warmbly` should later emit this observation shape from read-only fetches
- `control-center/contracts` CommercialSnapshot v1 is still thin; an additive revision should carry funnel + pipeline money + attention
- `control-center/persistence` should store the summary as an operational snapshot scoped `commercial`
- Context service / MCP: agents query by scope `commercial`

## Risks

- Canonical CommercialSnapshot schema is owned by the contracts workstream and is not imported here
- Warmbly CRM has no win-probability field; weighted pipeline is correctly `insufficient_data` unless the input marks probabilities reliable
- Stage mapping uses a local default map + optional `stage_map`; live Warmbly stage names may need the connector to fill `funnel_stage`

Does not merge automatically. Does not touch `commercial/`, `decisions/`, `scripts/`, root README, PR #8, Warmbly, web-cfg, extra-cli, or other Control Center workstream paths.