### PR TITLE
feat(control-center): executive engineering read model from GitHub collector snapshots

### DIFF
--- a/control-center/domains/engineering/.gitignore
+++ b/control-center/domains/engineering/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.env
+.env.*
+*.log
+coverage/

--- a/control-center/domains/engineering/README.md
+++ b/control-center/domains/engineering/README.md
@@ -1,0 +1,85 @@
+# Engineering executive read model
+
+Private Control Center domain package. It turns **GitHub collector snapshots** into an executive view the founder can read in seconds: where engineering is blocked, why, and with links.
+
+This is **not** chat, **not** an ERP, **not** a GitHub clone, and **not** the homepage UI. It does not call GitHub. It does not mutate issues, PRs, checks, Asaas, Warmbly, or any external system.
+
+## Decisions
+
+1. **GitHub collector remains the ingest authority.** This package consumes collector-shaped JSON (`schema: confenge.control_center.engineering_snapshot.v1`). It does not scrape GitHub or copy diffs.
+2. **Executive read model, not a wall of KPIs.** Per-repo output is health, blockers, open PRs, broken checks, P0/P1 issues, last activity, and aging. Company-wide output is aggregations plus ranked **attention candidates** with an explainable reason and a link.
+3. **Provenance is mandatory.** Every aggregated item carries `source` (system/kind/locator), `observed_at` (UTC Z), `freshness_status` (`FRESH|STALE|UNKNOWN|ERROR`), and `confidence` in `[0, 1]`. Missing collector provenance is rejected fail-closed.
+4. **`trabalho ativo sem evidência recente` is a hypothesis, never a fact.** A repo with a usable observation and no blockers is quiet-saudável (healthy silence or known recent-enough activity). A repo with no usable observation (`UNKNOWN`/`ERROR`) may emit the hypothesis and stays distinguishable.
+5. **Links and references only.** Titles, numbers, html_url, aging. Never PR/issue bodies, patches, or check logs.
+6. **Scoped reads.** `repo:<owner/name>` returns that repo. It does not dump company memory. `company` / `infrastructure` return the company aggregation.
+7. **In-process store this wave.** Query operations a later Postgres consumer must match: `ingest`, `getCompany`, `getRepo`, `listAttention`. No identity/password hardcoded.
+8. **Local adapter because sibling trees are absent on `origin/main`.** `control-center/connectors/github/` and `control-center/contracts/` are parallel workstreams. This package copies a **minimal** collector-snapshot + provenance/attention contract. Field names may need a convergence pass; do not import those trees from here.
+
+Collector freshness maps to canonical freshness:
+
+| Collector | Canonical |
+| --- | --- |
+| `fresh`, `not_modified` | `FRESH` |
+| `stale` | `STALE` |
+| `failed` | `ERROR` |
+| `unsupported` | `UNKNOWN` |
+
+`source` on collector items is the string `"github"`; output uses `{ system, kind, locator, label? }` so it can converge with `control-center/contracts` provenance.
+
+## Run
+
+From this directory:
+
+```bash
+npm install
+npm test
+npm run consumer
+npm run typecheck
+```
+
+Replay clock for fixtures: `2026-08-20T12:00:00.000Z`. Tests and the consumer inject that clock; they do not hit the network.
+
+## Env vars
+
+No secrets. Thresholds and a replay clock only:
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `CC_ENGINEERING_PR_STALE_AFTER_SECONDS` | Open PR aging threshold | `604800` (7d) |
+| `CC_ENGINEERING_FRESHNESS_WINDOW_SECONDS` | FRESH vs STALE window vs `now` | `21600` (6h) |
+| `CC_ENGINEERING_NOW` | Optional UTC Z replay timestamp | collector `observed_at` |
+
+Do not put PATs, tokens, or passwords in env files committed here. This package never reads `GITHUB_TOKEN`.
+
+## Query contract (homepage / MCP / persistence later)
+
+Ship payload, not a page.
+
+- **Homepage** should consume `attention_headlines` and `attention` (ranked, `homepage_eligible`). Privilege exceptions. Do not render a KPI wall from `aggregates` as the primary view.
+- **MCP / context API** should query by scope: `readByScope(model, "repo:owner/name")` or `store.listAttention("repo:owner/name")`. Agents must not receive every repo unless they requested and were granted `company`.
+- **Persistence** should store the executive view + provenance, not raw GitHub diffs. Ingest is idempotent on collector `snapshot_id` / per-repo `observation_id` once Postgres exists. Match `InMemoryEngineeringStore` operations.
+- **Canonical projection** is `model.canonical` (`control-center.engineering-snapshot.v1` counts + attention ids) for the contracts workstream.
+
+Attention candidate fields this wave: `repo`, `reason_code` (`stale_pr` \| `ci_red` \| `p0_issue` \| `p1_issue` \| `unknown_quiet`), `claim_kind` (`fact` \| `hypothesis`), `reference.html_url`, plus canonical-ish `id` / `scope` / `severity` / `summary` / `provenance`.
+
+## Fixtures
+
+Named fixtures under `fixtures/`:
+
+- `pr-stale.json` — open PR past the aging threshold
+- `ci-red.json` — failing checks
+- `repo-quiet-saudavel.json` — usable observation, no blockers
+- `repo-quiet-desconhecido.json` — failed/unusable observation
+
+`assembleCollectorSnapshots([...])` is the company-wide input.
+
+## Convergence
+
+Expected later, **not** in this campaign:
+
+- Replace local collector types with `@confenge/control-center-github-collector` once it lands on `main`.
+- Validate output against `@confenge/control-center-contracts` `engineering-snapshot.v1` / `attention-item.v1`.
+- Persist via the persistence/audit workstream.
+- Homepage and MCP consume this payload without this package rendering UI or serving MCP.
+
+Until then, this directory is the whole workstream.

--- a/control-center/domains/engineering/fixtures/ci-red.json
+++ b/control-center/domains/engineering/fixtures/ci-red.json
@@ -1,0 +1,127 @@
+{
+  "schema": "confenge.control_center.engineering_snapshot.v1",
+  "snapshot_id": "github:engineering_snapshot:confenge/web-cfg",
+  "collected_at": "2026-08-20T12:00:00.000Z",
+  "allowlist": ["confenge/web-cfg"],
+  "source": "github",
+  "observed_at": "2026-08-20T12:00:00.000Z",
+  "freshness_status": "fresh",
+  "confidence": 1,
+  "errors": [],
+  "repos": [
+    {
+      "repo": {
+        "source": "github",
+        "observed_at": "2026-08-20T12:00:00.000Z",
+        "freshness_status": "fresh",
+        "confidence": 1,
+        "observation_id": "github:repo:confenge%2Fweb-cfg",
+        "owner": "confenge",
+        "name": "web-cfg",
+        "full_name": "confenge/web-cfg",
+        "default_branch": "main",
+        "html_url": "https://github.com/confenge/web-cfg",
+        "pushed_at": "2026-08-20T10:00:00.000Z",
+        "updated_at": "2026-08-20T10:00:00.000Z",
+        "last_activity_at": "2026-08-20T10:00:00.000Z"
+      },
+      "repo_collection": {
+        "ok": true,
+        "freshness_status": "fresh"
+      },
+      "issues_collection": {
+        "ok": true,
+        "freshness_status": "fresh"
+      },
+      "recent_commits": [
+        {
+          "source": "github",
+          "observed_at": "2026-08-20T12:00:00.000Z",
+          "freshness_status": "fresh",
+          "confidence": 1,
+          "observation_id": "github:commit:confenge%2Fweb-cfg:ccc333",
+          "repo": "confenge/web-cfg",
+          "sha": "ccc333dddd4444eeee5555ffff666677778888",
+          "message": "fix: landing copy",
+          "committed_at": "2026-08-20T10:00:00.000Z",
+          "author_login": "dev"
+        }
+      ],
+      "open_issues": [],
+      "open_pull_requests": [
+        {
+          "source": "github",
+          "observed_at": "2026-08-20T12:00:00.000Z",
+          "freshness_status": "fresh",
+          "confidence": 1,
+          "observation_id": "github:pull_request:confenge%2Fweb-cfg:7",
+          "repo": "confenge/web-cfg",
+          "number": 7,
+          "title": "Update landing CTA",
+          "draft": false,
+          "created_at": "2026-08-20T08:00:00.000Z",
+          "age_seconds": 14400,
+          "review_status": "COMMENTED",
+          "check_status": "failure",
+          "html_url": "https://github.com/confenge/web-cfg/pull/7",
+          "updated_at": "2026-08-20T10:00:00.000Z",
+          "head_sha": "def456",
+          "head_ref": "fix/cta",
+          "base_ref": "main"
+        }
+      ],
+      "check_failures": [
+        {
+          "source": "github",
+          "observed_at": "2026-08-20T12:00:00.000Z",
+          "freshness_status": "fresh",
+          "confidence": 1,
+          "observation_id": "github:check_failure:confenge%2Fweb-cfg:9001",
+          "repo": "confenge/web-cfg",
+          "kind": "check_run",
+          "remote_id": 9001,
+          "name": "ci",
+          "conclusion": "failure",
+          "html_url": "https://github.com/confenge/web-cfg/runs/9001",
+          "started_at": "2026-08-20T09:50:00.000Z",
+          "completed_at": "2026-08-20T10:00:00.000Z",
+          "head_sha": "def456"
+        }
+      ],
+      "workflow_failures": [
+        {
+          "source": "github",
+          "observed_at": "2026-08-20T12:00:00.000Z",
+          "freshness_status": "fresh",
+          "confidence": 1,
+          "observation_id": "github:workflow_failure:confenge%2Fweb-cfg:77",
+          "repo": "confenge/web-cfg",
+          "kind": "workflow_run",
+          "remote_id": 77,
+          "name": "CI",
+          "conclusion": "failure",
+          "html_url": "https://github.com/confenge/web-cfg/actions/runs/77",
+          "started_at": "2026-08-20T09:50:00.000Z",
+          "completed_at": "2026-08-20T10:00:00.000Z",
+          "head_sha": "def456"
+        }
+      ],
+      "divergence": {
+        "source": "github",
+        "observed_at": "2026-08-20T12:00:00.000Z",
+        "freshness_status": "unsupported",
+        "confidence": 0.5,
+        "observation_id": "github:compare:confenge%2Fweb-cfg:none",
+        "repo": "confenge/web-cfg",
+        "base": null,
+        "head": null,
+        "support": "unsupported",
+        "ahead_by": null,
+        "behind_by": null,
+        "status": "unsupported",
+        "reason": "no_compare_target"
+      },
+      "errors": []
+    }
+  ]
+}

--- a/control-center/domains/engineering/fixtures/pr-stale.json
+++ b/control-center/domains/engineering/fixtures/pr-stale.json
@@ -1,0 +1,97 @@
+{
+  "schema": "confenge.control_center.engineering_snapshot.v1",
+  "snapshot_id": "github:engineering_snapshot:confenge/billing-api",
+  "collected_at": "2026-08-20T12:00:00.000Z",
+  "allowlist": ["confenge/billing-api"],
+  "source": "github",
+  "observed_at": "2026-08-20T12:00:00.000Z",
+  "freshness_status": "fresh",
+  "confidence": 1,
+  "token": "ghp_THIS_MUST_NOT_LEAK_IN_OUTPUT_1234567890",
+  "errors": [],
+  "repos": [
+    {
+      "repo": {
+        "source": "github",
+        "observed_at": "2026-08-20T12:00:00.000Z",
+        "freshness_status": "fresh",
+        "confidence": 1,
+        "observation_id": "github:repo:confenge%2Fbilling-api",
+        "owner": "confenge",
+        "name": "billing-api",
+        "full_name": "confenge/billing-api",
+        "default_branch": "main",
+        "html_url": "https://github.com/confenge/billing-api",
+        "pushed_at": "2026-08-19T09:00:00.000Z",
+        "updated_at": "2026-08-19T09:00:00.000Z",
+        "last_activity_at": "2026-08-19T09:00:00.000Z"
+      },
+      "repo_collection": {
+        "ok": true,
+        "freshness_status": "fresh"
+      },
+      "issues_collection": {
+        "ok": true,
+        "freshness_status": "fresh"
+      },
+      "recent_commits": [
+        {
+          "source": "github",
+          "observed_at": "2026-08-20T12:00:00.000Z",
+          "freshness_status": "fresh",
+          "confidence": 1,
+          "observation_id": "github:commit:confenge%2Fbilling-api:aaa111",
+          "repo": "confenge/billing-api",
+          "sha": "aaa111bbbbccccddddeeeeffff000011112222",
+          "message": "chore: bump invoice template",
+          "committed_at": "2026-08-19T09:00:00.000Z",
+          "author_login": "bot"
+        }
+      ],
+      "open_issues": [],
+      "open_pull_requests": [
+        {
+          "source": "github",
+          "observed_at": "2026-08-20T12:00:00.000Z",
+          "freshness_status": "fresh",
+          "confidence": 1,
+          "observation_id": "github:pull_request:confenge%2Fbilling-api:42",
+          "repo": "confenge/billing-api",
+          "number": 42,
+          "title": "Add invoice export",
+          "draft": false,
+          "created_at": "2026-08-08T12:00:00.000Z",
+          "age_seconds": 1036800,
+          "review_status": "REVIEW_REQUIRED",
+          "check_status": "success",
+          "html_url": "https://github.com/confenge/billing-api/pull/42",
+          "updated_at": "2026-08-10T12:00:00.000Z",
+          "head_sha": "abc123",
+          "head_ref": "feat/invoice-export",
+          "base_ref": "main",
+          "diff": "DIFF_BODY_MUST_NOT_LEAK\n@@ -1,200 +1,240 @@\n-huge patch omitted on purpose",
+          "patch": "DIFF_BODY_MUST_NOT_LEAK",
+          "body": "DIFF_BODY_MUST_NOT_LEAK long PR description that must never be copied into the executive read model"
+        }
+      ],
+      "check_failures": [],
+      "workflow_failures": [],
+      "divergence": {
+        "source": "github",
+        "observed_at": "2026-08-20T12:00:00.000Z",
+        "freshness_status": "unsupported",
+        "confidence": 0.5,
+        "observation_id": "github:compare:confenge%2Fbilling-api:none",
+        "repo": "confenge/billing-api",
+        "base": null,
+        "head": null,
+        "support": "unsupported",
+        "ahead_by": null,
+        "behind_by": null,
+        "status": "unsupported",
+        "reason": "no_compare_target"
+      },
+      "errors": []
+    }
+  ]
+}

