### PR TITLE
feat(control-center): deterministic attention engine (ATENÇÃO AGORA + today-3)

### DIFF
--- a/control-center/intelligence/attention/.gitignore
+++ b/control-center/intelligence/attention/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/control-center/intelligence/attention/README.md
+++ b/control-center/intelligence/attention/README.md
@@ -1,0 +1,105 @@
+# Control Center Attention Engine
+
+Deterministic ranking for **ATENÇÃO AGORA** (exceptions) and **se eu só puder fazer 3 coisas hoje** (homepage top-3). This package is the v1 ranking path: **no LLM**, no I/O, no provider mutations.
+
+Ownership path: `control-center/intelligence/attention/`. Sibling Control Center packages are not imported; local types and adapters document the interface for a later convergence campaign.
+
+## Decisions
+
+1. **Pure function.** `rankFromUnknown` / `rankAttention` take signals + scoring config + frozen clock + optional founder override. Same inputs always produce the same ordered ids, scores, and reasons.
+2. **Integer millipoint math.** Scores are reconstructible from the emitted `score_breakdown`:
+   ```
+   axis = impact_weight_bp * impact + urgency_weight_bp * urgency
+   raw  = floor(category_weight * axis / 10000)
+   score_milli = floor(raw * 1000 * freshness_bp * confidence_bp / 10000²)
+   score = score_milli / 1000
+   ```
+3. **Urgency cannot erase impact.** Config invariant: `impact_weight_bp > urgency_weight_bp` (default 7000 / 3000).
+4. **Category tiers.** Primary (`receita`, `cliente`, `prazo`, `risco_operacional`, `blocker`) outranks secondary (`estetica`, `refactor`) before score is compared. A max-urgency cosmetic item cannot beat a primary-category item.
+5. **Total order (tie-break).** kill-rule → category tier → `score_milli` → category weight → impact → urgency → id ascending. Distinct ids never tie.
+6. **Merge.** Signals that share `correlation_key` become one item (max impact, max urgency, worst freshness, min confidence, union of evidence). They do not compete as separate rows.
+7. **Kill rules.** `risco_operacional` or `blocker` at `critical` severity are forced to the front of ATENÇÃO AGORA so low-value work cannot crowd them out.
+8. **Freshness.** Non-`FRESH` multiplies the score down (`STALE` 0.45, `UNKNOWN` 0.55, `ERROR` 0.35) **and** emits an explicit `Dados stale: …` item.
+9. **Domain diversity** applies to the today-3 only. ATENÇÃO AGORA is an exception list and may repeat a domain. Greedy: pick global best, then the best remaining item of an unused domain, then fill.
+10. **Founder override** is an input record (`pin` | `reorder` | `dismiss`) plus an audit event naming actor, time, target ids, and the ranking before/after. Not a hidden branch. Pinning a cosmetic item does not hide a kill-rule from ATENÇÃO AGORA unless the founder dismisses it.
+11. **Provenance.** Every aggregated signal and the engine envelope carry `source`, `observed_at`, `freshness_status`, `confidence`. Engine output provenance is `FRESH` (the ranking was just computed); item provenance is that of the merged signal.
+12. **Fail-closed validation.** Runtime checks on ids, scopes, enums, money (integer cents + ISO currency), UTC `Z` timestamps, and forbidden secret-bearing keys. No identity or password is hardcoded; the founder handle arrives on the override record.
+13. **Money** is integer cents + `currency`. The engine does not charge, refund, or call Asaas.
+
+## How to run
+
+Requires Node ≥ 20. From this directory:
+
+```bash
+npm install
+npm test
+npx tsc --noEmit
+npm run rank -- fixtures/representative.json
+```
+
+`npm run rank` is the real package entry (CLI over a checked-in fixture). It writes ranking JSON to stdout. Run it twice; the outputs must match when the fixture freezes `now`.
+
+Tests live under `tests/` and call the **shipped** `rankFromUnknown` — they do not reimplement the ranker.
+
+## Env vars
+
+None required. The ranker is config-as-data on the request body.
+
+| Variable | Effect |
+| --- | --- |
+| `CC_ATTENTION_LOG=1` | Structured JSON logs on stderr (ids, counts, fingerprint only — no PII, no secrets) |
+
+Do not put API keys, tokens, or passwords in the request, logs, URLs, or a client bundle. Validation rejects secret-shaped property names.
+
+## Request / output contract
+
+Input (JSON):
+
+```json
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "signals": [ { "id": "cc:attention-signal:…", "category": "receita", "…": "…" } ],
+  "config": { "category_weights": { "cliente": 120 } },
+  "override": {
+    "actor": { "kind": "human", "id": "human:founder" },
+    "at": "2026-08-20T15:05:00.000Z",
+    "action": "pin",
+    "target_ids": ["cc:attention-signal:…"]
+  }
+}
+```
+
+`config` and `override` are optional. `now` should be set for determinism (tests and the CLI fixture freeze it).
+
+Output:
+
+- `attention_now` — ATENÇÃO AGORA, ranked, each with `reason`, `evidence_refs`, `score_breakdown`
+- `today` — at most 3 items, domain-diverse
+- `audit` — founder override events (empty if none)
+- `config_fingerprint` — sha256 prefix of canonical config
+- envelope `provenance`
+
+## Local vocab vs siblings (do not import)
+
+This package copies the *shape* of cc-01 contracts, not the package.
+
+| Field | This engine (contracts-shaped) | Persistence (cc-02) |
+| --- | --- | --- |
+| freshness | `FRESH` `STALE` `UNKNOWN` `ERROR` | `fresh` `stale` `unknown` `expired` |
+
+`ERROR` ↔ `expired` is an explicit divergence. Use `toPersistenceFreshness` / `fromPersistenceFreshness` at convergence. Do not wait on those packages in this campaign.
+
+Horizons: `now` | `today` | `this_week`. Homepage limit: `HOMEPAGE_PRIORITY_LIMIT = 3`.
+
+## Expected later integration
+
+- **Homepage:** exceptions from `attention_now`; the three things from `today`. Not a KPI wall.
+- **MCP / context service:** agents query by `scope`. Filter ranked items to granted scopes; never dump company-wide memory.
+- **Persistence:** store derived attention items / priority recommendations. This engine remains pure — no SQL, no collectors.
+- **Collectors (GitHub, Warmbly, Asaas, PNCP):** emit `AttentionSignal`s with provenance. Read-only. This campaign does not wire them.
+
+`asPriorityRecommendations(output, horizon)` maps engine rows onto the contracts `PriorityRecommendation` shape (`rationale` = `reason`) without importing cc-01.
+
+## Non-goals
+
+Homepage UI, MCP server, PostgreSQL schema, live collectors, LLM ranking, writes under `commercial/` or other Control Center workstreams, provider mutations (charge, checkout, refund, cancel, Asaas changes, commercial send).

--- a/control-center/intelligence/attention/fixtures/representative.json
+++ b/control-center/intelligence/attention/fixtures/representative.json
@@ -1,0 +1,395 @@
+{
+  "now": "2026-08-20T15:00:00.000Z",
+  "signals": [
+    {
+      "id": "cc:attention-signal:invoice-overdue-asaas",
+      "title": "Fatura ACME vencida",
+      "summary": "Recebível BRL 4.500,00 em atraso. Fonte Asaas, observação read-only.",
+      "category": "receita",
+      "domain": "finance",
+      "scope": "finance",
+      "impact": 85,
+      "urgency": 70,
+      "severity": "high",
+      "status": "open",
+      "correlation_key": "invoice:acme-2026-08",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "asaas",
+            "kind": "payment",
+            "locator": "pay_acme_2026_08",
+            "label": "asaas-payment"
+          },
+          "note": "overdue receivable"
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "asaas",
+          "kind": "payment",
+          "locator": "pay_acme_2026_08"
+        },
+        "observed_at": "2026-08-20T14:00:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 0.95
+      },
+      "money": { "amount_cents": 450000, "currency": "BRL" },
+      "recommended_action": "Cobrar ACME pela fatura vencida (read-only neste motor; sem mutação Asaas)."
+    },
+    {
+      "id": "cc:attention-signal:invoice-overdue-warmbly",
+      "title": "Fatura ACME marcada no CRM",
+      "summary": "Warmbly confirma o mesmo recebível em atraso. Deve mesclar com o sinal Asaas.",
+      "category": "receita",
+      "domain": "finance",
+      "scope": "finance",
+      "impact": 80,
+      "urgency": 90,
+      "severity": "high",
+      "status": "open",
+      "correlation_key": "invoice:acme-2026-08",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "warmbly",
+            "kind": "deal",
+            "locator": "deal_acme_invoice"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "warmbly",
+          "kind": "deal",
+          "locator": "deal_acme_invoice"
+        },
+        "observed_at": "2026-08-20T14:30:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 0.9
+      }
+    },
+    {
+      "id": "cc:attention-signal:churn-risk-beta",
+      "title": "Cliente Beta em risco de churn",
+      "summary": "Conta ativa com sinais de churn. Tratar o relacionamento.",
+      "category": "cliente",
+      "domain": "clients",
+      "scope": "client:beta",
+      "impact": 75,
+      "urgency": 40,
+      "severity": "high",
+      "status": "open",
+      "correlation_key": "client:beta:churn",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "warmbly",
+            "kind": "account",
+            "locator": "acct_beta"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "warmbly",
+          "kind": "account",
+          "locator": "acct_beta"
+        },
+        "observed_at": "2026-08-20T13:00:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 0.8
+      }
+    },
+    {
+      "id": "cc:attention-signal:deadline-pncp",
+      "title": "Prazo PNCP desta semana",
+      "summary": "Janela de edital fecha em 48h. Somente leitura.",
+      "category": "prazo",
+      "domain": "inbound",
+      "scope": "inbound",
+      "impact": 70,
+      "urgency": 85,
+      "severity": "high",
+      "status": "open",
+      "correlation_key": "pncp:edital-48h",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "unknown",
+            "kind": "pncp-notice",
+            "locator": "notice-48h"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "unknown",
+          "kind": "pncp-notice",
+          "locator": "notice-48h"
+        },
+        "observed_at": "2026-08-20T12:00:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 0.7
+      }
+    },
+    {
+      "id": "cc:attention-signal:prod-outage",
+      "title": "Produção indisponível",
+      "summary": "Incidente crítico em infraestrutura. Kill-rule.",
+      "category": "risco_operacional",
+      "domain": "infrastructure",
+      "scope": "infrastructure",
+      "impact": 95,
+      "urgency": 100,
+      "severity": "critical",
+      "status": "open",
+      "correlation_key": "infra:prod-outage",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "extra-cli",
+            "kind": "health",
+            "locator": "prod/healthz"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "extra-cli",
+          "kind": "health",
+          "locator": "prod/healthz"
+        },
+        "observed_at": "2026-08-20T14:55:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 0.99
+      },
+      "recommended_action": "Restaurar produção; não executar mutações financeiras."
+    },
+    {
+      "id": "cc:attention-signal:button-color",
+      "title": "Ajustar cor do botão do marketing",
+      "summary": "Pedido estético. Não deve vencer receita/cliente/prazo/risco/blocker.",
+      "category": "estetica",
+      "domain": "engineering",
+      "scope": "repo:web-cfg",
+      "impact": 15,
+      "urgency": 99,
+      "severity": "low",
+      "status": "open",
+      "correlation_key": "eng:button-color",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "github",
+            "kind": "issue",
+            "locator": "web-cfg#401"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "github",
+          "kind": "issue",
+          "locator": "web-cfg#401"
+        },
+        "observed_at": "2026-08-20T14:40:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 1
+      }
+    },
+    {
+      "id": "cc:attention-signal:refactor-css",
+      "title": "Refatorar CSS legado",
+      "summary": "Refactor sem impacto de receita.",
+      "category": "refactor",
+      "domain": "engineering",
+      "scope": "repo:web-cfg",
+      "impact": 25,
+      "urgency": 80,
+      "severity": "low",
+      "status": "open",
+      "correlation_key": "eng:refactor-css",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "github",
+            "kind": "issue",
+            "locator": "web-cfg#402"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "github",
+          "kind": "issue",
+          "locator": "web-cfg#402"
+        },
+        "observed_at": "2026-08-20T14:41:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 1
+      }
+    },
+    {
+      "id": "cc:attention-signal:rename-var",
+      "title": "Renomear variável no header",
+      "summary": "Estética. Urgência artificial alta.",
+      "category": "estetica",
+      "domain": "engineering",
+      "scope": "repo:web-cfg",
+      "impact": 10,
+      "urgency": 100,
+      "severity": "low",
+      "status": "open",
+      "correlation_key": "eng:rename-var",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "github",
+            "kind": "issue",
+            "locator": "web-cfg#403"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "github",
+          "kind": "issue",
+          "locator": "web-cfg#403"
+        },
+        "observed_at": "2026-08-20T14:42:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 1
+      }
+    },
+    {
+      "id": "cc:attention-signal:stale-receivable",
+      "title": "Carteira de recebíveis desatualizada",
+      "summary": "Última coleta Asaas expirou. Deve despromover e/ou emitir dados stale.",
+      "category": "receita",
+      "domain": "finance",
+      "scope": "finance",
+      "impact": 80,
+      "urgency": 50,
+      "severity": "medium",
+      "status": "open",
+      "correlation_key": "finance:receivables-book",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "asaas",
+            "kind": "receivable-book",
+            "locator": "book/main"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "asaas",
+          "kind": "receivable-book",
+          "locator": "book/main"
+        },
+        "observed_at": "2026-08-18T15:00:00.000Z",
+        "freshness_status": "STALE",
+        "confidence": 0.6,
+        "freshness_window_seconds": 86400
+      }
+    },
+    {
+      "id": "cc:attention-signal:deploy-blocker",
+      "title": "PR bloqueando deploy",
+      "summary": "Check vermelho no GitHub. Blocker, não crítico o suficiente para kill-rule.",
+      "category": "blocker",
+      "domain": "engineering",
+      "scope": "repo:Governance",
+      "impact": 65,
+      "urgency": 75,
+      "severity": "high",
+      "status": "open",
+      "correlation_key": "eng:deploy-blocker",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "github",
+            "kind": "check",
+            "locator": "Governance/ci#889"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "github",
+          "kind": "check",
+          "locator": "Governance/ci#889"
+        },
+        "observed_at": "2026-08-20T14:50:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 0.92
+      }
+    },
+    {
+      "id": "cc:attention-signal:warmbly-unread",
+      "title": "Inbox comercial sem leitura",
+      "summary": "Mensagens inbound não lidas no Warmbly.",
+      "category": "cliente",
+      "domain": "commercial",
+      "scope": "commercial",
+      "impact": 55,
+      "urgency": 60,
+      "severity": "medium",
+      "status": "open",
+      "correlation_key": "commercial:unread",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "warmbly",
+            "kind": "inbox",
+            "locator": "inbox/unread"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "warmbly",
+          "kind": "inbox",
+          "locator": "inbox/unread"
+        },
+        "observed_at": "2026-08-20T14:20:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 0.85
+      }
+    },
+    {
+      "id": "cc:attention-signal:resolved-noise",
+      "title": "Item já resolvido",
+      "summary": "Não deve entrar no ranking.",
+      "category": "estetica",
+      "domain": "engineering",
+      "scope": "repo:web-cfg",
+      "impact": 100,
+      "urgency": 100,
+      "severity": "critical",
+      "status": "resolved",
+      "correlation_key": "eng:resolved-noise",
+      "evidence_refs": [
+        {
+          "source": {
+            "system": "github",
+            "kind": "issue",
+            "locator": "web-cfg#1"
+          }
+        }
+      ],
+      "provenance": {
+        "source": {
+          "system": "github",
+          "kind": "issue",
+          "locator": "web-cfg#1"
+        },
+        "observed_at": "2026-08-20T10:00:00.000Z",
+        "freshness_status": "FRESH",
+        "confidence": 1
+      }
+    }
+  ]
+}