--- a/control-center/domains/engineering/fixtures/repo-quiet-desconhecido.json
+++ b/control-center/domains/engineering/fixtures/repo-quiet-desconhecido.json
@@ -1,0 +1,58 @@
+{
+  "schema": "confenge.control_center.engineering_snapshot.v1",
+  "snapshot_id": "github:engineering_snapshot:confenge/extra-cli",
+  "collected_at": "2026-08-20T12:00:00.000Z",
+  "allowlist": ["confenge/extra-cli"],
+  "source": "github",
+  "observed_at": "2026-08-20T12:00:00.000Z",
+  "freshness_status": "failed",
+  "confidence": 0,
+  "errors": [],
+  "repos": [
+    {
+      "repo": null,
+      "repo_collection": {
+        "ok": false,
+        "freshness_status": "failed",
+        "error_observation_id": "github:error:confenge%2Fextra-cli:repo:http_403"
+      },
+      "issues_collection": {
+        "skipped": true
+      },
+      "recent_commits": [],
+      "open_issues": [],
+      "open_pull_requests": [],
+      "check_failures": [],
+      "workflow_failures": [],
+      "divergence": {
+        "source": "github",
+        "observed_at": "2026-08-20T12:00:00.000Z",
+        "freshness_status": "unsupported",
+        "confidence": 0.5,
+        "observation_id": "github:compare:confenge%2Fextra-cli:none",
+        "repo": "confenge/extra-cli",
+        "base": null,
+        "head": null,
+        "support": "unavailable",
+        "ahead_by": null,
+        "behind_by": null,
+        "status": "unavailable",
+        "reason": "repo_unavailable"
+      },
+      "errors": [
+        {
+          "source": "github",
+          "observed_at": "2026-08-20T12:00:00.000Z",
+          "freshness_status": "failed",
+          "confidence": 0,
+          "observation_id": "github:error:confenge%2Fextra-cli:repo:http_403",
+          "repo": "confenge/extra-cli",
+          "resource": "repo",
+          "code": "http_403",
+          "message": "github returned 403 for repo",
+          "http_status": 403
+        }
+      ]
+    }
+  ]
+}

--- a/control-center/domains/engineering/fixtures/repo-quiet-saudavel.json
+++ b/control-center/domains/engineering/fixtures/repo-quiet-saudavel.json
@@ -1,0 +1,89 @@
+{
+  "schema": "confenge.control_center.engineering_snapshot.v1",
+  "snapshot_id": "github:engineering_snapshot:confenge/docs",
+  "collected_at": "2026-08-20T12:00:00.000Z",
+  "allowlist": ["confenge/docs"],
+  "source": "github",
+  "observed_at": "2026-08-20T12:00:00.000Z",
+  "freshness_status": "fresh",
+  "confidence": 1,
+  "errors": [],
+  "repos": [
+    {
+      "repo": {
+        "source": "github",
+        "observed_at": "2026-08-20T12:00:00.000Z",
+        "freshness_status": "fresh",
+        "confidence": 1,
+        "observation_id": "github:repo:confenge%2Fdocs",
+        "owner": "confenge",
+        "name": "docs",
+        "full_name": "confenge/docs",
+        "default_branch": "main",
+        "html_url": "https://github.com/confenge/docs",
+        "pushed_at": "2026-08-19T18:00:00.000Z",
+        "updated_at": "2026-08-19T18:00:00.000Z",
+        "last_activity_at": "2026-08-19T18:00:00.000Z"
+      },
+      "repo_collection": {
+        "ok": true,
+        "freshness_status": "fresh"
+      },
+      "issues_collection": {
+        "ok": true,
+        "freshness_status": "fresh"
+      },
+      "recent_commits": [
+        {
+          "source": "github",
+          "observed_at": "2026-08-20T12:00:00.000Z",
+          "freshness_status": "fresh",
+          "confidence": 1,
+          "observation_id": "github:commit:confenge%2Fdocs:eee555",
+          "repo": "confenge/docs",
+          "sha": "eee555ffff6666777788889999aaaabbbbcccc",
+          "message": "docs: refresh onboarding",
+          "committed_at": "2026-08-19T18:00:00.000Z",
+          "author_login": "writer"
+        }
+      ],
+      "open_issues": [
+        {
+          "source": "github",
+          "observed_at": "2026-08-20T12:00:00.000Z",
+          "freshness_status": "fresh",
+          "confidence": 1,
+          "observation_id": "github:issue:confenge%2Fdocs:3",
+          "repo": "confenge/docs",
+          "number": 3,
+          "title": "Typos in glossary",
+          "state": "open",
+          "labels": ["docs", "low"],
+          "priority": "low",
+          "html_url": "https://github.com/confenge/docs/issues/3",
+          "created_at": "2026-08-18T12:00:00.000Z",
+          "updated_at": "2026-08-18T12:00:00.000Z"
+        }
+      ],
+      "open_pull_requests": [],
+      "check_failures": [],
+      "workflow_failures": [],
+      "divergence": {
+        "source": "github",
+        "observed_at": "2026-08-20T12:00:00.000Z",
+        "freshness_status": "unsupported",
+        "confidence": 0.5,
+        "observation_id": "github:compare:confenge%2Fdocs:none",
+        "repo": "confenge/docs",
+        "base": null,
+        "head": null,
+        "support": "unsupported",
+        "ahead_by": null,
+        "behind_by": null,
+        "status": "unsupported",
+        "reason": "no_compare_target"
+      },
+      "errors": []
+    }
+  ]
+}

--- a/control-center/domains/engineering/package-lock.json
+++ b/control-center/domains/engineering/package-lock.json
@@ -1,0 +1,581 @@
+{
+  "name": "@confenge/control-center-engineering",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-engineering",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/control-center/domains/engineering/package.json
+++ b/control-center/domains/engineering/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@confenge/control-center-engineering",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Confenge Control Center — executive engineering read model from GitHub collector snapshots. Not a GitHub clone, chat, or ERP.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src",
+    "fixtures",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
+    "test": "tsx --test --test-concurrency=1 tests/executive-read-model.test.ts tests/adapter.test.ts",
+    "consumer": "tsx scripts/consumer.ts"
+  },
+  "dependencies": {
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/domains/engineering/scripts/consumer.ts
+++ b/control-center/domains/engineering/scripts/consumer.ts
@@ -1,0 +1,98 @@
+/**
+ * Fresh consumer of the shipped engineering read-model package.
+ * Not a test file. Loads the four named fixtures, calls the company-wide
+ * attention/aggregation entry, and asserts the returned value.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assembleCollectorSnapshots,
+  buildCompanyEngineeringReadModel,
+  serializeReadModel,
+} from "../src/index.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(root, "fixtures", name), "utf8"));
+}
+
+function fail(message: string): never {
+  process.stdout.write(`FAIL ${message}\n`);
+  process.exit(1);
+}
+
+const assembled = assembleCollectorSnapshots([
+  loadFixture("pr-stale.json"),
+  loadFixture("ci-red.json"),
+  loadFixture("repo-quiet-saudavel.json"),
+  loadFixture("repo-quiet-desconhecido.json"),
+]);
+
+const model = buildCompanyEngineeringReadModel(assembled, { now: NOW });
+
+const blocked = model.blocked_repos.map((item) => item.full_name).sort();
+const hypotheses = model.hypothesis_repos.map((item) => item.full_name).sort();
+const reasons = model.attention.map((item) => `${item.repo}:${item.reason_code}:${item.claim_kind}`);
+
+if (!blocked.includes("confenge/billing-api")) {
+  fail("blocked repos must include confenge/billing-api (stale PR)");
+}
+if (!blocked.includes("confenge/web-cfg")) {
+  fail("blocked repos must include confenge/web-cfg (CI red)");
+}
+if (blocked.includes("confenge/docs")) {
+  fail("healthy-quiet confenge/docs must not be a fact-blocker");
+}
+if (blocked.includes("confenge/extra-cli")) {
+  fail("unknown-quiet confenge/extra-cli must not be a fact-blocker");
+}
+if (!hypotheses.includes("confenge/extra-cli")) {
+  fail("unknown-quiet confenge/extra-cli must appear as a hypothesis repo");
+}
+
+const stale = model.attention.find(
+  (item) => item.reason_code === "stale_pr" && item.repo === "confenge/billing-api",
+);
+const ci = model.attention.find(
+  (item) => item.reason_code === "ci_red" && item.repo === "confenge/web-cfg",
+);
+const unknown = model.attention.find(
+  (item) => item.reason_code === "unknown_quiet" && item.repo === "confenge/extra-cli",
+);
+if (!stale || stale.claim_kind !== "fact") {
+  fail("stale PR attention candidate missing or not fact-typed");
+}
+if (!ci || ci.claim_kind !== "fact") {
+  fail("CI red attention candidate missing or not fact-typed");
+}
+if (!unknown || unknown.claim_kind !== "hypothesis") {
+  fail("unknown quiet must be hypothesis-typed when present");
+}
+if (unknown.title !== "trabalho ativo sem evidência recente") {
+  fail("unknown quiet hypothesis title is wrong");
+}
+
+const docs = model.repos.find((repo) => repo.repo.full_name === "confenge/docs");
+if (!docs || docs.health !== "healthy") {
+  fail("quiet saudável repo must be healthy");
+}
+if (docs.blockers.length !== 0) {
+  fail("quiet saudável repo must not have blockers");
+}
+
+const canonical = serializeReadModel(model);
+if (canonical.includes("DIFF_BODY_MUST_NOT_LEAK") || canonical.includes("ghp_")) {
+  fail("serialized output leaked a diff body or token");
+}
+
+process.stdout.write("PASS engineering-consumer\n");
+process.stdout.write(`blocked_repos=${blocked.join(",")}\n`);
+process.stdout.write(`hypothesis_repos=${hypotheses.join(",")}\n`);
+process.stdout.write(`reasons=${reasons.join("|")}\n`);
+process.stdout.write(`headlines=${model.attention_headlines.join(" || ")}\n`);
+process.stdout.write("CANONICAL_BEGIN\n");
+process.stdout.write(`${canonical}\n`);
+process.stdout.write("CANONICAL_END\n");

--- a/control-center/domains/engineering/src/adapter.ts
+++ b/control-center/domains/engineering/src/adapter.ts
@@ -1,0 +1,283 @@
+import { z, type ZodError } from "zod";
+import {
+  COLLECTOR_ENGINEERING_SNAPSHOT_SCHEMA,
+  COLLECTOR_FRESHNESS,
+  UTC_DATETIME_PATTERN,
+} from "./constants.js";
+import { EngineeringError } from "./errors.js";
+import type {
+  CollectorEngineeringSnapshot,
+  CollectorError,
+  CollectorRepoSnapshot,
+} from "./types.js";
+
+const utc = z
+  .string()
+  .regex(
+    UTC_DATETIME_PATTERN,
+    "timestamp must be RFC3339 UTC with a Z suffix",
+  );
+
+const freshness = z.enum(COLLECTOR_FRESHNESS);
+
+const collectorProvenance = z.object({
+  source: z.string().min(1),
+  observed_at: utc,
+  freshness_status: freshness,
+  confidence: z.number().min(0).max(1).optional(),
+});
+
+function requireProvenance<T extends z.ZodRawShape>(shape: T) {
+  return collectorProvenance.extend(shape);
+}
+
+const repoIdentity = requireProvenance({
+  observation_id: z.string().min(1),
+  owner: z.string().min(1),
+  name: z.string().min(1),
+  full_name: z.string().min(1),
+  default_branch: z.string().min(1),
+  html_url: z.string().min(1),
+  pushed_at: z.string().nullable(),
+  updated_at: z.string().nullable(),
+  last_activity_at: z.string().nullable(),
+});
+
+const commit = requireProvenance({
+  observation_id: z.string().min(1),
+  repo: z.string().min(1),
+  sha: z.string().min(1),
+  message: z.string(),
+  committed_at: z.string().nullable(),
+  author_login: z.string().nullable(),
+});
+
+const issue = requireProvenance({
+  observation_id: z.string().min(1),
+  repo: z.string().min(1),
+  number: z.number().int().nonnegative(),
+  title: z.string().min(1),
+  state: z.string().min(1),
+  labels: z.array(z.string()),
+  priority: z.string().nullable(),
+  html_url: z.string().min(1),
+  created_at: z.string().nullable(),
+  updated_at: z.string().nullable(),
+});
+
+const pullRequest = requireProvenance({
+  observation_id: z.string().min(1),
+  repo: z.string().min(1),
+  number: z.number().int().positive(),
+  title: z.string().min(1),
+  draft: z.boolean(),
+  created_at: utc,
+  age_seconds: z.number().int().nonnegative(),
+  review_status: z.string().min(1),
+  check_status: z.string().min(1),
+  html_url: z.string().min(1),
+  updated_at: z.string().nullable(),
+  head_sha: z.string().nullable(),
+  head_ref: z.string().nullable(),
+  base_ref: z.string().nullable(),
+});
+
+const checkFailure = requireProvenance({
+  observation_id: z.string().min(1),
+  repo: z.string().min(1),
+  kind: z.enum(["check_run", "workflow_run"]),
+  remote_id: z.number().int(),
+  name: z.string().min(1),
+  conclusion: z.string().nullable(),
+  html_url: z.string().nullable(),
+  started_at: z.string().nullable(),
+  completed_at: z.string().nullable(),
+  head_sha: z.string().nullable(),
+});
+
+const collectionError = requireProvenance({
+  observation_id: z.string().min(1),
+  repo: z.string().nullable(),
+  resource: z.string().min(1),
+  code: z.string().min(1),
+  message: z.string().min(1),
+  http_status: z.number().int().nullable(),
+});
+
+const supportedDivergence = requireProvenance({
+  observation_id: z.string().min(1),
+  repo: z.string().min(1),
+  base: z.string().min(1),
+  head: z.string().min(1),
+  support: z.literal("supported"),
+  ahead_by: z.number().int(),
+  behind_by: z.number().int(),
+  status: z.string().min(1),
+});
+
+const unsupportedDivergence = requireProvenance({
+  observation_id: z.string().min(1),
+  repo: z.string().min(1),
+  base: z.string().nullable(),
+  head: z.string().nullable(),
+  support: z.enum(["unsupported", "unavailable"]),
+  ahead_by: z.null(),
+  behind_by: z.null(),
+  status: z.enum(["unsupported", "unavailable"]),
+  reason: z.string().min(1),
+});
+
+const okCollection = z.object({
+  ok: z.literal(true),
+  freshness_status: z.enum(["fresh", "not_modified"]),
+});
+
+const failedCollection = z.object({
+  ok: z.literal(false),
+  freshness_status: z.enum(["failed", "stale"]),
+  error_observation_id: z.string().min(1),
+});
+
+const skippedCollection = z.object({
+  skipped: z.literal(true),
+});
+
+const repoSnapshot = z.object({
+  repo: repoIdentity.nullable(),
+  repo_collection: z.union([okCollection, failedCollection]),
+  issues_collection: z.union([okCollection, failedCollection, skippedCollection]),
+  recent_commits: z.array(commit),
+  open_issues: z.array(issue),
+  open_pull_requests: z.array(pullRequest),
+  check_failures: z.array(checkFailure),
+  workflow_failures: z.array(checkFailure),
+  divergence: z.union([supportedDivergence, unsupportedDivergence]),
+  errors: z.array(collectionError),
+});
+
+const snapshotSchema = requireProvenance({
+  schema: z.literal(COLLECTOR_ENGINEERING_SNAPSHOT_SCHEMA),
+  snapshot_id: z.string().min(1),
+  collected_at: utc,
+  allowlist: z.array(z.string().min(1)),
+  repos: z.array(repoSnapshot),
+  errors: z.array(collectionError),
+});
+
+function formatZod(error: ZodError): string {
+  const first = error.issues[0];
+  if (!first) {
+    return "collector snapshot is invalid";
+  }
+  const path = first.path.join(".") || "(root)";
+  return `${path}: ${first.message}`;
+}
+
+function isMissingProvenance(error: ZodError): boolean {
+  return error.issues.some((issue) => {
+    const last = issue.path[issue.path.length - 1];
+    return (
+      last === "source" ||
+      last === "observed_at" ||
+      last === "freshness_status"
+    );
+  });
+}
+
+export function parseCollectorSnapshot(input: unknown): CollectorEngineeringSnapshot {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new EngineeringError(
+      "invalid_input",
+      "collector snapshot must be an object",
+    );
+  }
+  const rec = input as Record<string, unknown>;
+  if (
+    rec.source === undefined ||
+    rec.observed_at === undefined ||
+    rec.freshness_status === undefined
+  ) {
+    throw new EngineeringError(
+      "missing_provenance",
+      "collector snapshot is missing source, observed_at, or freshness_status",
+    );
+  }
+
+  const parsed = snapshotSchema.safeParse(input);
+  if (!parsed.success) {
+    if (isMissingProvenance(parsed.error)) {
+      throw new EngineeringError("missing_provenance", formatZod(parsed.error));
+    }
+    throw new EngineeringError("invalid_input", formatZod(parsed.error));
+  }
+  return parsed.data;
+}
+
+export function assembleCollectorSnapshots(
+  inputs: readonly unknown[],
+): CollectorEngineeringSnapshot {
+  if (inputs.length === 0) {
+    throw new EngineeringError(
+      "invalid_input",
+      "assembleCollectorSnapshots requires at least one snapshot",
+    );
+  }
+  const parsed = inputs.map((item) => parseCollectorSnapshot(item));
+  const first = parsed[0];
+  if (!first) {
+    throw new EngineeringError("invalid_input", "assembleCollectorSnapshots is empty");
+  }
+
+  const repos: CollectorRepoSnapshot[] = [];
+  const allowlist: string[] = [];
+  const errors: CollectorError[] = [];
+  const seenRepos = new Set<string>();
+  const seenAllow = new Set<string>();
+
+  let freshness = first.freshness_status;
+  let confidence: number | undefined = first.confidence;
+
+  for (const snap of parsed) {
+    for (const name of snap.allowlist) {
+      if (!seenAllow.has(name)) {
+        seenAllow.add(name);
+        allowlist.push(name);
+      }
+    }
+    for (const repo of snap.repos) {
+      const key =
+        repo.repo?.full_name ??
+        repo.errors.find((err) => err.repo)?.repo ??
+        `idx:${repos.length}`;
+      if (seenRepos.has(key)) {
+        continue;
+      }
+      seenRepos.add(key);
+      repos.push(repo);
+    }
+    errors.push(...snap.errors);
+    if (snap.freshness_status === "failed") {
+      freshness = "failed";
+      confidence = 0;
+    } else if (freshness !== "failed" && snap.freshness_status === "stale") {
+      freshness = "stale";
+      confidence = Math.min(confidence ?? 0.4, snap.confidence ?? 0.4);
+    }
+  }
+
+  const assembled: CollectorEngineeringSnapshot = {
+    schema: COLLECTOR_ENGINEERING_SNAPSHOT_SCHEMA,
+    snapshot_id: "github:engineering_snapshot:assembled",
+    collected_at: first.collected_at,
+    allowlist,
+    repos,
+    errors,
+    source: first.source,
+    observed_at: first.observed_at,
+    freshness_status: freshness,
+  };
+  if (confidence !== undefined) {
+    assembled.confidence = confidence;
+  }
+  return parseCollectorSnapshot(assembled);
+}

--- a/control-center/domains/engineering/src/attention.ts
+++ b/control-center/domains/engineering/src/attention.ts
@@ -1,0 +1,51 @@
+import type { AttentionCandidate, AttentionSeverity, BlockerKind } from "./types.js";
+
+const SEVERITY_RANK: Record<AttentionSeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+const REASON_RANK: Record<BlockerKind, number> = {
+  p0_issue: 0,
+  ci_red: 1,
+  p1_issue: 2,
+  stale_pr: 3,
+  unknown_quiet: 4,
+};
+
+export function rankAttentionCandidates(
+  items: readonly AttentionCandidate[],
+): AttentionCandidate[] {
+  return [...items].sort((a, b) => {
+    const severity = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (severity !== 0) return severity;
+    const reason = REASON_RANK[a.reason_code] - REASON_RANK[b.reason_code];
+    if (reason !== 0) return reason;
+    const repo = a.repo.localeCompare(b.repo);
+    if (repo !== 0) return repo;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function attentionHeadline(item: AttentionCandidate): string {
+  if (item.claim_kind === "hypothesis") {
+    return `${item.repo}: hypothesis — ${item.title}`;
+  }
+  return `${item.repo}: ${item.title}`;
+}
+
+export function listAttentionCandidates(
+  items: readonly AttentionCandidate[],
+  scope?: string,
+): AttentionCandidate[] {
+  const ranked = rankAttentionCandidates(items);
+  if (!scope || scope === "company" || scope === "infrastructure") {
+    return ranked;
+  }
+  const wanted = scope.startsWith("repo:") ? scope.slice("repo:".length) : scope;
+  return ranked.filter(
+    (item) => item.scope === scope || item.repo === wanted || item.repo.endsWith(`/${wanted}`),
+  );
+}

--- a/control-center/domains/engineering/src/clock.ts
+++ b/control-center/domains/engineering/src/clock.ts
@@ -1,0 +1,48 @@
+import { UTC_DATETIME_PATTERN } from "./constants.js";
+import { EngineeringError } from "./errors.js";
+
+export type Clock = () => Date;
+
+export function parseUtc(value: string): Date {
+  if (!UTC_DATETIME_PATTERN.test(value)) {
+    throw new EngineeringError(
+      "invalid_input",
+      "observed_at must be RFC3339 UTC with a Z suffix",
+    );
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new EngineeringError("invalid_input", "observed_at is not a valid UTC timestamp");
+  }
+  return date;
+}
+
+export function toUtcIso(date: Date): string {
+  return date.toISOString();
+}
+
+export function ageSeconds(fromIso: string | null | undefined, now: Date): number | null {
+  if (!fromIso) {
+    return null;
+  }
+  const from = new Date(fromIso);
+  if (Number.isNaN(from.getTime())) {
+    return null;
+  }
+  return Math.max(0, Math.floor((now.getTime() - from.getTime()) / 1000));
+}
+
+export function maxTimestamp(values: Array<string | null | undefined>): string | null {
+  let best: string | null = null;
+  let bestMs = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    if (!value) continue;
+    const ms = Date.parse(value);
+    if (Number.isNaN(ms)) continue;
+    if (ms > bestMs) {
+      bestMs = ms;
+      best = new Date(ms).toISOString();
+    }
+  }
+  return best;
+}

--- a/control-center/domains/engineering/src/constants.ts
+++ b/control-center/domains/engineering/src/constants.ts
@@ -1,0 +1,93 @@
+/** Local copy of the GitHub collector snapshot schema id. */
+export const COLLECTOR_ENGINEERING_SNAPSHOT_SCHEMA =
+  "confenge.control_center.engineering_snapshot.v1" as const;
+
+/** Canonical Control Center engineering snapshot schema (convergence target). */
+export const CANONICAL_ENGINEERING_SNAPSHOT_SCHEMA =
+  "control-center.engineering-snapshot.v1" as const;
+
+export const ATTENTION_ITEM_SCHEMA = "control-center.attention-item.v1" as const;
+
+export const REPO_EXECUTIVE_SCHEMA =
+  "control-center.engineering-repo-executive.v1" as const;
+
+export const COMPANY_EXECUTIVE_SCHEMA =
+  "control-center.engineering-executive.v1" as const;
+
+export const SOURCE_SYSTEM_GITHUB = "github" as const;
+
+export const COLLECTOR_FRESHNESS = [
+  "fresh",
+  "stale",
+  "failed",
+  "not_modified",
+  "unsupported",
+] as const;
+
+export const CANONICAL_FRESHNESS = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+
+export const HEALTH_STATUSES = ["healthy", "degraded", "down", "unknown"] as const;
+
+export const CLAIM_KINDS = [
+  "decision",
+  "directive",
+  "fact",
+  "constraint",
+  "priority",
+  "risk",
+  "hypothesis",
+] as const;
+
+export const ATTENTION_SEVERITIES = ["critical", "high", "medium", "low"] as const;
+
+export const ATTENTION_STATUSES = [
+  "open",
+  "acknowledged",
+  "resolved",
+  "dismissed",
+] as const;
+
+export const BLOCKER_KINDS = [
+  "stale_pr",
+  "ci_red",
+  "p0_issue",
+  "p1_issue",
+  "unknown_quiet",
+] as const;
+
+export const HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE =
+  "trabalho ativo sem evidência recente" as const;
+
+export const HYPOTHESIS_CODE = "active_work_without_recent_evidence" as const;
+
+export const SYSTEM_ACTOR_ID = "system:engineering-read-model" as const;
+
+export const UTC_DATETIME_PATTERN =
+  /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,9})?Z$/;
+
+export const RESOURCE_ID_PATTERN = /^cc:[a-z][a-z0-9-]*:[A-Za-z0-9._~-]+$/;
+
+export const DEFAULT_PR_STALE_AFTER_SECONDS = 7 * 24 * 60 * 60;
+export const DEFAULT_FRESHNESS_WINDOW_SECONDS = 6 * 60 * 60;
+
+export const TITLE_MAX = 200;
+export const SUMMARY_MAX = 2000;
+export const LABEL_MAX = 128;
+export const LOCATOR_MAX = 512;
+export const COMMIT_SUBJECT_MAX = 120;
+
+export const SECRET_KEY_PATTERN =
+  /^(secret|token|password|authorization|api[_-]?key|cookie|credential|private[_-]?key|pat|github_pat|github_token)$/i;
+
+export const HUGE_BODY_KEYS = new Set([
+  "diff",
+  "patch",
+  "files",
+  "raw",
+  "diff_hunk",
+  "patch_text",
+]);
+
+export const FORBIDDEN_OUTPUT_SUBSTRINGS = [
+  "DIFF_BODY_MUST_NOT_LEAK",
+];

--- a/control-center/domains/engineering/src/errors.ts
+++ b/control-center/domains/engineering/src/errors.ts
@@ -1,0 +1,22 @@
+export const ENGINEERING_ERROR_CODES = [
+  "missing_provenance",
+  "invalid_input",
+  "invalid_scope",
+  "unusable_observation",
+] as const;
+
+export type EngineeringErrorCode = (typeof ENGINEERING_ERROR_CODES)[number];
+
+export class EngineeringError extends Error {
+  readonly code: EngineeringErrorCode;
+
+  constructor(code: EngineeringErrorCode, message: string) {
+    super(message);
+    this.name = "EngineeringError";
+    this.code = code;
+  }
+}
+
+export function isEngineeringError(value: unknown): value is EngineeringError {
+  return value instanceof EngineeringError;
+}