--- a/control-center/intelligence/attention/package-lock.json
+++ b/control-center/intelligence/attention/package-lock.json
@@ -1,0 +1,572 @@
+{
+  "name": "@confenge/control-center-attention",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-attention",
+      "version": "0.1.0",
+      "bin": {
+        "cc-attention-rank": "src/cli.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^22.18.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/control-center/intelligence/attention/package.json
+++ b/control-center/intelligence/attention/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@confenge/control-center-attention",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Deterministic Attention Engine for Confenge Control Center: ATENÇÃO AGORA and today's top 3. No LLM on the v1 path.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "cc-attention-rank": "./src/cli.ts"
+  },
+  "scripts": {
+    "test": "tsx --test tests/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "rank": "tsx src/cli.ts",
+    "cli": "tsx src/cli.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/intelligence/attention/src/adapters.ts
+++ b/control-center/intelligence/attention/src/adapters.ts
@@ -1,0 +1,73 @@
+import type { FreshnessStatus } from "./taxonomy.js";
+
+/**
+ * Local adapters for later convergence. Sibling packages are NOT imported.
+ *
+ * Vocab (documented, not unified in this campaign):
+ * - contracts (cc-01): FRESH | STALE | UNKNOWN | ERROR
+ * - persistence (cc-02): fresh | stale | unknown | expired
+ * - this engine: contracts-shaped uppercase enum
+ *
+ * Mapping `ERROR` ↔ `expired` is an explicit divergence to resolve at
+ * convergence; do not silently coerce in consumers.
+ */
+export const CONTRACTS_FRESHNESS = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+
+export const PERSISTENCE_FRESHNESS = ["fresh", "stale", "unknown", "expired"] as const;
+
+export type PersistenceFreshness = (typeof PERSISTENCE_FRESHNESS)[number];
+
+export function toPersistenceFreshness(status: FreshnessStatus): PersistenceFreshness {
+  switch (status) {
+    case "FRESH":
+      return "fresh";
+    case "STALE":
+      return "stale";
+    case "UNKNOWN":
+      return "unknown";
+    case "ERROR":
+      return "expired";
+  }
+}
+
+export function fromPersistenceFreshness(status: PersistenceFreshness): FreshnessStatus {
+  switch (status) {
+    case "fresh":
+      return "FRESH";
+    case "stale":
+      return "STALE";
+    case "unknown":
+      return "UNKNOWN";
+    case "expired":
+      return "ERROR";
+  }
+}
+
+/**
+ * Expected consumption at convergence (this package does not import them):
+ *
+ * Homepage: `attention_now` for exceptions; `today` (length ≤ 3) for
+ * "as 3 coisas mais importantes agora". Horizons `now` | `today` | `this_week`.
+ *
+ * MCP / context service: agents query by scope; pass only the ranked items
+ * whose `scope` is in the granted set. Never dump the whole company memory.
+ *
+ * Persistence: store engine output as derived attention_items /
+ * priority recommendations. Engine remains pure — no SQL here.
+ */
+export const CONVERGENCE_CONTRACT = {
+  homepage: {
+    exceptions_field: "attention_now",
+    today_field: "today",
+    today_limit: 3,
+    horizons: ["now", "today", "this_week"],
+  },
+  mcp: {
+    filter_by: "scope",
+    include_reason_and_breakdown: true,
+  },
+  persistence: {
+    freshness_adapter: "toPersistenceFreshness",
+    no_schema_in_this_package: true,
+  },
+} as const;

--- a/control-center/intelligence/attention/src/cli.ts
+++ b/control-center/intelligence/attention/src/cli.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * One-shot consumer of the published export `rankFromUnknown`.
+ * Reads a JSON request (signals + optional config/override/now) and writes
+ * the ranking JSON to stdout. Logs go to stderr only.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { rankFromUnknown } from "./rank.js";
+import { createLogger, silentLogger } from "./log.js";
+import { ValidationError, ConfigError } from "./errors.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const defaultFixture = join(here, "..", "fixtures", "representative.json");
+
+function main(argv: string[]): number {
+  const verbose = process.env.CC_ATTENTION_LOG === "1";
+  const log = verbose ? createLogger() : silentLogger;
+  const inputPath = argv[2] ?? defaultFixture;
+  log.info("rank.start", { input: inputPath });
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(inputPath, "utf8")) as unknown;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "read_failed";
+    log.error("rank.read_failed", { input: inputPath, err: message });
+    process.stderr.write(`failed to read ${inputPath}: ${message}\n`);
+    return 1;
+  }
+  try {
+    const output = rankFromUnknown(raw);
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    log.info("rank.done", {
+      now_count: output.attention_now.length,
+      today_count: output.today.length,
+      audit_count: output.audit.length,
+      fingerprint: output.config_fingerprint,
+    });
+    return 0;
+  } catch (err) {
+    if (err instanceof ValidationError || err instanceof ConfigError) {
+      log.error("rank.rejected", { code: err.code, err: err.message });
+      process.stderr.write(`${err.code}: ${err.message}\n`);
+      return 2;
+    }
+    const message = err instanceof Error ? err.message : "rank_failed";
+    log.error("rank.failed", { err: message });
+    process.stderr.write(`rank failed: ${message}\n`);
+    return 1;
+  }
+}
+
+const exitCode = main(process.argv);
+if (exitCode !== 0) {
+  process.exitCode = exitCode;
+}

--- a/control-center/intelligence/attention/src/clock.ts
+++ b/control-center/intelligence/attention/src/clock.ts
@@ -1,0 +1,29 @@
+import { UTC_DATETIME_RE } from "./taxonomy.js";
+import type { UtcDateTime } from "./types.js";
+import { ValidationError } from "./errors.js";
+
+export interface Clock {
+  now(): Date;
+}
+
+export const systemClock: Clock = {
+  now: () => new Date(),
+};
+
+export function frozenClock(iso: UtcDateTime): Clock {
+  if (!UTC_DATETIME_RE.test(iso)) {
+    throw new ValidationError("clock freeze must be UTC RFC3339 with Z", "now");
+  }
+  const frozen = new Date(iso);
+  if (Number.isNaN(frozen.getTime())) {
+    throw new ValidationError("clock freeze is not a valid date", "now");
+  }
+  return {
+    now: () => new Date(frozen.getTime()),
+  };
+}
+
+/** Internally always UTC. Presentation layers may convert to America/Sao_Paulo. */
+export function toUtcDateTime(date: Date): UtcDateTime {
+  return date.toISOString();
+}