--- a/control-center/domains/engineering/src/ids.ts
+++ b/control-center/domains/engineering/src/ids.ts
@@ -1,0 +1,52 @@
+import { RESOURCE_ID_PATTERN } from "./constants.js";
+
+export function slugPart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[/]/g, "--")
+    .replace(/[^a-z0-9._~-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 96);
+}
+
+export function resourceId(type: string, slug: string): string {
+  const id = `cc:${type}:${slugPart(slug)}`;
+  if (!RESOURCE_ID_PATTERN.test(id)) {
+    return `cc:${type}:generated`;
+  }
+  return id;
+}
+
+export function repoExecutiveId(fullName: string): string {
+  return resourceId("engineering-snapshot", `github-${fullName}`);
+}
+
+export function companyExecutiveId(): string {
+  return resourceId("engineering-snapshot", "company");
+}
+
+export function attentionId(reason: string, fullName: string, extra: string): string {
+  return resourceId("attention-item", `${reason}-${fullName}-${extra}`);
+}
+
+export function repoScope(fullName: string): string {
+  return `repo:${fullName}`;
+}
+
+export function parseRepoScope(scope: string): string | null {
+  const trimmed = scope.trim();
+  if (trimmed.startsWith("repo:")) {
+    const name = trimmed.slice("repo:".length).trim();
+    return name.length > 0 ? name : null;
+  }
+  if (/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(trimmed)) {
+    return trimmed;
+  }
+  return null;
+}
+
+export function isCompanyScope(scope: string): boolean {
+  return scope === "company" || scope === "infrastructure";
+}

--- a/control-center/domains/engineering/src/index.ts
+++ b/control-center/domains/engineering/src/index.ts
@@ -1,0 +1,42 @@
+export {
+  assembleCollectorSnapshots,
+  parseCollectorSnapshot,
+} from "./adapter.js";
+export { listAttentionCandidates, rankAttentionCandidates } from "./attention.js";
+export { DEFAULT_POLICY, nowFromEnv, policyFromEnv, resolvePolicy } from "./policy.js";
+export {
+  applyFreshnessWindow,
+  buildProvenance,
+  confidenceFor,
+  mapCollectorFreshness,
+} from "./provenance.js";
+export {
+  serializeReadModel,
+  serializeReadModelPretty,
+  canonicalize,
+} from "./serialize.js";
+export { InMemoryEngineeringStore, ingestCollectorSnapshot } from "./store.js";
+export {
+  buildCompanyEngineeringReadModel,
+  readByScope,
+} from "./transform.js";
+export { EngineeringError, isEngineeringError } from "./errors.js";
+export {
+  COLLECTOR_ENGINEERING_SNAPSHOT_SCHEMA,
+  CANONICAL_ENGINEERING_SNAPSHOT_SCHEMA,
+  HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE,
+  HYPOTHESIS_CODE,
+  COMPANY_EXECUTIVE_SCHEMA,
+  REPO_EXECUTIVE_SCHEMA,
+} from "./constants.js";
+export { silentLogger, createLogger } from "./log.js";
+export type {
+  AttentionCandidate,
+  CompanyEngineeringReadModel,
+  CollectorEngineeringSnapshot,
+  RepoExecutiveView,
+  TransformOptions,
+  Provenance,
+  Blocker,
+  CanonicalEngineeringSnapshot,
+} from "./types.js";

--- a/control-center/domains/engineering/src/log.ts
+++ b/control-center/domains/engineering/src/log.ts
@@ -1,0 +1,55 @@
+import { SECRET_KEY_PATTERN } from "./constants.js";
+
+export type StructuredLogger = (
+  event: string,
+  fields: Record<string, unknown>,
+) => void;
+
+function redact(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value
+      .replace(/ghp_[A-Za-z0-9_]{20,}/g, "[redacted]")
+      .replace(/github_pat_[A-Za-z0-9_]{20,}/g, "[redacted]");
+  }
+  if (Array.isArray(value)) {
+    return value.map(redact);
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, inner] of Object.entries(value)) {
+      if (SECRET_KEY_PATTERN.test(key)) {
+        out[key] = "[redacted]";
+      } else {
+        out[key] = redact(inner);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+export function createLogger(
+  sink: (line: string) => void = (line) => {
+    process.stderr.write(`${line}\n`);
+  },
+  now: () => Date = () => new Date(),
+): StructuredLogger {
+  return (event, fields) => {
+    const redacted = redact(fields);
+    const payload =
+      redacted !== null && typeof redacted === "object" && !Array.isArray(redacted)
+        ? (redacted as Record<string, unknown>)
+        : { fields: redacted };
+    sink(
+      JSON.stringify({
+        ts: now().toISOString(),
+        event,
+        ...payload,
+      }),
+    );
+  };
+}
+
+export function silentLogger(): StructuredLogger {
+  return () => undefined;
+}

--- a/control-center/domains/engineering/src/policy.ts
+++ b/control-center/domains/engineering/src/policy.ts
@@ -1,0 +1,65 @@
+import {
+  DEFAULT_FRESHNESS_WINDOW_SECONDS,
+  DEFAULT_PR_STALE_AFTER_SECONDS,
+} from "./constants.js";
+
+export type EngineeringPolicy = {
+  prStaleAfterSeconds: number;
+  freshnessWindowSeconds: number;
+};
+
+export const DEFAULT_POLICY: EngineeringPolicy = {
+  prStaleAfterSeconds: DEFAULT_PR_STALE_AFTER_SECONDS,
+  freshnessWindowSeconds: DEFAULT_FRESHNESS_WINDOW_SECONDS,
+};
+
+export function resolvePolicy(overrides?: Partial<EngineeringPolicy>): EngineeringPolicy {
+  return {
+    prStaleAfterSeconds:
+      overrides?.prStaleAfterSeconds ?? DEFAULT_POLICY.prStaleAfterSeconds,
+    freshnessWindowSeconds:
+      overrides?.freshnessWindowSeconds ?? DEFAULT_POLICY.freshnessWindowSeconds,
+  };
+}
+
+function readPositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Env vars carry thresholds only. No tokens, PATs, or identity.
+ * CC_ENGINEERING_NOW is a replay clock (UTC Z), not a secret.
+ */
+export function policyFromEnv(
+  env: NodeJS.Dict<string> = process.env,
+): EngineeringPolicy {
+  return {
+    prStaleAfterSeconds: readPositiveInt(
+      env.CC_ENGINEERING_PR_STALE_AFTER_SECONDS,
+      DEFAULT_POLICY.prStaleAfterSeconds,
+    ),
+    freshnessWindowSeconds: readPositiveInt(
+      env.CC_ENGINEERING_FRESHNESS_WINDOW_SECONDS,
+      DEFAULT_POLICY.freshnessWindowSeconds,
+    ),
+  };
+}
+
+export function nowFromEnv(env: NodeJS.Dict<string> = process.env): Date | undefined {
+  const raw = env.CC_ENGINEERING_NOW;
+  if (!raw || raw.trim() === "") {
+    return undefined;
+  }
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date;
+}

--- a/control-center/domains/engineering/src/provenance.ts
+++ b/control-center/domains/engineering/src/provenance.ts
@@ -1,0 +1,105 @@
+import {
+  type CanonicalFreshness,
+  type CollectorFreshness,
+  type Provenance,
+  type SourceRef,
+} from "./types.js";
+import { ageSeconds, parseUtc, toUtcIso } from "./clock.js";
+import { SOURCE_SYSTEM_GITHUB } from "./constants.js";
+
+export function mapCollectorFreshness(status: CollectorFreshness): CanonicalFreshness {
+  switch (status) {
+    case "fresh":
+    case "not_modified":
+      return "FRESH";
+    case "stale":
+      return "STALE";
+    case "failed":
+      return "ERROR";
+    case "unsupported":
+      return "UNKNOWN";
+  }
+}
+
+export function applyFreshnessWindow(
+  status: CanonicalFreshness,
+  observedAt: string,
+  now: Date,
+  windowSeconds: number,
+): CanonicalFreshness {
+  if (status === "ERROR" || status === "UNKNOWN") {
+    return status;
+  }
+  const age = ageSeconds(observedAt, now);
+  if (age !== null && age > windowSeconds) {
+    return "STALE";
+  }
+  return status;
+}
+
+export function confidenceFor(
+  status: CanonicalFreshness,
+  collectorConfidence: number | undefined,
+): number {
+  if (
+    typeof collectorConfidence === "number" &&
+    collectorConfidence >= 0 &&
+    collectorConfidence <= 1
+  ) {
+    return collectorConfidence;
+  }
+  switch (status) {
+    case "FRESH":
+      return 1;
+    case "STALE":
+      return 0.4;
+    case "UNKNOWN":
+      return 0.2;
+    case "ERROR":
+      return 0;
+  }
+}
+
+export function githubSource(
+  kind: string,
+  locator: string,
+  label?: string,
+): SourceRef {
+  const ref: SourceRef = {
+    system: SOURCE_SYSTEM_GITHUB,
+    kind,
+    locator: locator.slice(0, 512),
+  };
+  if (label && label.trim().length > 0) {
+    ref.label = label.trim().slice(0, 128);
+  }
+  return ref;
+}
+
+export function buildProvenance(input: {
+  source: SourceRef;
+  observedAt: string;
+  collectorFreshness: CollectorFreshness;
+  collectorConfidence: number | undefined;
+  now: Date;
+  freshnessWindowSeconds: number;
+}): Provenance {
+  parseUtc(input.observedAt);
+  const mapped = applyFreshnessWindow(
+    mapCollectorFreshness(input.collectorFreshness),
+    input.observedAt,
+    input.now,
+    input.freshnessWindowSeconds,
+  );
+  return {
+    source: input.source,
+    observed_at: toUtcIso(parseUtc(input.observedAt)),
+    freshness_status: mapped,
+    confidence: confidenceFor(mapped, input.collectorConfidence),
+    freshness_window_seconds: input.freshnessWindowSeconds,
+  };
+}
+
+export function isUsableFreshness(status: CanonicalFreshness): boolean {
+  return status === "FRESH" || status === "STALE";
+}

--- a/control-center/domains/engineering/src/serialize.ts
+++ b/control-center/domains/engineering/src/serialize.ts
@@ -1,0 +1,45 @@
+import { HUGE_BODY_KEYS, SECRET_KEY_PATTERN } from "./constants.js";
+
+export function canonicalize(value: unknown): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+  if (typeof value === "object") {
+    const rec = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(rec).sort()) {
+      if (SECRET_KEY_PATTERN.test(key) || HUGE_BODY_KEYS.has(key)) {
+        continue;
+      }
+      const inner = canonicalize(rec[key]);
+      if (inner !== undefined) {
+        out[key] = inner;
+      }
+    }
+    return out;
+  }
+  return String(value);
+}
+
+export function serializeReadModel(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function serializeReadModelPretty(value: unknown): string {
+  return `${JSON.stringify(canonicalize(value), null, 2)}\n`;
+}
+
+export function serializedContainsSecretKey(serialized: string): boolean {
+  return /"(secret|token|password|authorization|api[_-]?key|cookie|credential|private[_-]?key|pat|github_pat|github_token)"\s*:/i.test(
+    serialized,
+  );
+}

--- a/control-center/domains/engineering/src/store.ts
+++ b/control-center/domains/engineering/src/store.ts
@@ -1,0 +1,60 @@
+import { isCompanyScope } from "./ids.js";
+import {
+  buildCompanyEngineeringReadModel,
+  readByScope,
+} from "./transform.js";
+import type {
+  AttentionCandidate,
+  CompanyEngineeringReadModel,
+  RepoExecutiveView,
+  TransformOptions,
+} from "./types.js";
+
+/**
+ * In-process store. Query operations a later Postgres consumer must match:
+ * - ingest(collectorSnapshot)
+ * - getCompany()
+ * - getRepo(scope)
+ * - listAttention(scope?)
+ */
+export class InMemoryEngineeringStore {
+  private model: CompanyEngineeringReadModel | null = null;
+
+  ingest(
+    input: unknown,
+    options?: TransformOptions,
+  ): CompanyEngineeringReadModel {
+    this.model = buildCompanyEngineeringReadModel(input, options);
+    return this.model;
+  }
+
+  getCompany(): CompanyEngineeringReadModel | null {
+    return this.model;
+  }
+
+  getRepo(scope: string): RepoExecutiveView | null {
+    if (!this.model) {
+      return null;
+    }
+    const read = readByScope(this.model, scope);
+    return read.kind === "repo" ? read.value : null;
+  }
+
+  listAttention(scope?: string): AttentionCandidate[] {
+    if (!this.model) {
+      return [];
+    }
+    if (!scope || isCompanyScope(scope)) {
+      return this.model.attention;
+    }
+    const repo = this.getRepo(scope);
+    return repo?.attention ?? [];
+  }
+}
+
+export function ingestCollectorSnapshot(
+  input: unknown,
+  options?: TransformOptions,
+): CompanyEngineeringReadModel {
+  return buildCompanyEngineeringReadModel(input, options);
+}

--- a/control-center/domains/engineering/src/transform.ts
+++ b/control-center/domains/engineering/src/transform.ts
@@ -1,0 +1,805 @@
+import { parseCollectorSnapshot } from "./adapter.js";
+import { attentionHeadline, rankAttentionCandidates } from "./attention.js";
+import { ageSeconds, maxTimestamp, parseUtc, toUtcIso } from "./clock.js";
+import {
+  ATTENTION_ITEM_SCHEMA,
+  CANONICAL_ENGINEERING_SNAPSHOT_SCHEMA,
+  COMPANY_EXECUTIVE_SCHEMA,
+  HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE,
+  HYPOTHESIS_CODE,
+  REPO_EXECUTIVE_SCHEMA,
+  SOURCE_SYSTEM_GITHUB,
+  SYSTEM_ACTOR_ID,
+  TITLE_MAX,
+} from "./constants.js";
+import {
+  attentionId,
+  companyExecutiveId,
+  isCompanyScope,
+  parseRepoScope,
+  repoExecutiveId,
+  repoScope,
+} from "./ids.js";
+import { resolvePolicy } from "./policy.js";
+import { buildProvenance, githubSource, isUsableFreshness } from "./provenance.js";
+import type {
+  Aging,
+  AttentionCandidate,
+  Blocker,
+  BrokenCheckRef,
+  CanonicalEngineeringSnapshot,
+  CollectorCheckFailure,
+  CollectorEngineeringSnapshot,
+  CollectorIssue,
+  CollectorPullRequest,
+  CollectorRepoSnapshot,
+  CompanyAggregates,
+  CompanyEngineeringReadModel,
+  LastActivity,
+  LinkRef,
+  OpenPrRef,
+  PriorityIssueRef,
+  Provenance,
+  RepoAttentionSummary,
+  RepoExecutiveView,
+  RepoIdentityView,
+  ScopedRead,
+  StructuredClaim,
+  TransformOptions,
+} from "./types.js";
+
+function clip(value: string, max: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function safeUrl(url: string | null | undefined, fallback: string): string {
+  if (!url) return fallback;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return fallback;
+    }
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return fallback;
+  }
+}
+
+function splitFullName(fullName: string): { owner: string; name: string; full_name: string } {
+  const match = /^([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)$/.exec(fullName.trim());
+  if (match?.[1] && match[2]) {
+    return { owner: match[1], name: match[2], full_name: `${match[1]}/${match[2]}` };
+  }
+  return { owner: "unknown", name: fullName.trim(), full_name: fullName.trim() };
+}
+
+function githubRepoUrl(fullName: string): string {
+  return `https://github.com/${fullName}`;
+}
+
+function resolveRepoIdentity(
+  repoSnap: CollectorRepoSnapshot,
+  snapshot: CollectorEngineeringSnapshot,
+  index: number,
+): RepoIdentityView {
+  if (repoSnap.repo) {
+    return {
+      owner: repoSnap.repo.owner,
+      name: repoSnap.repo.name,
+      full_name: repoSnap.repo.full_name,
+      html_url: safeUrl(repoSnap.repo.html_url, githubRepoUrl(repoSnap.repo.full_name)),
+      default_branch: repoSnap.repo.default_branch,
+    };
+  }
+  const fromError = repoSnap.errors.find((err) => err.repo)?.repo;
+  const fromAllow = snapshot.allowlist[index];
+  const fullName = fromError ?? fromAllow ?? "unknown/unknown";
+  const parts = splitFullName(fullName);
+  return {
+    owner: parts.owner,
+    name: parts.name,
+    full_name: parts.full_name,
+    html_url: githubRepoUrl(parts.full_name),
+    default_branch: null,
+  };
+}
+
+function repoCollectorFreshness(repoSnap: CollectorRepoSnapshot): {
+  usable: boolean;
+  freshness: import("./types.js").CollectorFreshness;
+  observedAt: string;
+  confidence: number | undefined;
+} {
+  if (!repoSnap.repo || repoSnap.repo_collection.ok === false) {
+    const err = repoSnap.errors[0];
+    const collection = repoSnap.repo_collection;
+    const freshness =
+      collection.ok === false
+        ? collection.freshness_status
+        : (err?.freshness_status ?? "failed");
+    return {
+      usable: false,
+      freshness,
+      observedAt: repoSnap.repo?.observed_at ?? err?.observed_at ?? "",
+      confidence: repoSnap.repo?.confidence ?? err?.confidence,
+    };
+  }
+  const mapped = buildProvenance({
+    source: githubSource("repo", repoSnap.repo.full_name),
+    observedAt: repoSnap.repo.observed_at,
+    collectorFreshness: repoSnap.repo.freshness_status,
+    collectorConfidence: repoSnap.repo.confidence,
+    now: parseUtc(repoSnap.repo.observed_at),
+    freshnessWindowSeconds: Number.MAX_SAFE_INTEGER,
+  }).freshness_status;
+  return {
+    usable: isUsableFreshness(mapped),
+    freshness: repoSnap.repo.freshness_status,
+    observedAt: repoSnap.repo.observed_at,
+    confidence: repoSnap.repo.confidence,
+  };
+}
+
+function itemProvenance(
+  item: {
+    source: string;
+    observed_at: string;
+    freshness_status: import("./types.js").CollectorFreshness;
+    confidence?: number;
+  },
+  source: Provenance["source"],
+  now: Date,
+  freshnessWindowSeconds: number,
+): Provenance {
+  return buildProvenance({
+    source,
+    observedAt: item.observed_at,
+    collectorFreshness: item.freshness_status,
+    collectorConfidence: item.confidence,
+    now,
+    freshnessWindowSeconds,
+  });
+}
+
+function linkRef(
+  kind: string,
+  locator: string,
+  htmlUrl: string,
+  label: string,
+): LinkRef {
+  return {
+    system: SOURCE_SYSTEM_GITHUB,
+    kind,
+    locator: locator.slice(0, 512),
+    html_url: htmlUrl,
+    label: clip(label, 128),
+  };
+}
+
+function classifyIssuePriority(issue: CollectorIssue): "P0" | "P1" | null {
+  const token = (issue.priority ?? "").trim().toLowerCase();
+  if (token === "p0" || token === "critical" || token === "urgent") {
+    return "P0";
+  }
+  if (token === "p1" || token === "high") {
+    return "P1";
+  }
+  for (const label of issue.labels) {
+    const name = label.trim().toLowerCase();
+    if (
+      name === "p0" ||
+      name === "priority:p0" ||
+      name === "priority-p0" ||
+      name === "critical" ||
+      name === "urgent"
+    ) {
+      return "P0";
+    }
+    if (name === "p1" || name === "priority:p1" || name === "priority-p1" || name === "high") {
+      return "P1";
+    }
+  }
+  return null;
+}
+
+function isFailingCheckStatus(status: string): boolean {
+  const normalized = status.trim().toLowerCase();
+  return (
+    normalized === "failure" ||
+    normalized === "error" ||
+    normalized === "cancelled" ||
+    normalized === "timed_out" ||
+    normalized === "action_required"
+  );
+}
+
+function daysLabel(age: number): string {
+  const days = Math.floor(age / 86400);
+  if (days <= 0) {
+    const hours = Math.max(1, Math.floor(age / 3600));
+    return `${hours}h`;
+  }
+  return `${days}d`;
+}
+
+function lastActivityOf(
+  repoSnap: CollectorRepoSnapshot,
+  now: Date,
+): LastActivity | null {
+  const candidates: Array<{ at: string; source_kind: LastActivity["source_kind"] }> = [];
+  const identity = repoSnap.repo;
+  if (identity?.last_activity_at) {
+    candidates.push({ at: identity.last_activity_at, source_kind: "repo" });
+  }
+  if (identity?.pushed_at) {
+    candidates.push({ at: identity.pushed_at, source_kind: "repo" });
+  }
+  for (const commit of repoSnap.recent_commits) {
+    if (commit.committed_at) {
+      candidates.push({ at: commit.committed_at, source_kind: "commit" });
+    }
+  }
+  for (const pr of repoSnap.open_pull_requests) {
+    candidates.push({ at: pr.updated_at ?? pr.created_at, source_kind: "pull_request" });
+  }
+  for (const issue of repoSnap.open_issues) {
+    const at = issue.updated_at ?? issue.created_at;
+    if (at) {
+      candidates.push({ at, source_kind: "issue" });
+    }
+  }
+  const latest = maxTimestamp(candidates.map((item) => item.at));
+  if (!latest) {
+    return null;
+  }
+  const source = candidates.find((item) => {
+    const iso = new Date(item.at).toISOString();
+    return iso === latest || item.at === latest;
+  });
+  const age = ageSeconds(latest, now);
+  if (age === null) {
+    return null;
+  }
+  return {
+    at: latest,
+    age_seconds: age,
+    source_kind: source?.source_kind ?? "repo",
+  };
+}
+
+function blockerToAttention(
+  blocker: Blocker,
+  repoFullName: string,
+  extra: string,
+  detectedAt: string,
+): AttentionCandidate {
+  const severity =
+    blocker.kind === "p0_issue"
+      ? "critical"
+      : blocker.kind === "ci_red" || blocker.kind === "p1_issue"
+        ? "high"
+        : "medium";
+  const recommended =
+    blocker.kind === "stale_pr"
+      ? "Review or close the stale pull request."
+      : blocker.kind === "ci_red"
+        ? "Inspect the failing check and restore a green pipeline."
+        : blocker.kind === "p0_issue"
+          ? "Triage the P0 issue now."
+          : blocker.kind === "p1_issue"
+            ? "Triage the P1 issue today."
+            : "Restore GitHub collector visibility for this repository; do not treat silence as a fact.";
+  return {
+    schema_version: ATTENTION_ITEM_SCHEMA,
+    id: attentionId(blocker.kind, repoFullName, extra),
+    scope: repoScope(repoFullName),
+    repo: repoFullName,
+    severity,
+    status: "open",
+    title: clip(blocker.title, TITLE_MAX),
+    summary: clip(blocker.reason, 2000),
+    reason_code: blocker.kind,
+    claim_kind: blocker.claim_kind,
+    reference: blocker.reference,
+    provenance: blocker.provenance,
+    detected_at: detectedAt,
+    homepage_eligible: true,
+    recommended_action: recommended,
+  };
+}
+
+function unknownRepoView(input: {
+  identity: RepoIdentityView;
+  snapshot: CollectorEngineeringSnapshot;
+  repoSnap: CollectorRepoSnapshot;
+  now: Date;
+  generatedAt: string;
+  freshnessWindowSeconds: number;
+  collectorFreshness: import("./types.js").CollectorFreshness;
+  observedAt: string;
+  confidence: number | undefined;
+}): RepoExecutiveView {
+  const observedAt = input.observedAt || input.snapshot.observed_at;
+  const provenance = buildProvenance({
+    source: githubSource("repo", input.identity.full_name, input.identity.full_name),
+    observedAt,
+    collectorFreshness: input.collectorFreshness,
+    collectorConfidence: input.confidence,
+    now: input.now,
+    freshnessWindowSeconds: input.freshnessWindowSeconds,
+  });
+  const reference = linkRef(
+    "repo",
+    input.identity.full_name,
+    input.identity.html_url,
+    input.identity.full_name,
+  );
+  const title = HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE;
+  const reason = `Collector observation for ${input.identity.full_name} is unusable (${provenance.freshness_status}). ${HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE} — hypothesis only, not a fact.`;
+  const blocker: Blocker = {
+    kind: "unknown_quiet",
+    claim_kind: "hypothesis",
+    title,
+    reason,
+    reference,
+    provenance,
+  };
+  const claim: StructuredClaim = {
+    kind: "hypothesis",
+    code: HYPOTHESIS_CODE,
+    title,
+    body: reason,
+    scope: repoScope(input.identity.full_name),
+    status: "active",
+    effective_from: input.generatedAt,
+    expires_at: null,
+    supersedes: null,
+    created_by: { kind: "system", id: SYSTEM_ACTOR_ID },
+  };
+  const aging: Aging = {
+    last_activity_age_seconds: null,
+    oldest_open_pr_age_seconds: null,
+    stale_pr_count: 0,
+    oldest_p0_p1_age_seconds: null,
+  };
+  const attention = [
+    blockerToAttention(blocker, input.identity.full_name, "repo", input.generatedAt),
+  ];
+  return {
+    schema_version: REPO_EXECUTIVE_SCHEMA,
+    id: repoExecutiveId(input.identity.full_name),
+    scope: repoScope(input.identity.full_name),
+    generated_at: input.generatedAt,
+    provenance,
+    repo: input.identity,
+    health: "unknown",
+    blockers: [blocker],
+    open_prs: [],
+    broken_checks: [],
+    p0_p1_issues: [],
+    last_activity: null,
+    aging,
+    claims: [claim],
+    attention,
+  };
+}
+
+function mapOpenPr(
+  pr: CollectorPullRequest,
+  now: Date,
+  staleAfter: number,
+  freshnessWindowSeconds: number,
+): OpenPrRef {
+  const age = pr.age_seconds >= 0 ? pr.age_seconds : (ageSeconds(pr.created_at, now) ?? 0);
+  const htmlUrl = safeUrl(pr.html_url, githubRepoUrl(pr.repo) + `/pull/${pr.number}`);
+  return {
+    number: pr.number,
+    title: clip(pr.title, TITLE_MAX),
+    html_url: htmlUrl,
+    draft: pr.draft,
+    created_at: pr.created_at,
+    updated_at: pr.updated_at,
+    age_seconds: age,
+    stale: age >= staleAfter,
+    review_status: pr.review_status,
+    check_status: pr.check_status,
+    head_ref: pr.head_ref,
+    base_ref: pr.base_ref,
+    provenance: itemProvenance(
+      pr,
+      githubSource("pull_request", `${pr.repo}/pull/${pr.number}`, `#${pr.number}`),
+      now,
+      freshnessWindowSeconds,
+    ),
+  };
+}
+
+function mapCheck(
+  check: CollectorCheckFailure,
+  now: Date,
+  freshnessWindowSeconds: number,
+): BrokenCheckRef {
+  const fallback = `${githubRepoUrl(check.repo)}/actions`;
+  return {
+    name: clip(check.name, TITLE_MAX),
+    kind: check.kind,
+    conclusion: check.conclusion,
+    html_url: safeUrl(check.html_url, fallback),
+    remote_id: check.remote_id,
+    head_sha: check.head_sha,
+    provenance: itemProvenance(
+      check,
+      githubSource(check.kind, `${check.repo}/checks/${check.remote_id}`, check.name),
+      now,
+      freshnessWindowSeconds,
+    ),
+  };
+}
+
+function mapPriorityIssue(
+  issue: CollectorIssue,
+  priority: "P0" | "P1",
+  now: Date,
+  freshnessWindowSeconds: number,
+): PriorityIssueRef {
+  const htmlUrl = safeUrl(issue.html_url, `${githubRepoUrl(issue.repo)}/issues/${issue.number}`);
+  return {
+    number: issue.number,
+    title: clip(issue.title, TITLE_MAX),
+    html_url: htmlUrl,
+    priority,
+    labels: [...issue.labels],
+    created_at: issue.created_at,
+    updated_at: issue.updated_at,
+    age_seconds: ageSeconds(issue.created_at, now),
+    provenance: itemProvenance(
+      issue,
+      githubSource("issue", `${issue.repo}/issues/${issue.number}`, `#${issue.number}`),
+      now,
+      freshnessWindowSeconds,
+    ),
+  };
+}
+
+function buildUsableRepo(input: {
+  identity: RepoIdentityView;
+  repoSnap: CollectorRepoSnapshot;
+  now: Date;
+  generatedAt: string;
+  staleAfter: number;
+  freshnessWindowSeconds: number;
+  collectorFreshness: import("./types.js").CollectorFreshness;
+  observedAt: string;
+  confidence: number | undefined;
+}): RepoExecutiveView {
+  const provenance = buildProvenance({
+    source: githubSource("repo", input.identity.full_name, input.identity.full_name),
+    observedAt: input.observedAt,
+    collectorFreshness: input.collectorFreshness,
+    collectorConfidence: input.confidence,
+    now: input.now,
+    freshnessWindowSeconds: input.freshnessWindowSeconds,
+  });
+
+  const openPrs = input.repoSnap.open_pull_requests
+    .map((pr) => mapOpenPr(pr, input.now, input.staleAfter, input.freshnessWindowSeconds))
+    .sort((a, b) => a.number - b.number);
+
+  const fromFailures = [
+    ...input.repoSnap.check_failures,
+    ...input.repoSnap.workflow_failures,
+  ].map((check) => mapCheck(check, input.now, input.freshnessWindowSeconds));
+
+  const brokenByUrl = new Set(fromFailures.map((item) => item.html_url));
+  const fromPrs: BrokenCheckRef[] = [];
+  if (fromFailures.length === 0) {
+    for (const pr of openPrs) {
+      if (!isFailingCheckStatus(pr.check_status)) continue;
+      if (brokenByUrl.has(pr.html_url)) continue;
+      fromPrs.push({
+        name: `pr-${pr.number}-checks`,
+        kind: "pull_request_check",
+        conclusion: pr.check_status,
+        html_url: pr.html_url,
+        remote_id: pr.number,
+        head_sha: null,
+        provenance: pr.provenance,
+      });
+    }
+  }
+  const brokenChecks = [...fromFailures, ...fromPrs].sort((a, b) => a.name.localeCompare(b.name));
+
+  const p0p1 = input.repoSnap.open_issues
+    .map((issue) => {
+      const priority = classifyIssuePriority(issue);
+      if (!priority) return null;
+      return mapPriorityIssue(issue, priority, input.now, input.freshnessWindowSeconds);
+    })
+    .filter((item): item is PriorityIssueRef => item !== null)
+    .sort((a, b) => a.number - b.number);
+
+  const lastActivity = lastActivityOf(input.repoSnap, input.now);
+  const stalePrs = openPrs.filter((pr) => pr.stale);
+  const oldestPrAge =
+    openPrs.length === 0
+      ? null
+      : Math.max(...openPrs.map((pr) => pr.age_seconds));
+  const oldestIssueAgeValues = p0p1
+    .map((issue) => issue.age_seconds)
+    .filter((age): age is number => age !== null);
+  const aging: Aging = {
+    last_activity_age_seconds: lastActivity?.age_seconds ?? null,
+    oldest_open_pr_age_seconds: oldestPrAge,
+    stale_pr_count: stalePrs.length,
+    oldest_p0_p1_age_seconds:
+      oldestIssueAgeValues.length === 0 ? null : Math.max(...oldestIssueAgeValues),
+  };
+
+  const blockers: Blocker[] = [];
+  const attention: AttentionCandidate[] = [];
+
+  for (const check of brokenChecks) {
+    const blocker: Blocker = {
+      kind: "ci_red",
+      claim_kind: "fact",
+      title: `CI red: ${check.name}`,
+      reason: `Broken check '${check.name}' on ${input.identity.full_name} (conclusion ${check.conclusion ?? "failure"}).`,
+      reference: linkRef(
+        check.kind,
+        `${input.identity.full_name}/checks/${check.remote_id ?? check.name}`,
+        check.html_url,
+        check.name,
+      ),
+      provenance: check.provenance,
+    };
+    blockers.push(blocker);
+    attention.push(
+      blockerToAttention(
+        blocker,
+        input.identity.full_name,
+        String(check.remote_id ?? check.name),
+        input.generatedAt,
+      ),
+    );
+  }
+
+  for (const issue of p0p1) {
+    const kind = issue.priority === "P0" ? "p0_issue" : "p1_issue";
+    const blocker: Blocker = {
+      kind,
+      claim_kind: "fact",
+      title: `${issue.priority} issue #${issue.number}`,
+      reason: `${issue.priority} issue #${issue.number} on ${input.identity.full_name}: ${issue.title}`,
+      reference: linkRef(
+        "issue",
+        `${input.identity.full_name}/issues/${issue.number}`,
+        issue.html_url,
+        `#${issue.number}`,
+      ),
+      provenance: issue.provenance,
+    };
+    blockers.push(blocker);
+    attention.push(
+      blockerToAttention(blocker, input.identity.full_name, String(issue.number), input.generatedAt),
+    );
+  }
+
+  for (const pr of stalePrs) {
+    const blocker: Blocker = {
+      kind: "stale_pr",
+      claim_kind: "fact",
+      title: `Stale PR #${pr.number}`,
+      reason: `Open PR #${pr.number} on ${input.identity.full_name} is stale (${daysLabel(pr.age_seconds)}).`,
+      reference: linkRef(
+        "pull_request",
+        `${input.identity.full_name}/pull/${pr.number}`,
+        pr.html_url,
+        `#${pr.number}`,
+      ),
+      provenance: pr.provenance,
+    };
+    blockers.push(blocker);
+    attention.push(
+      blockerToAttention(blocker, input.identity.full_name, String(pr.number), input.generatedAt),
+    );
+  }
+
+  const hasFactBlocker = blockers.some((item) => item.claim_kind === "fact");
+  const health = hasFactBlocker ? "degraded" : "healthy";
+
+  return {
+    schema_version: REPO_EXECUTIVE_SCHEMA,
+    id: repoExecutiveId(input.identity.full_name),
+    scope: repoScope(input.identity.full_name),
+    generated_at: input.generatedAt,
+    provenance,
+    repo: input.identity,
+    health,
+    blockers,
+    open_prs: openPrs,
+    broken_checks: brokenChecks,
+    p0_p1_issues: p0p1,
+    last_activity: lastActivity,
+    aging,
+    claims: [],
+    attention: rankAttentionCandidates(attention),
+  };
+}
+
+function buildRepoExecutive(
+  repoSnap: CollectorRepoSnapshot,
+  snapshot: CollectorEngineeringSnapshot,
+  now: Date,
+  policy: { prStaleAfterSeconds: number; freshnessWindowSeconds: number },
+  generatedAt: string,
+  index: number,
+): RepoExecutiveView {
+  const identity = resolveRepoIdentity(repoSnap, snapshot, index);
+  const usability = repoCollectorFreshness(repoSnap);
+  const observedAt = usability.observedAt || snapshot.observed_at;
+  if (!usability.usable) {
+    return unknownRepoView({
+      identity,
+      snapshot,
+      repoSnap,
+      now,
+      generatedAt,
+      freshnessWindowSeconds: policy.freshnessWindowSeconds,
+      collectorFreshness: usability.freshness,
+      observedAt,
+      confidence: usability.confidence,
+    });
+  }
+  return buildUsableRepo({
+    identity,
+    repoSnap,
+    now,
+    generatedAt,
+    staleAfter: policy.prStaleAfterSeconds,
+    freshnessWindowSeconds: policy.freshnessWindowSeconds,
+    collectorFreshness: usability.freshness,
+    observedAt,
+    confidence: usability.confidence,
+  });
+}
+
+function summarizeRepo(
+  repo: RepoExecutiveView,
+  claimKind: "fact" | "hypothesis",
+): RepoAttentionSummary {
+  const reasons = repo.blockers
+    .filter((blocker) => blocker.claim_kind === claimKind)
+    .map((blocker) => blocker.kind);
+  return {
+    full_name: repo.repo.full_name,
+    scope: repo.scope,
+    health: repo.health,
+    reasons,
+    claim_kind: claimKind,
+  };
+}
+
+function aggregatesOf(repos: readonly RepoExecutiveView[]): CompanyAggregates {
+  return {
+    repo_count: repos.length,
+    healthy_count: repos.filter((repo) => repo.health === "healthy").length,
+    degraded_count: repos.filter((repo) => repo.health === "degraded").length,
+    unknown_count: repos.filter((repo) => repo.health === "unknown").length,
+    open_pr_count: repos.reduce((sum, repo) => sum + repo.open_prs.length, 0),
+    stale_pr_count: repos.reduce((sum, repo) => sum + repo.aging.stale_pr_count, 0),
+    failing_check_count: repos.reduce((sum, repo) => sum + repo.broken_checks.length, 0),
+    p0_issue_count: repos.reduce(
+      (sum, repo) => sum + repo.p0_p1_issues.filter((issue) => issue.priority === "P0").length,
+      0,
+    ),
+    p1_issue_count: repos.reduce(
+      (sum, repo) => sum + repo.p0_p1_issues.filter((issue) => issue.priority === "P1").length,
+      0,
+    ),
+    fact_blocked_repo_count: repos.filter((repo) =>
+      repo.blockers.some((blocker) => blocker.claim_kind === "fact"),
+    ).length,
+    hypothesis_repo_count: repos.filter((repo) =>
+      repo.blockers.some((blocker) => blocker.claim_kind === "hypothesis"),
+    ).length,
+  };
+}
+
+function canonicalOf(
+  repos: readonly RepoExecutiveView[],
+  attention: readonly AttentionCandidate[],
+  generatedAt: string,
+  provenance: Provenance,
+  aggregates: CompanyAggregates,
+): CanonicalEngineeringSnapshot {
+  return {
+    schema_version: CANONICAL_ENGINEERING_SNAPSHOT_SCHEMA,
+    id: companyExecutiveId(),
+    scope: "company",
+    generated_at: generatedAt,
+    provenance,
+    open_pr_count: aggregates.open_pr_count,
+    failing_check_count: aggregates.failing_check_count,
+    open_incident_count:
+      aggregates.failing_check_count +
+      aggregates.p0_issue_count +
+      aggregates.p1_issue_count +
+      aggregates.stale_pr_count,
+    repo_scopes: repos.map((repo) => repo.scope).slice(0, 64),
+    attention_item_ids: attention.map((item) => item.id).slice(0, 32),
+  };
+}
+
+export function buildCompanyEngineeringReadModel(
+  input: unknown,
+  options?: TransformOptions,
+): CompanyEngineeringReadModel {
+  const snapshot = parseCollectorSnapshot(input);
+  const policy = resolvePolicy(options?.policy);
+  const now = options?.now ?? parseUtc(snapshot.observed_at);
+  const generatedAt = toUtcIso(now);
+
+  const repos = snapshot.repos
+    .map((repoSnap, index) =>
+      buildRepoExecutive(repoSnap, snapshot, now, policy, generatedAt, index),
+    )
+    .sort((a, b) => a.repo.full_name.localeCompare(b.repo.full_name));
+
+  const attention = rankAttentionCandidates(repos.flatMap((repo) => repo.attention));
+  const agg = aggregatesOf(repos);
+  const companyProvenance = buildProvenance({
+    source: githubSource("engineering_snapshot", snapshot.snapshot_id, "github-collector"),
+    observedAt: snapshot.observed_at,
+    collectorFreshness: snapshot.freshness_status,
+    collectorConfidence: snapshot.confidence,
+    now,
+    freshnessWindowSeconds: policy.freshnessWindowSeconds,
+  });
+
+  const blocked = repos
+    .filter((repo) => repo.blockers.some((blocker) => blocker.claim_kind === "fact"))
+    .map((repo) => summarizeRepo(repo, "fact"));
+  const hypotheses = repos
+    .filter((repo) => repo.blockers.some((blocker) => blocker.claim_kind === "hypothesis"))
+    .map((repo) => summarizeRepo(repo, "hypothesis"));
+
+  return {
+    schema_version: COMPANY_EXECUTIVE_SCHEMA,
+    id: companyExecutiveId(),
+    scope: "company",
+    generated_at: generatedAt,
+    provenance: companyProvenance,
+    repos,
+    aggregates: agg,
+    blocked_repos: blocked,
+    hypothesis_repos: hypotheses,
+    attention,
+    attention_headlines: attention.map(attentionHeadline),
+    canonical: canonicalOf(repos, attention, generatedAt, companyProvenance, agg),
+  };
+}
+
+export function readByScope(
+  model: CompanyEngineeringReadModel,
+  scope: string,
+): ScopedRead {
+  if (isCompanyScope(scope)) {
+    return { kind: "company", value: model };
+  }
+  const wanted = parseRepoScope(scope) ?? scope.replace(/^repo:/, "").trim();
+  const exact = model.repos.filter(
+    (repo) => repo.scope === scope || repo.repo.full_name === wanted,
+  );
+  if (exact.length === 1 && exact[0]) {
+    return { kind: "repo", value: exact[0] };
+  }
+  const short = model.repos.filter((repo) => repo.repo.name === wanted);
+  if (short.length === 1 && short[0]) {
+    return { kind: "repo", value: short[0] };
+  }
+  return { kind: "empty", scope };
+}

--- a/control-center/domains/engineering/src/types.ts
+++ b/control-center/domains/engineering/src/types.ts
@@ -1,0 +1,375 @@
+import type {
+  ATTENTION_SEVERITIES,
+  ATTENTION_STATUSES,
+  BLOCKER_KINDS,
+  CANONICAL_FRESHNESS,
+  CLAIM_KINDS,
+  COLLECTOR_FRESHNESS,
+  HEALTH_STATUSES,
+} from "./constants.js";
+import type { EngineeringPolicy } from "./policy.js";
+
+export type CollectorFreshness = (typeof COLLECTOR_FRESHNESS)[number];
+export type CanonicalFreshness = (typeof CANONICAL_FRESHNESS)[number];
+export type HealthStatus = (typeof HEALTH_STATUSES)[number];
+export type ClaimKind = (typeof CLAIM_KINDS)[number];
+export type AttentionSeverity = (typeof ATTENTION_SEVERITIES)[number];
+export type AttentionStatus = (typeof ATTENTION_STATUSES)[number];
+export type BlockerKind = (typeof BLOCKER_KINDS)[number];
+
+export type UtcDateTime = string;
+export type ResourceId = string;
+export type Scope = string;
+
+export type SourceRef = {
+  system: string;
+  kind: string;
+  locator: string;
+  label?: string;
+};
+
+export type Provenance = {
+  source: SourceRef;
+  observed_at: UtcDateTime;
+  freshness_status: CanonicalFreshness;
+  confidence: number;
+  freshness_window_seconds?: number;
+};
+
+export type LinkRef = {
+  system: string;
+  kind: string;
+  locator: string;
+  html_url: string;
+  label: string;
+};
+
+export type CollectorProvenance = {
+  source: string;
+  observed_at: string;
+  freshness_status: CollectorFreshness;
+  confidence?: number;
+};
+
+export type CollectorRepoIdentity = CollectorProvenance & {
+  observation_id: string;
+  owner: string;
+  name: string;
+  full_name: string;
+  default_branch: string;
+  html_url: string;
+  pushed_at: string | null;
+  updated_at: string | null;
+  last_activity_at: string | null;
+};
+
+export type CollectorCommit = CollectorProvenance & {
+  observation_id: string;
+  repo: string;
+  sha: string;
+  message: string;
+  committed_at: string | null;
+  author_login: string | null;
+};
+
+export type CollectorIssue = CollectorProvenance & {
+  observation_id: string;
+  repo: string;
+  number: number;
+  title: string;
+  state: string;
+  labels: string[];
+  priority: string | null;
+  html_url: string;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type CollectorPullRequest = CollectorProvenance & {
+  observation_id: string;
+  repo: string;
+  number: number;
+  title: string;
+  draft: boolean;
+  created_at: string;
+  age_seconds: number;
+  review_status: string;
+  check_status: string;
+  html_url: string;
+  updated_at: string | null;
+  head_sha: string | null;
+  head_ref: string | null;
+  base_ref: string | null;
+};
+
+export type CollectorCheckFailure = CollectorProvenance & {
+  observation_id: string;
+  repo: string;
+  kind: "check_run" | "workflow_run";
+  remote_id: number;
+  name: string;
+  conclusion: string | null;
+  html_url: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  head_sha: string | null;
+};
+
+export type CollectorSupportedDivergence = CollectorProvenance & {
+  observation_id: string;
+  repo: string;
+  base: string;
+  head: string;
+  support: "supported";
+  ahead_by: number;
+  behind_by: number;
+  status: string;
+};
+
+export type CollectorUnsupportedDivergence = CollectorProvenance & {
+  observation_id: string;
+  repo: string;
+  base: string | null;
+  head: string | null;
+  support: "unsupported" | "unavailable";
+  ahead_by: null;
+  behind_by: null;
+  status: "unsupported" | "unavailable";
+  reason: string;
+};
+
+export type CollectorDivergence =
+  | CollectorSupportedDivergence
+  | CollectorUnsupportedDivergence;
+
+export type CollectorError = CollectorProvenance & {
+  observation_id: string;
+  repo: string | null;
+  resource: string;
+  code: string;
+  message: string;
+  http_status: number | null;
+};
+
+export type CollectorOkCollection = {
+  ok: true;
+  freshness_status: "fresh" | "not_modified";
+};
+
+export type CollectorFailedCollection = {
+  ok: false;
+  freshness_status: "failed" | "stale";
+  error_observation_id: string;
+};
+
+export type CollectorSkippedCollection = {
+  skipped: true;
+};
+
+export type CollectorRepoCollection =
+  | CollectorOkCollection
+  | CollectorFailedCollection;
+
+export type CollectorIssuesCollection =
+  | CollectorOkCollection
+  | CollectorFailedCollection
+  | CollectorSkippedCollection;
+
+export type CollectorRepoSnapshot = {
+  repo: CollectorRepoIdentity | null;
+  repo_collection: CollectorRepoCollection;
+  issues_collection: CollectorIssuesCollection;
+  recent_commits: CollectorCommit[];
+  open_issues: CollectorIssue[];
+  open_pull_requests: CollectorPullRequest[];
+  check_failures: CollectorCheckFailure[];
+  workflow_failures: CollectorCheckFailure[];
+  divergence: CollectorDivergence;
+  errors: CollectorError[];
+};
+
+export type CollectorEngineeringSnapshot = CollectorProvenance & {
+  schema: typeof import("./constants.js").COLLECTOR_ENGINEERING_SNAPSHOT_SCHEMA;
+  snapshot_id: string;
+  collected_at: string;
+  allowlist: string[];
+  repos: CollectorRepoSnapshot[];
+  errors: CollectorError[];
+};
+
+export type OpenPrRef = {
+  number: number;
+  title: string;
+  html_url: string;
+  draft: boolean;
+  created_at: UtcDateTime;
+  updated_at: UtcDateTime | null;
+  age_seconds: number;
+  stale: boolean;
+  review_status: string;
+  check_status: string;
+  head_ref: string | null;
+  base_ref: string | null;
+  provenance: Provenance;
+};
+
+export type BrokenCheckRef = {
+  name: string;
+  kind: "check_run" | "workflow_run" | "pull_request_check";
+  conclusion: string | null;
+  html_url: string;
+  remote_id: number | null;
+  head_sha: string | null;
+  provenance: Provenance;
+};
+
+export type PriorityIssueRef = {
+  number: number;
+  title: string;
+  html_url: string;
+  priority: "P0" | "P1";
+  labels: string[];
+  created_at: UtcDateTime | null;
+  updated_at: UtcDateTime | null;
+  age_seconds: number | null;
+  provenance: Provenance;
+};
+
+export type LastActivity = {
+  at: UtcDateTime;
+  age_seconds: number;
+  source_kind: "repo" | "commit" | "pull_request" | "issue";
+};
+
+export type Aging = {
+  last_activity_age_seconds: number | null;
+  oldest_open_pr_age_seconds: number | null;
+  stale_pr_count: number;
+  oldest_p0_p1_age_seconds: number | null;
+};
+
+export type Blocker = {
+  kind: BlockerKind;
+  claim_kind: Extract<ClaimKind, "fact" | "hypothesis">;
+  title: string;
+  reason: string;
+  reference: LinkRef;
+  provenance: Provenance;
+};
+
+export type StructuredClaim = {
+  kind: Extract<ClaimKind, "fact" | "hypothesis">;
+  code: string;
+  title: string;
+  body: string;
+  scope: Scope;
+  status: "active";
+  effective_from: UtcDateTime;
+  expires_at: null;
+  supersedes: null;
+  created_by: { kind: "system"; id: string };
+};
+
+export type AttentionCandidate = {
+  schema_version: typeof import("./constants.js").ATTENTION_ITEM_SCHEMA;
+  id: ResourceId;
+  scope: Scope;
+  repo: string;
+  severity: AttentionSeverity;
+  status: AttentionStatus;
+  title: string;
+  summary: string;
+  reason_code: BlockerKind;
+  claim_kind: Extract<ClaimKind, "fact" | "hypothesis">;
+  reference: LinkRef;
+  provenance: Provenance;
+  detected_at: UtcDateTime;
+  homepage_eligible: boolean;
+  recommended_action: string;
+};
+
+export type RepoIdentityView = {
+  owner: string;
+  name: string;
+  full_name: string;
+  html_url: string;
+  default_branch: string | null;
+};
+
+export type RepoExecutiveView = {
+  schema_version: typeof import("./constants.js").REPO_EXECUTIVE_SCHEMA;
+  id: ResourceId;
+  scope: Scope;
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  repo: RepoIdentityView;
+  health: HealthStatus;
+  blockers: Blocker[];
+  open_prs: OpenPrRef[];
+  broken_checks: BrokenCheckRef[];
+  p0_p1_issues: PriorityIssueRef[];
+  last_activity: LastActivity | null;
+  aging: Aging;
+  claims: StructuredClaim[];
+  attention: AttentionCandidate[];
+};
+
+export type RepoAttentionSummary = {
+  full_name: string;
+  scope: Scope;
+  health: HealthStatus;
+  reasons: string[];
+  claim_kind: Extract<ClaimKind, "fact" | "hypothesis">;
+};
+
+export type CompanyAggregates = {
+  repo_count: number;
+  healthy_count: number;
+  degraded_count: number;
+  unknown_count: number;
+  open_pr_count: number;
+  stale_pr_count: number;
+  failing_check_count: number;
+  p0_issue_count: number;
+  p1_issue_count: number;
+  fact_blocked_repo_count: number;
+  hypothesis_repo_count: number;
+};
+
+export type CanonicalEngineeringSnapshot = {
+  schema_version: typeof import("./constants.js").CANONICAL_ENGINEERING_SNAPSHOT_SCHEMA;
+  id: ResourceId;
+  scope: Scope;
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  open_pr_count: number;
+  failing_check_count: number;
+  open_incident_count: number;
+  repo_scopes: Scope[];
+  attention_item_ids: ResourceId[];
+};
+
+export type CompanyEngineeringReadModel = {
+  schema_version: typeof import("./constants.js").COMPANY_EXECUTIVE_SCHEMA;
+  id: ResourceId;
+  scope: "company";
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  repos: RepoExecutiveView[];
+  aggregates: CompanyAggregates;
+  blocked_repos: RepoAttentionSummary[];
+  hypothesis_repos: RepoAttentionSummary[];
+  attention: AttentionCandidate[];
+  attention_headlines: string[];
+  canonical: CanonicalEngineeringSnapshot;
+};
+
+export type TransformOptions = {
+  now?: Date;
+  policy?: Partial<EngineeringPolicy>;
+};
+
+export type ScopedRead =
+  | { kind: "company"; value: CompanyEngineeringReadModel }
+  | { kind: "repo"; value: RepoExecutiveView }
+  | { kind: "empty"; scope: string };

--- a/control-center/domains/engineering/tests/adapter.test.ts
+++ b/control-center/domains/engineering/tests/adapter.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  assembleCollectorSnapshots,
+  EngineeringError,
+  parseCollectorSnapshot,
+} from "../src/index.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(root, "fixtures", name), "utf8"));
+}
+
+describe("collector snapshot adapter", () => {
+  it("accepts GitHub-collector-shaped fixtures", () => {
+    const parsed = parseCollectorSnapshot(loadFixture("pr-stale.json"));
+    assert.equal(parsed.schema, "confenge.control_center.engineering_snapshot.v1");
+    assert.equal(parsed.repos[0]?.repo?.full_name, "confenge/billing-api");
+    assert.equal("token" in parsed, false);
+    assert.equal("diff" in (parsed.repos[0]?.open_pull_requests[0] ?? {}), false);
+  });
+
+  it("rejects a snapshot missing provenance fail-closed", () => {
+    const raw = loadFixture("ci-red.json") as Record<string, unknown>;
+    delete raw.source;
+    assert.throws(
+      () => parseCollectorSnapshot(raw),
+      (error: unknown) =>
+        error instanceof EngineeringError && error.code === "missing_provenance",
+    );
+  });
+
+  it("rejects a nested observation missing observed_at", () => {
+    const raw = loadFixture("ci-red.json") as {
+      repos: Array<{ repo: Record<string, unknown> | null }>;
+    };
+    const identity = raw.repos[0]?.repo;
+    assert.ok(identity);
+    delete identity.observed_at;
+    assert.throws(
+      () => parseCollectorSnapshot(raw),
+      (error: unknown) =>
+        error instanceof EngineeringError &&
+        (error.code === "missing_provenance" || error.code === "invalid_input"),
+    );
+  });
+
+  it("assembles the four named fixtures into one collector snapshot", () => {
+    const assembled = assembleCollectorSnapshots([
+      loadFixture("pr-stale.json"),
+      loadFixture("ci-red.json"),
+      loadFixture("repo-quiet-saudavel.json"),
+      loadFixture("repo-quiet-desconhecido.json"),
+    ]);
+    assert.equal(assembled.repos.length, 4);
+    assert.equal(assembled.allowlist.length, 4);
+    assert.equal(assembled.freshness_status, "failed");
+  });
+});