--- a/control-center/intelligence/attention/src/default-config.ts
+++ b/control-center/intelligence/attention/src/default-config.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import {
+  HOMEPAGE_PRIORITY_LIMIT,
+  SIGNAL_CATEGORIES,
+  WEIGHT_DENOM,
+  type SignalCategory,
+} from "./taxonomy.js";
+import { ConfigError } from "./errors.js";
+import type { ScoringConfig, ScoringConfigPatch } from "./types.js";
+
+/**
+ * Default scoring config (data, not code branches).
+ *
+ * Impact weight (0.70) > urgency weight (0.30): urgency cannot erase impact
+ * inside a tier. Category tiers (primary 2, secondary 1) encode
+ * receita/cliente/prazo/risco_operacional/blocker > estética/refactor.
+ */
+export const DEFAULT_SCORING_CONFIG: ScoringConfig = {
+  category_weights: {
+    receita: 100,
+    cliente: 90,
+    prazo: 80,
+    risco_operacional: 85,
+    blocker: 95,
+    estetica: 10,
+    refactor: 15,
+  },
+  impact_weight_bp: 7_000,
+  urgency_weight_bp: 3_000,
+  freshness_bp: {
+    FRESH: 10_000,
+    UNKNOWN: 5_500,
+    STALE: 4_500,
+    ERROR: 3_500,
+  },
+  kill_rule: {
+    categories: ["risco_operacional", "blocker"],
+    min_severity: "critical",
+    min_impact: 0,
+  },
+  today_limit: HOMEPAGE_PRIORITY_LIMIT,
+  atencao_agora_limit: 10,
+  eligible_statuses: ["open", "acknowledged"],
+};
+
+export function categoryTier(category: SignalCategory): number {
+  return category === "estetica" || category === "refactor" ? 1 : 2;
+}
+
+export function fingerprintConfig(config: ScoringConfig): string {
+  const canonical = canonicalize(config);
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalize(item)).join(",")}]`;
+  }
+  const rec = value as Record<string, unknown>;
+  const keys = Object.keys(rec).sort();
+  const parts = keys.map((k) => `${JSON.stringify(k)}:${canonicalize(rec[k])}`);
+  return `{${parts.join(",")}}`;
+}
+
+export function mergeScoringConfig(partial: ScoringConfigPatch | undefined): ScoringConfig {
+  if (!partial) {
+    return { ...DEFAULT_SCORING_CONFIG, category_weights: { ...DEFAULT_SCORING_CONFIG.category_weights }, freshness_bp: { ...DEFAULT_SCORING_CONFIG.freshness_bp }, kill_rule: { ...DEFAULT_SCORING_CONFIG.kill_rule, categories: [...DEFAULT_SCORING_CONFIG.kill_rule.categories] }, eligible_statuses: [...DEFAULT_SCORING_CONFIG.eligible_statuses] };
+  }
+  const weights = {
+    ...DEFAULT_SCORING_CONFIG.category_weights,
+    ...(partial.category_weights ?? {}),
+  };
+  const freshness = {
+    ...DEFAULT_SCORING_CONFIG.freshness_bp,
+    ...(partial.freshness_bp ?? {}),
+  };
+  const kill = {
+    ...DEFAULT_SCORING_CONFIG.kill_rule,
+    categories: partial.kill_rule?.categories
+      ? [...partial.kill_rule.categories]
+      : [...DEFAULT_SCORING_CONFIG.kill_rule.categories],
+    min_severity: partial.kill_rule?.min_severity ?? DEFAULT_SCORING_CONFIG.kill_rule.min_severity,
+    min_impact: partial.kill_rule?.min_impact ?? DEFAULT_SCORING_CONFIG.kill_rule.min_impact,
+  };
+  const merged: ScoringConfig = {
+    category_weights: weights,
+    impact_weight_bp: partial.impact_weight_bp ?? DEFAULT_SCORING_CONFIG.impact_weight_bp,
+    urgency_weight_bp: partial.urgency_weight_bp ?? DEFAULT_SCORING_CONFIG.urgency_weight_bp,
+    freshness_bp: freshness,
+    kill_rule: kill,
+    today_limit: partial.today_limit ?? DEFAULT_SCORING_CONFIG.today_limit,
+    atencao_agora_limit:
+      partial.atencao_agora_limit ?? DEFAULT_SCORING_CONFIG.atencao_agora_limit,
+    eligible_statuses: partial.eligible_statuses
+      ? [...partial.eligible_statuses]
+      : [...DEFAULT_SCORING_CONFIG.eligible_statuses],
+  };
+  assertValidConfig(merged);
+  return merged;
+}
+
+export function assertValidConfig(config: ScoringConfig): void {
+  if (config.impact_weight_bp + config.urgency_weight_bp !== WEIGHT_DENOM) {
+    throw new ConfigError(
+      `impact_weight_bp + urgency_weight_bp must equal ${WEIGHT_DENOM}`,
+    );
+  }
+  if (config.impact_weight_bp <= config.urgency_weight_bp) {
+    throw new ConfigError("impact_weight_bp must be greater than urgency_weight_bp so urgency cannot erase impact");
+  }
+  if (config.today_limit < 1 || config.today_limit > 3) {
+    throw new ConfigError("today_limit must be in 1..3 (homepage top-N)");
+  }
+  if (config.atencao_agora_limit < 1 || config.atencao_agora_limit > 99) {
+    throw new ConfigError("atencao_agora_limit must be in 1..99");
+  }
+  for (const cat of SIGNAL_CATEGORIES) {
+    const w = config.category_weights[cat];
+    if (!Number.isInteger(w) || w < 0 || w > 10_000) {
+      throw new ConfigError(`category_weights.${cat} must be an integer 0..10000`);
+    }
+  }
+  for (const bp of Object.values(config.freshness_bp)) {
+    if (!Number.isInteger(bp) || bp < 0 || bp > WEIGHT_DENOM) {
+      throw new ConfigError("freshness_bp values must be integers 0..10000");
+    }
+  }
+}

--- a/control-center/intelligence/attention/src/diversity.ts
+++ b/control-center/intelligence/attention/src/diversity.ts
@@ -1,0 +1,56 @@
+import type { SignalDomain } from "./taxonomy.js";
+
+/**
+ * Greedy domain-diverse top-N.
+ *
+ * Walks a pre-sorted list (total order already applied). Slot 1 is always
+ * the global best. Each later slot prefers the best remaining item whose
+ * domain is not yet represented. If no unused domain remains, fill with the
+ * next best item. Same-domain bags therefore still fill N; mixed bags cannot
+ * produce three identical domains while another domain is eligible.
+ */
+export function diverseTopN<T extends { domain: SignalDomain; id: string }>(
+  ordered: readonly T[],
+  n: number,
+): T[] {
+  if (n <= 0) {
+    return [];
+  }
+  const picked: T[] = [];
+  const usedIdx = new Set<number>();
+  while (picked.length < n) {
+    const usedDomains = new Set(picked.map((p) => p.domain));
+    let found = -1;
+    for (let i = 0; i < ordered.length; i += 1) {
+      if (usedIdx.has(i)) {
+        continue;
+      }
+      const item = ordered[i];
+      if (item === undefined) {
+        continue;
+      }
+      if (!usedDomains.has(item.domain)) {
+        found = i;
+        break;
+      }
+    }
+    if (found === -1) {
+      for (let i = 0; i < ordered.length; i += 1) {
+        if (!usedIdx.has(i)) {
+          found = i;
+          break;
+        }
+      }
+    }
+    if (found === -1) {
+      break;
+    }
+    const chosen = ordered[found];
+    if (chosen === undefined) {
+      break;
+    }
+    usedIdx.add(found);
+    picked.push(chosen);
+  }
+  return picked;
+}

--- a/control-center/intelligence/attention/src/errors.ts
+++ b/control-center/intelligence/attention/src/errors.ts
@@ -1,0 +1,19 @@
+export class ValidationError extends Error {
+  readonly code = "VALIDATION_ERROR";
+  readonly path: string;
+
+  constructor(message: string, path: string) {
+    super(`${path}: ${message}`);
+    this.name = "ValidationError";
+    this.path = path;
+  }
+}
+
+export class ConfigError extends Error {
+  readonly code = "CONFIG_ERROR";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}

--- a/control-center/intelligence/attention/src/explain.ts
+++ b/control-center/intelligence/attention/src/explain.ts
@@ -1,0 +1,76 @@
+import type { PriorityHorizon } from "./taxonomy.js";
+import type { RankedItem, ScoredCandidate } from "./types.js";
+
+function formatScore(milli: number): string {
+  const whole = Math.floor(milli / 1000);
+  const frac = Math.abs(milli % 1000).toString().padStart(3, "0");
+  return `${whole}.${frac}`;
+}
+
+/**
+ * Deterministic reason string. No LLM. A reader can verify A vs B from
+ * `score_breakdown` using scoreMilliFromBreakdown.
+ */
+export function buildReason(item: ScoredCandidate, horizon: PriorityHorizon): string {
+  const b = item.breakdown;
+  const parts: string[] = [];
+  if (item.item_kind === "dados_stale") {
+    parts.push(
+      `Dados stale: freshness original ${b.freshness_status} reduz prioridade do sinal-fonte; este item pede atualização da evidência.`,
+    );
+  }
+  if (item.forced_by_kill_rule) {
+    parts.push("KILL-RULE: risco crítico forçado em ATENÇÃO AGORA.");
+  }
+  if (b.merge_count > 1) {
+    parts.push(`Sinal mesclado (${b.merge_count} correlações; impacto e urgência = max).`);
+  }
+  if (b.freshness_demoted && item.item_kind === "work") {
+    parts.push(
+      `Freshness ${b.freshness_status} aplica multiplicador ${b.freshness_multiplier.toFixed(2)} (despromoção).`,
+    );
+  }
+  parts.push(
+    `Score ${formatScore(b.score_milli)} = peso_categoria ${b.category_weight} (tier ${b.category_tier}, ${b.category}) × eixo ${b.axis} (impacto ${b.impact}×${b.impact_weight_bp}/${10000} + urgência ${b.urgency}×${b.urgency_weight_bp}/${10000}) × freshness_bp ${b.freshness_bp} × confidence_bp ${b.confidence_bp} / 10000², horizonte ${horizon}.`,
+  );
+  const locators = item.evidence_refs
+    .map((e) => `${e.source.system}:${e.source.kind}:${e.source.locator}`)
+    .slice(0, 4)
+    .join("; ");
+  if (locators.length > 0) {
+    parts.push(`Evidências: ${locators}.`);
+  }
+  return parts.join(" ").slice(0, 2000);
+}
+
+export function toRankedItem(
+  item: ScoredCandidate,
+  rank: number,
+  horizon: PriorityHorizon,
+): RankedItem {
+  const ranked: RankedItem = {
+    id: item.id,
+    rank,
+    title: item.title,
+    reason: buildReason(item, horizon),
+    evidence_refs: item.evidence_refs,
+    score: item.breakdown.score,
+    score_milli: item.score_milli,
+    score_breakdown: item.breakdown,
+    category: item.category,
+    domain: item.domain,
+    scope: item.scope,
+    severity: item.severity,
+    status: item.status,
+    item_kind: item.item_kind,
+    provenance: item.provenance,
+    horizon,
+    attention_item_ids: item.source_ids,
+    forced_by_kill_rule: item.forced_by_kill_rule,
+    merge_count: item.merge_count,
+  };
+  if (item.recommended_action !== undefined) {
+    ranked.recommended_action = item.recommended_action;
+  }
+  return ranked;
+}

--- a/control-center/intelligence/attention/src/explain.ts
+++ b/control-center/intelligence/attention/src/explain.ts
@@ -16,7 +16,7 @@ export function buildReason(item: ScoredCandidate, horizon: PriorityHorizon): st
   const parts: string[] = [];
   if (item.item_kind === "dados_stale") {
     parts.push(
-      `Dados stale: freshness original ${b.freshness_status} reduz prioridade do sinal-fonte; este item pede atualização da evidência.`,
+      `Dados stale: freshness original ${b.source_freshness_status} reduz prioridade do sinal-fonte; este item pede atualização da evidência.`,
     );
   }
   if (item.forced_by_kill_rule) {

--- a/control-center/intelligence/attention/src/freshness.ts
+++ b/control-center/intelligence/attention/src/freshness.ts
@@ -58,6 +58,8 @@ export function synthesizeDadosStale(
     related_ids: [original.id, ...original.source_ids],
     source_ids: [original.id, ...original.source_ids],
     merge_count: 1,
+    item_kind: "dados_stale",
+    source_freshness_status: original.provenance.freshness_status,
     recommended_action: `Atualizar dados da fonte ${original.provenance.source.system}:${original.provenance.source.kind} (${original.provenance.source.locator}).`,
   };
   return stale;

--- a/control-center/intelligence/attention/src/freshness.ts
+++ b/control-center/intelligence/attention/src/freshness.ts
@@ -1,0 +1,86 @@
+import type { MergedSignal } from "./merge.js";
+import type { EvidenceRef, Provenance } from "./types.js";
+
+function slugFromId(id: string): string {
+  const parts = id.split(":");
+  const last = parts[parts.length - 1];
+  return (last ?? id).replace(/[^A-Za-z0-9._~-]/g, "-").slice(0, 80);
+}
+
+function staleTitle(original: MergedSignal): string {
+  return `Dados stale: ${original.title}`.slice(0, 200);
+}
+
+/**
+ * Low freshness demotes the original via the freshness multiplier in scoring.
+ * High-value (or any non-FRESH) observations also emit an explicit "dados stale"
+ * work item so the founder sees a data-refresh action instead of silent decay.
+ */
+export function synthesizeDadosStale(
+  original: MergedSignal,
+  generated_at: string,
+): MergedSignal | null {
+  if (original.provenance.freshness_status === "FRESH") {
+    return null;
+  }
+  const evidence: EvidenceRef[] = [
+    {
+      source: original.provenance.source,
+      note: `freshness_status=${original.provenance.freshness_status} observed_at=${original.provenance.observed_at}`,
+    },
+    ...original.evidence_refs,
+  ];
+  const provenance: Provenance = {
+    source: {
+      system: "governance",
+      kind: "attention-engine",
+      locator: `dados-stale/${slugFromId(original.id)}`,
+      label: "dados-stale",
+    },
+    observed_at: generated_at,
+    freshness_status: "FRESH",
+    confidence: 1,
+  };
+  const stale: MergedSignal = {
+    id: `cc:attention-item:dados-stale-${slugFromId(original.id)}`,
+    title: staleTitle(original),
+    summary: `A observação de "${original.title}" está ${original.provenance.freshness_status} (observed_at ${original.provenance.observed_at}). O item original foi despromovido; atualize a fonte antes de decidir.`,
+    category: "risco_operacional",
+    domain: original.domain,
+    scope: original.scope,
+    impact: Math.max(40, Math.min(100, original.impact)),
+    urgency: Math.max(50, original.urgency),
+    severity: original.severity === "low" ? "medium" : original.severity,
+    status: "open",
+    correlation_key: `stale:${original.correlation_key}`,
+    evidence_refs: evidence,
+    provenance,
+    related_ids: [original.id, ...original.source_ids],
+    source_ids: [original.id, ...original.source_ids],
+    merge_count: 1,
+    recommended_action: `Atualizar dados da fonte ${original.provenance.source.system}:${original.provenance.source.kind} (${original.provenance.source.locator}).`,
+  };
+  return stale;
+}
+
+export function appendDadosStale(
+  merged: MergedSignal[],
+  generated_at: string,
+): MergedSignal[] {
+  const extra: MergedSignal[] = [];
+  for (const item of merged) {
+    const stale = synthesizeDadosStale(item, generated_at);
+    if (stale) {
+      extra.push(stale);
+    }
+  }
+  return [...merged, ...extra];
+}
+
+export function isDadosStaleId(id: string): boolean {
+  return id.startsWith("cc:attention-item:dados-stale-");
+}
+
+export function isDadosStaleTitle(title: string): boolean {
+  return title.startsWith("Dados stale:");
+}

--- a/control-center/intelligence/attention/src/index.ts
+++ b/control-center/intelligence/attention/src/index.ts
@@ -1,0 +1,37 @@
+export { rankAttention, rankFromUnknown, asPriorityRecommendations } from "./rank.js";
+export { DEFAULT_SCORING_CONFIG, mergeScoringConfig, fingerprintConfig, categoryTier } from "./default-config.js";
+export { parseRankRequest, parseSignal } from "./validate.js";
+export { scoreMilliFromBreakdown, compareAttention, sortCandidates, explainPair, buildBreakdown } from "./score.js";
+export { mergeSignals } from "./merge.js";
+export { isKillRule } from "./kill-rules.js";
+export { diverseTopN } from "./diversity.js";
+export { synthesizeDadosStale, appendDadosStale, isDadosStaleTitle } from "./freshness.js";
+export { applyOverride } from "./override.js";
+export { buildReason, toRankedItem } from "./explain.js";
+export {
+  toPersistenceFreshness,
+  fromPersistenceFreshness,
+  CONVERGENCE_CONTRACT,
+} from "./adapters.js";
+export { frozenClock, systemClock, toUtcDateTime } from "./clock.js";
+export { ValidationError, ConfigError } from "./errors.js";
+export { HOMEPAGE_PRIORITY_LIMIT, SCHEMA_VERSIONS, WEIGHT_DENOM, SCORE_SCALE } from "./taxonomy.js";
+export type {
+  AttentionSignal,
+  RankInput,
+  RankOutput,
+  RankedItem,
+  ScoringConfig,
+  ScoringConfigPatch,
+  FounderOverride,
+  ScoreBreakdown,
+  ScoredCandidate,
+  Provenance,
+  PriorityRecommendationView,
+} from "./types.js";
+export type {
+  SignalCategory,
+  SignalDomain,
+  FreshnessStatus,
+  PriorityHorizon,
+} from "./taxonomy.js";

--- a/control-center/intelligence/attention/src/kill-rules.ts
+++ b/control-center/intelligence/attention/src/kill-rules.ts
@@ -8,6 +8,9 @@ import type { MergedSignal } from "./merge.js";
  * would otherwise fill the list by count.
  */
 export function isKillRule(signal: MergedSignal, config: ScoringConfig): boolean {
+  if (signal.item_kind === "dados_stale") {
+    return false;
+  }
   if (!config.kill_rule.categories.includes(signal.category)) {
     return false;
   }

--- a/control-center/intelligence/attention/src/kill-rules.ts
+++ b/control-center/intelligence/attention/src/kill-rules.ts
@@ -1,0 +1,21 @@
+import { severityAtLeast } from "./score.js";
+import type { ScoringConfig } from "./types.js";
+import type { MergedSignal } from "./merge.js";
+
+/**
+ * Kill rules force critical operational risks / blockers into ATENÇÃO AGORA
+ * even when the rest of the bag is low-value work (estética/refactor) that
+ * would otherwise fill the list by count.
+ */
+export function isKillRule(signal: MergedSignal, config: ScoringConfig): boolean {
+  if (!config.kill_rule.categories.includes(signal.category)) {
+    return false;
+  }
+  if (!severityAtLeast(signal.severity, config.kill_rule.min_severity)) {
+    return false;
+  }
+  if (signal.impact < config.kill_rule.min_impact) {
+    return false;
+  }
+  return true;
+}

--- a/control-center/intelligence/attention/src/log.ts
+++ b/control-center/intelligence/attention/src/log.ts
@@ -1,0 +1,56 @@
+import { FORBIDDEN_SECRET_KEY_RE } from "./taxonomy.js";
+
+export type LogLevel = "info" | "warn" | "error";
+
+export type LogFields = Record<string, string | number | boolean | null>;
+
+export interface Logger {
+  info(msg: string, fields?: LogFields): void;
+  warn(msg: string, fields?: LogFields): void;
+  error(msg: string, fields?: LogFields): void;
+}
+
+function assertSafeFields(fields: LogFields | undefined): void {
+  if (!fields) {
+    return;
+  }
+  for (const key of Object.keys(fields)) {
+    if (FORBIDDEN_SECRET_KEY_RE.test(key)) {
+      throw new Error("refusing to log a secret-bearing field name");
+    }
+  }
+}
+
+export function createLogger(service = "control-center-attention"): Logger {
+  const write = (level: LogLevel, msg: string, fields?: LogFields): void => {
+    assertSafeFields(fields);
+    const rec: LogFields = {
+      level,
+      msg,
+      service,
+      ts: new Date().toISOString(),
+    };
+    if (fields) {
+      for (const [k, v] of Object.entries(fields)) {
+        rec[k] = v;
+      }
+    }
+    const line = `${JSON.stringify(rec)}\n`;
+    if (level === "error") {
+      process.stderr.write(line);
+    } else {
+      process.stderr.write(line);
+    }
+  };
+  return {
+    info: (msg, fields) => write("info", msg, fields),
+    warn: (msg, fields) => write("warn", msg, fields),
+    error: (msg, fields) => write("error", msg, fields),
+  };
+}
+
+export const silentLogger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+};

--- a/control-center/intelligence/attention/src/merge.ts
+++ b/control-center/intelligence/attention/src/merge.ts
@@ -1,9 +1,12 @@
-import { FRESHNESS_RANK, SEVERITY_RANK } from "./taxonomy.js";
+import { FRESHNESS_RANK, SEVERITY_RANK, type FreshnessStatus, type ItemKind } from "./taxonomy.js";
 import type { AttentionSignal, EvidenceRef, Provenance, SourceRef } from "./types.js";
 
 export interface MergedSignal extends AttentionSignal {
   source_ids: string[];
   merge_count: number;
+  item_kind: ItemKind;
+  /** Freshness of the underlying observation. For `dados_stale` this is the source signal, not the synthetic FRESH envelope. */
+  source_freshness_status: FreshnessStatus;
 }
 
 function evidenceKey(ref: EvidenceRef): string {
@@ -133,6 +136,8 @@ function mergeOne(items: AttentionSignal[]): MergedSignal {
     related_ids: mergeRelated(items),
     source_ids: ids,
     merge_count: items.length,
+    item_kind: "work",
+    source_freshness_status: provenance.freshness_status,
   };
   if (canonical.recommended_action !== undefined) {
     merged.recommended_action = canonical.recommended_action;

--- a/control-center/intelligence/attention/src/merge.ts
+++ b/control-center/intelligence/attention/src/merge.ts
@@ -1,0 +1,177 @@
+import { FRESHNESS_RANK, SEVERITY_RANK } from "./taxonomy.js";
+import type { AttentionSignal, EvidenceRef, Provenance, SourceRef } from "./types.js";
+
+export interface MergedSignal extends AttentionSignal {
+  source_ids: string[];
+  merge_count: number;
+}
+
+function evidenceKey(ref: EvidenceRef): string {
+  return `${ref.source.system}|${ref.source.kind}|${ref.source.locator}|${ref.note ?? ""}`;
+}
+
+function mergeEvidence(items: AttentionSignal[]): EvidenceRef[] {
+  const seen = new Set<string>();
+  const out: EvidenceRef[] = [];
+  const sorted = [...items].sort((a, b) => a.id.localeCompare(b.id));
+  for (const item of sorted) {
+    for (const ref of item.evidence_refs) {
+      const key = evidenceKey(ref);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      out.push(ref);
+    }
+  }
+  return out;
+}
+
+function mergeRelated(items: AttentionSignal[]): string[] {
+  const set = new Set<string>();
+  for (const item of items) {
+    for (const id of item.related_ids ?? []) {
+      set.add(id);
+    }
+  }
+  return [...set].sort();
+}
+
+function worstFreshness(items: AttentionSignal[]): Provenance["freshness_status"] {
+  let worst = items[0]?.provenance.freshness_status ?? "UNKNOWN";
+  for (const item of items) {
+    if (FRESHNESS_RANK[item.provenance.freshness_status] < FRESHNESS_RANK[worst]) {
+      worst = item.provenance.freshness_status;
+    }
+  }
+  return worst;
+}
+
+function latestObserved(items: AttentionSignal[]): string {
+  let latest = items[0]?.provenance.observed_at ?? "";
+  for (const item of items) {
+    if (item.provenance.observed_at > latest) {
+      latest = item.provenance.observed_at;
+    }
+  }
+  return latest;
+}
+
+function pickCanonical(items: AttentionSignal[]): AttentionSignal {
+  const ranked = [...items].sort((a, b) => {
+    if (a.impact !== b.impact) {
+      return b.impact - a.impact;
+    }
+    if (a.urgency !== b.urgency) {
+      return b.urgency - a.urgency;
+    }
+    return a.id.localeCompare(b.id);
+  });
+  const first = ranked[0];
+  if (!first) {
+    throw new Error("merge group must be non-empty");
+  }
+  return first;
+}
+
+function mergeSource(items: AttentionSignal[]): SourceRef {
+  const systems = new Set(items.map((i) => i.provenance.source.system));
+  const canonical = pickCanonical(items);
+  if (systems.size === 1) {
+    return { ...canonical.provenance.source };
+  }
+  const locators = [...items]
+    .map((i) => i.provenance.source.locator)
+    .sort()
+    .join(",");
+  return {
+    system: "governance",
+    kind: "merged-signal",
+    locator: locators.slice(0, 512),
+    label: "merged",
+  };
+}
+
+function mergeOne(items: AttentionSignal[]): MergedSignal {
+  const canonical = pickCanonical(items);
+  const ids = [...items].map((i) => i.id).sort();
+  const maxImpact = Math.max(...items.map((i) => i.impact));
+  const maxUrgency = Math.max(...items.map((i) => i.urgency));
+  let worstSeverity = canonical.severity;
+  for (const item of items) {
+    if (SEVERITY_RANK[item.severity] < SEVERITY_RANK[worstSeverity]) {
+      worstSeverity = item.severity;
+    }
+  }
+  const minConfidence = Math.min(...items.map((i) => i.provenance.confidence));
+  const provenance: Provenance = {
+    source: mergeSource(items),
+    observed_at: latestObserved(items),
+    freshness_status: worstFreshness(items),
+    confidence: minConfidence,
+  };
+  const window = items
+    .map((i) => i.provenance.freshness_window_seconds)
+    .find((w) => w !== undefined);
+  if (window !== undefined) {
+    provenance.freshness_window_seconds = window;
+  }
+  const merged: MergedSignal = {
+    id: ids[0] ?? canonical.id,
+    title: canonical.title,
+    summary: canonical.summary,
+    category: canonical.category,
+    domain: canonical.domain,
+    scope: canonical.scope,
+    impact: maxImpact,
+    urgency: maxUrgency,
+    severity: worstSeverity,
+    status: canonical.status,
+    correlation_key: canonical.correlation_key,
+    evidence_refs: mergeEvidence(items),
+    provenance,
+    related_ids: mergeRelated(items),
+    source_ids: ids,
+    merge_count: items.length,
+  };
+  if (canonical.recommended_action !== undefined) {
+    merged.recommended_action = canonical.recommended_action;
+  }
+  if (canonical.money !== undefined) {
+    merged.money = canonical.money;
+  } else {
+    const withMoney = items.find((i) => i.money !== undefined);
+    if (withMoney?.money !== undefined) {
+      merged.money = withMoney.money;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Correlated signals (same correlation_key) merge to one item and do not
+ * compete as separate ranked rows. Groups of size 1 pass through unchanged.
+ * Group order and member order do not affect the merged result.
+ */
+export function mergeSignals(signals: AttentionSignal[]): MergedSignal[] {
+  const groups = new Map<string, AttentionSignal[]>();
+  const order: string[] = [];
+  for (const signal of signals) {
+    const existing = groups.get(signal.correlation_key);
+    if (existing) {
+      existing.push(signal);
+    } else {
+      groups.set(signal.correlation_key, [signal]);
+      order.push(signal.correlation_key);
+    }
+  }
+  const merged = order.map((key) => {
+    const group = groups.get(key);
+    if (!group || group.length === 0) {
+      throw new Error(`empty merge group for ${key}`);
+    }
+    return mergeOne(group);
+  });
+  merged.sort((a, b) => a.id.localeCompare(b.id));
+  return merged;
+}

--- a/control-center/intelligence/attention/src/override.ts
+++ b/control-center/intelligence/attention/src/override.ts
@@ -1,0 +1,147 @@
+import { diverseTopN } from "./diversity.js";
+import type {
+  FounderOverride,
+  OverrideAudit,
+  RankingSnapshot,
+  ResourceId,
+  ScoredCandidate,
+  ScoringConfig,
+} from "./types.js";
+
+export interface OverrideResult {
+  now: ScoredCandidate[];
+  today: ScoredCandidate[];
+  audit: OverrideAudit[];
+}
+
+function snapshotOf(now: ScoredCandidate[], today: ScoredCandidate[]): RankingSnapshot {
+  return {
+    now: now.map((i) => i.id),
+    today: today.map((i) => i.id),
+  };
+}
+
+function indexById(items: ScoredCandidate[]): Map<string, ScoredCandidate> {
+  const map = new Map<string, ScoredCandidate>();
+  for (const item of items) {
+    map.set(item.id, item);
+  }
+  return map;
+}
+
+function resolveTargets(
+  target_ids: ResourceId[],
+  byId: Map<string, ScoredCandidate>,
+): ScoredCandidate[] {
+  const out: ScoredCandidate[] = [];
+  const seen = new Set<string>();
+  for (const id of target_ids) {
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    const item = byId.get(id);
+    if (item) {
+      out.push(item);
+    }
+  }
+  return out;
+}
+
+function fillToday(
+  pinned: ScoredCandidate[],
+  pool: ScoredCandidate[],
+  limit: number,
+): ScoredCandidate[] {
+  const pinnedIds = new Set(pinned.map((p) => p.id));
+  const rest = pool.filter((p) => !pinnedIds.has(p.id));
+  const remainingSlots = Math.max(0, limit - pinned.length);
+  const filled = remainingSlots > 0 ? diverseTopN(rest, remainingSlots) : [];
+  return [...pinned, ...filled].slice(0, limit);
+}
+
+function applyPin(
+  now: ScoredCandidate[],
+  pool: ScoredCandidate[],
+  targets: ScoredCandidate[],
+  config: ScoringConfig,
+): { now: ScoredCandidate[]; today: ScoredCandidate[] } {
+  const pinnedIds = new Set(targets.map((t) => t.id));
+  const nowRest = now.filter((i) => !pinnedIds.has(i.id));
+  const nextNow = [...targets, ...nowRest].slice(0, config.atencao_agora_limit);
+  const nextToday = fillToday(targets.slice(0, config.today_limit), pool, config.today_limit);
+  return { now: nextNow, today: nextToday };
+}
+
+function applyReorder(
+  now: ScoredCandidate[],
+  pool: ScoredCandidate[],
+  targets: ScoredCandidate[],
+  config: ScoringConfig,
+): { now: ScoredCandidate[]; today: ScoredCandidate[] } {
+  const nextToday = fillToday(targets.slice(0, config.today_limit), pool, config.today_limit);
+  const todayIds = new Set(nextToday.map((t) => t.id));
+  const nowRest = now.filter((i) => !todayIds.has(i.id));
+  const nextNow = [...nextToday, ...nowRest].slice(0, config.atencao_agora_limit);
+  return { now: nextNow, today: nextToday };
+}
+
+function applyDismiss(
+  now: ScoredCandidate[],
+  pool: ScoredCandidate[],
+  targets: ScoredCandidate[],
+  config: ScoringConfig,
+): { now: ScoredCandidate[]; today: ScoredCandidate[] } {
+  const dismissed = new Set(targets.map((t) => t.id));
+  const nextPool = pool.filter((i) => !dismissed.has(i.id));
+  const nextNow = now.filter((i) => !dismissed.has(i.id)).slice(0, config.atencao_agora_limit);
+  const nextToday = diverseTopN(nextPool, config.today_limit);
+  return { now: nextNow, today: nextToday };
+}
+
+/**
+ * Founder override is an input record plus an audit event, not a hidden
+ * branch. Kill-rule items remain in ATENÇÃO AGORA unless explicitly dismissed.
+ * Audit always names actor, time, target ids, and the ranking before/after.
+ */
+export function applyOverride(
+  now: ScoredCandidate[],
+  today: ScoredCandidate[],
+  pool: ScoredCandidate[],
+  override: FounderOverride | null,
+  config: ScoringConfig,
+): OverrideResult {
+  if (!override) {
+    return { now, today, audit: [] };
+  }
+  const byId = indexById(pool);
+  const targets = resolveTargets(override.target_ids, byId);
+  const previous = snapshotOf(now, today);
+  let next: { now: ScoredCandidate[]; today: ScoredCandidate[] };
+  if (override.action === "pin") {
+    next = applyPin(now, pool, targets, config);
+  } else if (override.action === "reorder") {
+    next = applyReorder(now, pool, targets, config);
+  } else {
+    next = applyDismiss(now, pool, targets, config);
+  }
+  const stamp = override.at.replace(/[^A-Za-z0-9._~-]/g, "");
+  const audit: OverrideAudit = {
+    schema_version: "control-center.audit-event.v1",
+    id: `cc:audit-event:founder-override-${stamp}`,
+    at: override.at,
+    actor: override.actor,
+    action: "founder_override",
+    resource_type: "PriorityRecommendation",
+    resource_id: null,
+    scope: null,
+    outcome: "success",
+    detail: {
+      override_action: override.action,
+      target_ids: [...override.target_ids],
+      previous_ranking: previous,
+      resulting_ranking: snapshotOf(next.now, next.today),
+    },
+  };
+  return { now: next.now, today: next.today, audit: [audit] };
+}

--- a/control-center/intelligence/attention/src/rank.ts
+++ b/control-center/intelligence/attention/src/rank.ts
@@ -19,7 +19,18 @@ import { parseRankRequest } from "./validate.js";
 
 function toCandidate(merged: MergedSignal, config: ScoringConfig): ScoredCandidate {
   const forced = isKillRule(merged, config);
-  const breakdown = buildBreakdown(merged, config, forced);
+  const breakdown = buildBreakdown(
+    {
+      category: merged.category,
+      impact: merged.impact,
+      urgency: merged.urgency,
+      provenance: merged.provenance,
+      merge_count: merged.merge_count,
+      source_freshness_status: merged.source_freshness_status,
+    },
+    config,
+    forced,
+  );
   const candidate: ScoredCandidate = {
     id: merged.id,
     title: merged.title,
@@ -31,7 +42,7 @@ function toCandidate(merged: MergedSignal, config: ScoringConfig): ScoredCandida
     urgency: merged.urgency,
     severity: merged.severity,
     status: merged.status,
-    item_kind: merged.id.includes(":dados-stale-") ? "dados_stale" : "work",
+    item_kind: merged.item_kind,
     correlation_key: merged.correlation_key,
     evidence_refs: merged.evidence_refs,
     provenance: merged.provenance,

--- a/control-center/intelligence/attention/src/rank.ts
+++ b/control-center/intelligence/attention/src/rank.ts
@@ -1,0 +1,125 @@
+import { fingerprintConfig } from "./default-config.js";
+import { diverseTopN } from "./diversity.js";
+import { toRankedItem } from "./explain.js";
+import { appendDadosStale } from "./freshness.js";
+import { isKillRule } from "./kill-rules.js";
+import { mergeSignals, type MergedSignal } from "./merge.js";
+import { applyOverride } from "./override.js";
+import { buildBreakdown, sortCandidates } from "./score.js";
+import { SCHEMA_VERSIONS } from "./taxonomy.js";
+import type {
+  PriorityRecommendationView,
+  RankInput,
+  RankOutput,
+  RankedItem,
+  ScoredCandidate,
+  ScoringConfig,
+} from "./types.js";
+import { parseRankRequest } from "./validate.js";
+
+function toCandidate(merged: MergedSignal, config: ScoringConfig): ScoredCandidate {
+  const forced = isKillRule(merged, config);
+  const breakdown = buildBreakdown(merged, config, forced);
+  const candidate: ScoredCandidate = {
+    id: merged.id,
+    title: merged.title,
+    summary: merged.summary,
+    category: merged.category,
+    domain: merged.domain,
+    scope: merged.scope,
+    impact: merged.impact,
+    urgency: merged.urgency,
+    severity: merged.severity,
+    status: merged.status,
+    item_kind: merged.id.includes(":dados-stale-") ? "dados_stale" : "work",
+    correlation_key: merged.correlation_key,
+    evidence_refs: merged.evidence_refs,
+    provenance: merged.provenance,
+    related_ids: merged.related_ids ?? [],
+    source_ids: merged.source_ids,
+    merge_count: merged.merge_count,
+    forced_by_kill_rule: forced,
+    score_milli: breakdown.score_milli,
+    breakdown,
+  };
+  if (merged.recommended_action !== undefined) {
+    candidate.recommended_action = merged.recommended_action;
+  }
+  if (merged.money !== undefined) {
+    candidate.money = merged.money;
+  }
+  return candidate;
+}
+
+function engineProvenance(generated_at: string): RankOutput["provenance"] {
+  return {
+    source: {
+      system: "governance",
+      kind: "attention-engine",
+      locator: "control-center/intelligence/attention",
+      label: "attention-engine",
+    },
+    observed_at: generated_at,
+    freshness_status: "FRESH",
+    confidence: 1,
+  };
+}
+
+/**
+ * Pure ranking pipeline. Injected clock via `clock_now`. No I/O, no LLM.
+ *
+ * normalize → merge → dados-stale → score → kill-rule flag → total-order
+ * → ATENÇÃO AGORA (top limit, kill-rules already first) → diversity today-N
+ * → founder override + audit → explain.
+ */
+export function rankAttention(input: RankInput): RankOutput {
+  const generated_at = input.clock_now;
+  const config = input.config;
+  const eligible = input.signals.filter((s) => config.eligible_statuses.includes(s.status));
+  const merged = mergeSignals(eligible);
+  const withStale = appendDadosStale(merged, generated_at);
+  const scored = withStale.map((m) => toCandidate(m, config));
+  const ordered = sortCandidates(scored);
+  const nowList = ordered.slice(0, config.atencao_agora_limit);
+  const todayList = diverseTopN(ordered, config.today_limit);
+  const applied = applyOverride(nowList, todayList, ordered, input.override, config);
+  const attention_now = applied.now.map((item, i) => toRankedItem(item, i + 1, "now"));
+  const today = applied.today.map((item, i) => toRankedItem(item, i + 1, "today"));
+  return {
+    schema_version: SCHEMA_VERSIONS.AttentionEngineOutput,
+    generated_at,
+    provenance: engineProvenance(generated_at),
+    config_fingerprint: fingerprintConfig(config),
+    attention_now,
+    today,
+    audit: applied.audit,
+  };
+}
+
+/**
+ * Runtime-validated entry. This is the shipped ranker surface used by the
+ * CLI and by tests — not a copy, not a mock.
+ */
+export function rankFromUnknown(value: unknown): RankOutput {
+  const input = parseRankRequest(value);
+  return rankAttention(input);
+}
+
+export function asPriorityRecommendations(
+  output: RankOutput,
+  horizon: "now" | "today",
+): PriorityRecommendationView[] {
+  const items: RankedItem[] = horizon === "now" ? output.attention_now : output.today;
+  return items.map((item) => ({
+    schema_version: SCHEMA_VERSIONS.PriorityRecommendation,
+    id: `cc:priority-recommendation:${horizon}-${item.rank}-${item.id.split(":").slice(2).join("-")}`.slice(0, 128),
+    scope: item.scope,
+    rank: item.rank,
+    title: item.title,
+    rationale: item.reason,
+    provenance: item.provenance,
+    generated_at: output.generated_at,
+    horizon,
+    attention_item_ids: item.attention_item_ids,
+  }));
+}

--- a/control-center/intelligence/attention/src/score.ts
+++ b/control-center/intelligence/attention/src/score.ts
@@ -38,6 +38,7 @@ export function buildBreakdown(
     urgency: number;
     provenance: { freshness_status: ScoreBreakdown["freshness_status"]; confidence: number };
     merge_count: number;
+    source_freshness_status: ScoreBreakdown["source_freshness_status"];
   },
   config: ScoringConfig,
   forced_by_kill_rule: boolean,
@@ -70,6 +71,7 @@ export function buildBreakdown(
     kill_rule_applied: forced_by_kill_rule,
     merge_count: candidate.merge_count,
     freshness_demoted,
+    source_freshness_status: candidate.source_freshness_status,
   };
   breakdown.score_milli = scoreMilliFromBreakdown(breakdown);
   breakdown.score = breakdown.score_milli / SCORE_SCALE;

--- a/control-center/intelligence/attention/src/score.ts
+++ b/control-center/intelligence/attention/src/score.ts
@@ -1,0 +1,148 @@
+import { categoryTier } from "./default-config.js";
+import { ConfigError } from "./errors.js";
+import {
+  SCORE_SCALE,
+  SEVERITY_RANK,
+  WEIGHT_DENOM,
+  type AttentionSeverity,
+} from "./taxonomy.js";
+import type { ScoreBreakdown, ScoredCandidate, ScoringConfig } from "./types.js";
+
+/**
+ * Integer millipoint score. Reconstructible from the emitted breakdown:
+ *
+ *   axis = impact_weight_bp * impact + urgency_weight_bp * urgency
+ *   raw  = floor(category_weight * axis / WEIGHT_DENOM)
+ *   score_milli = floor(raw * SCORE_SCALE * freshness_bp * confidence_bp / WEIGHT_DENOM²)
+ *
+ * Display score = score_milli / SCORE_SCALE.
+ *
+ * Urgency cannot erase impact: impact_weight_bp > urgency_weight_bp is a
+ * config invariant. Cross-category, category_tier (primary=2, secondary=1)
+ * is compared before score, so estética/refactor never outrank
+ * receita/cliente/prazo/risco_operacional/blocker.
+ */
+export function scoreMilliFromBreakdown(b: ScoreBreakdown): number {
+  const axis = b.impact_weight_bp * b.impact + b.urgency_weight_bp * b.urgency;
+  const raw = Math.floor((b.category_weight * axis) / WEIGHT_DENOM);
+  return Math.floor(
+    (raw * SCORE_SCALE * b.freshness_bp * b.confidence_bp) /
+      (WEIGHT_DENOM * WEIGHT_DENOM),
+  );
+}
+
+export function buildBreakdown(
+  candidate: {
+    category: ScoreBreakdown["category"];
+    impact: number;
+    urgency: number;
+    provenance: { freshness_status: ScoreBreakdown["freshness_status"]; confidence: number };
+    merge_count: number;
+  },
+  config: ScoringConfig,
+  forced_by_kill_rule: boolean,
+): ScoreBreakdown {
+  const category_weight = config.category_weights[candidate.category];
+  const freshness_bp = config.freshness_bp[candidate.provenance.freshness_status];
+  const confidence_bp = Math.round(candidate.provenance.confidence * WEIGHT_DENOM);
+  const axis = config.impact_weight_bp * candidate.impact + config.urgency_weight_bp * candidate.urgency;
+  const raw = Math.floor((category_weight * axis) / WEIGHT_DENOM);
+  const freshness_demoted = candidate.provenance.freshness_status !== "FRESH";
+  const breakdown: ScoreBreakdown = {
+    category: candidate.category,
+    category_weight,
+    category_tier: categoryTier(candidate.category),
+    impact: candidate.impact,
+    urgency: candidate.urgency,
+    impact_weight: config.impact_weight_bp / WEIGHT_DENOM,
+    urgency_weight: config.urgency_weight_bp / WEIGHT_DENOM,
+    impact_weight_bp: config.impact_weight_bp,
+    urgency_weight_bp: config.urgency_weight_bp,
+    axis,
+    raw,
+    freshness_status: candidate.provenance.freshness_status,
+    freshness_multiplier: freshness_bp / WEIGHT_DENOM,
+    freshness_bp,
+    confidence: candidate.provenance.confidence,
+    confidence_bp,
+    score_milli: 0,
+    score: 0,
+    kill_rule_applied: forced_by_kill_rule,
+    merge_count: candidate.merge_count,
+    freshness_demoted,
+  };
+  breakdown.score_milli = scoreMilliFromBreakdown(breakdown);
+  breakdown.score = breakdown.score_milli / SCORE_SCALE;
+  return breakdown;
+}
+
+/**
+ * Total order: more important first (negative means `a` ranks above `b`).
+ * Never returns 0 for distinct ids — the last key is id ascending.
+ */
+export function compareAttention(a: ScoredCandidate, b: ScoredCandidate): number {
+  if (a.forced_by_kill_rule !== b.forced_by_kill_rule) {
+    return a.forced_by_kill_rule ? -1 : 1;
+  }
+  if (a.breakdown.category_tier !== b.breakdown.category_tier) {
+    return b.breakdown.category_tier - a.breakdown.category_tier;
+  }
+  if (a.score_milli !== b.score_milli) {
+    return b.score_milli - a.score_milli;
+  }
+  if (a.breakdown.category_weight !== b.breakdown.category_weight) {
+    return b.breakdown.category_weight - a.breakdown.category_weight;
+  }
+  if (a.impact !== b.impact) {
+    return b.impact - a.impact;
+  }
+  if (a.urgency !== b.urgency) {
+    return b.urgency - a.urgency;
+  }
+  if (a.id < b.id) {
+    return -1;
+  }
+  if (a.id > b.id) {
+    return 1;
+  }
+  return 0;
+}
+
+export function sortCandidates(items: ScoredCandidate[]): ScoredCandidate[] {
+  return [...items].sort(compareAttention);
+}
+
+export function severityAtLeast(actual: AttentionSeverity, min: AttentionSeverity): boolean {
+  return SEVERITY_RANK[actual] <= SEVERITY_RANK[min];
+}
+
+export function assertImpactDominatesUrgency(config: ScoringConfig): void {
+  if (config.impact_weight_bp <= config.urgency_weight_bp) {
+    throw new ConfigError("impact weight must dominate urgency weight");
+  }
+}
+
+/**
+ * Why A beat B, using only emitted breakdown fields (no hidden state).
+ */
+export function explainPair(a: ScoredCandidate, b: ScoredCandidate): string {
+  if (a.forced_by_kill_rule && !b.forced_by_kill_rule) {
+    return `${a.id} vence ${b.id}: kill-rule (risco crítico) tem precedência sobre trabalho sem kill-rule.`;
+  }
+  if (a.breakdown.category_tier !== b.breakdown.category_tier) {
+    return `${a.id} vence ${b.id}: categoria ${a.category} (tier ${a.breakdown.category_tier}) outrank ${b.category} (tier ${b.breakdown.category_tier}).`;
+  }
+  if (a.score_milli !== b.score_milli) {
+    return `${a.id} vence ${b.id}: score_milli ${a.score_milli} > ${b.score_milli} (A: peso ${a.breakdown.category_weight} × raw ${a.breakdown.raw} × freshness_bp ${a.breakdown.freshness_bp} × confidence_bp ${a.breakdown.confidence_bp}; B: peso ${b.breakdown.category_weight} × raw ${b.breakdown.raw} × freshness_bp ${b.breakdown.freshness_bp} × confidence_bp ${b.breakdown.confidence_bp}).`;
+  }
+  if (a.breakdown.category_weight !== b.breakdown.category_weight) {
+    return `${a.id} vence ${b.id}: empate de score, peso de categoria ${a.breakdown.category_weight} > ${b.breakdown.category_weight}.`;
+  }
+  if (a.impact !== b.impact) {
+    return `${a.id} vence ${b.id}: empate de score/peso, impacto ${a.impact} > ${b.impact}.`;
+  }
+  if (a.urgency !== b.urgency) {
+    return `${a.id} vence ${b.id}: empate até impacto, urgência ${a.urgency} > ${b.urgency}.`;
+  }
+  return `${a.id} vence ${b.id}: empate total, desempate lexicográfico de id.`;
+}

--- a/control-center/intelligence/attention/src/taxonomy.ts
+++ b/control-center/intelligence/attention/src/taxonomy.ts
@@ -1,0 +1,131 @@
+/**
+ * Local Control Center taxonomies for the attention engine.
+ *
+ * This package MUST NOT import sibling worktrees (`control-center/contracts`
+ * or `control-center/persistence`). Vocab here mirrors contracts v1 where
+ * possible and documents persistence divergence in `adapters.ts`.
+ */
+
+export const UTC_DATETIME_PATTERN =
+  "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$";
+
+export const UTC_DATETIME_RE = new RegExp(UTC_DATETIME_PATTERN);
+
+export const RESOURCE_ID_PATTERN = "^cc:[a-z][a-z0-9-]*:[A-Za-z0-9._~-]+$";
+
+export const RESOURCE_ID_RE = new RegExp(RESOURCE_ID_PATTERN);
+
+export const CURRENCY_PATTERN = "^[A-Z]{3}$";
+
+export const CURRENCY_RE = new RegExp(CURRENCY_PATTERN);
+
+export const SCOPE_PATTERN =
+  "^(company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$";
+
+export const SCOPE_RE = new RegExp(SCOPE_PATTERN);
+
+export const SOURCE_SYSTEM_PATTERN = "^[a-z][a-z0-9-]*$";
+
+export const SOURCE_SYSTEM_RE = new RegExp(SOURCE_SYSTEM_PATTERN);
+
+export const SOURCE_KIND_PATTERN = "^[a-z][a-z0-9._-]*$";
+
+export const SOURCE_KIND_RE = new RegExp(SOURCE_KIND_PATTERN);
+
+export const ACTOR_ID_PATTERN = "^[A-Za-z0-9._:@-]+$";
+
+export const ACTOR_ID_RE = new RegExp(ACTOR_ID_PATTERN);
+
+/** Contracts v1 recency enum. Persistence uses lowercase + `expired` instead of `ERROR`. */
+export const FRESHNESS_STATUSES = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const ATTENTION_SEVERITIES = ["critical", "high", "medium", "low"] as const;
+export type AttentionSeverity = (typeof ATTENTION_SEVERITIES)[number];
+
+export const ATTENTION_STATUSES = [
+  "open",
+  "acknowledged",
+  "resolved",
+  "dismissed",
+] as const;
+export type AttentionStatus = (typeof ATTENTION_STATUSES)[number];
+
+export const PRIORITY_HORIZONS = ["now", "today", "this_week"] as const;
+export type PriorityHorizon = (typeof PRIORITY_HORIZONS)[number];
+
+export const ACTOR_KINDS = ["human", "agent", "system"] as const;
+export type ActorKind = (typeof ACTOR_KINDS)[number];
+
+export const SIGNAL_CATEGORIES = [
+  "receita",
+  "cliente",
+  "prazo",
+  "risco_operacional",
+  "blocker",
+  "estetica",
+  "refactor",
+] as const;
+export type SignalCategory = (typeof SIGNAL_CATEGORIES)[number];
+
+/**
+ * Diversity domain. Distinct from category: category is *why it matters*,
+ * domain is *which operational surface*. Today-3 avoids three items of the
+ * same domain when other domains have eligible items.
+ */
+export const SIGNAL_DOMAINS = [
+  "finance",
+  "commercial",
+  "clients",
+  "infrastructure",
+  "engineering",
+  "inbound",
+  "company",
+] as const;
+export type SignalDomain = (typeof SIGNAL_DOMAINS)[number];
+
+export const ITEM_KINDS = ["work", "dados_stale"] as const;
+export type ItemKind = (typeof ITEM_KINDS)[number];
+
+export const OVERRIDE_ACTIONS = ["pin", "reorder", "dismiss"] as const;
+export type OverrideAction = (typeof OVERRIDE_ACTIONS)[number];
+
+export const PRIMARY_CATEGORIES: readonly SignalCategory[] = [
+  "receita",
+  "cliente",
+  "prazo",
+  "risco_operacional",
+  "blocker",
+];
+
+export const SECONDARY_CATEGORIES: readonly SignalCategory[] = ["estetica", "refactor"];
+
+/** Homepage / "se eu só puder fazer 3 coisas hoje". Mirrors contracts HOMEPAGE_PRIORITY_LIMIT. */
+export const HOMEPAGE_PRIORITY_LIMIT = 3;
+
+export const SCHEMA_VERSIONS = {
+  AttentionEngineOutput: "control-center.attention-engine.v1",
+  AttentionItem: "control-center.attention-item.v1",
+  PriorityRecommendation: "control-center.priority-recommendation.v1",
+  AuditEvent: "control-center.audit-event.v1",
+} as const;
+
+export const WEIGHT_DENOM = 10_000;
+export const SCORE_SCALE = 1_000;
+
+export const SEVERITY_RANK: Record<AttentionSeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+export const FRESHNESS_RANK: Record<FreshnessStatus, number> = {
+  ERROR: 0,
+  STALE: 1,
+  UNKNOWN: 2,
+  FRESH: 3,
+};
+
+export const FORBIDDEN_SECRET_KEY_RE =
+  /^(secret|token|password|authorization|api[_-]?key|cookie|credential|private[_-]?key)$/i;

--- a/control-center/intelligence/attention/src/types.ts
+++ b/control-center/intelligence/attention/src/types.ts
@@ -1,0 +1,247 @@
+import type {
+  ActorKind,
+  AttentionSeverity,
+  AttentionStatus,
+  FreshnessStatus,
+  ItemKind,
+  OverrideAction,
+  PriorityHorizon,
+  SignalCategory,
+  SignalDomain,
+} from "./taxonomy.js";
+
+/** UTC RFC3339 with mandatory Z. */
+export type UtcDateTime = string;
+
+/** Stable Control Center ID: `cc:<type-kebab>:<ulid-or-slug>`. */
+export type ResourceId = string;
+
+export type Scope = string;
+
+export interface SourceRef {
+  system: string;
+  kind: string;
+  locator: string;
+  label?: string;
+}
+
+export interface ActorRef {
+  kind: ActorKind;
+  id: string;
+  display_name?: string;
+}
+
+export interface Money {
+  amount_cents: number;
+  currency: string;
+}
+
+/**
+ * Provenance of aggregated information.
+ * `freshness_status` is recency; `confidence` is trust. They are not aliases.
+ */
+export interface Provenance {
+  source: SourceRef;
+  observed_at: UtcDateTime;
+  freshness_status: FreshnessStatus;
+  confidence: number;
+  freshness_window_seconds?: number;
+}
+
+export interface EvidenceRef {
+  source: SourceRef;
+  note?: string;
+}
+
+export interface AttentionSignal {
+  id: ResourceId;
+  title: string;
+  summary: string;
+  category: SignalCategory;
+  domain: SignalDomain;
+  scope: Scope;
+  impact: number;
+  urgency: number;
+  severity: AttentionSeverity;
+  status: AttentionStatus;
+  correlation_key: string;
+  evidence_refs: EvidenceRef[];
+  provenance: Provenance;
+  money?: Money;
+  recommended_action?: string;
+  related_ids?: ResourceId[];
+}
+
+export interface ScoringConfig {
+  category_weights: Record<SignalCategory, number>;
+  impact_weight_bp: number;
+  urgency_weight_bp: number;
+  freshness_bp: Record<FreshnessStatus, number>;
+  kill_rule: {
+    categories: SignalCategory[];
+    min_severity: AttentionSeverity;
+    min_impact: number;
+  };
+  today_limit: number;
+  atencao_agora_limit: number;
+  eligible_statuses: AttentionStatus[];
+}
+
+/** Patch accepted on the request body; merged onto DEFAULT_SCORING_CONFIG. */
+export interface ScoringConfigPatch {
+  category_weights?: Partial<Record<SignalCategory, number>>;
+  impact_weight_bp?: number;
+  urgency_weight_bp?: number;
+  freshness_bp?: Partial<Record<FreshnessStatus, number>>;
+  kill_rule?: {
+    categories?: SignalCategory[];
+    min_severity?: AttentionSeverity;
+    min_impact?: number;
+  };
+  today_limit?: number;
+  atencao_agora_limit?: number;
+  eligible_statuses?: AttentionStatus[];
+}
+
+export interface FounderOverride {
+  actor: ActorRef;
+  at: UtcDateTime;
+  action: OverrideAction;
+  target_ids: ResourceId[];
+}
+
+export interface RankInput {
+  signals: AttentionSignal[];
+  config: ScoringConfig;
+  clock_now: UtcDateTime;
+  override: FounderOverride | null;
+}
+
+export interface ScoreBreakdown {
+  category: SignalCategory;
+  category_weight: number;
+  category_tier: number;
+  impact: number;
+  urgency: number;
+  impact_weight: number;
+  urgency_weight: number;
+  impact_weight_bp: number;
+  urgency_weight_bp: number;
+  axis: number;
+  raw: number;
+  freshness_status: FreshnessStatus;
+  freshness_multiplier: number;
+  freshness_bp: number;
+  confidence: number;
+  confidence_bp: number;
+  score_milli: number;
+  score: number;
+  kill_rule_applied: boolean;
+  merge_count: number;
+  freshness_demoted: boolean;
+}
+
+export interface ScoredCandidate {
+  id: ResourceId;
+  title: string;
+  summary: string;
+  category: SignalCategory;
+  domain: SignalDomain;
+  scope: Scope;
+  impact: number;
+  urgency: number;
+  severity: AttentionSeverity;
+  status: AttentionStatus;
+  item_kind: ItemKind;
+  correlation_key: string;
+  evidence_refs: EvidenceRef[];
+  provenance: Provenance;
+  recommended_action?: string;
+  related_ids: ResourceId[];
+  source_ids: ResourceId[];
+  money?: Money;
+  merge_count: number;
+  forced_by_kill_rule: boolean;
+  score_milli: number;
+  breakdown: ScoreBreakdown;
+}
+
+export interface RankedItem {
+  id: ResourceId;
+  rank: number;
+  title: string;
+  reason: string;
+  evidence_refs: EvidenceRef[];
+  score: number;
+  score_milli: number;
+  score_breakdown: ScoreBreakdown;
+  category: SignalCategory;
+  domain: SignalDomain;
+  scope: Scope;
+  severity: AttentionSeverity;
+  status: AttentionStatus;
+  item_kind: ItemKind;
+  provenance: Provenance;
+  horizon: PriorityHorizon;
+  attention_item_ids: ResourceId[];
+  forced_by_kill_rule: boolean;
+  merge_count: number;
+  recommended_action?: string;
+}
+
+export interface RankingSnapshot {
+  now: ResourceId[];
+  today: ResourceId[];
+}
+
+export interface OverrideAudit {
+  schema_version: "control-center.audit-event.v1";
+  id: ResourceId;
+  at: UtcDateTime;
+  actor: ActorRef;
+  action: "founder_override";
+  resource_type: "PriorityRecommendation";
+  resource_id: null;
+  scope: Scope | null;
+  outcome: "success";
+  detail: {
+    override_action: OverrideAction;
+    target_ids: ResourceId[];
+    previous_ranking: RankingSnapshot;
+    resulting_ranking: RankingSnapshot;
+  };
+}
+
+export interface EngineProvenance extends Provenance {
+  source: SourceRef;
+}
+
+export interface RankOutput {
+  schema_version: "control-center.attention-engine.v1";
+  generated_at: UtcDateTime;
+  provenance: EngineProvenance;
+  config_fingerprint: string;
+  attention_now: RankedItem[];
+  today: RankedItem[];
+  audit: OverrideAudit[];
+}
+
+export interface PriorityRecommendationView {
+  schema_version: "control-center.priority-recommendation.v1";
+  id: ResourceId;
+  scope: Scope;
+  rank: number;
+  title: string;
+  rationale: string;
+  provenance: Provenance;
+  generated_at: UtcDateTime;
+  horizon: PriorityHorizon;
+  attention_item_ids: ResourceId[];
+}
+
+export interface UnknownRankRequest {
+  signals: unknown;
+  config?: unknown;
+  override?: unknown;
+  now?: unknown;
+}

--- a/control-center/intelligence/attention/src/types.ts
+++ b/control-center/intelligence/attention/src/types.ts
@@ -139,6 +139,8 @@ export interface ScoreBreakdown {
   kill_rule_applied: boolean;
   merge_count: number;
   freshness_demoted: boolean;
+  /** Underlying observation freshness. For `dados_stale` this is the source signal, not the synthetic FRESH envelope. */
+  source_freshness_status: FreshnessStatus;
 }
 
 export interface ScoredCandidate {

--- a/control-center/intelligence/attention/src/validate.ts
+++ b/control-center/intelligence/attention/src/validate.ts
@@ -1,0 +1,316 @@
+import { ValidationError } from "./errors.js";
+import {
+  ACTOR_ID_RE,
+  ACTOR_KINDS,
+  ATTENTION_SEVERITIES,
+  ATTENTION_STATUSES,
+  CURRENCY_RE,
+  FORBIDDEN_SECRET_KEY_RE,
+  FRESHNESS_STATUSES,
+  OVERRIDE_ACTIONS,
+  RESOURCE_ID_RE,
+  SCOPE_RE,
+  SIGNAL_CATEGORIES,
+  SIGNAL_DOMAINS,
+  SOURCE_KIND_RE,
+  SOURCE_SYSTEM_RE,
+  UTC_DATETIME_RE,
+  type AttentionSeverity,
+  type AttentionStatus,
+  type FreshnessStatus,
+  type OverrideAction,
+  type SignalCategory,
+  type SignalDomain,
+} from "./taxonomy.js";
+import type {
+  ActorRef,
+  AttentionSignal,
+  EvidenceRef,
+  FounderOverride,
+  Money,
+  Provenance,
+  RankInput,
+  ScoringConfigPatch,
+  SourceRef,
+  UnknownRankRequest,
+} from "./types.js";
+import { mergeScoringConfig } from "./default-config.js";
+
+const TITLE_MAX = 200;
+const SUMMARY_MAX = 2000;
+const LOCATOR_MAX = 512;
+const CORRELATION_MAX = 128;
+const ACTION_MAX = 1000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertNoSecretKeys(value: unknown, path: string): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => assertNoSecretKeys(item, `${path}[${i}]`));
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_SECRET_KEY_RE.test(key)) {
+      throw new ValidationError("forbidden secret-bearing key", `${path}.${key}`);
+    }
+    assertNoSecretKeys(child, `${path}.${key}`);
+  }
+}
+
+function expectString(value: unknown, path: string, min = 1, max = 512): string {
+  if (typeof value !== "string") {
+    throw new ValidationError("expected string", path);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length < min || value.length > max) {
+    throw new ValidationError(`string length must be ${min}..${max}`, path);
+  }
+  return value;
+}
+
+function expectInt(value: unknown, path: string, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < min || value > max) {
+    throw new ValidationError(`expected integer in ${min}..${max}`, path);
+  }
+  return value;
+}
+
+function expectEnum<T extends string>(
+  value: unknown,
+  path: string,
+  allowed: readonly T[],
+): T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    throw new ValidationError(`expected one of ${allowed.join("|")}`, path);
+  }
+  return value as T;
+}
+
+function parseSourceRef(value: unknown, path: string): SourceRef {
+  if (!isRecord(value)) {
+    throw new ValidationError("expected source object", path);
+  }
+  const system = expectString(value.system, `${path}.system`, 1, 64);
+  if (!SOURCE_SYSTEM_RE.test(system)) {
+    throw new ValidationError("invalid source.system", `${path}.system`);
+  }
+  const kind = expectString(value.kind, `${path}.kind`, 1, 64);
+  if (!SOURCE_KIND_RE.test(kind)) {
+    throw new ValidationError("invalid source.kind", `${path}.kind`);
+  }
+  const locator = expectString(value.locator, `${path}.locator`, 1, LOCATOR_MAX);
+  const ref: SourceRef = { system, kind, locator };
+  if (value.label !== undefined) {
+    ref.label = expectString(value.label, `${path}.label`, 1, 128);
+  }
+  return ref;
+}
+
+function parseProvenance(value: unknown, path: string): Provenance {
+  if (!isRecord(value)) {
+    throw new ValidationError("expected provenance object", path);
+  }
+  const observed_at = expectString(value.observed_at, `${path}.observed_at`, 20, 40);
+  if (!UTC_DATETIME_RE.test(observed_at)) {
+    throw new ValidationError("observed_at must be UTC RFC3339 with Z", `${path}.observed_at`);
+  }
+  const freshness_status = expectEnum<FreshnessStatus>(
+    value.freshness_status,
+    `${path}.freshness_status`,
+    FRESHNESS_STATUSES,
+  );
+  if (typeof value.confidence !== "number" || Number.isNaN(value.confidence) || value.confidence < 0 || value.confidence > 1) {
+    throw new ValidationError("confidence must be a number in [0, 1]", `${path}.confidence`);
+  }
+  const provenance: Provenance = {
+    source: parseSourceRef(value.source, `${path}.source`),
+    observed_at,
+    freshness_status,
+    confidence: value.confidence,
+  };
+  if (value.freshness_window_seconds !== undefined) {
+    provenance.freshness_window_seconds = expectInt(
+      value.freshness_window_seconds,
+      `${path}.freshness_window_seconds`,
+      0,
+      2_592_000,
+    );
+  }
+  return provenance;
+}
+
+function parseMoney(value: unknown, path: string): Money {
+  if (!isRecord(value)) {
+    throw new ValidationError("expected money object", path);
+  }
+  const amount_cents = expectInt(value.amount_cents, `${path}.amount_cents`, -1_000_000_000_000, 1_000_000_000_000);
+  const currency = expectString(value.currency, `${path}.currency`, 3, 3);
+  if (!CURRENCY_RE.test(currency)) {
+    throw new ValidationError("currency must be ISO-4217 (A-Z{3})", `${path}.currency`);
+  }
+  return { amount_cents, currency };
+}
+
+function parseEvidenceRef(value: unknown, path: string): EvidenceRef {
+  if (!isRecord(value)) {
+    throw new ValidationError("expected evidence ref object", path);
+  }
+  const ref: EvidenceRef = { source: parseSourceRef(value.source, `${path}.source`) };
+  if (value.note !== undefined) {
+    ref.note = expectString(value.note, `${path}.note`, 1, 256);
+  }
+  return ref;
+}
+
+function parseActor(value: unknown, path: string): ActorRef {
+  if (!isRecord(value)) {
+    throw new ValidationError("expected actor object", path);
+  }
+  const kind = expectEnum(value.kind, `${path}.kind`, ACTOR_KINDS);
+  const id = expectString(value.id, `${path}.id`, 1, 128);
+  if (!ACTOR_ID_RE.test(id)) {
+    throw new ValidationError("invalid actor id", `${path}.id`);
+  }
+  const actor: ActorRef = { kind, id };
+  if (value.display_name !== undefined) {
+    actor.display_name = expectString(value.display_name, `${path}.display_name`, 1, 128);
+  }
+  return actor;
+}
+
+export function parseSignal(value: unknown, path: string): AttentionSignal {
+  if (!isRecord(value)) {
+    throw new ValidationError("expected signal object", path);
+  }
+  assertNoSecretKeys(value, path);
+  const id = expectString(value.id, `${path}.id`, 6, 128);
+  if (!RESOURCE_ID_RE.test(id)) {
+    throw new ValidationError("id must match cc:<type>:<slug>", `${path}.id`);
+  }
+  const scope = expectString(value.scope, `${path}.scope`, 2, 128);
+  if (!SCOPE_RE.test(scope)) {
+    throw new ValidationError("invalid scope", `${path}.scope`);
+  }
+  const correlation_key = expectString(value.correlation_key, `${path}.correlation_key`, 1, CORRELATION_MAX);
+  if (!Array.isArray(value.evidence_refs) || value.evidence_refs.length < 1 || value.evidence_refs.length > 32) {
+    throw new ValidationError("evidence_refs must be a non-empty array of at most 32", `${path}.evidence_refs`);
+  }
+  const signal: AttentionSignal = {
+    id,
+    title: expectString(value.title, `${path}.title`, 1, TITLE_MAX),
+    summary: expectString(value.summary, `${path}.summary`, 1, SUMMARY_MAX),
+    category: expectEnum<SignalCategory>(value.category, `${path}.category`, SIGNAL_CATEGORIES),
+    domain: expectEnum<SignalDomain>(value.domain, `${path}.domain`, SIGNAL_DOMAINS),
+    scope,
+    impact: expectInt(value.impact, `${path}.impact`, 0, 100),
+    urgency: expectInt(value.urgency, `${path}.urgency`, 0, 100),
+    severity: expectEnum<AttentionSeverity>(value.severity, `${path}.severity`, ATTENTION_SEVERITIES),
+    status: expectEnum<AttentionStatus>(value.status, `${path}.status`, ATTENTION_STATUSES),
+    correlation_key,
+    evidence_refs: value.evidence_refs.map((ref, i) => parseEvidenceRef(ref, `${path}.evidence_refs[${i}]`)),
+    provenance: parseProvenance(value.provenance, `${path}.provenance`),
+  };
+  if (value.money !== undefined) {
+    signal.money = parseMoney(value.money, `${path}.money`);
+  }
+  if (value.recommended_action !== undefined) {
+    signal.recommended_action = expectString(
+      value.recommended_action,
+      `${path}.recommended_action`,
+      1,
+      ACTION_MAX,
+    );
+  }
+  if (value.related_ids !== undefined) {
+    if (!Array.isArray(value.related_ids) || value.related_ids.length > 32) {
+      throw new ValidationError("related_ids must be an array of at most 32", `${path}.related_ids`);
+    }
+    signal.related_ids = value.related_ids.map((rid, i) => {
+      const s = expectString(rid, `${path}.related_ids[${i}]`, 6, 128);
+      if (!RESOURCE_ID_RE.test(s)) {
+        throw new ValidationError("invalid related id", `${path}.related_ids[${i}]`);
+      }
+      return s;
+    });
+  }
+  return signal;
+}
+
+function parseOverride(value: unknown, path: string): FounderOverride {
+  if (!isRecord(value)) {
+    throw new ValidationError("expected override object", path);
+  }
+  assertNoSecretKeys(value, path);
+  const at = expectString(value.at, `${path}.at`, 20, 40);
+  if (!UTC_DATETIME_RE.test(at)) {
+    throw new ValidationError("override.at must be UTC RFC3339 with Z", `${path}.at`);
+  }
+  if (!Array.isArray(value.target_ids) || value.target_ids.length < 1 || value.target_ids.length > 16) {
+    throw new ValidationError("target_ids must be a non-empty array of at most 16", `${path}.target_ids`);
+  }
+  return {
+    actor: parseActor(value.actor, `${path}.actor`),
+    at,
+    action: expectEnum<OverrideAction>(value.action, `${path}.action`, OVERRIDE_ACTIONS),
+    target_ids: value.target_ids.map((id, i) => {
+      const s = expectString(id, `${path}.target_ids[${i}]`, 6, 128);
+      if (!RESOURCE_ID_RE.test(s)) {
+        throw new ValidationError("invalid target id", `${path}.target_ids[${i}]`);
+      }
+      return s;
+    }),
+  };
+}
+
+function parsePartialConfig(value: unknown, path: string): ScoringConfigPatch {
+  if (value === undefined) {
+    return {};
+  }
+  if (!isRecord(value)) {
+    throw new ValidationError("expected config object", path);
+  }
+  assertNoSecretKeys(value, path);
+  return value as ScoringConfigPatch;
+}
+
+export function parseRankRequest(value: unknown): RankInput {
+  if (!isRecord(value)) {
+    throw new ValidationError("request must be an object", "$");
+  }
+  assertNoSecretKeys(value, "$");
+  const req = value as UnknownRankRequest & Record<string, unknown>;
+  if (!Array.isArray(req.signals)) {
+    throw new ValidationError("signals must be an array", "$.signals");
+  }
+  if (req.signals.length > 500) {
+    throw new ValidationError("signals exceeds 500", "$.signals");
+  }
+  const signals = req.signals.map((s, i) => parseSignal(s, `$.signals[${i}]`));
+  const seen = new Set<string>();
+  for (const signal of signals) {
+    if (seen.has(signal.id)) {
+      throw new ValidationError(`duplicate signal id ${signal.id}`, "$.signals");
+    }
+    seen.add(signal.id);
+  }
+  let clock_now: string;
+  if (req.now === undefined) {
+    clock_now = new Date().toISOString();
+  } else {
+    clock_now = expectString(req.now, "$.now", 20, 40);
+    if (!UTC_DATETIME_RE.test(clock_now)) {
+      throw new ValidationError("now must be UTC RFC3339 with Z", "$.now");
+    }
+  }
+  const config = mergeScoringConfig(parsePartialConfig(req.config, "$.config"));
+  let override: FounderOverride | null = null;
+  if (req.override !== undefined && req.override !== null) {
+    override = parseOverride(req.override, "$.override");
+  }
+  return { signals, config, clock_now, override };
+}

--- a/control-center/intelligence/attention/tests/helpers.ts
+++ b/control-center/intelligence/attention/tests/helpers.ts
@@ -1,0 +1,90 @@
+import type { AttentionSignal, FounderOverride, ScoringConfigPatch } from "../src/types.js";
+import { mergeScoringConfig } from "../src/default-config.js";
+import type { SignalCategory, SignalDomain, FreshnessStatus, AttentionSeverity, AttentionStatus } from "../src/taxonomy.js";
+
+export const FROZEN_NOW = "2026-08-20T15:00:00.000Z";
+
+export interface SignalOverrides {
+  id: string;
+  title?: string;
+  summary?: string;
+  category: SignalCategory;
+  domain: SignalDomain;
+  scope?: string;
+  impact: number;
+  urgency: number;
+  severity?: AttentionSeverity;
+  status?: AttentionStatus;
+  correlation_key?: string;
+  freshness_status?: FreshnessStatus;
+  confidence?: number;
+  observed_at?: string;
+  source_system?: string;
+  source_kind?: string;
+  locator?: string;
+  recommended_action?: string;
+}
+
+export function makeSignal(over: SignalOverrides): AttentionSignal {
+  const signal: AttentionSignal = {
+    id: over.id,
+    title: over.title ?? over.id,
+    summary: over.summary ?? over.title ?? over.id,
+    category: over.category,
+    domain: over.domain,
+    scope: over.scope ?? "company",
+    impact: over.impact,
+    urgency: over.urgency,
+    severity: over.severity ?? "medium",
+    status: over.status ?? "open",
+    correlation_key: over.correlation_key ?? over.id,
+    evidence_refs: [
+      {
+        source: {
+          system: over.source_system ?? "manual",
+          kind: over.source_kind ?? "note",
+          locator: over.locator ?? over.id,
+        },
+      },
+    ],
+    provenance: {
+      source: {
+        system: over.source_system ?? "manual",
+        kind: over.source_kind ?? "note",
+        locator: over.locator ?? over.id,
+      },
+      observed_at: over.observed_at ?? "2026-08-20T14:00:00.000Z",
+      freshness_status: over.freshness_status ?? "FRESH",
+      confidence: over.confidence ?? 1,
+    },
+  };
+  if (over.recommended_action !== undefined) {
+    signal.recommended_action = over.recommended_action;
+  }
+  return signal;
+}
+
+export function request(opts: {
+  signals: AttentionSignal[];
+  config?: ScoringConfigPatch;
+  override?: FounderOverride | null;
+  now?: string;
+}): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    now: opts.now ?? FROZEN_NOW,
+    signals: opts.signals,
+  };
+  if (opts.config !== undefined) {
+    body.config = opts.config;
+  }
+  if (opts.override !== undefined && opts.override !== null) {
+    body.override = opts.override;
+  }
+  return body;
+}
+
+export function idsOf(items: { id: string }[]): string[] {
+  return items.map((i) => i.id);
+}
+
+export { mergeScoringConfig };

--- a/control-center/intelligence/attention/tests/property.test.ts
+++ b/control-center/intelligence/attention/tests/property.test.ts
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  compareAttention,
+  isDadosStaleTitle,
+  rankFromUnknown,
+  scoreMilliFromBreakdown,
+} from "../src/index.js";
+import type { AttentionSignal, RankedItem, ScoredCandidate } from "../src/types.js";
+import { idsOf, makeSignal, request } from "./helpers.js";
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffle<T>(items: T[], rand: () => number): T[] {
+  const arr = [...items];
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rand() * (i + 1));
+    const tmp = arr[i];
+    const swap = arr[j];
+    if (tmp === undefined || swap === undefined) {
+      continue;
+    }
+    arr[i] = swap;
+    arr[j] = tmp;
+  }
+  return arr;
+}
+
+function bag(): AttentionSignal[] {
+  return [
+    makeSignal({
+      id: "cc:attention-signal:p-outage",
+      category: "risco_operacional",
+      domain: "infrastructure",
+      impact: 90,
+      urgency: 95,
+      severity: "critical",
+    }),
+    makeSignal({
+      id: "cc:attention-signal:p-invoice-a",
+      category: "receita",
+      domain: "finance",
+      impact: 80,
+      urgency: 60,
+      correlation_key: "inv-1",
+    }),
+    makeSignal({
+      id: "cc:attention-signal:p-invoice-b",
+      category: "receita",
+      domain: "finance",
+      impact: 70,
+      urgency: 85,
+      correlation_key: "inv-1",
+    }),
+    makeSignal({
+      id: "cc:attention-signal:p-churn",
+      category: "cliente",
+      domain: "clients",
+      impact: 65,
+      urgency: 40,
+    }),
+    makeSignal({
+      id: "cc:attention-signal:p-deadline",
+      category: "prazo",
+      domain: "inbound",
+      impact: 55,
+      urgency: 80,
+    }),
+    makeSignal({
+      id: "cc:attention-signal:p-css",
+      category: "estetica",
+      domain: "engineering",
+      impact: 20,
+      urgency: 99,
+    }),
+    makeSignal({
+      id: "cc:attention-signal:p-stale",
+      category: "receita",
+      domain: "finance",
+      impact: 75,
+      urgency: 40,
+      freshness_status: "STALE",
+      correlation_key: "stale-book",
+    }),
+  ];
+}
+
+function asCandidate(item: RankedItem): ScoredCandidate {
+  return {
+    id: item.id,
+    title: item.title,
+    summary: item.title,
+    category: item.category,
+    domain: item.domain,
+    scope: item.scope,
+    impact: item.score_breakdown.impact,
+    urgency: item.score_breakdown.urgency,
+    severity: item.severity,
+    status: item.status,
+    item_kind: item.item_kind,
+    correlation_key: item.id,
+    evidence_refs: item.evidence_refs,
+    provenance: item.provenance,
+    related_ids: [],
+    source_ids: item.attention_item_ids,
+    merge_count: item.merge_count,
+    forced_by_kill_rule: item.forced_by_kill_rule,
+    score_milli: item.score_milli,
+    breakdown: item.score_breakdown,
+  };
+}
+
+function assertExplanationsConsistent(items: RankedItem[]): void {
+  for (const item of items) {
+    assert.equal(scoreMilliFromBreakdown(item.score_breakdown), item.score_milli);
+  }
+  for (let i = 0; i < items.length - 1; i += 1) {
+    const a = items[i];
+    const b = items[i + 1];
+    assert.ok(a && b);
+    assert.ok(compareAttention(asCandidate(a), asCandidate(b)) < 0);
+  }
+}
+
+test("permutation of input does not change ordered ids (stable tie-break)", () => {
+  const base = bag();
+  const expected = rankFromUnknown(request({ signals: base }));
+  const rand = mulberry32(20260820);
+  for (let i = 0; i < 48; i += 1) {
+    const shuffled = shuffle(base, rand);
+    const got = rankFromUnknown(request({ signals: shuffled }));
+    assert.deepEqual(idsOf(got.attention_now), idsOf(expected.attention_now), `now mismatch seed iter ${i}`);
+    assert.deepEqual(idsOf(got.today), idsOf(expected.today), `today mismatch seed iter ${i}`);
+    assert.deepEqual(
+      got.attention_now.map((x) => x.score_milli),
+      expected.attention_now.map((x) => x.score_milli),
+    );
+    assertExplanationsConsistent(got.attention_now);
+  }
+});
+
+test("duplicate/correlated signals never appear as competing rows", () => {
+  const signals = [
+    makeSignal({
+      id: "cc:attention-signal:dup-a",
+      category: "cliente",
+      domain: "clients",
+      impact: 40,
+      urgency: 40,
+      correlation_key: "same-client",
+    }),
+    makeSignal({
+      id: "cc:attention-signal:dup-b",
+      category: "cliente",
+      domain: "clients",
+      impact: 60,
+      urgency: 10,
+      correlation_key: "same-client",
+    }),
+    makeSignal({
+      id: "cc:attention-signal:dup-c",
+      category: "cliente",
+      domain: "clients",
+      impact: 20,
+      urgency: 90,
+      correlation_key: "same-client",
+    }),
+  ];
+  const out = rankFromUnknown(request({ signals }));
+  const work = out.attention_now.filter((i) => i.item_kind === "work");
+  assert.equal(work.length, 1);
+  assert.equal(work[0]?.merge_count, 3);
+  assert.equal(work[0]?.score_breakdown.impact, 60);
+  assert.equal(work[0]?.score_breakdown.urgency, 90);
+});
+
+test("all-same-domain bag still fills today-N from that domain", () => {
+  const signals = [0, 1, 2, 3, 4].map((i) =>
+    makeSignal({
+      id: `cc:attention-signal:same-${i}`,
+      category: "receita",
+      domain: "finance",
+      impact: 50 + i,
+      urgency: 40 + i,
+    }),
+  );
+  const out = rankFromUnknown(request({ signals }));
+  assert.equal(out.today.length, 3);
+  assert.ok(out.today.every((i) => i.domain === "finance"));
+  assertExplanationsConsistent(out.today);
+});
+
+test("all-stale bag yields dados stale items and demotes originals", () => {
+  const signals = [
+    makeSignal({
+      id: "cc:attention-signal:stale-a",
+      category: "receita",
+      domain: "finance",
+      impact: 70,
+      urgency: 40,
+      freshness_status: "STALE",
+    }),
+    makeSignal({
+      id: "cc:attention-signal:stale-b",
+      category: "cliente",
+      domain: "clients",
+      impact: 60,
+      urgency: 40,
+      freshness_status: "ERROR",
+    }),
+    makeSignal({
+      id: "cc:attention-signal:stale-c",
+      category: "prazo",
+      domain: "inbound",
+      impact: 50,
+      urgency: 50,
+      freshness_status: "UNKNOWN",
+    }),
+  ];
+  const out = rankFromUnknown(request({ signals }));
+  const all = [...out.attention_now, ...out.today];
+  const dados = all.filter((i) => i.item_kind === "dados_stale" || isDadosStaleTitle(i.title));
+  assert.ok(dados.length >= 1, "all-stale bag must emit dados stale");
+  const originals = out.attention_now.filter((i) => i.item_kind === "work");
+  for (const item of originals) {
+    assert.equal(item.score_breakdown.freshness_demoted, true);
+    assert.ok(item.score_breakdown.freshness_multiplier < 1);
+  }
+});
+
+test("founder override vs kill-rule: pin does not hide the kill-rule from ATENÇÃO AGORA", () => {
+  const kill = makeSignal({
+    id: "cc:attention-signal:kill-me",
+    category: "blocker",
+    domain: "infrastructure",
+    impact: 80,
+    urgency: 80,
+    severity: "critical",
+  });
+  const cosmetic = makeSignal({
+    id: "cc:attention-signal:pin-me",
+    category: "estetica",
+    domain: "engineering",
+    impact: 10,
+    urgency: 10,
+  });
+  const other = makeSignal({
+    id: "cc:attention-signal:other-work",
+    category: "cliente",
+    domain: "clients",
+    impact: 50,
+    urgency: 50,
+  });
+  const out = rankFromUnknown(
+    request({
+      signals: [kill, cosmetic, other],
+      override: {
+        actor: { kind: "human", id: "human:founder" },
+        at: "2026-08-20T16:00:00.000Z",
+        action: "pin",
+        target_ids: [cosmetic.id],
+      },
+    }),
+  );
+  assert.equal(out.today[0]?.id, cosmetic.id);
+  const nowIds = idsOf(out.attention_now);
+  assert.ok(nowIds.includes(kill.id), "kill-rule vanished from ATENÇÃO AGORA after pin");
+  const killItem = out.attention_now.find((i) => i.id === kill.id);
+  assert.equal(killItem?.forced_by_kill_rule, true);
+  assert.equal(out.audit[0]?.actor.id, "human:founder");
+  assert.ok(out.audit[0]?.detail.previous_ranking.now.includes(kill.id));
+});
+
+test("explanations remain consistent with scores across adversarial mixes", () => {
+  const rand = mulberry32(99);
+  const categories = ["receita", "cliente", "prazo", "risco_operacional", "blocker", "estetica", "refactor"] as const;
+  const domains = ["finance", "commercial", "clients", "infrastructure", "engineering", "inbound", "company"] as const;
+  const freshness = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+  const signals: AttentionSignal[] = [];
+  for (let i = 0; i < 24; i += 1) {
+    const cat = categories[Math.floor(rand() * categories.length)] ?? "receita";
+    const domain = domains[Math.floor(rand() * domains.length)] ?? "company";
+    const fresh = freshness[Math.floor(rand() * freshness.length)] ?? "FRESH";
+    signals.push(
+      makeSignal({
+        id: `cc:attention-signal:adv-${i}`,
+        category: cat,
+        domain,
+        impact: Math.floor(rand() * 101),
+        urgency: Math.floor(rand() * 101),
+        severity: cat === "risco_operacional" && rand() > 0.5 ? "critical" : "medium",
+        freshness_status: fresh,
+        correlation_key: rand() > 0.8 ? "shared-adv" : `adv-${i}`,
+        confidence: Math.round(rand() * 100) / 100,
+      }),
+    );
+  }
+  const out = rankFromUnknown(request({ signals }));
+  assert.ok(out.today.length <= 3);
+  assertExplanationsConsistent(out.attention_now);
+  assertExplanationsConsistent(out.today);
+});

--- a/control-center/intelligence/attention/tests/property.test.ts
+++ b/control-center/intelligence/attention/tests/property.test.ts
@@ -122,6 +122,16 @@ function asCandidate(item: RankedItem): ScoredCandidate {
 function assertExplanationsConsistent(items: RankedItem[]): void {
   for (const item of items) {
     assert.equal(scoreMilliFromBreakdown(item.score_breakdown), item.score_milli);
+    if (item.item_kind === "dados_stale") {
+      assert.equal(item.forced_by_kill_rule, false);
+      assert.equal(item.score_breakdown.kill_rule_applied, false);
+      assert.notEqual(item.score_breakdown.source_freshness_status, "FRESH");
+      assert.ok(
+        item.reason.includes(`freshness original ${item.score_breakdown.source_freshness_status}`),
+        item.reason,
+      );
+      assert.equal(item.reason.includes("freshness original FRESH"), false);
+    }
   }
   for (let i = 0; i < items.length - 1; i += 1) {
     const a = items[i];

--- a/control-center/intelligence/attention/tests/ranker.test.ts
+++ b/control-center/intelligence/attention/tests/ranker.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import {
+  compareAttention,
+  explainPair,
+  rankFromUnknown,
+  scoreMilliFromBreakdown,
+} from "../src/index.js";
+import type { RankedItem, ScoredCandidate } from "../src/types.js";
+import { FROZEN_NOW, idsOf, makeSignal, request } from "./helpers.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const fixturePath = join(root, "fixtures", "representative.json");
+
+function asCandidate(item: RankedItem): ScoredCandidate {
+  const c: ScoredCandidate = {
+    id: item.id,
+    title: item.title,
+    summary: item.title,
+    category: item.category,
+    domain: item.domain,
+    scope: item.scope,
+    impact: item.score_breakdown.impact,
+    urgency: item.score_breakdown.urgency,
+    severity: item.severity,
+    status: item.status,
+    item_kind: item.item_kind,
+    correlation_key: item.id,
+    evidence_refs: item.evidence_refs,
+    provenance: item.provenance,
+    related_ids: [],
+    source_ids: item.attention_item_ids,
+    merge_count: item.merge_count,
+    forced_by_kill_rule: item.forced_by_kill_rule,
+    score_milli: item.score_milli,
+    breakdown: item.score_breakdown,
+  };
+  return c;
+}
+
+test("same input twice yields identical ordered ids and scores", () => {
+  const raw = JSON.parse(readFileSync(fixturePath, "utf8")) as unknown;
+  const a = rankFromUnknown(raw);
+  const b = rankFromUnknown(raw);
+  assert.deepEqual(idsOf(a.attention_now), idsOf(b.attention_now));
+  assert.deepEqual(idsOf(a.today), idsOf(b.today));
+  assert.deepEqual(
+    a.attention_now.map((i) => i.score_milli),
+    b.attention_now.map((i) => i.score_milli),
+  );
+  assert.deepEqual(
+    a.today.map((i) => i.score_milli),
+    b.today.map((i) => i.score_milli),
+  );
+  assert.equal(a.config_fingerprint, b.config_fingerprint);
+  assert.equal(a.generated_at, FROZEN_NOW);
+});
+
+test("every ranked item carries reason, evidence refs, and reconstructible breakdown", () => {
+  const raw = JSON.parse(readFileSync(fixturePath, "utf8")) as unknown;
+  const out = rankFromUnknown(raw);
+  assert.ok(out.attention_now.length > 0);
+  assert.ok(out.today.length > 0);
+  assert.ok(out.today.length <= 3);
+  for (const item of [...out.attention_now, ...out.today]) {
+    assert.ok(item.reason.length > 0, `missing reason on ${item.id}`);
+    assert.ok(item.evidence_refs.length > 0, `missing evidence on ${item.id}`);
+    const reconstructed = scoreMilliFromBreakdown(item.score_breakdown);
+    assert.equal(
+      reconstructed,
+      item.score_milli,
+      `breakdown does not reconstruct score for ${item.id}`,
+    );
+    assert.equal(item.score_breakdown.score_milli, item.score_milli);
+    assert.ok(item.provenance.source.system.length > 0);
+    assert.ok(item.provenance.observed_at.endsWith("Z"));
+    assert.ok(item.provenance.freshness_status);
+    assert.ok(item.provenance.confidence >= 0 && item.provenance.confidence <= 1);
+  }
+});
+
+test("A vs B is explained by emitted breakdown fields, not a hardcoded oracle", () => {
+  const raw = JSON.parse(readFileSync(fixturePath, "utf8")) as unknown;
+  const out = rankFromUnknown(raw);
+  assert.ok(out.attention_now.length >= 2);
+  for (let i = 0; i < out.attention_now.length - 1; i += 1) {
+    const a = out.attention_now[i];
+    const b = out.attention_now[i + 1];
+    assert.ok(a && b);
+    const ca = asCandidate(a);
+    const cb = asCandidate(b);
+    const cmp = compareAttention(ca, cb);
+    assert.ok(cmp < 0, `order violation at ${i}: ${explainPair(ca, cb)}`);
+    const sa = scoreMilliFromBreakdown(a.score_breakdown);
+    const sb = scoreMilliFromBreakdown(b.score_breakdown);
+    if (a.forced_by_kill_rule === b.forced_by_kill_rule && a.score_breakdown.category_tier === b.score_breakdown.category_tier) {
+      assert.ok(
+        sa > sb || (sa === sb && cmp < 0),
+        `same-tier pair ${a.id} vs ${b.id}: scores ${sa} ${sb} cmp ${cmp}`,
+      );
+    }
+    if (sa !== sb && a.forced_by_kill_rule === b.forced_by_kill_rule && a.score_breakdown.category_tier === b.score_breakdown.category_tier) {
+      assert.ok(sa > sb, `${a.id} ranked above ${b.id} but score_milli ${sa} <= ${sb}`);
+    }
+  }
+});
+
+test("resolved signals are excluded from ranking", () => {
+  const out = rankFromUnknown(
+    request({
+      signals: [
+        makeSignal({
+          id: "cc:attention-signal:open-one",
+          category: "receita",
+          domain: "finance",
+          impact: 50,
+          urgency: 50,
+        }),
+        makeSignal({
+          id: "cc:attention-signal:resolved-one",
+          category: "receita",
+          domain: "finance",
+          impact: 100,
+          urgency: 100,
+          status: "resolved",
+        }),
+      ],
+    }),
+  );
+  assert.deepEqual(idsOf(out.attention_now), ["cc:attention-signal:open-one"]);
+});
+
+test("rankFromUnknown rejects secret-bearing keys fail-closed", () => {
+  assert.throws(
+    () =>
+      rankFromUnknown({
+        now: FROZEN_NOW,
+        signals: [
+          {
+            ...makeSignal({
+              id: "cc:attention-signal:x",
+              category: "receita",
+              domain: "finance",
+              impact: 1,
+              urgency: 1,
+            }),
+            password: "nope",
+          },
+        ],
+      }),
+    /forbidden secret-bearing key/,
+  );
+});
+
+test("rankFromUnknown rejects missing provenance", () => {
+  assert.throws(
+    () =>
+      rankFromUnknown({
+        now: FROZEN_NOW,
+        signals: [
+          {
+            id: "cc:attention-signal:x",
+            title: "x",
+            summary: "x",
+            category: "receita",
+            domain: "finance",
+            scope: "finance",
+            impact: 1,
+            urgency: 1,
+            severity: "low",
+            status: "open",
+            correlation_key: "x",
+            evidence_refs: [
+              { source: { system: "manual", kind: "note", locator: "x" } },
+            ],
+          },
+        ],
+      }),
+    /provenance/,
+  );
+});

--- a/control-center/intelligence/attention/tests/rules.test.ts
+++ b/control-center/intelligence/attention/tests/rules.test.ts
@@ -1,0 +1,346 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  isDadosStaleTitle,
+  rankFromUnknown,
+  scoreMilliFromBreakdown,
+} from "../src/index.js";
+import { PRIMARY_CATEGORIES, SECONDARY_CATEGORIES } from "../src/taxonomy.js";
+import { idsOf, makeSignal, request } from "./helpers.js";
+
+test("per-category weight change alters order", () => {
+  const signals = [
+    makeSignal({
+      id: "cc:attention-signal:receita-mid",
+      category: "receita",
+      domain: "finance",
+      impact: 50,
+      urgency: 50,
+    }),
+    makeSignal({
+      id: "cc:attention-signal:cliente-mid",
+      category: "cliente",
+      domain: "clients",
+      impact: 50,
+      urgency: 50,
+    }),
+  ];
+  const baseline = rankFromUnknown(request({ signals }));
+  assert.equal(baseline.attention_now[0]?.id, "cc:attention-signal:receita-mid");
+  const flipped = rankFromUnknown(
+    request({
+      signals,
+      config: { category_weights: { cliente: 400 } },
+    }),
+  );
+  assert.equal(flipped.attention_now[0]?.id, "cc:attention-signal:cliente-mid");
+  const a = flipped.attention_now[0];
+  const b = flipped.attention_now[1];
+  assert.ok(a && b);
+  assert.ok(scoreMilliFromBreakdown(a.score_breakdown) > scoreMilliFromBreakdown(b.score_breakdown));
+});
+
+test("receita/cliente/prazo/risco_operacional/blocker beat estetica/refactor", () => {
+  const primaries = PRIMARY_CATEGORIES.map((category) =>
+    makeSignal({
+      id: `cc:attention-signal:primary-${category}`,
+      category,
+      domain: "company",
+      impact: 5,
+      urgency: 0,
+      severity: category === "risco_operacional" || category === "blocker" ? "medium" : "low",
+    }),
+  );
+  const secondaries = SECONDARY_CATEGORIES.map((category) =>
+    makeSignal({
+      id: `cc:attention-signal:secondary-${category}`,
+      category,
+      domain: "engineering",
+      impact: 100,
+      urgency: 100,
+    }),
+  );
+  const out = rankFromUnknown(request({ signals: [...primaries, ...secondaries] }));
+  const ranked = out.attention_now;
+  const primaryIds = new Set(primaries.map((p) => p.id));
+  const lastPrimary = Math.max(
+    ...ranked.map((item, idx) => (primaryIds.has(item.id) ? idx : -1)),
+  );
+  const firstSecondary = Math.min(
+    ...ranked.map((item, idx) => (primaryIds.has(item.id) ? Number.POSITIVE_INFINITY : idx)),
+  );
+  assert.ok(lastPrimary < firstSecondary, "a secondary item ranked above a primary item");
+  for (const item of ranked) {
+    if (primaryIds.has(item.id)) {
+      assert.equal(item.score_breakdown.category_tier, 2);
+    } else {
+      assert.equal(item.score_breakdown.category_tier, 1);
+    }
+  }
+});
+
+test("high-urgency low-impact item does not beat higher-impact higher-category on urgency alone", () => {
+  const highImpact = makeSignal({
+    id: "cc:attention-signal:high-impact-receita",
+    category: "receita",
+    domain: "finance",
+    impact: 80,
+    urgency: 5,
+  });
+  const urgentCosmetic = makeSignal({
+    id: "cc:attention-signal:urgent-estetica",
+    category: "estetica",
+    domain: "engineering",
+    impact: 10,
+    urgency: 100,
+  });
+  const urgentLowerCat = makeSignal({
+    id: "cc:attention-signal:urgent-cliente",
+    category: "cliente",
+    domain: "clients",
+    impact: 15,
+    urgency: 100,
+  });
+  const out = rankFromUnknown(request({ signals: [urgentCosmetic, urgentLowerCat, highImpact] }));
+  const ids = idsOf(out.attention_now);
+  assert.equal(ids[0], "cc:attention-signal:high-impact-receita");
+  const a = out.attention_now[0];
+  const cosmetic = out.attention_now.find((i) => i.id === urgentCosmetic.id);
+  const lower = out.attention_now.find((i) => i.id === urgentLowerCat.id);
+  assert.ok(a && cosmetic && lower);
+  assert.ok(a.score_breakdown.category_tier > cosmetic.score_breakdown.category_tier);
+  assert.ok(
+    scoreMilliFromBreakdown(a.score_breakdown) > scoreMilliFromBreakdown(lower.score_breakdown),
+    "receita high-impact lost to cliente high-urgency on score",
+  );
+  assert.ok(a.score_breakdown.urgency < lower.score_breakdown.urgency);
+  assert.ok(a.score_breakdown.impact > lower.score_breakdown.impact);
+});
+
+test("correlated signals merge to one ranked item", () => {
+  const a = makeSignal({
+    id: "cc:attention-signal:merge-a",
+    category: "receita",
+    domain: "finance",
+    impact: 40,
+    urgency: 20,
+    correlation_key: "invoice:same",
+  });
+  const b = makeSignal({
+    id: "cc:attention-signal:merge-b",
+    category: "receita",
+    domain: "finance",
+    impact: 70,
+    urgency: 90,
+    correlation_key: "invoice:same",
+  });
+  const other = makeSignal({
+    id: "cc:attention-signal:other",
+    category: "cliente",
+    domain: "clients",
+    impact: 30,
+    urgency: 30,
+  });
+  const out = rankFromUnknown(request({ signals: [b, other, a] }));
+  const merged = out.attention_now.find((i) => i.merge_count === 2);
+  assert.ok(merged, "expected a merged item");
+  assert.equal(merged.merge_count, 2);
+  assert.equal(merged.score_breakdown.merge_count, 2);
+  assert.equal(merged.score_breakdown.impact, 70);
+  assert.equal(merged.score_breakdown.urgency, 90);
+  assert.ok(merged.attention_item_ids.includes("cc:attention-signal:merge-a"));
+  assert.ok(merged.attention_item_ids.includes("cc:attention-signal:merge-b"));
+  const competing = out.attention_now.filter(
+    (i) => i.id === a.id || i.id === b.id || i.merge_count === 2,
+  );
+  assert.equal(competing.length, 1, "merged signals must not compete as separate items");
+});
+
+test("today-3 from a same-domain-heavy bag still includes another domain when eligible", () => {
+  const finance: ReturnType<typeof makeSignal>[] = [];
+  for (let i = 0; i < 5; i += 1) {
+    finance.push(
+      makeSignal({
+        id: `cc:attention-signal:fin-${i}`,
+        category: "receita",
+        domain: "finance",
+        impact: 90 - i,
+        urgency: 80 - i,
+      }),
+    );
+  }
+  const client = makeSignal({
+    id: "cc:attention-signal:client-only",
+    category: "cliente",
+    domain: "clients",
+    impact: 40,
+    urgency: 40,
+  });
+  const out = rankFromUnknown(request({ signals: [...finance, client] }));
+  assert.equal(out.today.length, 3);
+  const domains = new Set(out.today.map((i) => i.domain));
+  assert.ok(domains.has("clients"), `today domains were ${[...domains].join(",")}`);
+  assert.ok(domains.has("finance"));
+  assert.ok(idsOf(out.today).includes("cc:attention-signal:client-only"));
+});
+
+test("critical-risk kill rule appears in ATENÇÃO AGORA against low-value work", () => {
+  const cosmetics = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) =>
+    makeSignal({
+      id: `cc:attention-signal:cosmetic-${i}`,
+      category: "estetica",
+      domain: "engineering",
+      impact: 100,
+      urgency: 100,
+    }),
+  );
+  const critical = makeSignal({
+    id: "cc:attention-signal:kill-outage",
+    category: "risco_operacional",
+    domain: "infrastructure",
+    impact: 20,
+    urgency: 10,
+    severity: "critical",
+  });
+  const out = rankFromUnknown(request({ signals: [...cosmetics, critical] }));
+  const kill = out.attention_now.find((i) => i.id === critical.id);
+  assert.ok(kill, "kill-rule item missing from ATENÇÃO AGORA");
+  assert.equal(kill.forced_by_kill_rule, true);
+  assert.equal(out.attention_now[0]?.id, critical.id);
+  assert.ok(kill.reason.includes("KILL-RULE"));
+});
+
+test("stale freshness demotes the original and yields a dados stale item", () => {
+  const stale = makeSignal({
+    id: "cc:attention-signal:stale-book",
+    category: "receita",
+    domain: "finance",
+    impact: 80,
+    urgency: 50,
+    freshness_status: "STALE",
+    confidence: 0.6,
+  });
+  const freshPeer = makeSignal({
+    id: "cc:attention-signal:fresh-peer",
+    category: "receita",
+    domain: "finance",
+    impact: 80,
+    urgency: 50,
+    freshness_status: "FRESH",
+    confidence: 0.6,
+    correlation_key: "other",
+  });
+  const out = rankFromUnknown(request({ signals: [stale, freshPeer] }));
+  const original = [...out.attention_now, ...out.today].find((i) => i.id === stale.id);
+  assert.ok(original);
+  assert.equal(original.score_breakdown.freshness_demoted, true);
+  assert.equal(original.score_breakdown.freshness_status, "STALE");
+  assert.ok(original.score_breakdown.freshness_multiplier < 1);
+  const peer = out.attention_now.find((i) => i.id === freshPeer.id);
+  assert.ok(peer);
+  assert.ok(
+    scoreMilliFromBreakdown(peer.score_breakdown) >
+      scoreMilliFromBreakdown(original.score_breakdown),
+  );
+  const dados = [...out.attention_now, ...out.today].find(
+    (i) => i.item_kind === "dados_stale" || isDadosStaleTitle(i.title),
+  );
+  assert.ok(dados, "expected an explicit dados stale item");
+  assert.ok(dados.title.startsWith("Dados stale:"));
+  assert.ok(dados.reason.toLowerCase().includes("stale"));
+});
+
+test("founder override pins a target and records actor, time, target, previous ranking", () => {
+  const a = makeSignal({
+    id: "cc:attention-signal:alpha",
+    category: "receita",
+    domain: "finance",
+    impact: 90,
+    urgency: 90,
+  });
+  const b = makeSignal({
+    id: "cc:attention-signal:beta",
+    category: "cliente",
+    domain: "clients",
+    impact: 40,
+    urgency: 40,
+  });
+  const c = makeSignal({
+    id: "cc:attention-signal:gamma",
+    category: "prazo",
+    domain: "inbound",
+    impact: 30,
+    urgency: 30,
+  });
+  const baseline = rankFromUnknown(request({ signals: [a, b, c] }));
+  const pinId = "cc:attention-signal:gamma";
+  assert.notEqual(baseline.today[0]?.id, pinId);
+  const out = rankFromUnknown(
+    request({
+      signals: [a, b, c],
+      override: {
+        actor: { kind: "human", id: "human:founder" },
+        at: "2026-08-20T15:05:00.000Z",
+        action: "pin",
+        target_ids: [pinId],
+      },
+    }),
+  );
+  assert.equal(out.today[0]?.id, pinId);
+  assert.equal(out.audit.length, 1);
+  const audit = out.audit[0];
+  assert.ok(audit);
+  assert.equal(audit.actor.id, "human:founder");
+  assert.equal(audit.at, "2026-08-20T15:05:00.000Z");
+  assert.deepEqual(audit.detail.target_ids, [pinId]);
+  assert.deepEqual(audit.detail.previous_ranking.today, idsOf(baseline.today));
+  assert.deepEqual(audit.detail.previous_ranking.now, idsOf(baseline.attention_now));
+  assert.deepEqual(audit.detail.resulting_ranking.today, idsOf(out.today));
+  assert.equal(audit.action, "founder_override");
+});
+
+test("v1 ranking path has no LLM-shaped fields or generative hooks", () => {
+  const srcHints = ["prompt", "openai", "anthropic", "llm", "chat.completions"];
+  const out = rankFromUnknown(
+    request({
+      signals: [
+        makeSignal({
+          id: "cc:attention-signal:plain",
+          category: "receita",
+          domain: "finance",
+          impact: 10,
+          urgency: 10,
+        }),
+      ],
+    }),
+  );
+  const blob = JSON.stringify(out).toLowerCase();
+  for (const hint of srcHints) {
+    assert.equal(blob.includes(hint), false, `output leaked ${hint}`);
+  }
+});
+
+test("each output item carries source, observed_at, freshness_status, confidence", () => {
+  const out = rankFromUnknown(
+    request({
+      signals: [
+        makeSignal({
+          id: "cc:attention-signal:prov",
+          category: "cliente",
+          domain: "clients",
+          impact: 20,
+          urgency: 20,
+        }),
+      ],
+    }),
+  );
+  assert.equal(out.provenance.source.system, "governance");
+  assert.equal(out.provenance.freshness_status, "FRESH");
+  assert.equal(out.provenance.confidence, 1);
+  const item = out.attention_now[0];
+  assert.ok(item);
+  assert.ok(item.provenance.source.system);
+  assert.ok(item.provenance.observed_at);
+  assert.ok(item.provenance.freshness_status);
+  assert.equal(typeof item.provenance.confidence, "number");
+});

--- a/control-center/intelligence/attention/tests/rules.test.ts
+++ b/control-center/intelligence/attention/tests/rules.test.ts
@@ -247,7 +247,89 @@ test("stale freshness demotes the original and yields a dados stale item", () =>
   );
   assert.ok(dados, "expected an explicit dados stale item");
   assert.ok(dados.title.startsWith("Dados stale:"));
-  assert.ok(dados.reason.toLowerCase().includes("stale"));
+  assert.equal(dados.score_breakdown.freshness_status, "FRESH");
+  assert.equal(dados.score_breakdown.source_freshness_status, "STALE");
+  assert.ok(
+    dados.reason.includes("freshness original STALE"),
+    `dados_stale reason must cite the source observation, got: ${dados.reason}`,
+  );
+  assert.equal(dados.reason.includes("freshness original FRESH"), false);
+});
+
+test("dados_stale reason cites ERROR source freshness, not the synthetic FRESH envelope", () => {
+  const out = rankFromUnknown(
+    request({
+      signals: [
+        makeSignal({
+          id: "cc:attention-signal:error-book",
+          category: "receita",
+          domain: "finance",
+          impact: 70,
+          urgency: 40,
+          freshness_status: "ERROR",
+        }),
+      ],
+    }),
+  );
+  const dados = [...out.attention_now, ...out.today].find((i) => i.item_kind === "dados_stale");
+  assert.ok(dados);
+  assert.equal(dados.score_breakdown.source_freshness_status, "ERROR");
+  assert.ok(dados.reason.includes("freshness original ERROR"));
+  assert.equal(dados.reason.includes("freshness original FRESH"), false);
+});
+
+test("stale critical risk keeps kill-rule on the original; dados_stale twin does not outrank it", () => {
+  const incident = makeSignal({
+    id: "cc:attention-signal:stale-outage",
+    category: "risco_operacional",
+    domain: "infrastructure",
+    impact: 90,
+    urgency: 95,
+    severity: "critical",
+    freshness_status: "STALE",
+    confidence: 0.99,
+  });
+  const out = rankFromUnknown(request({ signals: [incident] }));
+  const original = out.attention_now.find((i) => i.id === incident.id);
+  const dados = out.attention_now.find((i) => i.item_kind === "dados_stale");
+  assert.ok(original, "original incident missing from ATENÇÃO AGORA");
+  assert.ok(dados, "dados stale twin missing from ATENÇÃO AGORA");
+  assert.equal(original.forced_by_kill_rule, true);
+  assert.equal(original.score_breakdown.kill_rule_applied, true);
+  assert.equal(dados.forced_by_kill_rule, false);
+  assert.equal(dados.score_breakdown.kill_rule_applied, false);
+  const originalIdx = out.attention_now.findIndex((i) => i.id === incident.id);
+  const dadosIdx = out.attention_now.findIndex((i) => i.item_kind === "dados_stale");
+  assert.ok(originalIdx >= 0 && dadosIdx >= 0);
+  assert.ok(
+    originalIdx < dadosIdx,
+    `dados_stale ranked above the incident: now=${out.attention_now.map((i) => i.id).join(",")}`,
+  );
+  assert.equal(out.attention_now[0]?.id, incident.id);
+  assert.equal(dados.score_breakdown.source_freshness_status, "STALE");
+  assert.ok(dados.reason.includes("freshness original STALE"));
+});
+
+test("stale critical blocker keeps kill-rule on the original work item", () => {
+  const blocker = makeSignal({
+    id: "cc:attention-signal:stale-blocker",
+    category: "blocker",
+    domain: "engineering",
+    impact: 80,
+    urgency: 80,
+    severity: "critical",
+    freshness_status: "STALE",
+  });
+  const out = rankFromUnknown(request({ signals: [blocker] }));
+  const original = out.attention_now.find((i) => i.id === blocker.id);
+  const dados = out.attention_now.find((i) => i.item_kind === "dados_stale");
+  assert.ok(original && dados);
+  assert.equal(original.forced_by_kill_rule, true);
+  assert.equal(dados.forced_by_kill_rule, false);
+  assert.ok(
+    (out.attention_now.findIndex((i) => i.id === blocker.id) ?? 99) <
+      (out.attention_now.findIndex((i) => i.item_kind === "dados_stale") ?? -1),
+  );
 });
 
 test("founder override pins a target and records actor, time, target, previous ranking", () => {

--- a/control-center/intelligence/attention/tsconfig.json
+++ b/control-center/intelligence/attention/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "useUnknownInCatchVariables": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds the v1 **deterministic Attention Engine** under `control-center/intelligence/attention/` for Confenge Control Center.

- **ATENÇÃO AGORA** (exceptions, kill-rules first) and **se eu só puder fazer 3 coisas hoje** (domain-diverse top-3).
- Configurable per-category scoring with integer millipoint math. Same input + config + clock → same ordered ids/scores. Every ranked item has `reason`, evidence refs, and a reconstructible `score_breakdown` (why A beat B).
- Primary categories (receita / cliente / prazo / risco operacional / blocker) outrank estética / refactor. Urgency cannot erase impact (`impact_weight_bp > urgency_weight_bp`).
- Correlated signals merge (do not compete as separate rows).
- Kill rules force critical risco_operacional / blocker into ATENÇÃO AGORA.
- Low freshness demotes the original **and** emits an explicit `Dados stale:` item.
- Founder override (`pin` | `reorder` | `dismiss`) is an input record plus an audit event (actor, time, targets, previous ranking).
- **No LLM** on the v1 path. Fail-closed runtime validation. No secrets in git/logs/URLs/client bundle.

This wave does **not** touch `commercial/`, other `control-center/*` workstreams, Warmbly, or live providers. Sibling contracts/persistence are **not imported**; local adapters document freshness vocab divergence (`FRESH` vs `fresh`, `ERROR` vs `expired`) for the convergence campaign.

## How to run

```bash
cd control-center/intelligence/attention
npm install
npm test
npm run rank -- fixtures/representative.json
```

## Tests

22 tests via `tsx --test` driving the shipped `rankFromUnknown` (determinism, A-vs-B breakdown math, category/urgency/impact, merge, diversity, kill rules, stale, override, property/adversarial permutations).

## Convergence contracts exposed

- `rankFromUnknown` / `rankAttention` → `{ attention_now, today, audit, provenance, config_fingerprint }`
- `asPriorityRecommendations(output, horizon)` maps onto contracts `PriorityRecommendation` shape
- `toPersistenceFreshness` / `fromPersistenceFreshness` adapters (not wired)
- Homepage should consume `attention_now` (exceptions) and `today` (≤3); MCP should filter by `scope`

Never merge this PR as part of this campaign; it is a draft for later integration.