--- a/control-center/domains/engineering/tests/executive-read-model.test.ts
+++ b/control-center/domains/engineering/tests/executive-read-model.test.ts
@@ -1,0 +1,305 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  assembleCollectorSnapshots,
+  buildCompanyEngineeringReadModel,
+  HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE,
+  ingestCollectorSnapshot,
+  InMemoryEngineeringStore,
+  parseCollectorSnapshot,
+  readByScope,
+  serializeReadModel,
+} from "../src/index.js";
+import type { CompanyEngineeringReadModel, RepoExecutiveView } from "../src/types.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(root, "fixtures", name), "utf8"));
+}
+
+function modelFrom(name: string): CompanyEngineeringReadModel {
+  return buildCompanyEngineeringReadModel(loadFixture(name), { now: NOW });
+}
+
+function onlyRepo(model: CompanyEngineeringReadModel): RepoExecutiveView {
+  assert.equal(model.repos.length, 1);
+  const repo = model.repos[0];
+  assert.ok(repo);
+  return repo;
+}
+
+function hasProvenance(item: {
+  provenance?: {
+    source?: { system?: string; kind?: string; locator?: string };
+    observed_at?: string;
+    freshness_status?: string;
+    confidence?: number;
+  };
+}): void {
+  const provenance = item.provenance;
+  assert.ok(provenance, "aggregated item is missing provenance");
+  assert.equal(typeof provenance.source?.system, "string");
+  assert.ok(provenance.source?.system);
+  assert.equal(typeof provenance.source.kind, "string");
+  assert.equal(typeof provenance.source.locator, "string");
+  assert.match(provenance.observed_at ?? "", /Z$/);
+  assert.match(provenance.freshness_status ?? "", /^(FRESH|STALE|UNKNOWN|ERROR)$/);
+  assert.equal(typeof provenance.confidence, "number");
+  const confidence = provenance.confidence ?? -1;
+  assert.ok(confidence >= 0 && confidence <= 1);
+}
+
+function assertNoSecretsOrDiffs(serialized: string): void {
+  assert.equal(serialized.includes("DIFF_BODY_MUST_NOT_LEAK"), false);
+  assert.equal(serialized.includes("ghp_"), false);
+  assert.equal(serialized.includes("THIS_MUST_NOT_LEAK"), false);
+  assert.equal(/"(token|pat|password|secret|authorization)"\s*:/i.test(serialized), false);
+}
+
+describe("PR stale fixture", () => {
+  it("surfaces an explainable stale PR attention candidate with provenance and a link, never a diff", () => {
+    const model = modelFrom("pr-stale.json");
+    const repo = onlyRepo(model);
+    assert.equal(repo.repo.full_name, "confenge/billing-api");
+    assert.ok(repo.open_prs.length >= 1);
+    const stale = repo.open_prs.find((pr) => pr.number === 42);
+    assert.ok(stale);
+    assert.equal(stale.stale, true);
+    assert.ok(stale.age_seconds >= 7 * 24 * 60 * 60);
+    assert.equal(repo.aging.stale_pr_count, 1);
+    assert.ok(repo.aging.oldest_open_pr_age_seconds !== null);
+    hasProvenance(stale);
+    assert.match(stale.html_url, /^https:\/\/github\.com\/confenge\/billing-api\/pull\/42$/);
+
+    const candidate = model.attention.find(
+      (item) => item.reason_code === "stale_pr" && item.repo === "confenge/billing-api",
+    );
+    assert.ok(candidate);
+    assert.equal(candidate.claim_kind, "fact");
+    assert.match(candidate.summary, /stale/i);
+    assert.equal(candidate.reference.html_url, stale.html_url);
+    hasProvenance(candidate);
+    assert.ok(model.blocked_repos.some((item) => item.full_name === "confenge/billing-api"));
+
+    const serialized = serializeReadModel(model);
+    assertNoSecretsOrDiffs(serialized);
+    assert.equal(serialized.includes("@@ -1,200"), false);
+  });
+});
+
+describe("CI red fixture", () => {
+  it("marks health not healthy and lists broken checks as blockers and attention", () => {
+    const model = modelFrom("ci-red.json");
+    const repo = onlyRepo(model);
+    assert.equal(repo.repo.full_name, "confenge/web-cfg");
+    assert.notEqual(repo.health, "healthy");
+    assert.ok(repo.broken_checks.length >= 1);
+    const ci = repo.broken_checks.find((check) => check.name.toLowerCase() === "ci");
+    assert.ok(ci);
+    assert.match(ci.html_url, /^https:\/\/github\.com\//);
+    hasProvenance(ci);
+
+    const blocker = repo.blockers.find((item) => item.kind === "ci_red");
+    assert.ok(blocker);
+    assert.equal(blocker.claim_kind, "fact");
+    assert.match(blocker.reference.html_url, /^https:\/\/github\.com\//);
+
+    const candidate = model.attention.find(
+      (item) => item.reason_code === "ci_red" && item.repo === "confenge/web-cfg",
+    );
+    assert.ok(candidate);
+    assert.match(candidate.summary, /check|CI|ci/i);
+    assert.ok(
+      model.attention_headlines.some(
+        (line) => line.includes("confenge/web-cfg") && /CI|ci/.test(line),
+      ),
+    );
+    hasProvenance(candidate);
+    assertNoSecretsOrDiffs(serializeReadModel(model));
+  });
+});
+
+describe("repo quiet saudável fixture", () => {
+  it("is not blocked and is not a fact 'trabalho ativo sem evidência recente'", () => {
+    const model = modelFrom("repo-quiet-saudavel.json");
+    const repo = onlyRepo(model);
+    assert.equal(repo.repo.full_name, "confenge/docs");
+    assert.equal(repo.health, "healthy");
+    assert.equal(repo.blockers.length, 0);
+    assert.ok(repo.last_activity);
+    assert.equal(typeof repo.last_activity.at, "string");
+    assert.equal(repo.p0_p1_issues.length, 0);
+    assert.equal(repo.broken_checks.length, 0);
+    assert.equal(repo.aging.stale_pr_count, 0);
+    assert.equal(model.blocked_repos.length, 0);
+    assert.equal(model.hypothesis_repos.length, 0);
+    assert.equal(
+      repo.claims.some((claim) => claim.kind === "fact" && claim.title === HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE),
+      false,
+    );
+    assert.equal(
+      model.attention.some(
+        (item) =>
+          item.claim_kind === "fact" && item.title.includes(HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE),
+      ),
+      false,
+    );
+    assert.equal(
+      JSON.stringify(model).includes(HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE),
+      false,
+    );
+    hasProvenance(repo);
+    assert.match(repo.provenance.freshness_status, /^(FRESH|STALE)$/);
+  });
+});
+
+describe("repo quiet desconhecido fixture", () => {
+  it("emits trabalho ativo sem evidência recente only as hypothesis and stays distinguishable", () => {
+    const model = modelFrom("repo-quiet-desconhecido.json");
+    const repo = onlyRepo(model);
+    assert.equal(repo.repo.full_name, "confenge/extra-cli");
+    assert.equal(repo.health, "unknown");
+    assert.match(repo.provenance.freshness_status, /^(UNKNOWN|ERROR)$/);
+    const hypothesis = repo.claims.find((claim) => claim.code === "active_work_without_recent_evidence");
+    assert.ok(hypothesis);
+    assert.equal(hypothesis.kind, "hypothesis");
+    assert.notEqual(hypothesis.kind, "fact");
+    assert.equal(hypothesis.title, HYPOTHESIS_ACTIVE_WORK_WITHOUT_EVIDENCE);
+    const blocker = repo.blockers.find((item) => item.kind === "unknown_quiet");
+    assert.ok(blocker);
+    assert.equal(blocker.claim_kind, "hypothesis");
+    const candidate = model.attention.find((item) => item.reason_code === "unknown_quiet");
+    assert.ok(candidate);
+    assert.equal(candidate.claim_kind, "hypothesis");
+    assert.notEqual(candidate.claim_kind, "fact");
+    assert.equal(
+      model.blocked_repos.some((item) => item.full_name === "confenge/extra-cli"),
+      false,
+    );
+    assert.ok(model.hypothesis_repos.some((item) => item.full_name === "confenge/extra-cli"));
+    hasProvenance(repo);
+    hasProvenance(candidate);
+  });
+});
+
+describe("company-wide aggregation and scoped reads", () => {
+  it("lists fact-blocked repos, keeps unknown as hypothesis, omits healthy-quiet, and scopes per repo", () => {
+    const assembled = assembleCollectorSnapshots([
+      loadFixture("pr-stale.json"),
+      loadFixture("ci-red.json"),
+      loadFixture("repo-quiet-saudavel.json"),
+      loadFixture("repo-quiet-desconhecido.json"),
+    ]);
+    const model = ingestCollectorSnapshot(assembled, { now: NOW });
+    const names = model.repos.map((repo) => repo.repo.full_name).sort();
+    assert.deepEqual(names, [
+      "confenge/billing-api",
+      "confenge/docs",
+      "confenge/extra-cli",
+      "confenge/web-cfg",
+    ]);
+
+    const blocked = model.blocked_repos.map((item) => item.full_name).sort();
+    assert.deepEqual(blocked, ["confenge/billing-api", "confenge/web-cfg"]);
+    assert.equal(blocked.includes("confenge/docs"), false);
+    assert.equal(blocked.includes("confenge/extra-cli"), false);
+
+    assert.ok(model.hypothesis_repos.some((item) => item.full_name === "confenge/extra-cli"));
+    assert.equal(
+      model.hypothesis_repos.every((item) => item.claim_kind === "hypothesis"),
+      true,
+    );
+    assert.equal(
+      model.blocked_repos.every((item) => item.claim_kind === "fact"),
+      true,
+    );
+
+    const headlines = model.attention_headlines.join("\n");
+    assert.match(headlines, /billing-api/);
+    assert.match(headlines, /web-cfg/);
+    assert.match(headlines, /stale/i);
+    assert.match(headlines, /CI|ci/);
+    assert.match(headlines, /extra-cli/);
+    assert.match(headlines, /hypothesis/);
+    assert.equal(headlines.includes("confenge/docs"), false);
+
+    const parsed = parseCollectorSnapshot(assembled);
+    assert.equal(parsed.repos.length, 4);
+
+    const store = new InMemoryEngineeringStore();
+    store.ingest(assembled, { now: NOW });
+    const scoped = store.getRepo("repo:confenge/docs");
+    assert.ok(scoped);
+    assert.equal(scoped.repo.full_name, "confenge/docs");
+    const scopedJson = serializeReadModel(scoped);
+    assert.equal(scopedJson.includes("confenge/billing-api"), false);
+    assert.equal(scopedJson.includes("confenge/web-cfg"), false);
+    assert.equal(scopedJson.includes("confenge/extra-cli"), false);
+
+    const companyRead = readByScope(model, "company");
+    assert.equal(companyRead.kind, "company");
+    const missing = readByScope(model, "repo:does-not-exist");
+    assert.equal(missing.kind, "empty");
+
+    const attentionForDocs = store.listAttention("repo:confenge/docs");
+    assert.equal(attentionForDocs.length, 0);
+    const companyAttention = store.listAttention("company");
+    assert.ok(companyAttention.length >= 2);
+    assert.ok(companyAttention.every((item) => item.repo !== "confenge/docs" || item.claim_kind === "hypothesis"));
+
+    for (const repo of model.repos) {
+      hasProvenance(repo);
+      for (const pr of repo.open_prs) hasProvenance(pr);
+      for (const check of repo.broken_checks) hasProvenance(check);
+      for (const issue of repo.p0_p1_issues) hasProvenance(issue);
+      for (const blocker of repo.blockers) hasProvenance(blocker);
+    }
+    for (const item of model.attention) {
+      hasProvenance(item);
+      assert.ok(item.reference.html_url.startsWith("https://"));
+    }
+
+    const serialized = serializeReadModel(model);
+    assertNoSecretsOrDiffs(serialized);
+    assert.equal(serialized.includes("DIFF_BODY_MUST_NOT_LEAK"), false);
+  });
+});
+
+describe("P0/P1 issues", () => {
+  it("classifies collector priority labels as P0/P1 fact blockers", () => {
+    const base = loadFixture("repo-quiet-saudavel.json") as {
+      repos: Array<{
+        open_issues: Array<Record<string, unknown>>;
+      }>;
+    };
+    const repo = base.repos[0];
+    assert.ok(repo);
+    repo.open_issues.push({
+      source: "github",
+      observed_at: "2026-08-20T12:00:00.000Z",
+      freshness_status: "fresh",
+      confidence: 1,
+      observation_id: "github:issue:confenge%2Fdocs:99",
+      repo: "confenge/docs",
+      number: 99,
+      title: "Payment webhook silently dropped",
+      state: "open",
+      labels: ["P0"],
+      priority: "p0",
+      html_url: "https://github.com/confenge/docs/issues/99",
+      created_at: "2026-08-20T01:00:00.000Z",
+      updated_at: "2026-08-20T01:00:00.000Z",
+    });
+    const model = buildCompanyEngineeringReadModel(base, { now: NOW });
+    const view = onlyRepo(model);
+    assert.equal(view.health, "degraded");
+    assert.equal(view.p0_p1_issues[0]?.priority, "P0");
+    assert.ok(view.blockers.some((item) => item.kind === "p0_issue" && item.claim_kind === "fact"));
+    assert.ok(model.attention.some((item) => item.reason_code === "p0_issue"));
+  });
+});

--- a/control-center/domains/engineering/tsconfig.json
+++ b/control-center/domains/engineering/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/control-center/domains/engineering/tsconfig.test.json
+++ b/control-center/domains/engineering/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts"]
+}


### PR DESCRIPTION
Draft PR for Control Center wave 13. Does not merge automatically.

## What
Adds `control-center/domains/engineering/`: a TypeScript executive read model that consumes **GitHub-collector-shaped** snapshots (not live GitHub) and produces:

- per-repo health, blockers, open PRs, broken checks, P0/P1 issues, last activity, aging
- company-wide aggregations and ranked **attention candidates** with explainable reasons + links
- scoped `repo:<name>` reads that do not dump other repos

This is not chat, not ERP, not a GitHub clone, and not the homepage UI.

## Rules honored
- Every aggregated item carries `source`, `observed_at` (UTC), `freshness_status`, and `confidence`.
- Links/references only — no PR/issue/check diffs or huge bodies.
- **`trabalho ativo sem evidência recente` is hypothesis, never fact.** Quiet-saudável (usable observation, no blockers) is not that claim. Quiet-desconhecido (`ERROR`/`UNKNOWN`) is distinguishable.
- Local collector/provenance adapter because `control-center/connectors/github/` and `control-center/contracts/` are not on `main` yet. Documented handoff in the workstream README.
- No writes outside `control-center/domains/engineering/`. No GitHub/Asaas/commercial mutations. No secrets in git.

## Tests
From `control-center/domains/engineering/`:

```bash
npm test
npm run consumer
```

Four named fixtures: PR stale, CI red, repo quiet saudável, repo quiet desconhecido. Tests and a fresh consumer script both drive the shipped transform.

## Convergence later
Homepage/MCP/Postgres should consume `attention_headlines` / `attention` / `readByScope`. Replace the local adapter with the collector + contracts packages when those land. Do not absorb PR #8.
