### PR TITLE
feat(control-center): fixture-backed mobile-first web shell

### DIFF
--- a/control-center/apps/web-shell/.gitignore
+++ b/control-center/apps/web-shell/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/control-center/apps/web-shell/README.md
+++ b/control-center/apps/web-shell/README.md
@@ -1,0 +1,77 @@
+# Control Center web shell
+
+Mobile-first cockpit for Confenge Control Center. This workstream is **fixture-backed and decoupled from a live backend**. It is not chat, not a generic ERP, and not a KPI wall.
+
+## Destinations
+
+Chrome navigation exposes exactly these eight areas:
+
+1. Hoje
+2. Comercial
+3. Clientes
+4. Financeiro
+5. Engenharia
+6. Infra
+7. Memória/Decisões
+8. Agentes
+
+Hoje is an attention cockpit: open exceptions plus **at most three** current priorities. There is no chat composer. Financial and commercial-send mutations (cobrança, checkout, refund, cancelamento, Asaas write, commercial send) are not offered.
+
+## Decisions (local)
+
+- Governance remains the strategic/canonical authority; Warmbly remains the commercial/CRM operational authority. This shell only renders a read-model recorte.
+- Persistence of aggregated state (PostgreSQL), HTTP APIs, and MCP for agents land in **later convergence campaigns**. This package copies v1 field names locally (`source`, `observed_at`, `freshness_status`, `confidence`, cents+currency, directive kinds, freshness `FRESH|STALE|UNKNOWN|ERROR`) and does **not** import unpublished sibling `control-center/*` packages.
+- Mock adapters are the only I/O. They never `fetch`. Swap the adapter implementation later; keep the `ControlCenterReadAdapter` port.
+- Single-user human is implicit. The operator is an opaque display handle (`human:operator`). No identity, password, or secret is hardcoded.
+- Dates are UTC in data (`…Z`). Presentation uses `America/Sao_Paulo`.
+- PWA: a web manifest + SVG icons only. No service worker / offline cache.
+
+## Run (no env vars required)
+
+```bash
+cd control-center/apps/web-shell
+npm install
+npm test
+npm run dev          # http://127.0.0.1:5173
+npm run build
+npm run preview      # http://127.0.0.1:4173
+```
+
+Do not open `index.html` via `file:`. The page detects that protocol and tells you to use `npm run dev` or `npm run preview`.
+
+### Mock view states
+
+Each destination is independently exercisable:
+
+- `#/hoje` ready fixture data
+- `#/hoje?view=loading`
+- `#/hoje?view=error`
+- `#/hoje?view=stale`
+- `#/hoje?view=empty`
+
+The chrome also exposes a labeled “Estado da vista (mock)” control (keyboard-accessible).
+
+## Env vars
+
+None required for mock mode. Do not put secrets in git, URLs, logs, analytics, or the client bundle. There is no analytics SDK here.
+
+## Expected later convergence
+
+| Later workstream | Expected swap |
+| --- | --- |
+| `control-center/contracts` | Replace local types with the published JSON Schema / TS package. Field names already match v1. |
+| Context / HTTP API | `MockControlCenterAdapter` → HTTP read adapter. Keep provenance on every aggregated record. |
+| MCP server | Agents consume scoped context via MCP, not this UI. |
+| PostgreSQL | Operational aggregate + structured memory. This UI stays a client. |
+| Collectors (GitHub, Warmbly, Asaas, infra) | Feed the read models this shell already shapes. |
+
+Do not merge this package into `commercial/`, `decisions/`, `scripts/`, or other Control Center workstreams in this campaign.
+
+## Tests
+
+```bash
+npm test
+npm run typecheck
+```
+
+Unit/contract tests drive the shipped registry, mock adapters, Hoje selection, view-state helpers, and provenance mapping.

--- a/control-center/apps/web-shell/index.html
+++ b/control-center/apps/web-shell/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#121418" />
+    <meta
+      name="description"
+      content="Confenge Control Center — cockpit operacional de exceções e prioridades. Sem chat. Sem mutações financeiras."
+    />
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icon.svg" />
+    <title>Control Center — Confenge</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <noscript>
+      Este cockpit precisa de JavaScript. No diretório
+      <code>control-center/apps/web-shell</code> execute
+      <code>npm run dev</code> ou <code>npm run preview</code>.
+    </noscript>
+    <script>
+      (function () {
+        if (typeof location === "undefined" || location.protocol !== "file:") return;
+        var root = document.getElementById("root");
+        if (!root) return;
+        root.innerHTML =
+          '<main class="file-protocol" role="alert">' +
+          "<h1>Control Center precisa de um servidor local</h1>" +
+          "<p>Abrir este arquivo via <code>file:</code> não carrega o módulo ES. " +
+          "No diretório <code>control-center/apps/web-shell</code> execute:</p>" +
+          "<pre>npm install\nnpm run dev\n# ou\nnpm run preview</pre>" +
+          "</main>";
+      })();
+    </script>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/control-center/apps/web-shell/package-lock.json
+++ b/control-center/apps/web-shell/package-lock.json
@@ -1,0 +1,1704 @@
+{
+  "name": "@confenge/control-center-web-shell",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-web-shell",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.18.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2",
+        "vite": "^6.3.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.5.tgz",
+      "integrity": "sha512-jfkGfTwhQpsiSckPF8r9bU3pn3vyd72NlWaO+TgEO6WPSDnUhXzrNYCHBMOYj0ACaUgjm6eERLF+XV9a6RstoA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.5.tgz",
+      "integrity": "sha512-oGVqyQlxnrz9/ty89oHpU857VUHEl5/Xu4R2lS+aivCTrNnSsbiENzTnNaBsjxH0CNWGPhzHArOLFwo+oKXveA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.5.tgz",
+      "integrity": "sha512-bW7B8xMEq8n99Q3ieEcPRGuphurdZAaFzQc9Efyyw3FL6DZO6pMy9xhdN+kBoD7Sy05xNXSr4OyPPnpkYriS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.5.tgz",
+      "integrity": "sha512-YSwBS86QeHOGlrxJ1PSOIZSkzRL/JmKeunhc+lV6M1a6En8QuVCD/T/qIA0J4Gd2Y86RIOBYrLcOUtqGh9+/1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.5.tgz",
+      "integrity": "sha512-2fST8lILgl7cKbme/1KDdPCmbXbG+gqoV3bHp19L0ypX/3akYMBVdOunPleRCwonoLnXOZ/0F+Mt/v8POFmfcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.5.tgz",
+      "integrity": "sha512-cpIxQCP9J+EVad0a6LO1kY3ZGODlk80VlI+2I96B8xMcdHZ4pLVhfQ49JFpYqjPF91FFkQWftf57YlDcTiw9yQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.5.tgz",
+      "integrity": "sha512-r9fGh3eFs3e/udWh5ZjXQtxiYK/xoFxQaYR/cELxac/Udkl5Th+IsFm0CX3Kl9hmUH/we7EoMpjJgeQNnE0+IA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.5.tgz",
+      "integrity": "sha512-xdvFdp7OM6KLJviJT2g/YuRSUjnZgGHk4RNgwIbN7X6cPugOucV60DdHXWzsBVCUdrGb6qSXnJQrrAKMmQuj3Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.5.tgz",
+      "integrity": "sha512-rRqILAndyzHzP7T9NFQrq+4HFWNhqkqkKur7eiBpfLmz01PO0JKx5Vchu3YllE4YXI/Ftgq/szrDWg5GJ0mI8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.5.tgz",
+      "integrity": "sha512-Gf4X3qVMucayUvux6aXXPgXovocSFUC0rrffDuPI/S2nHhNMhjcZxsrAFYCOF350PRreW1XwzFj3CT/3bKsWCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.5.tgz",
+      "integrity": "sha512-+s5qA0TNM0qm8PK/a5gt/1Hpx+NV08uSuCncvhziIlQzT6AEV2fnUQo7eBtFTFO0nA9scauvoR2HusfXmQnO4w==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.5.tgz",
+      "integrity": "sha512-ybb6QvWwWJCbBWqERpc8K3pYVGIrXlG8MEQ8IIuJY6Y9KdHQxoFoNyfkAOtKn1VHu3KuLidXvwrvGR1mEjeWCw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.5.tgz",
+      "integrity": "sha512-nZb1DtnOyhCmYvsC8A2CwOkopVg+IS1+fPUa7rMOAXtNw5+lLCLLPqd6XAiNrGtoQKsbvIBOwsHnBH/3wnb4HQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.5.tgz",
+      "integrity": "sha512-yMbj63Sp89ryrXLWyz+sy+fYD2HpOnMCLGbe4Oa1smclFSUukdtD/BgdiHaAetJNb74URD8U4hM+qG5KVzMEkg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.5.tgz",
+      "integrity": "sha512-mhoan3OJw2kYV/e1jtIdmvUZgyBFeA6zGWsOswmR0Tg19TQbowZuR+JMLID6spbbBN7Zee2ejrgmy3+FxGrIdA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.5.tgz",
+      "integrity": "sha512-5ZTLmjWbb1VZdjuyhe83K/8QO0/h11midQCBP+X5OYn32ra7eOBoM0ZqtaY4nkgNsYgmdVhMYPoyVPTjUpHf3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.5.tgz",
+      "integrity": "sha512-m53kG+br6PGxOTmgBEM2DHSDs9RVjsyEbUwjJPJGTFm1grWOG8EKJggDCTb60unD4Tjby8fi7/m9XfkEWasVWg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.5.tgz",
+      "integrity": "sha512-6RHPJR1g/uvdYU8uXBnfq3nlqyZCP82Fr6NHgfGoaIeSh0YEqnX/x6uA9MmJJbnSH7swqX4F+CkGdUF+6doiQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.5.tgz",
+      "integrity": "sha512-xs+OXQtEXgpXT0DmA5+U3qnRZHdCST/5HRQxS8wSPZTUZN/EMWeHuSIod32LQklTBZBV9DyfncKBQ8n5V3eFdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.5.tgz",
+      "integrity": "sha512-e7hD+sl3s+mcLQDZ8pbudBVsdG6r5yN4w3LqG2TJ8sQHDpblWj5lrJs/3m01Cvlxbt4x13zu5thLjgypgtkYzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.5.tgz",
+      "integrity": "sha512-GiyJaCf+WpMub/17aPcKk27QMl5W6f+KhdPTjlFOn5akH5Wa/DCM9Stdx5cDfmasyKB08MqpVQ1uJE2RkkpbXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.5.tgz",
+      "integrity": "sha512-+OQ8U2DdoEfXl8T4Fb18AjmEwbXMerKDKCL8yCPAYhKCEEKoul7rkbeGCBFCbAlaGaa7pmtRTpkAJM2LE/i5FA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.5.tgz",
+      "integrity": "sha512-KanvAZrPKbDBFwrgiU9yEVpQoox9QPV1WZOXX7HudJQY+eSlu82CtWxDU8WtuRRvtN5EGkLczkd6Y6DTcvm9wA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.5.tgz",
+      "integrity": "sha512-1aC3UEWTtRl3RK3VpDJ/Tqk1XI4SLTmXIthAq6wRWo8XiSXJNd+VprJM4/1P4+i6HIaFEFlVi9sTTziniD2tOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.5.tgz",
+      "integrity": "sha512-/gDJaRs4gl0NPIwqCz+6PkpmhhjRAD2j6P4rSNHBzUkO3naEx2mIU0pRle1vUNRQ7mE/+8OOeXLTv/J56FKiQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.5.tgz",
+      "integrity": "sha512-/tqMfgP7GPA3PHhCmuiS4vIjrSVhHLgY++i+dhbG462euyAj7FpM4D9uq1X3BgjlqRdpcOrYhcQtfiQLNc8tqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.5",
+        "@rollup/rollup-android-arm64": "4.62.5",
+        "@rollup/rollup-darwin-arm64": "4.62.5",
+        "@rollup/rollup-darwin-x64": "4.62.5",
+        "@rollup/rollup-freebsd-arm64": "4.62.5",
+        "@rollup/rollup-freebsd-x64": "4.62.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.5",
+        "@rollup/rollup-linux-arm64-musl": "4.62.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.5",
+        "@rollup/rollup-linux-loong64-musl": "4.62.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.5",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.5",
+        "@rollup/rollup-linux-x64-gnu": "4.62.5",
+        "@rollup/rollup-linux-x64-musl": "4.62.5",
+        "@rollup/rollup-openbsd-x64": "4.62.5",
+        "@rollup/rollup-openharmony-arm64": "4.62.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.5",
+        "@rollup/rollup-win32-x64-gnu": "4.62.5",
+        "@rollup/rollup-win32-x64-msvc": "4.62.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    }
+  }
+}

--- a/control-center/apps/web-shell/package.json
+++ b/control-center/apps/web-shell/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@confenge/control-center-web-shell",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Mobile-first Control Center shell. Fixture-backed mock adapters only. No live HTTP, MCP, or PostgreSQL in this workstream.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview --host 127.0.0.1 --port 4173",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test tests/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2",
+    "vite": "^6.3.5"
+  }
+}

--- a/control-center/apps/web-shell/public/favicon.svg
+++ b/control-center/apps/web-shell/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Control Center">
+  <rect width="32" height="32" rx="6" fill="#121418"/>
+  <rect x="4" y="4" width="24" height="24" rx="3" fill="#1b1e24" stroke="#c4b59a" stroke-width="1.5"/>
+  <text x="16" y="21" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#e8eaed">CC</text>
+</svg>

--- a/control-center/apps/web-shell/public/icon.svg
+++ b/control-center/apps/web-shell/public/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Confenge Control Center">
+  <rect width="512" height="512" rx="96" fill="#121418"/>
+  <rect x="64" y="64" width="384" height="384" rx="48" fill="#1b1e24" stroke="#c4b59a" stroke-width="16"/>
+  <text x="256" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="168" font-weight="700" fill="#e8eaed">CC</text>
+</svg>

--- a/control-center/apps/web-shell/public/manifest.webmanifest
+++ b/control-center/apps/web-shell/public/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Confenge Control Center",
+  "short_name": "Control Center",
+  "description": "Cockpit operacional privado. Exceções e as 3 coisas mais importantes agora.",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#121418",
+  "theme_color": "#121418",
+  "lang": "pt-BR",
+  "icons": [
+    {
+      "src": "./icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/control-center/apps/web-shell/scripts/browser-load.mjs
+++ b/control-center/apps/web-shell/scripts/browser-load.mjs
@@ -1,0 +1,46 @@
+/**
+ * Evaluate the shipped browser entry in a browser-like environment.
+ * window is defined; the entry must not throw; globals/root mount install.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appRoot = join(here, "..");
+const bootUrl = pathToFileURL(join(appRoot, "src/boot.ts")).href;
+
+const mainSrc = readFileSync(join(appRoot, "src/main.ts"), "utf8");
+if (/\brequire\s*\(/.test(mainSrc) || /module\.exports/.test(mainSrc)) {
+  throw new Error("browser entry uses unguarded Node require/module");
+}
+
+const { startBrowser, installShellGlobals, applyFileProtocolGuard } = await import(bootUrl);
+
+const fileRoot = { innerHTML: "" };
+const fileWin = { location: { protocol: "file:" } };
+startBrowser(fileWin, { getElementById: (id) => (id === "root" ? fileRoot : null) });
+if (!fileRoot.innerHTML.includes("npm run dev") || !fileRoot.innerHTML.includes("npm run preview")) {
+  throw new Error("file: guard did not install serve instructions");
+}
+
+const httpWin = { location: { protocol: "http:" } };
+const globals = installShellGlobals(httpWin);
+if (!httpWin.__CONFENGE_CONTROL_CENTER__) {
+  throw new Error("expected globals on window");
+}
+if (globals.destinations.length !== 8) {
+  throw new Error("expected eight destinations");
+}
+
+const skipped = applyFileProtocolGuard({ protocol: "https:" }, { innerHTML: "" });
+if (skipped !== false) {
+  throw new Error("https should not trip the file: guard");
+}
+
+console.log("browser-load ok");
+console.log(`globals.version=${globals.version}`);
+console.log(`globals.destinations=${globals.destinations.join(",")}`);
+console.log(`globals.primarySurface=${globals.primarySurface}`);
+console.log("file-protocol-guard=installed");
+console.log("require-unguarded=false");

--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -1,0 +1,135 @@
+/**
+ * Headless launch of the previewed shell. Asserts the primary observable:
+ * eight nav labels, Hoje attention + ≤3 priorities, nav changes destination.
+ *
+ * Usage: node scripts/launch-probe.mjs <baseUrl> <screenshotPath>
+ */
+import { createRequire } from "node:module";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+function chromiumFrom(mod) {
+  const chromium = mod?.chromium ?? mod?.default?.chromium;
+  return chromium && typeof chromium.launch === "function" ? chromium : null;
+}
+
+async function loadPlaywright() {
+  try {
+    const local = chromiumFrom(await import("playwright"));
+    if (local) return local;
+  } catch {
+    // fall through to npx cache
+  }
+  const require = createRequire(import.meta.url);
+  const npxRoot = join(homedir(), ".npm/_npx");
+  if (existsSync(npxRoot)) {
+    for (const entry of readdirSync(npxRoot)) {
+      const candidate = join(npxRoot, entry, "node_modules/playwright");
+      if (!existsSync(join(candidate, "package.json"))) continue;
+      const resolved = chromiumFrom(await import(require.resolve(candidate)));
+      if (resolved) return resolved;
+    }
+  }
+  throw new Error("playwright chromium not resolvable");
+}
+
+const chromium = await loadPlaywright();
+
+const baseUrl = process.argv[2];
+const screenshotPath = process.argv[3];
+if (!baseUrl || !screenshotPath) {
+  console.error("usage: node scripts/launch-probe.mjs <baseUrl> <screenshotPath>");
+  process.exit(2);
+}
+
+const labels = [
+  "Hoje",
+  "Comercial",
+  "Clientes",
+  "Financeiro",
+  "Engenharia",
+  "Infra",
+  "Memória/Decisões",
+  "Agentes",
+];
+
+const cachedChrome = join(
+  homedir(),
+  ".cache/ms-playwright/chromium-1234/chrome-linux64/chrome",
+);
+const launchOptions = { headless: true, args: ["--no-sandbox", "--disable-dev-shm-usage"] };
+if (existsSync(cachedChrome)) {
+  launchOptions.executablePath = cachedChrome;
+}
+const browser = await chromium.launch(launchOptions);
+const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+const errors = [];
+page.on("pageerror", (err) => errors.push(String(err)));
+page.on("crash", () => errors.push("page crashed"));
+
+try {
+  const response = await page.goto(baseUrl, { waitUntil: "networkidle" });
+  const status = response?.status() ?? 0;
+  console.log(`status=${status}`);
+  if (status !== 200) {
+    throw new Error(`unexpected status ${status}`);
+  }
+
+  await page.waitForSelector('[data-destination="hoje"]');
+  const box = await page.locator("#root").boundingBox();
+  if (!box || box.width < 300 || box.height < 400) {
+    throw new Error(`render surface too small: ${JSON.stringify(box)}`);
+  }
+  const filled = await page.locator("#root").evaluate((el) => el.innerText.length);
+  if (filled < 80) {
+    throw new Error(`render surface not substantially filled: ${filled} chars`);
+  }
+  console.log(`surface=${Math.round(box.width)}x${Math.round(box.height)}`);
+  console.log(`filled_chars=${filled}`);
+
+  for (const label of labels) {
+    const nav = page.locator("nav[aria-label='Áreas do Control Center'] a", { hasText: label });
+    const count = await nav.count();
+    if (count < 1) throw new Error(`missing nav label ${label}`);
+  }
+  console.log(`nav_labels=${labels.length}`);
+
+  const dest = await page.locator("[data-destination]").getAttribute("data-destination");
+  if (dest !== "hoje") throw new Error(`expected hoje, got ${dest}`);
+
+  const attention = await page.locator(".attention").count();
+  const priorities = await page.locator(".priority").count();
+  if (attention < 1) throw new Error("Hoje has no attention items");
+  if (priorities < 1 || priorities > 3) {
+    throw new Error(`Hoje priorities out of range: ${priorities}`);
+  }
+  const hojeText = await page.locator("main").innerText();
+  if (!hojeText.includes("As 3 coisas mais importantes agora")) {
+    throw new Error("missing Hoje priority heading");
+  }
+  if (!hojeText.includes("Exceções")) {
+    throw new Error("missing Exceções heading");
+  }
+  console.log(`hoje_attention=${attention}`);
+  console.log(`hoje_priorities=${priorities}`);
+
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  console.log(`screenshot=${screenshotPath}`);
+
+  await page.locator("nav[aria-label='Áreas do Control Center'] a", { hasText: "Comercial" }).click();
+  await page.waitForSelector('[data-destination="comercial"]');
+  const after = await page.locator("[data-destination]").getAttribute("data-destination");
+  if (after !== "comercial") throw new Error(`nav did not change destination: ${after}`);
+  const heading = await page.locator("main h1").innerText();
+  if (heading !== "Comercial") throw new Error(`heading ${heading}`);
+  console.log(`nav_changed_to=${after}`);
+
+  if (errors.length > 0) {
+    throw new Error(`page errors: ${errors.join(" | ")}`);
+  }
+  console.log("page_errors=0");
+  console.log("launch-probe ok");
+} finally {
+  await browser.close();
+}

--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -1,0 +1,84 @@
+import type { DestinationId } from "../destinations";
+import type {
+  ActorRef,
+  AgentSession,
+  AttentionItem,
+  ClientStatus,
+  CommercialSnapshot,
+  Directive,
+  EngineeringSnapshot,
+  FinanceSnapshot,
+  PriorityRecommendation,
+  ServiceHealth,
+  UtcDateTime,
+} from "../types";
+
+/** The mock/HTTP adapter is read-only. Mutation verbs are not part of the contract. */
+export const ADAPTER_ACTIONS = ["read"] as const;
+export type AdapterAction = (typeof ADAPTER_ACTIONS)[number];
+
+/**
+ * Financial/provider and commercial-send mutations stay forbidden in this campaign.
+ * Listed so tests can assert they are absent from the adapter contract.
+ */
+export const FORBIDDEN_ADAPTER_ACTIONS = [
+  "cobranca",
+  "checkout",
+  "refund",
+  "cancelamento",
+  "asaas_write",
+  "commercial_send",
+] as const;
+export type ForbiddenAdapterAction = (typeof FORBIDDEN_ADAPTER_ACTIONS)[number];
+
+export const CHAT_SURFACE_ACTIONS = ["compose", "send_message", "open_thread"] as const;
+
+export interface DestinationPage {
+  id: DestinationId;
+  label: string;
+  scope: string;
+  generated_at: UtcDateTime;
+  operator: ActorRef;
+  headline: string;
+  attention: AttentionItem[];
+  priorities: PriorityRecommendation[];
+  commercial?: CommercialSnapshot;
+  finance?: FinanceSnapshot;
+  engineering?: EngineeringSnapshot;
+  clients?: ClientStatus[];
+  health?: ServiceHealth[];
+  directives?: Directive[];
+  sessions?: AgentSession[];
+}
+
+export interface AdapterError {
+  code: string;
+  message: string;
+}
+
+export type AdapterReadResult =
+  | { ok: true; loading: false; page: DestinationPage }
+  | { ok: false; loading: false; error: AdapterError }
+  | { ok: true; loading: true; page: null };
+
+/**
+ * Read-only Control Center port. Default implementation is in-repo fixtures.
+ * A later convergence campaign may swap this for HTTP; MCP stays the agent
+ * interface and is not consumed here.
+ */
+export interface ControlCenterReadAdapter {
+  readonly mode: "mock";
+  readonly actions: readonly AdapterAction[];
+  readOperator(): ActorRef;
+  readDestination(id: DestinationId): AdapterReadResult;
+  readAttention(): AttentionItem[];
+  readPriorities(): PriorityRecommendation[];
+}
+
+export function adapterAllows(action: string): action is AdapterAction {
+  return (ADAPTER_ACTIONS as readonly string[]).includes(action);
+}
+
+export function isForbiddenAdapterAction(action: string): action is ForbiddenAdapterAction {
+  return (FORBIDDEN_ADAPTER_ACTIONS as readonly string[]).includes(action);
+}

--- a/control-center/apps/web-shell/src/adapters/index.ts
+++ b/control-center/apps/web-shell/src/adapters/index.ts
@@ -1,0 +1,13 @@
+export {
+  ADAPTER_ACTIONS,
+  CHAT_SURFACE_ACTIONS,
+  FORBIDDEN_ADAPTER_ACTIONS,
+  adapterAllows,
+  isForbiddenAdapterAction,
+  type AdapterAction,
+  type AdapterReadResult,
+  type ControlCenterReadAdapter,
+  type DestinationPage,
+  type ForbiddenAdapterAction,
+} from "./contract";
+export { MockControlCenterAdapter, createMockAdapter, type MockScenario } from "./mock";

--- a/control-center/apps/web-shell/src/adapters/mock.ts
+++ b/control-center/apps/web-shell/src/adapters/mock.ts
@@ -1,0 +1,85 @@
+import type { DestinationId } from "../destinations";
+import {
+  defaultPages,
+  emptyPages,
+  MOCK_OPERATOR,
+  stalePages,
+} from "../fixtures/catalog";
+import type { ActorRef } from "../types";
+import {
+  ADAPTER_ACTIONS,
+  type AdapterAction,
+  type AdapterReadResult,
+  type ControlCenterReadAdapter,
+  type DestinationPage,
+} from "./contract";
+
+export type MockScenario = "default" | "loading" | "error" | "stale" | "empty";
+
+const ERROR_MESSAGE =
+  "Falha simulada ao montar o recorte (modo mock). Nenhuma chamada de rede foi feita.";
+
+function clonePage(page: DestinationPage): DestinationPage {
+  return structuredClone(page);
+}
+
+export class MockControlCenterAdapter implements ControlCenterReadAdapter {
+  readonly mode = "mock" as const;
+  readonly actions: readonly AdapterAction[] = ADAPTER_ACTIONS;
+  private scenario: MockScenario = "default";
+
+  setScenario(scenario: MockScenario): void {
+    this.scenario = scenario;
+  }
+
+  getScenario(): MockScenario {
+    return this.scenario;
+  }
+
+  readOperator(): ActorRef {
+    return { ...MOCK_OPERATOR };
+  }
+
+  readDestination(id: DestinationId): AdapterReadResult {
+    if (this.scenario === "loading") {
+      return { ok: true, loading: true, page: null };
+    }
+    if (this.scenario === "error") {
+      return {
+        ok: false,
+        loading: false,
+        error: { code: "MOCK_VIEW_ERROR", message: ERROR_MESSAGE },
+      };
+    }
+    const catalog = this.catalog();
+    const page = catalog[id];
+    if (!page) {
+      return {
+        ok: false,
+        loading: false,
+        error: { code: "UNKNOWN_DESTINATION", message: `Destino desconhecido: ${id}` },
+      };
+    }
+    return { ok: true, loading: false, page: clonePage(page) };
+  }
+
+  readAttention() {
+    return clonePage(defaultPages().hoje).attention;
+  }
+
+  readPriorities() {
+    return clonePage(defaultPages().hoje).priorities;
+  }
+
+  private catalog(): Record<DestinationId, DestinationPage> {
+    if (this.scenario === "empty") return emptyPages();
+    if (this.scenario === "stale") return stalePages();
+    return defaultPages();
+  }
+}
+
+export function createMockAdapter(scenario: MockScenario = "default"): MockControlCenterAdapter {
+  const adapter = new MockControlCenterAdapter();
+  adapter.setScenario(scenario);
+  return adapter;
+}

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -1,0 +1,121 @@
+import { createMockAdapter, type MockScenario } from "./adapters/mock";
+import type { ControlCenterReadAdapter, DestinationPage } from "./adapters/contract";
+import { parseHash } from "./destinations";
+import { pageIsEmpty, pageIsStale } from "./page";
+import { renderShell } from "./ui/render";
+import {
+  parseViewKind,
+  resolveViewState,
+  type ResolveViewInput,
+  type ViewKind,
+} from "./view-state";
+
+export function scenarioFromView(view: ViewKind | null): MockScenario {
+  if (view === "loading" || view === "error" || view === "stale" || view === "empty") {
+    return view;
+  }
+  return "default";
+}
+
+export interface ShellRuntime {
+  getHash(): string;
+  setHash(hash: string): void;
+  onHashChange(handler: () => void): () => void;
+}
+
+export function browserRuntime(): ShellRuntime {
+  return {
+    getHash(): string {
+      return window.location.hash;
+    },
+    setHash(hash: string): void {
+      window.location.hash = hash;
+    },
+    onHashChange(handler: () => void): () => void {
+      window.addEventListener("hashchange", handler);
+      return () => {
+        window.removeEventListener("hashchange", handler);
+      };
+    },
+  };
+}
+
+export function createMemoryRuntime(initialHash = "#/hoje"): ShellRuntime {
+  let hash = initialHash;
+  const listeners: Array<() => void> = [];
+  return {
+    getHash(): string {
+      return hash;
+    },
+    setHash(next: string): void {
+      hash = next;
+      for (const listener of listeners) listener();
+    },
+    onHashChange(handler: () => void): () => void {
+      listeners.push(handler);
+      return () => {
+        const index = listeners.indexOf(handler);
+        if (index >= 0) listeners.splice(index, 1);
+      };
+    },
+  };
+}
+
+export interface MountableRoot {
+  innerHTML: string;
+}
+
+export function paintShell(
+  root: MountableRoot,
+  adapter: ControlCenterReadAdapter & {
+    setScenario?(s: MockScenario): void;
+    getScenario?(): MockScenario;
+  },
+  hash: string,
+): void {
+  const parsed = parseHash(hash || "#/hoje");
+  const override = parseViewKind(parsed.view);
+  adapter.setScenario?.(scenarioFromView(override));
+  const result = adapter.readDestination(parsed.destination);
+  const input: ResolveViewInput<DestinationPage> = {
+    loading: result.ok && result.loading,
+    data: result.ok && !result.loading ? result.page : null,
+    isEmpty: pageIsEmpty,
+    isStale: pageIsStale,
+    override,
+  };
+  if (!result.ok) {
+    input.error = result.error;
+  }
+  const view = resolveViewState(input);
+  root.innerHTML = renderShell({
+    destination: parsed.destination,
+    viewKind: view.kind,
+    view,
+    mockScenario: adapter.getScenario?.() ?? adapter.mode,
+  });
+}
+
+export function mount(
+  root: MountableRoot,
+  adapter: ControlCenterReadAdapter & {
+    setScenario?(s: MockScenario): void;
+    getScenario?(): MockScenario;
+  } = createMockAdapter(),
+  runtime: ShellRuntime = browserRuntime(),
+): { unmount: () => void } {
+  const paint = (): void => {
+    paintShell(root, adapter, runtime.getHash());
+  };
+  const stop = runtime.onHashChange(paint);
+  if (!runtime.getHash()) {
+    runtime.setHash("#/hoje");
+  }
+  paint();
+  return {
+    unmount(): void {
+      stop();
+      root.innerHTML = "";
+    },
+  };
+}

--- a/control-center/apps/web-shell/src/boot.ts
+++ b/control-center/apps/web-shell/src/boot.ts
@@ -1,0 +1,74 @@
+import { mount, type MountableRoot } from "./app";
+import { DESTINATION_IDS, PRIMARY_SURFACE } from "./destinations";
+
+export const SHELL_VERSION = "0.1.0";
+export const SHELL_GLOBAL_KEY = "__CONFENGE_CONTROL_CENTER__";
+
+export const FILE_PROTOCOL_NOTICE_TITLE = "Control Center precisa de um servidor local";
+export const FILE_PROTOCOL_DEV = "npm run dev";
+export const FILE_PROTOCOL_PREVIEW = "npm run preview";
+
+export interface ShellGlobals {
+  version: string;
+  destinations: readonly string[];
+  primarySurface: typeof PRIMARY_SURFACE;
+  mount: typeof mount;
+}
+
+export interface ShellWindow {
+  location: { protocol: string };
+  __CONFENGE_CONTROL_CENTER__?: ShellGlobals;
+}
+
+export function installShellGlobals(win: ShellWindow): ShellGlobals {
+  const globals: ShellGlobals = {
+    version: SHELL_VERSION,
+    destinations: DESTINATION_IDS,
+    primarySurface: PRIMARY_SURFACE,
+    mount,
+  };
+  win.__CONFENGE_CONTROL_CENTER__ = globals;
+  return globals;
+}
+
+export function isFileProtocol(protocol: string): boolean {
+  return protocol === "file:";
+}
+
+export function fileProtocolHtml(): string {
+  return (
+    `<main class="file-protocol" role="alert">` +
+    `<h1>${FILE_PROTOCOL_NOTICE_TITLE}</h1>` +
+    `<p>Abrir este arquivo via <code>file:</code> não carrega o módulo ES. ` +
+    `No diretório <code>control-center/apps/web-shell</code> execute:</p>` +
+    `<pre>${FILE_PROTOCOL_DEV}\n# ou\n${FILE_PROTOCOL_PREVIEW}</pre>` +
+    `</main>`
+  );
+}
+
+export function applyFileProtocolGuard(
+  location: { protocol: string },
+  root: { innerHTML: string },
+): boolean {
+  if (!isFileProtocol(location.protocol)) return false;
+  root.innerHTML = fileProtocolHtml();
+  return true;
+}
+
+export function startBrowser(
+  win: ShellWindow | undefined = globalThis.window as unknown as ShellWindow | undefined,
+  doc: { getElementById(id: string): MountableRoot | null } | undefined = globalThis.document,
+): void {
+  if (win == null || doc == null) {
+    return;
+  }
+  installShellGlobals(win);
+  const root = doc.getElementById("root");
+  if (!root) {
+    throw new Error("Control Center shell: missing #root");
+  }
+  if (applyFileProtocolGuard(win.location, root)) {
+    return;
+  }
+  mount(root);
+}

--- a/control-center/apps/web-shell/src/datetime.ts
+++ b/control-center/apps/web-shell/src/datetime.ts
@@ -1,0 +1,30 @@
+/** Internal timestamps are UTC (`...Z`). Presentation may use America/Sao_Paulo. */
+export const PRESENTATION_TIME_ZONE = "America/Sao_Paulo";
+
+const UTC_PATTERN =
+  /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,9})?Z$/;
+
+export function isUtcDateTime(value: string): boolean {
+  return UTC_PATTERN.test(value);
+}
+
+export function formatUtc(value: string): string {
+  return value;
+}
+
+export function formatLocal(value: string, timeZone = PRESENTATION_TIME_ZONE): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  const formatted = new Intl.DateTimeFormat("pt-BR", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(date);
+  return `${formatted} (${timeZone})`;
+}

--- a/control-center/apps/web-shell/src/destinations.ts
+++ b/control-center/apps/web-shell/src/destinations.ts
@@ -1,0 +1,133 @@
+export const DESTINATION_IDS = [
+  "hoje",
+  "comercial",
+  "clientes",
+  "financeiro",
+  "engenharia",
+  "infra",
+  "memoria",
+  "agentes",
+] as const;
+
+export type DestinationId = (typeof DESTINATION_IDS)[number];
+
+export interface DestinationDef {
+  readonly id: DestinationId;
+  readonly label: string;
+  readonly path: string;
+  readonly scope: string;
+  readonly description: string;
+}
+
+/**
+ * Chrome registry. Labels are the eight product destinations.
+ * There is no chat destination. Navigation is hash-based so the
+ * mock shell stays backend-free.
+ */
+export const DESTINATIONS: readonly DestinationDef[] = [
+  {
+    id: "hoje",
+    label: "Hoje",
+    path: "#/hoje",
+    scope: "company",
+    description: "Cockpit de atenção: exceções e no máximo três prioridades atuais.",
+  },
+  {
+    id: "comercial",
+    label: "Comercial",
+    path: "#/comercial",
+    scope: "commercial",
+    description: "Recorte comercial somente leitura. Autoridade operacional permanece no Warmbly.",
+  },
+  {
+    id: "clientes",
+    label: "Clientes",
+    path: "#/clientes",
+    scope: "clients",
+    description: "Estado agregado de clientes com proveniência e exceções abertas.",
+  },
+  {
+    id: "financeiro",
+    label: "Financeiro",
+    path: "#/financeiro",
+    scope: "finance",
+    description: "Recorte financeiro somente leitura. Mutações de provedor são proibidas.",
+  },
+  {
+    id: "engenharia",
+    label: "Engenharia",
+    path: "#/engenharia",
+    scope: "repo:tjsasakifln/Governance",
+    description: "Sinais de engenharia por repositório. Sem absorver PRs de outros workstreams.",
+  },
+  {
+    id: "infra",
+    label: "Infra",
+    path: "#/infra",
+    scope: "infrastructure",
+    description: "Saúde de serviços e freshness das últimas coletas.",
+  },
+  {
+    id: "memoria",
+    label: "Memória/Decisões",
+    path: "#/memoria",
+    scope: "company",
+    description: "Diretivas humanas tipadas por kind, escopo, vigência e auditoria.",
+  },
+  {
+    id: "agentes",
+    label: "Agentes",
+    path: "#/agentes",
+    scope: "company",
+    description: "Sessões de agentes com escopos concedidos. Sem dump indiscriminado da memória.",
+  },
+] as const;
+
+export const PRIMARY_SURFACE = "attention-cockpit" as const;
+
+export function isDestinationId(value: string): value is DestinationId {
+  return (DESTINATION_IDS as readonly string[]).includes(value);
+}
+
+export function getDestination(id: DestinationId): DestinationDef {
+  const found = DESTINATIONS.find((item) => item.id === id);
+  if (!found) {
+    throw new Error(`Unknown destination: ${id}`);
+  }
+  return found;
+}
+
+export function destinationLabels(): readonly string[] {
+  return DESTINATIONS.map((item) => item.label);
+}
+
+export function hasChatDestination(): boolean {
+  return DESTINATIONS.some(
+    (item) =>
+      item.id.includes("chat") ||
+      item.label.toLowerCase() === "chat" ||
+      item.path.includes("chat"),
+  );
+}
+
+export interface ParsedLocation {
+  destination: DestinationId;
+  view: string | null;
+}
+
+export function parseHash(hash: string): ParsedLocation {
+  const stripped = hash.startsWith("#") ? hash.slice(1) : hash;
+  const [pathPart, queryPart] = stripped.split("?");
+  const path = (pathPart ?? "").replace(/^\/+/, "");
+  const destination = isDestinationId(path) ? path : "hoje";
+  const params = new URLSearchParams(queryPart ?? "");
+  const view = params.get("view");
+  return { destination, view };
+}
+
+export function hashFor(destination: DestinationId, view?: string | null): string {
+  if (view && view.length > 0) {
+    return `#/${destination}?view=${encodeURIComponent(view)}`;
+  }
+  return `#/${destination}`;
+}

--- a/control-center/apps/web-shell/src/escape.ts
+++ b/control-center/apps/web-shell/src/escape.ts
@@ -1,0 +1,8 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/control-center/apps/web-shell/src/fixtures/catalog.ts
+++ b/control-center/apps/web-shell/src/fixtures/catalog.ts
@@ -1,0 +1,757 @@
+import type { DestinationId } from "../destinations";
+import { DESTINATIONS, getDestination } from "../destinations";
+import { selectHomepageAttention, selectHomepagePriorities } from "../homepage";
+import type { DestinationPage } from "../adapters/contract";
+import type {
+  ActorRef,
+  AgentSession,
+  AttentionItem,
+  ClientStatus,
+  CommercialSnapshot,
+  Directive,
+  EngineeringSnapshot,
+  FinanceSnapshot,
+  PriorityRecommendation,
+  Provenance,
+  ServiceHealth,
+} from "../types";
+
+export const MOCK_OPERATOR: ActorRef = {
+  kind: "human",
+  id: "human:operator",
+  display_name: "Operador",
+};
+
+const GENERATED_AT = "2026-08-20T18:00:00Z";
+
+function provenance(
+  system: string,
+  kind: string,
+  locator: string,
+  observed_at: string,
+  freshness_status: Provenance["freshness_status"],
+  confidence: number,
+  extras: Partial<Pick<Provenance, "freshness_window_seconds" | "source">> = {},
+): Provenance {
+  return {
+    source: extras.source ?? { system, kind, locator },
+    observed_at,
+    freshness_status,
+    confidence,
+    ...(extras.freshness_window_seconds !== undefined
+      ? { freshness_window_seconds: extras.freshness_window_seconds }
+      : {}),
+  };
+}
+
+export const ATTENTION_FIXTURES: AttentionItem[] = [
+  {
+    schema_version: "control-center.attention-item.v1",
+    id: "cc:attention-item:01K3CC-COLLECTOR-ERROR",
+    scope: "infrastructure",
+    severity: "critical",
+    status: "open",
+    title: "Coleta de saúde da infra falhou",
+    summary:
+      "A última corrida do coletor de saúde retornou ERROR. Não há observação utilizável para o serviço de contexto.",
+    provenance: provenance(
+      "collector",
+      "health-probe",
+      "health/context-service",
+      "2026-08-20T17:12:00Z",
+      "ERROR",
+      0.21,
+      { freshness_window_seconds: 60 },
+    ),
+    detected_at: "2026-08-20T17:12:00Z",
+    homepage_eligible: true,
+    recommended_action: "Inspecionar o coletor no workstream de infra. Não reabrir túneis ad hoc.",
+  },
+  {
+    schema_version: "control-center.attention-item.v1",
+    id: "cc:attention-item:01K3CC-OVERDUE-INVOICE",
+    scope: "client:acme-industria",
+    severity: "high",
+    status: "open",
+    title: "Fatura em atraso — Acme Indústria",
+    summary:
+      "Recebível aberto fora da janela acordada. Origem Asaas via observação somente leitura; não cobrar a partir deste cockpit.",
+    provenance: provenance(
+      "asaas",
+      "receivable-read",
+      "finance/receivables/open",
+      "2026-08-20T17:00:00Z",
+      "STALE",
+      0.74,
+      { freshness_window_seconds: 1800 },
+    ),
+    detected_at: "2026-08-20T17:00:00Z",
+    homepage_eligible: true,
+    recommended_action: "Revisar em Warmbly/Asaas de origem. Não mutar daqui.",
+  },
+  {
+    schema_version: "control-center.attention-item.v1",
+    id: "cc:attention-item:01K3CC-FAILING-CHECK",
+    scope: "repo:tjsasakifln/Governance",
+    severity: "high",
+    status: "open",
+    title: "Check de CI falhando em Governance",
+    summary: "Há um check vermelho no repositório canônico. Control Center apenas observa.",
+    provenance: provenance(
+      "github",
+      "repo-read",
+      "repos/tjsasakifln/Governance/checks",
+      "2026-08-20T17:54:00Z",
+      "FRESH",
+      0.95,
+    ),
+    detected_at: "2026-08-20T17:54:00Z",
+    homepage_eligible: true,
+    recommended_action: "Tratar no workstream dono do check. Não absorver o PR #8.",
+  },
+  {
+    schema_version: "control-center.attention-item.v1",
+    id: "cc:attention-item:01K3CC-INBOUND-UNREAD",
+    scope: "inbound",
+    severity: "medium",
+    status: "open",
+    title: "Inbound sem leitura há mais de quatro horas",
+    summary: "Fila Warmbly com itens não lidos. Autoridade operacional comercial permanece no Warmbly.",
+    provenance: provenance(
+      "warmbly",
+      "inbound-queue",
+      "inbound/unread",
+      "2026-08-20T17:45:00Z",
+      "FRESH",
+      0.88,
+    ),
+    detected_at: "2026-08-20T17:45:00Z",
+    homepage_eligible: true,
+    recommended_action: "Triagem no Warmbly. Este cockpit não envia mensagem comercial.",
+  },
+  {
+    schema_version: "control-center.attention-item.v1",
+    id: "cc:attention-item:01K3CC-CLIENT-NOTE-UNKNOWN",
+    scope: "client:beta-logistica",
+    severity: "low",
+    status: "acknowledged",
+    title: "Nota de cliente sem observação recente",
+    summary: "Não há observação utilizável do ciclo de vida deste cliente desde a última sincronização.",
+    provenance: provenance(
+      "unknown",
+      "client-record",
+      "clients/beta-logistica",
+      "2026-08-19T12:00:00Z",
+      "UNKNOWN",
+      0.4,
+    ),
+    detected_at: "2026-08-19T12:00:00Z",
+    homepage_eligible: true,
+    recommended_action: "Confirmar o recorte no Warmbly quando a coleta voltar.",
+  },
+  {
+    schema_version: "control-center.attention-item.v1",
+    id: "cc:attention-item:01K3CC-RESOLVED-OLD",
+    scope: "commercial",
+    severity: "medium",
+    status: "resolved",
+    title: "Lead duplicado (já resolvido)",
+    summary: "Item resolvido; não deve aparecer no cockpit de Hoje.",
+    provenance: provenance(
+      "warmbly",
+      "crm-read-model",
+      "commercial/leads/dup",
+      "2026-08-18T10:00:00Z",
+      "FRESH",
+      0.9,
+    ),
+    detected_at: "2026-08-18T10:00:00Z",
+    homepage_eligible: false,
+  },
+];
+
+export const PRIORITY_FIXTURES: PriorityRecommendation[] = [
+  {
+    schema_version: "control-center.priority-recommendation.v1",
+    id: "cc:priority-recommendation:01K3CC-RANK-1-INBOUND",
+    scope: "company",
+    rank: 1,
+    title: "Destravar os três inbound sem leitura",
+    rationale:
+      "A fila de inbound tem itens com mais de quatro horas. Esta é a primeira das no máximo três prioridades atuais.",
+    provenance: provenance(
+      "warmbly",
+      "inbound-queue",
+      "inbound/unread",
+      "2026-08-20T17:45:00Z",
+      "FRESH",
+      0.88,
+    ),
+    generated_at: "2026-08-20T17:46:00Z",
+    horizon: "now",
+    attention_item_ids: ["cc:attention-item:01K3CC-INBOUND-UNREAD"],
+  },
+  {
+    schema_version: "control-center.priority-recommendation.v1",
+    id: "cc:priority-recommendation:01K3CC-RANK-2-OVERDUE",
+    scope: "company",
+    rank: 2,
+    title: "Revisar o recebível em atraso da Acme",
+    rationale: "Exceção financeira de alta severidade, observação defasada. Origem Asaas; sem mutação daqui.",
+    provenance: provenance(
+      "asaas",
+      "receivable-read",
+      "finance/receivables/open",
+      "2026-08-20T17:00:00Z",
+      "STALE",
+      0.74,
+    ),
+    generated_at: "2026-08-20T17:46:00Z",
+    horizon: "today",
+    attention_item_ids: ["cc:attention-item:01K3CC-OVERDUE-INVOICE"],
+  },
+  {
+    schema_version: "control-center.priority-recommendation.v1",
+    id: "cc:priority-recommendation:01K3CC-RANK-3-CI",
+    scope: "company",
+    rank: 3,
+    title: "Tratar o check vermelho de Governance",
+    rationale: "Falha de CI no repositório canônico. Terceira e última prioridade do recorte de Hoje.",
+    provenance: provenance(
+      "github",
+      "repo-read",
+      "repos/tjsasakifln/Governance/checks",
+      "2026-08-20T17:54:00Z",
+      "FRESH",
+      0.95,
+    ),
+    generated_at: "2026-08-20T17:55:00Z",
+    horizon: "today",
+    attention_item_ids: ["cc:attention-item:01K3CC-FAILING-CHECK"],
+  },
+  {
+    schema_version: "control-center.priority-recommendation.v1",
+    id: "cc:priority-recommendation:01K3CC-RANK-4-EXCLUDED",
+    scope: "company",
+    rank: 4,
+    title: "Backlog de documentação (fora do recorte de Hoje)",
+    rationale: "Rank 4 não entra nas três coisas mais importantes agora.",
+    provenance: provenance(
+      "governance",
+      "manual",
+      "docs/ops",
+      "2026-08-20T16:00:00Z",
+      "FRESH",
+      0.6,
+    ),
+    generated_at: "2026-08-20T16:00:00Z",
+    horizon: "this_week",
+  },
+];
+
+export const COMMERCIAL_SNAPSHOT: CommercialSnapshot = {
+  schema_version: "control-center.commercial-snapshot.v1",
+  id: "cc:commercial-snapshot:01K3CC-WARMBLY-OPS",
+  scope: "commercial",
+  generated_at: "2026-08-20T17:40:00Z",
+  provenance: provenance(
+    "warmbly",
+    "crm-read-model",
+    "commercial/pipeline",
+    "2026-08-20T17:39:00Z",
+    "FRESH",
+    0.84,
+  ),
+  authority: {
+    catalog_authority: "governance",
+    commercial_runtime: "warmbly",
+    this_document: "read_model",
+  },
+  pipeline_open_count: 4,
+  inbound_unread_count: 3,
+  at_risk_client_count: 1,
+  attention_item_ids: ["cc:attention-item:01K3CC-INBOUND-UNREAD"],
+};
+
+export const FINANCE_SNAPSHOT: FinanceSnapshot = {
+  schema_version: "control-center.finance-snapshot.v1",
+  id: "cc:finance-snapshot:01K3CC-RO-RECEIVABLES",
+  scope: "finance",
+  generated_at: "2026-08-20T17:20:00Z",
+  provenance: provenance(
+    "asaas",
+    "receivable-read",
+    "finance/receivables",
+    "2026-08-20T17:10:00Z",
+    "STALE",
+    0.7,
+  ),
+  read_model_only: true,
+  provider_mutations: "forbidden",
+  receivables_open: { amount_cents: 2500000, currency: "BRL" },
+  receivables_overdue: { amount_cents: 1500000, currency: "BRL" },
+  attention_item_ids: ["cc:attention-item:01K3CC-OVERDUE-INVOICE"],
+};
+
+export const ENGINEERING_SNAPSHOT: EngineeringSnapshot = {
+  schema_version: "control-center.engineering-snapshot.v1",
+  id: "cc:engineering-snapshot:01K3CC-GOVERNANCE-REPO",
+  scope: "repo:tjsasakifln/Governance",
+  generated_at: "2026-08-20T17:55:00Z",
+  provenance: provenance(
+    "github",
+    "repo-read",
+    "repos/tjsasakifln/Governance",
+    "2026-08-20T17:54:00Z",
+    "FRESH",
+    0.95,
+  ),
+  open_pr_count: 2,
+  failing_check_count: 1,
+  open_incident_count: 0,
+  repo_scopes: ["repo:tjsasakifln/Governance"],
+  attention_item_ids: ["cc:attention-item:01K3CC-FAILING-CHECK"],
+};
+
+export const CLIENT_FIXTURES: ClientStatus[] = [
+  {
+    schema_version: "control-center.client-status.v1",
+    id: "cc:client-status:acme-industria",
+    scope: "client:acme-industria",
+    client_slug: "acme-industria",
+    display_name: "Acme Indústria",
+    lifecycle: "churn_risk",
+    provenance: provenance(
+      "warmbly",
+      "client-record",
+      "clients/acme-industria",
+      "2026-08-20T16:30:00Z",
+      "FRESH",
+      0.8,
+    ),
+    open_receivables: { amount_cents: 1500000, currency: "BRL" },
+    attention_item_ids: ["cc:attention-item:01K3CC-OVERDUE-INVOICE"],
+    notes: "Recebível em atraso. Origem Warmbly/Asaas; sem cobrança daqui.",
+  },
+  {
+    schema_version: "control-center.client-status.v1",
+    id: "cc:client-status:beta-logistica",
+    scope: "client:beta-logistica",
+    client_slug: "beta-logistica",
+    display_name: "Beta Logística",
+    lifecycle: "paused",
+    provenance: provenance(
+      "unknown",
+      "client-record",
+      "clients/beta-logistica",
+      "2026-08-19T12:00:00Z",
+      "UNKNOWN",
+      0.4,
+    ),
+    attention_item_ids: ["cc:attention-item:01K3CC-CLIENT-NOTE-UNKNOWN"],
+    notes: "Ciclo de vida sem observação recente.",
+  },
+  {
+    schema_version: "control-center.client-status.v1",
+    id: "cc:client-status:gama-saude",
+    scope: "client:gama-saude",
+    client_slug: "gama-saude",
+    display_name: "Gama Saúde",
+    lifecycle: "active",
+    provenance: provenance(
+      "warmbly",
+      "client-record",
+      "clients/gama-saude",
+      "2026-08-20T17:20:00Z",
+      "FRESH",
+      0.86,
+    ),
+  },
+];
+
+export const HEALTH_FIXTURES: ServiceHealth[] = [
+  {
+    schema_version: "control-center.service-health.v1",
+    id: "cc:service-health:01K3CC-CONTEXT-API",
+    scope: "infrastructure",
+    service_name: "context-service",
+    status: "unknown",
+    provenance: provenance(
+      "collector",
+      "health-probe",
+      "health/context-service",
+      "2026-08-20T17:12:00Z",
+      "ERROR",
+      0.21,
+      { freshness_window_seconds: 60 },
+    ),
+    checked_at: "2026-08-20T17:12:00Z",
+    message: "Última sonda falhou. Sem chute de saúde.",
+    checks: [{ name: "ready", status: "unknown", detail: "probe error" }],
+  },
+  {
+    schema_version: "control-center.service-health.v1",
+    id: "cc:service-health:01K3CC-WEB-CFG",
+    scope: "infrastructure",
+    service_name: "web-cfg",
+    status: "degraded",
+    provenance: provenance(
+      "collector",
+      "health-probe",
+      "health/web-cfg",
+      "2026-08-20T16:00:00Z",
+      "STALE",
+      0.55,
+      { freshness_window_seconds: 60 },
+    ),
+    checked_at: "2026-08-20T16:00:00Z",
+    latency_ms: 820,
+    checks: [{ name: "ready", status: "degraded", detail: "observation older than window" }],
+  },
+  {
+    schema_version: "control-center.service-health.v1",
+    id: "cc:service-health:01K3CC-GITHUB-COLLECTOR",
+    scope: "infrastructure",
+    service_name: "github-collector",
+    status: "healthy",
+    provenance: provenance(
+      "collector",
+      "health-probe",
+      "health/github-collector",
+      "2026-08-20T17:58:00Z",
+      "FRESH",
+      0.99,
+      { freshness_window_seconds: 60 },
+    ),
+    checked_at: "2026-08-20T17:58:00Z",
+    latency_ms: 42,
+    checks: [{ name: "ready", status: "healthy" }],
+  },
+];
+
+export const DIRECTIVE_FIXTURES: Directive[] = [
+  {
+    schema_version: "control-center.directive.v1",
+    id: "cc:directive:01K3CC-NO-PROVIDER-MUTATION",
+    kind: "constraint",
+    scope: "finance",
+    status: "active",
+    title: "Sem mutações financeiras de provedor no Control Center",
+    body: "Coletores e agentes NÃO executam cobrança, checkout, refund, cancelamento, escritas Asaas ou envio comercial. Isso permanece nos sistemas de origem.",
+    effective_from: "2026-08-20T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: MOCK_OPERATOR,
+    created_at: "2026-08-20T12:00:00Z",
+    updated_at: "2026-08-20T12:00:00Z",
+    audit: [
+      {
+        at: "2026-08-20T12:00:00Z",
+        actor: MOCK_OPERATOR,
+        action: "created",
+        to_status: "active",
+      },
+    ],
+    tags: ["fail-closed", "finance"],
+  },
+  {
+    schema_version: "control-center.directive.v1",
+    id: "cc:directive:01K3CC-GOVERNANCE-AUTHORITY",
+    kind: "decision",
+    scope: "company",
+    status: "active",
+    title: "Governance é a autoridade estratégica; Warmbly a operacional comercial",
+    body: "Catálogo e decisões canônicas vivem em Governance. CRM/pipeline executam no Warmbly. Este cockpit agrega estado, não substitui origem.",
+    effective_from: "2026-08-17T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: MOCK_OPERATOR,
+    created_at: "2026-08-17T12:00:00Z",
+    updated_at: "2026-08-17T12:00:00Z",
+    audit: [
+      {
+        at: "2026-08-17T12:00:00Z",
+        actor: MOCK_OPERATOR,
+        action: "created",
+        to_status: "active",
+      },
+    ],
+  },
+  {
+    schema_version: "control-center.directive.v1",
+    id: "cc:directive:01K3CC-SCOPE-CONTEXT",
+    kind: "directive",
+    scope: "company",
+    status: "active",
+    title: "Agentes consultam contexto por escopo",
+    body: "Nenhum agente recebe a memória inteira da empresa. Contexto é recortado pelos escopos concedidos na sessão.",
+    effective_from: "2026-08-20T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: MOCK_OPERATOR,
+    created_at: "2026-08-20T12:10:00Z",
+    updated_at: "2026-08-20T12:10:00Z",
+    audit: [
+      {
+        at: "2026-08-20T12:10:00Z",
+        actor: MOCK_OPERATOR,
+        action: "created",
+        to_status: "active",
+      },
+    ],
+  },
+  {
+    schema_version: "control-center.directive.v1",
+    id: "cc:directive:01K3CC-MONEY-CENTS",
+    kind: "fact",
+    scope: "finance",
+    status: "active",
+    title: "Valores financeiros são inteiros em centavos mais currency",
+    body: "Floats são inválidos. Apresentação pode formatar; o modelo permanece amount_cents + currency.",
+    effective_from: "2026-08-20T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: MOCK_OPERATOR,
+    created_at: "2026-08-20T12:20:00Z",
+    updated_at: "2026-08-20T12:20:00Z",
+    audit: [
+      {
+        at: "2026-08-20T12:20:00Z",
+        actor: MOCK_OPERATOR,
+        action: "created",
+        to_status: "active",
+      },
+    ],
+  },
+  {
+    schema_version: "control-center.directive.v1",
+    id: "cc:directive:01K3CC-HOJE-THREE",
+    kind: "priority",
+    scope: "company",
+    status: "active",
+    title: "Hoje privilegia exceções e no máximo três prioridades",
+    body: "Homepage não é parede de KPIs e não é chat.",
+    effective_from: "2026-08-20T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    created_by: MOCK_OPERATOR,
+    created_at: "2026-08-20T12:30:00Z",
+    updated_at: "2026-08-20T12:30:00Z",
+    audit: [
+      {
+        at: "2026-08-20T12:30:00Z",
+        actor: MOCK_OPERATOR,
+        action: "created",
+        to_status: "active",
+      },
+    ],
+  },
+  {
+    schema_version: "control-center.directive.v1",
+    id: "cc:directive:01K3CC-STALE-RISK",
+    kind: "risk",
+    scope: "finance",
+    status: "active",
+    title: "Observação financeira defasada não deve ser tratada como saldo ao vivo",
+    body: "Freshness STALE no recorte Asaas. Confiança e recência são eixos distintos.",
+    effective_from: "2026-08-20T17:00:00Z",
+    expires_at: "2026-08-27T00:00:00Z",
+    supersedes: null,
+    created_by: MOCK_OPERATOR,
+    created_at: "2026-08-20T17:05:00Z",
+    updated_at: "2026-08-20T17:05:00Z",
+    audit: [
+      {
+        at: "2026-08-20T17:05:00Z",
+        actor: MOCK_OPERATOR,
+        action: "created",
+        to_status: "active",
+      },
+    ],
+  },
+  {
+    schema_version: "control-center.directive.v1",
+    id: "cc:directive:01K3CC-COLLECTOR-HYPOTHESIS",
+    kind: "hypothesis",
+    scope: "infrastructure",
+    status: "active",
+    title: "A falha da sonda pode ser janela de freshness, não queda do serviço",
+    body: "Hipótese a confirmar no coletor. Não promover a incidente sem evidência.",
+    effective_from: "2026-08-20T17:12:00Z",
+    expires_at: "2026-08-21T17:12:00Z",
+    supersedes: null,
+    created_by: { kind: "agent", id: "agent:cc-context", display_name: "Agente de contexto" },
+    created_at: "2026-08-20T17:15:00Z",
+    updated_at: "2026-08-20T17:15:00Z",
+    audit: [
+      {
+        at: "2026-08-20T17:15:00Z",
+        actor: { kind: "agent", id: "agent:cc-context" },
+        action: "created",
+        to_status: "active",
+      },
+    ],
+  },
+];
+
+export const AGENT_SESSION_FIXTURES: AgentSession[] = [
+  {
+    schema_version: "control-center.agent-session.v1",
+    id: "cc:agent-session:01K3CC-CTX-FINANCE",
+    agent_id: "agent:cc-context",
+    requested_scopes: ["finance", "client:acme-industria"],
+    granted_scopes: ["finance", "client:acme-industria"],
+    purpose:
+      "Preparar briefing recortado de recebíveis em atraso. Não despejar a memória da empresa.",
+    started_at: "2026-08-20T17:50:00Z",
+    ended_at: null,
+    status: "open",
+    created_by: { kind: "agent", id: "agent:cc-context" },
+    include_directives: true,
+    include_snapshots: true,
+    include_attention: true,
+  },
+  {
+    schema_version: "control-center.agent-session.v1",
+    id: "cc:agent-session:01K3CC-CTX-DENIED-COMPANY",
+    agent_id: "agent:cc-context",
+    requested_scopes: ["company"],
+    granted_scopes: [],
+    purpose: "Pedido de dump company-wide. Negado: agentes consultam por escopo.",
+    started_at: "2026-08-20T17:10:00Z",
+    ended_at: "2026-08-20T17:10:02Z",
+    status: "denied",
+    created_by: { kind: "system", id: "system:mcp-guard" },
+    include_directives: false,
+    include_snapshots: false,
+    include_attention: false,
+  },
+];
+
+export const FRESHNESS_SAMPLES: Record<Provenance["freshness_status"], Provenance> = {
+  FRESH: ATTENTION_FIXTURES[2]!.provenance,
+  STALE: ATTENTION_FIXTURES[1]!.provenance,
+  UNKNOWN: ATTENTION_FIXTURES[4]!.provenance,
+  ERROR: ATTENTION_FIXTURES[0]!.provenance,
+};
+
+function pageFor(
+  id: DestinationId,
+  extras: Omit<DestinationPage, "id" | "label" | "scope" | "generated_at" | "operator">,
+): DestinationPage {
+  const dest = getDestination(id);
+  return {
+    id,
+    label: dest.label,
+    scope: dest.scope,
+    generated_at: GENERATED_AT,
+    operator: MOCK_OPERATOR,
+    ...extras,
+  };
+}
+
+function attentionByScope(predicate: (item: AttentionItem) => boolean): AttentionItem[] {
+  return ATTENTION_FIXTURES.filter(predicate);
+}
+
+export function defaultPages(): Record<DestinationId, DestinationPage> {
+  const hojeAttention = selectHomepageAttention(ATTENTION_FIXTURES);
+  const hojePriorities = selectHomepagePriorities(PRIORITY_FIXTURES);
+  return {
+    hoje: pageFor("hoje", {
+      headline: "O que exige atenção agora. Não é chat e não é parede de KPIs.",
+      attention: hojeAttention,
+      priorities: hojePriorities,
+    }),
+    comercial: pageFor("comercial", {
+      headline: "Recorte comercial somente leitura. Origem Warmbly; catálogo canônico em Governance.",
+      attention: attentionByScope(
+        (item) => item.scope === "inbound" || item.scope === "commercial" || item.scope === "clients",
+      ).filter((item) => item.status === "open" || item.status === "acknowledged"),
+      priorities: PRIORITY_FIXTURES.filter((item) => item.rank === 1),
+      commercial: COMMERCIAL_SNAPSHOT,
+    }),
+    clientes: pageFor("clientes", {
+      headline: "Estado agregado por cliente. Exceções primeiro.",
+      attention: attentionByScope((item) => item.scope.startsWith("client:")),
+      priorities: PRIORITY_FIXTURES.filter((item) => item.rank === 2),
+      clients: CLIENT_FIXTURES,
+    }),
+    financeiro: pageFor("financeiro", {
+      headline:
+        "Somente leitura. Cobrança, checkout, refund, cancelamento e escritas Asaas são proibidas neste cockpit.",
+      attention: attentionByScope((item) => item.scope.startsWith("client:") || item.scope === "finance"),
+      priorities: PRIORITY_FIXTURES.filter((item) => item.rank === 2),
+      finance: FINANCE_SNAPSHOT,
+    }),
+    engenharia: pageFor("engenharia", {
+      headline: "Sinais de repositório. Sem mutar origem e sem absorver o PR Governance #8.",
+      attention: attentionByScope((item) => item.scope.startsWith("repo:")),
+      priorities: PRIORITY_FIXTURES.filter((item) => item.rank === 3),
+      engineering: ENGINEERING_SNAPSHOT,
+    }),
+    infra: pageFor("infra", {
+      headline: "Saúde observada. Freshness e confiança são eixos distintos.",
+      attention: attentionByScope((item) => item.scope === "infrastructure"),
+      priorities: [],
+      health: HEALTH_FIXTURES,
+    }),
+    memoria: pageFor("memoria", {
+      headline: "Diretivas humanas por kind, escopo, vigência e trilha de auditoria.",
+      attention: [],
+      priorities: [],
+      directives: DIRECTIVE_FIXTURES,
+    }),
+    agentes: pageFor("agentes", {
+      headline: "Sessões com escopos concedidos. Pedido company-wide é negado.",
+      attention: [],
+      priorities: [],
+      sessions: AGENT_SESSION_FIXTURES,
+    }),
+  };
+}
+
+export function emptyPages(): Record<DestinationId, DestinationPage> {
+  const empty: Record<DestinationId, DestinationPage> = {} as Record<DestinationId, DestinationPage>;
+  for (const dest of DESTINATIONS) {
+    empty[dest.id] = pageFor(dest.id, {
+      headline: dest.description,
+      attention: [],
+      priorities: [],
+    });
+  }
+  return empty;
+}
+
+export function stalePages(): Record<DestinationId, DestinationPage> {
+  const pages = defaultPages();
+  const stamp = (item: Provenance): Provenance => ({
+    ...item,
+    freshness_status: "STALE",
+  });
+  for (const id of Object.keys(pages) as DestinationId[]) {
+    const page = pages[id];
+    page.attention = page.attention.map((item) => ({
+      ...item,
+      provenance: stamp(item.provenance),
+    }));
+    page.priorities = page.priorities.map((item) => ({
+      ...item,
+      provenance: stamp(item.provenance),
+    }));
+    if (page.finance) page.finance = { ...page.finance, provenance: stamp(page.finance.provenance) };
+    if (page.commercial) {
+      page.commercial = { ...page.commercial, provenance: stamp(page.commercial.provenance) };
+    }
+    if (page.engineering) {
+      page.engineering = { ...page.engineering, provenance: stamp(page.engineering.provenance) };
+    }
+    if (page.health) {
+      page.health = page.health.map((item) => ({ ...item, provenance: stamp(item.provenance) }));
+    }
+    if (page.clients) {
+      page.clients = page.clients.map((item) => ({ ...item, provenance: stamp(item.provenance) }));
+    }
+  }
+  return pages;
+}

--- a/control-center/apps/web-shell/src/homepage.ts
+++ b/control-center/apps/web-shell/src/homepage.ts
@@ -1,0 +1,63 @@
+import type { AttentionItem, AttentionSeverity, PriorityRecommendation } from "./types";
+
+/** Homepage consumes ranks 1–3. Duplicated from contracts v1; do not import the other workstream. */
+export const HOMEPAGE_PRIORITY_LIMIT = 3;
+
+const SEVERITY_RANK: Record<AttentionSeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+const HOMEPAGE_STATUSES = new Set(["open", "acknowledged"]);
+
+export function selectHomepageAttention(items: readonly AttentionItem[]): AttentionItem[] {
+  return items
+    .filter((item) => item.homepage_eligible && HOMEPAGE_STATUSES.has(item.status))
+    .slice()
+    .sort((a, b) => {
+      const severity = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+      if (severity !== 0) return severity;
+      if (a.detected_at === b.detected_at) return a.id.localeCompare(b.id);
+      return a.detected_at < b.detected_at ? 1 : -1;
+    });
+}
+
+export function selectHomepagePriorities(
+  recommendations: readonly PriorityRecommendation[],
+): PriorityRecommendation[] {
+  return recommendations
+    .filter((item) => item.rank >= 1 && item.rank <= HOMEPAGE_PRIORITY_LIMIT)
+    .slice()
+    .sort((a, b) => a.rank - b.rank || a.id.localeCompare(b.id))
+    .slice(0, HOMEPAGE_PRIORITY_LIMIT);
+}
+
+export interface HojeModel {
+  attention: AttentionItem[];
+  priorities: PriorityRecommendation[];
+}
+
+/**
+ * Hoje is an attention cockpit: exceptions first, then at most three
+ * current priorities. Not a chat thread and not a KPI wall.
+ */
+export function selectHojeModel(input: {
+  attention: readonly AttentionItem[];
+  priorities: readonly PriorityRecommendation[];
+}): HojeModel {
+  return {
+    attention: selectHomepageAttention(input.attention),
+    priorities: selectHomepagePriorities(input.priorities),
+  };
+}
+
+export function hasOpenHighSeverity(items: readonly AttentionItem[]): boolean {
+  return items.some(
+    (item) =>
+      item.homepage_eligible &&
+      item.status === "open" &&
+      (item.severity === "high" || item.severity === "critical"),
+  );
+}

--- a/control-center/apps/web-shell/src/main.ts
+++ b/control-center/apps/web-shell/src/main.ts
@@ -1,0 +1,4 @@
+import { startBrowser } from "./boot";
+import "./styles.css";
+
+startBrowser();

--- a/control-center/apps/web-shell/src/money.ts
+++ b/control-center/apps/web-shell/src/money.ts
@@ -1,0 +1,24 @@
+import type { Money } from "./types";
+
+const CURRENCY_PATTERN = /^[A-Z]{3}$/;
+
+export function isMoney(value: Money): boolean {
+  return Number.isInteger(value.amount_cents) && CURRENCY_PATTERN.test(value.currency);
+}
+
+/**
+ * Integer cents + ISO-4217 currency. Never a float.
+ * Presentation uses pt-BR grouping; the model stays cents.
+ */
+export function formatMoney(value: Money): string {
+  if (!isMoney(value)) {
+    throw new Error("Money must be integer cents plus ISO-4217 currency");
+  }
+  const negative = value.amount_cents < 0;
+  const abs = Math.abs(value.amount_cents);
+  const major = Math.floor(abs / 100);
+  const minor = String(abs % 100).padStart(2, "0");
+  const grouped = major.toLocaleString("pt-BR");
+  const sign = negative ? "-" : "";
+  return `${sign}${value.currency} ${grouped},${minor}`;
+}

--- a/control-center/apps/web-shell/src/page.ts
+++ b/control-center/apps/web-shell/src/page.ts
@@ -1,0 +1,37 @@
+import type { DestinationPage } from "./adapters/contract";
+import type { Provenance } from "./types";
+
+export function collectProvenance(page: DestinationPage): Provenance[] {
+  const items: Provenance[] = [];
+  for (const row of page.attention) items.push(row.provenance);
+  for (const row of page.priorities) items.push(row.provenance);
+  if (page.commercial) items.push(page.commercial.provenance);
+  if (page.finance) items.push(page.finance.provenance);
+  if (page.engineering) items.push(page.engineering.provenance);
+  if (page.clients) {
+    for (const row of page.clients) items.push(row.provenance);
+  }
+  if (page.health) {
+    for (const row of page.health) items.push(row.provenance);
+  }
+  return items;
+}
+
+export function pageIsEmpty(page: DestinationPage): boolean {
+  return (
+    page.attention.length === 0 &&
+    page.priorities.length === 0 &&
+    page.commercial === undefined &&
+    page.finance === undefined &&
+    page.engineering === undefined &&
+    (page.clients?.length ?? 0) === 0 &&
+    (page.health?.length ?? 0) === 0 &&
+    (page.directives?.length ?? 0) === 0 &&
+    (page.sessions?.length ?? 0) === 0
+  );
+}
+
+export function pageIsStale(page: DestinationPage): boolean {
+  const provenances = collectProvenance(page);
+  return provenances.length > 0 && provenances.every((item) => item.freshness_status === "STALE");
+}

--- a/control-center/apps/web-shell/src/provenance.ts
+++ b/control-center/apps/web-shell/src/provenance.ts
@@ -1,0 +1,81 @@
+import { formatLocal, formatUtc, isUtcDateTime } from "./datetime";
+import {
+  FRESHNESS_STATUSES,
+  type FreshnessStatus,
+  type Provenance,
+} from "./types";
+
+export interface ProvenancePresentation {
+  sourceSystem: string;
+  sourceKind: string;
+  sourceLocator: string;
+  sourceLabel: string;
+  observedAtUtc: string;
+  observedAtLocal: string;
+  freshnessStatus: FreshnessStatus;
+  freshnessLabel: string;
+  confidence: number;
+  confidenceLabel: string;
+}
+
+const FRESHNESS_LABELS: Record<FreshnessStatus, string> = {
+  FRESH: "fresco",
+  STALE: "defasado",
+  UNKNOWN: "desconhecido",
+  ERROR: "erro de coleta",
+};
+
+export function freshnessLabel(status: FreshnessStatus): string {
+  return FRESHNESS_LABELS[status];
+}
+
+export function isFreshnessStatus(value: string): value is FreshnessStatus {
+  return (FRESHNESS_STATUSES as readonly string[]).includes(value);
+}
+
+/**
+ * Round-trips aggregated provenance into a labeled presentation model.
+ * Freshness is recency; confidence is trust. They are not aliases.
+ */
+export function mapProvenance(provenance: Provenance): ProvenancePresentation {
+  if (!isFreshnessStatus(provenance.freshness_status)) {
+    throw new Error(`Invalid freshness_status: ${provenance.freshness_status}`);
+  }
+  if (!isUtcDateTime(provenance.observed_at)) {
+    throw new Error("observed_at must be UTC RFC3339 with Z");
+  }
+  if (provenance.confidence < 0 || provenance.confidence > 1) {
+    throw new Error("confidence must be in [0, 1]");
+  }
+  const sourceLabel =
+    provenance.source.label ?? `${provenance.source.system} · ${provenance.source.kind}`;
+  return {
+    sourceSystem: provenance.source.system,
+    sourceKind: provenance.source.kind,
+    sourceLocator: provenance.source.locator,
+    sourceLabel,
+    observedAtUtc: formatUtc(provenance.observed_at),
+    observedAtLocal: formatLocal(provenance.observed_at),
+    freshnessStatus: provenance.freshness_status,
+    freshnessLabel: freshnessLabel(provenance.freshness_status),
+    confidence: provenance.confidence,
+    confidenceLabel: `confiança ${provenance.confidence.toFixed(2).replace(".", ",")}`,
+  };
+}
+
+export function provenanceFromPresentation(
+  presentation: ProvenancePresentation,
+): Pick<Provenance, "observed_at" | "freshness_status" | "confidence"> & {
+  source: { system: string; kind: string; locator: string };
+} {
+  return {
+    source: {
+      system: presentation.sourceSystem,
+      kind: presentation.sourceKind,
+      locator: presentation.sourceLocator,
+    },
+    observed_at: presentation.observedAtUtc,
+    freshness_status: presentation.freshnessStatus,
+    confidence: presentation.confidence,
+  };
+}

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -1,0 +1,434 @@
+:root {
+  color-scheme: dark;
+  --bg: #121418;
+  --bg-elev: #1b1e24;
+  --bg-card: #22262e;
+  --fg: #e8eaed;
+  --fg-muted: #c5ccd4;
+  --line: #3a404a;
+  --accent: #c4b59a;
+  --focus: #e6d7a8;
+  --crit: #f3b4b4;
+  --high: #f3d0a4;
+  --med: #d7d3a8;
+  --low: #b7c4d4;
+  --ok: #b5c9b0;
+  --space: 0.85rem;
+  --font: "Segoe UI", system-ui, -apple-system, sans-serif;
+  --mono: ui-monospace, "SFMono-Regular", "Cascadia Code", Menlo, monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font);
+  font-size: 16px;
+  line-height: 1.45;
+}
+
+#root {
+  min-height: 100dvh;
+}
+
+a {
+  color: var(--accent);
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 0.75rem;
+  top: -3rem;
+  z-index: 20;
+  background: var(--bg-elev);
+  color: var(--fg);
+  padding: 0.5rem 0.75rem;
+}
+
+.skip-link:focus {
+  top: 0.5rem;
+}
+
+.shell {
+  min-height: 100dvh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "top"
+    "main"
+    "nav";
+}
+
+.topbar {
+  grid-area: top;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-elev);
+}
+
+.brand {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.operator {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+}
+
+.nav {
+  grid-area: nav;
+  display: flex;
+  gap: 0.25rem;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+  padding: 0.4rem 0.5rem calc(0.4rem + env(safe-area-inset-bottom));
+  background: var(--bg-elev);
+  border-top: 1px solid var(--line);
+}
+
+.nav a {
+  flex: 0 0 auto;
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 0.8rem;
+  color: var(--fg);
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 0.92rem;
+  white-space: nowrap;
+}
+
+.nav a[aria-current="page"] {
+  border-color: var(--accent);
+  background: #2a2620;
+}
+
+main {
+  grid-area: main;
+  padding: 0.9rem 0.9rem 1.4rem;
+  max-width: 52rem;
+}
+
+.page-head h1 {
+  margin: 0 0 0.3rem;
+  font-size: 1.35rem;
+  font-weight: 650;
+}
+
+.page-head p {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+.mock-lab {
+  margin: 0.9rem 0;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--line);
+  background: var(--bg-elev);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.55rem;
+  align-items: center;
+}
+
+.mock-lab p {
+  margin: 0;
+  width: 100%;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.mock-lab a {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--fg);
+  font-size: 0.85rem;
+}
+
+.mock-lab a[aria-current="true"] {
+  border-color: var(--accent);
+}
+
+.banner {
+  margin: 0 0 1rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--line);
+}
+
+.banner.loading {
+  border-color: var(--low);
+}
+
+.banner.error {
+  border-color: var(--crit);
+}
+
+.banner.stale {
+  border-color: var(--high);
+}
+
+.banner.empty {
+  border-color: var(--line);
+  color: var(--fg-muted);
+}
+
+.banner .code {
+  margin: 0.35rem 0 0;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+}
+
+h2 {
+  margin: 1.15rem 0 0.55rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 650;
+}
+
+.stack,
+.priorities ol {
+  display: grid;
+  gap: 0.7rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--line);
+  padding: 0.8rem 0.85rem 0.7rem;
+}
+
+.card h3 {
+  margin: 0.15rem 0 0.4rem;
+  font-size: 1.02rem;
+  font-weight: 650;
+}
+
+.card p {
+  margin: 0 0 0.55rem;
+}
+
+.kicker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+  margin: 0 0 0.2rem;
+  color: var(--fg-muted);
+  font-size: 0.8rem;
+}
+
+.scope {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+}
+
+.pill {
+  display: inline-block;
+  border: 1px solid var(--line);
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.attention[data-severity="critical"] {
+  border-left: 3px solid var(--crit);
+}
+
+.attention[data-severity="high"] {
+  border-left: 3px solid var(--high);
+}
+
+.attention[data-severity="medium"] {
+  border-left: 3px solid var(--med);
+}
+
+.attention[data-severity="low"] {
+  border-left: 3px solid var(--low);
+}
+
+.prov {
+  display: grid;
+  gap: 0.35rem 0.8rem;
+  margin: 0.4rem 0 0;
+  padding-top: 0.45rem;
+  border-top: 1px solid var(--line);
+  font-size: 0.8rem;
+}
+
+.prov div {
+  display: grid;
+  grid-template-columns: 6.2rem 1fr;
+  gap: 0.35rem;
+}
+
+.prov dt {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+.prov dd {
+  margin: 0;
+}
+
+.pill-fresh {
+  border-color: var(--ok);
+}
+
+.pill-stale {
+  border-color: var(--high);
+}
+
+.pill-unknown {
+  border-color: var(--low);
+}
+
+.pill-error {
+  border-color: var(--crit);
+}
+
+.facts {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0 0 0.6rem;
+}
+
+.facts div,
+.money {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+  padding: 0.2rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.facts dt,
+.money dt {
+  color: var(--fg-muted);
+}
+
+.facts dd,
+.money dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.compact {
+  margin-top: 1rem;
+}
+
+.authority,
+.constraint,
+.action,
+.audit {
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.file-protocol {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 1rem;
+}
+
+.file-protocol pre {
+  background: var(--bg-card);
+  padding: 0.8rem;
+  overflow-x: auto;
+}
+
+@media (min-width: 880px) {
+  .shell {
+    grid-template-columns: 13.5rem 1fr;
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+      "top top"
+      "nav main";
+  }
+
+  .nav {
+    flex-direction: column;
+    overflow: visible;
+    border-top: 0;
+    border-right: 1px solid var(--line);
+    padding: 0.8rem 0.55rem;
+    position: sticky;
+    top: 0;
+    align-self: start;
+    height: calc(100dvh - 3rem);
+  }
+
+  .nav a {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  main {
+    padding: 1.2rem 1.6rem 2rem;
+  }
+
+  .page-head h1 {
+    font-size: 1.6rem;
+  }
+}
+
+@media (max-width: 430px) {
+  body {
+    font-size: 15px;
+  }
+
+  main {
+    padding: 0.75rem 0.75rem 1.1rem;
+  }
+}

--- a/control-center/apps/web-shell/src/types.ts
+++ b/control-center/apps/web-shell/src/types.ts
@@ -1,0 +1,246 @@
+/**
+ * Local copies of Control Center v1 field names.
+ * Canonical JSON Schema lives in the contracts workstream
+ * (`control-center/contracts`). This shell MUST NOT import that package
+ * until the convergence campaign. Keep names in lockstep:
+ * source, observed_at, freshness_status, confidence, cents+currency,
+ * directive kinds, freshness FRESH|STALE|UNKNOWN|ERROR.
+ */
+
+export type UtcDateTime = string;
+
+export type ResourceId = string;
+
+export type Scope = string;
+
+export const FRESHNESS_STATUSES = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const DIRECTIVE_KINDS = [
+  "decision",
+  "directive",
+  "fact",
+  "constraint",
+  "priority",
+  "risk",
+  "hypothesis",
+] as const;
+export type DirectiveKind = (typeof DIRECTIVE_KINDS)[number];
+
+export const DIRECTIVE_STATUSES = [
+  "draft",
+  "active",
+  "superseded",
+  "revoked",
+  "expired",
+] as const;
+export type DirectiveStatus = (typeof DIRECTIVE_STATUSES)[number];
+
+export const ATTENTION_SEVERITIES = ["critical", "high", "medium", "low"] as const;
+export type AttentionSeverity = (typeof ATTENTION_SEVERITIES)[number];
+
+export const ATTENTION_STATUSES = [
+  "open",
+  "acknowledged",
+  "resolved",
+  "dismissed",
+] as const;
+export type AttentionStatus = (typeof ATTENTION_STATUSES)[number];
+
+export const PRIORITY_HORIZONS = ["now", "today", "this_week"] as const;
+export type PriorityHorizon = (typeof PRIORITY_HORIZONS)[number];
+
+export const AGENT_SESSION_STATUSES = ["open", "closed", "denied"] as const;
+export type AgentSessionStatus = (typeof AGENT_SESSION_STATUSES)[number];
+
+export const CLIENT_LIFECYCLES = [
+  "lead",
+  "active",
+  "paused",
+  "churn_risk",
+  "churned",
+  "unknown",
+] as const;
+export type ClientLifecycle = (typeof CLIENT_LIFECYCLES)[number];
+
+export const HEALTH_STATUSES = ["healthy", "degraded", "down", "unknown"] as const;
+export type HealthStatus = (typeof HEALTH_STATUSES)[number];
+
+export const ACTOR_KINDS = ["human", "agent", "system"] as const;
+export type ActorKind = (typeof ACTOR_KINDS)[number];
+
+export interface SourceRef {
+  system: string;
+  kind: string;
+  locator: string;
+  label?: string;
+}
+
+export interface ActorRef {
+  kind: ActorKind;
+  id: string;
+  display_name?: string;
+}
+
+export interface Money {
+  amount_cents: number;
+  currency: string;
+}
+
+export interface Provenance {
+  source: SourceRef;
+  observed_at: UtcDateTime;
+  freshness_status: FreshnessStatus;
+  confidence: number;
+  freshness_window_seconds?: number;
+}
+
+export interface DirectiveAuditEntry {
+  at: UtcDateTime;
+  actor: ActorRef;
+  action: "created" | "updated" | "status_changed" | "superseded" | "revoked";
+  from_status?: DirectiveStatus;
+  to_status?: DirectiveStatus;
+  note?: string;
+}
+
+export interface Directive {
+  schema_version: "control-center.directive.v1";
+  id: ResourceId;
+  kind: DirectiveKind;
+  scope: Scope;
+  status: DirectiveStatus;
+  title: string;
+  body: string;
+  effective_from: UtcDateTime;
+  expires_at: UtcDateTime | null;
+  supersedes: ResourceId[] | null;
+  created_by: ActorRef;
+  created_at: UtcDateTime;
+  updated_at: UtcDateTime;
+  audit: DirectiveAuditEntry[];
+  tags?: string[];
+  related_ids?: ResourceId[];
+}
+
+export interface AttentionItem {
+  schema_version: "control-center.attention-item.v1";
+  id: ResourceId;
+  scope: Scope;
+  severity: AttentionSeverity;
+  status: AttentionStatus;
+  title: string;
+  summary: string;
+  provenance: Provenance;
+  detected_at: UtcDateTime;
+  homepage_eligible: boolean;
+  recommended_action?: string;
+  related_ids?: ResourceId[];
+}
+
+export interface PriorityRecommendation {
+  schema_version: "control-center.priority-recommendation.v1";
+  id: ResourceId;
+  scope: Scope;
+  rank: number;
+  title: string;
+  rationale: string;
+  provenance: Provenance;
+  generated_at: UtcDateTime;
+  horizon: PriorityHorizon;
+  attention_item_ids?: ResourceId[];
+  directive_ids?: ResourceId[];
+}
+
+export interface AgentSession {
+  schema_version: "control-center.agent-session.v1";
+  id: ResourceId;
+  agent_id: string;
+  requested_scopes: Scope[];
+  granted_scopes: Scope[];
+  purpose: string;
+  started_at: UtcDateTime;
+  ended_at: UtcDateTime | null;
+  status: AgentSessionStatus;
+  created_by: ActorRef;
+  include_directives: boolean;
+  include_snapshots: boolean;
+  include_attention: boolean;
+}
+
+export interface ClientStatus {
+  schema_version: "control-center.client-status.v1";
+  id: ResourceId;
+  scope: Scope;
+  client_slug: string;
+  display_name: string;
+  lifecycle: ClientLifecycle;
+  provenance: Provenance;
+  attention_item_ids?: ResourceId[];
+  open_receivables?: Money;
+  notes?: string;
+}
+
+export interface CommercialAuthorityStamp {
+  catalog_authority: "governance";
+  commercial_runtime: "warmbly";
+  this_document: "read_model";
+}
+
+export interface CommercialSnapshot {
+  schema_version: "control-center.commercial-snapshot.v1";
+  id: ResourceId;
+  scope: Scope;
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  authority: CommercialAuthorityStamp;
+  pipeline_open_count: number;
+  inbound_unread_count: number;
+  at_risk_client_count: number;
+  attention_item_ids?: ResourceId[];
+}
+
+export interface FinanceSnapshot {
+  schema_version: "control-center.finance-snapshot.v1";
+  id: ResourceId;
+  scope: Scope;
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  read_model_only: true;
+  provider_mutations: "forbidden";
+  receivables_open: Money;
+  receivables_overdue: Money;
+  attention_item_ids?: ResourceId[];
+}
+
+export interface EngineeringSnapshot {
+  schema_version: "control-center.engineering-snapshot.v1";
+  id: ResourceId;
+  scope: Scope;
+  generated_at: UtcDateTime;
+  provenance: Provenance;
+  open_pr_count: number;
+  failing_check_count: number;
+  open_incident_count: number;
+  repo_scopes?: Scope[];
+  attention_item_ids?: ResourceId[];
+}
+
+export interface ServiceHealthCheck {
+  name: string;
+  status: HealthStatus;
+  detail?: string;
+}
+
+export interface ServiceHealth {
+  schema_version: "control-center.service-health.v1";
+  id: ResourceId;
+  scope: Scope;
+  service_name: string;
+  status: HealthStatus;
+  provenance: Provenance;
+  checked_at: UtcDateTime;
+  latency_ms?: number;
+  message?: string;
+  checks?: ServiceHealthCheck[];
+}

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -1,0 +1,330 @@
+import type { DestinationPage } from "../adapters/contract";
+import { DESTINATIONS, hashFor, type DestinationId } from "../destinations";
+import { escapeHtml } from "../escape";
+import { formatMoney } from "../money";
+import { mapProvenance, type ProvenancePresentation } from "../provenance";
+import {
+  DEFAULT_LOADING_LABEL,
+  VIEW_KINDS,
+  type ViewKind,
+  type ViewState,
+} from "../view-state";
+import type {
+  AgentSession,
+  AttentionItem,
+  ClientStatus,
+  CommercialSnapshot,
+  Directive,
+  EngineeringSnapshot,
+  FinanceSnapshot,
+  PriorityRecommendation,
+  Provenance,
+  ServiceHealth,
+} from "../types";
+
+export interface ShellModel {
+  destination: DestinationId;
+  viewKind: ViewKind;
+  view: ViewState<DestinationPage>;
+  mockScenario: string;
+}
+
+function provenanceBlock(provenance: Provenance): string {
+  const p: ProvenancePresentation = mapProvenance(provenance);
+  return `
+    <dl class="prov" data-freshness="${escapeHtml(p.freshnessStatus)}" data-source="${escapeHtml(p.sourceSystem)}">
+      <div>
+        <dt>Origem</dt>
+        <dd>${escapeHtml(p.sourceLabel)}</dd>
+      </div>
+      <div>
+        <dt>Observado</dt>
+        <dd>
+          <time datetime="${escapeHtml(p.observedAtUtc)}">${escapeHtml(p.observedAtLocal)}</time>
+          <span class="sr-only">UTC ${escapeHtml(p.observedAtUtc)}</span>
+        </dd>
+      </div>
+      <div>
+        <dt>Freshness</dt>
+        <dd><span class="pill pill-${escapeHtml(p.freshnessStatus.toLowerCase())}">${escapeHtml(p.freshnessStatus)} · ${escapeHtml(p.freshnessLabel)}</span></dd>
+      </div>
+      <div>
+        <dt>Confiança</dt>
+        <dd>${escapeHtml(p.confidenceLabel)}</dd>
+      </div>
+    </dl>
+  `;
+}
+
+function attentionCard(item: AttentionItem): string {
+  return `
+    <article class="card attention" data-severity="${escapeHtml(item.severity)}" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}">
+      <header>
+        <p class="kicker"><span class="pill">${escapeHtml(item.severity)}</span> <span class="pill">${escapeHtml(item.status)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
+        <h3>${escapeHtml(item.title)}</h3>
+      </header>
+      <p>${escapeHtml(item.summary)}</p>
+      ${item.recommended_action ? `<p class="action">Ação sugerida: ${escapeHtml(item.recommended_action)}</p>` : ""}
+      ${provenanceBlock(item.provenance)}
+    </article>
+  `;
+}
+
+function priorityCard(item: PriorityRecommendation): string {
+  return `
+    <li class="card priority" data-rank="${item.rank}" data-id="${escapeHtml(item.id)}">
+      <p class="kicker">Prioridade ${item.rank} · ${escapeHtml(item.horizon)}</p>
+      <h3>${escapeHtml(item.title)}</h3>
+      <p>${escapeHtml(item.rationale)}</p>
+      ${provenanceBlock(item.provenance)}
+    </li>
+  `;
+}
+
+function moneyDl(label: string, money: { amount_cents: number; currency: string }): string {
+  return `
+    <div class="money" data-amount-cents="${money.amount_cents}" data-currency="${escapeHtml(money.currency)}">
+      <dt>${escapeHtml(label)}</dt>
+      <dd>${escapeHtml(formatMoney(money))}</dd>
+    </div>
+  `;
+}
+
+function commercialBlock(snapshot: CommercialSnapshot): string {
+  return `
+    <section class="compact" aria-labelledby="comercial-recorte">
+      <h2 id="comercial-recorte">Recorte comercial (somente leitura)</h2>
+      <p class="authority">Autoridade do catálogo: ${escapeHtml(snapshot.authority.catalog_authority)}. Runtime comercial: ${escapeHtml(snapshot.authority.commercial_runtime)}. Este documento: ${escapeHtml(snapshot.authority.this_document)}.</p>
+      <dl class="facts">
+        <div><dt>Pipeline aberto</dt><dd>${snapshot.pipeline_open_count}</dd></div>
+        <div><dt>Inbound sem leitura</dt><dd>${snapshot.inbound_unread_count}</dd></div>
+        <div><dt>Clientes em risco</dt><dd>${snapshot.at_risk_client_count}</dd></div>
+      </dl>
+      ${provenanceBlock(snapshot.provenance)}
+    </section>
+  `;
+}
+
+function financeBlock(snapshot: FinanceSnapshot): string {
+  return `
+    <section class="compact" aria-labelledby="financeiro-recorte">
+      <h2 id="financeiro-recorte">Recorte financeiro (somente leitura)</h2>
+      <p class="constraint" role="note">Mutações de provedor: ${escapeHtml(snapshot.provider_mutations)}. read_model_only=${String(snapshot.read_model_only)}. Sem cobrança, checkout, refund, cancelamento ou escrita Asaas neste cockpit.</p>
+      <dl class="facts">
+        ${moneyDl("Recebíveis abertos", snapshot.receivables_open)}
+        ${moneyDl("Recebíveis em atraso", snapshot.receivables_overdue)}
+      </dl>
+      ${provenanceBlock(snapshot.provenance)}
+    </section>
+  `;
+}
+
+function engineeringBlock(snapshot: EngineeringSnapshot): string {
+  return `
+    <section class="compact" aria-labelledby="engenharia-recorte">
+      <h2 id="engenharia-recorte">Recorte de engenharia</h2>
+      <dl class="facts">
+        <div><dt>PRs abertos</dt><dd>${snapshot.open_pr_count}</dd></div>
+        <div><dt>Checks falhando</dt><dd>${snapshot.failing_check_count}</dd></div>
+        <div><dt>Incidentes abertos</dt><dd>${snapshot.open_incident_count}</dd></div>
+      </dl>
+      ${provenanceBlock(snapshot.provenance)}
+    </section>
+  `;
+}
+
+function clientCard(item: ClientStatus): string {
+  const money = item.open_receivables
+    ? `<p class="money" data-amount-cents="${item.open_receivables.amount_cents}" data-currency="${escapeHtml(item.open_receivables.currency)}">${escapeHtml(formatMoney(item.open_receivables))}</p>`
+    : "";
+  return `
+    <article class="card client" data-lifecycle="${escapeHtml(item.lifecycle)}" data-id="${escapeHtml(item.id)}">
+      <header>
+        <p class="kicker"><span class="pill">${escapeHtml(item.lifecycle)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
+        <h3>${escapeHtml(item.display_name)}</h3>
+      </header>
+      ${item.notes ? `<p>${escapeHtml(item.notes)}</p>` : ""}
+      ${money}
+      ${provenanceBlock(item.provenance)}
+    </article>
+  `;
+}
+
+function healthCard(item: ServiceHealth): string {
+  return `
+    <article class="card health" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}">
+      <header>
+        <p class="kicker"><span class="pill">${escapeHtml(item.status)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
+        <h3>${escapeHtml(item.service_name)}</h3>
+      </header>
+      ${item.message ? `<p>${escapeHtml(item.message)}</p>` : ""}
+      ${item.latency_ms !== undefined ? `<p>Latência observada: ${item.latency_ms} ms</p>` : ""}
+      ${provenanceBlock(item.provenance)}
+    </article>
+  `;
+}
+
+function directiveCard(item: Directive): string {
+  const expires = item.expires_at ?? "sem expiração";
+  const supersedes = item.supersedes?.join(", ") ?? "nenhuma";
+  const actor = item.created_by.display_name ?? item.created_by.id;
+  return `
+    <article class="card directive" data-kind="${escapeHtml(item.kind)}" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}">
+      <header>
+        <p class="kicker"><span class="pill">${escapeHtml(item.kind)}</span> <span class="pill">${escapeHtml(item.status)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
+        <h3>${escapeHtml(item.title)}</h3>
+      </header>
+      <p>${escapeHtml(item.body)}</p>
+      <dl class="facts">
+        <div><dt>Vigente desde</dt><dd><time datetime="${escapeHtml(item.effective_from)}">${escapeHtml(item.effective_from)}</time></dd></div>
+        <div><dt>Expira</dt><dd>${escapeHtml(expires)}</dd></div>
+        <div><dt>Substitui</dt><dd>${escapeHtml(supersedes)}</dd></div>
+        <div><dt>Criado por</dt><dd>${escapeHtml(actor)}</dd></div>
+      </dl>
+      <p class="audit">Auditoria: ${item.audit.length} evento(s).</p>
+    </article>
+  `;
+}
+
+function sessionCard(item: AgentSession): string {
+  return `
+    <article class="card session" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}">
+      <header>
+        <p class="kicker"><span class="pill">${escapeHtml(item.status)}</span> <span class="scope">${escapeHtml(item.agent_id)}</span></p>
+        <h3>${escapeHtml(item.agent_id)}</h3>
+      </header>
+      <p>${escapeHtml(item.purpose)}</p>
+      <dl class="facts">
+        <div><dt>Pedidos</dt><dd>${escapeHtml(item.requested_scopes.join(", ") || "—")}</dd></div>
+        <div><dt>Concedidos</dt><dd>${escapeHtml(item.granted_scopes.join(", ") || "nenhum")}</dd></div>
+      </dl>
+    </article>
+  `;
+}
+
+function viewBanner(view: ViewState<DestinationPage>): string {
+  if (view.kind === "loading") {
+    return `<div class="banner loading" role="status">${escapeHtml(DEFAULT_LOADING_LABEL)}</div>`;
+  }
+  if (view.kind === "error") {
+    return `<div class="banner error" role="alert"><p>${escapeHtml(view.message)}</p><p class="code">${escapeHtml(view.code)}</p></div>`;
+  }
+  if (view.kind === "empty") {
+    return `<div class="banner empty" role="status">${escapeHtml(view.message)}</div>`;
+  }
+  if (view.kind === "stale") {
+    return `<div class="banner stale" role="status">${escapeHtml(view.message)}</div>`;
+  }
+  return "";
+}
+
+function pageBody(page: DestinationPage, destination: DestinationId): string {
+  const priorities =
+    page.priorities.length > 0
+      ? `
+        <section class="priorities" aria-labelledby="prioridades-title">
+          <h2 id="prioridades-title">${destination === "hoje" ? "As 3 coisas mais importantes agora" : "Prioridades deste recorte"}</h2>
+          <ol>${page.priorities.map(priorityCard).join("")}</ol>
+        </section>
+      `
+      : "";
+  const attention =
+    page.attention.length > 0
+      ? `
+        <section class="exceptions" aria-labelledby="excecoes-title">
+          <h2 id="excecoes-title">Exceções</h2>
+          <div class="stack">${page.attention.map(attentionCard).join("")}</div>
+        </section>
+      `
+      : "";
+  const extra = [
+    page.commercial ? commercialBlock(page.commercial) : "",
+    page.finance ? financeBlock(page.finance) : "",
+    page.engineering ? engineeringBlock(page.engineering) : "",
+    page.clients && page.clients.length > 0
+      ? `<section aria-labelledby="clientes-title"><h2 id="clientes-title">Clientes</h2><div class="stack">${page.clients.map(clientCard).join("")}</div></section>`
+      : "",
+    page.health && page.health.length > 0
+      ? `<section aria-labelledby="infra-title"><h2 id="infra-title">Serviços</h2><div class="stack">${page.health.map(healthCard).join("")}</div></section>`
+      : "",
+    page.directives && page.directives.length > 0
+      ? `<section aria-labelledby="memoria-title"><h2 id="memoria-title">Diretivas</h2><div class="stack">${page.directives.map(directiveCard).join("")}</div></section>`
+      : "",
+    page.sessions && page.sessions.length > 0
+      ? `<section aria-labelledby="agentes-title"><h2 id="agentes-title">Sessões</h2><div class="stack">${page.sessions.map(sessionCard).join("")}</div></section>`
+      : "",
+  ].join("");
+  return `${priorities}${attention}${extra}`;
+}
+
+function mockLab(destination: DestinationId, current: ViewKind): string {
+  const links = VIEW_KINDS.map((kind) => {
+    const href = kind === "ready" ? hashFor(destination) : hashFor(destination, kind);
+    const selected = kind === current ? "true" : "false";
+    return `<a href="${href}" data-view="${kind}" aria-current="${selected}">${kind}</a>`;
+  }).join("");
+  return `
+    <div class="mock-lab" role="group" aria-label="Simular estado da vista (somente mock)">
+      <p>Estado da vista (mock)</p>
+      ${links}
+    </div>
+  `;
+}
+
+export function renderShell(model: ShellModel): string {
+  const dest = DESTINATIONS.find((item) => item.id === model.destination);
+  const label = dest?.label ?? model.destination;
+  const nav = DESTINATIONS.map((item) => {
+    const current = item.id === model.destination;
+    return `
+      <a
+        href="${hashFor(item.id, model.viewKind === "ready" ? null : model.viewKind)}"
+        data-nav="${item.id}"
+        aria-current="${current ? "page" : "false"}"
+      >${escapeHtml(item.label)}</a>
+    `;
+  }).join("");
+
+  const page =
+    model.view.kind === "ready" || model.view.kind === "stale" ? model.view.data : null;
+  const headline = page?.headline ?? dest?.description ?? "";
+  const operator = page?.operator.display_name ?? page?.operator.id ?? "Operador";
+  const operatorId = page?.operator.id ?? "human:operator";
+
+  const body =
+    page && (model.view.kind === "ready" || model.view.kind === "stale")
+      ? pageBody(page, model.destination)
+      : "";
+
+  return `
+    <a class="skip-link" href="#conteudo">Saltar para o conteúdo</a>
+    <div class="shell" data-destination="${escapeHtml(model.destination)}" data-view-state="${escapeHtml(model.viewKind)}">
+      <header class="topbar">
+        <p class="brand">Control Center</p>
+        <p class="operator" title="${escapeHtml(operatorId)}">${escapeHtml(operator)} · modo mock</p>
+      </header>
+      <nav class="nav" aria-label="Áreas do Control Center">
+        ${nav}
+      </nav>
+      <main id="conteudo" tabindex="-1">
+        <header class="page-head">
+          <h1>${escapeHtml(label)}</h1>
+          <p>${escapeHtml(headline)}</p>
+        </header>
+        ${mockLab(model.destination, model.viewKind)}
+        ${viewBanner(model.view)}
+        ${body}
+      </main>
+    </div>
+  `;
+}
+
+export function hasChatComposer(html: string): boolean {
+  return /data-chat|role="textbox"|chat-composer|composer/i.test(html);
+}
+
+export function hasMutationControls(html: string): boolean {
+  return /data-mutate=|data-action="(cobranca|checkout|refund|cancelamento|asaas_write|commercial_send)"/i.test(
+    html,
+  );
+}

--- a/control-center/apps/web-shell/src/view-state.ts
+++ b/control-center/apps/web-shell/src/view-state.ts
@@ -1,0 +1,121 @@
+export const VIEW_KINDS = ["loading", "error", "stale", "empty", "ready"] as const;
+export type ViewKind = (typeof VIEW_KINDS)[number];
+
+export interface LoadingViewState {
+  kind: "loading";
+}
+
+export interface ErrorViewState {
+  kind: "error";
+  message: string;
+  code: string;
+}
+
+export interface EmptyViewState {
+  kind: "empty";
+  message: string;
+}
+
+export interface StaleViewState<T> {
+  kind: "stale";
+  data: T;
+  message: string;
+}
+
+export interface ReadyViewState<T> {
+  kind: "ready";
+  data: T;
+}
+
+export type ViewState<T> =
+  | LoadingViewState
+  | ErrorViewState
+  | EmptyViewState
+  | StaleViewState<T>
+  | ReadyViewState<T>;
+
+export const DEFAULT_EMPTY_MESSAGE = "Nada exige atenção neste recorte.";
+export const DEFAULT_STALE_MESSAGE =
+  "Este recorte está defasado. Trate as observações com cautela.";
+export const DEFAULT_ERROR_CODE = "VIEW_ERROR";
+export const DEFAULT_ERROR_MESSAGE = "Falha ao montar o recorte.";
+export const DEFAULT_LOADING_LABEL = "Carregando observações…";
+
+export function loadingState(): LoadingViewState {
+  return { kind: "loading" };
+}
+
+export function errorState(
+  message = DEFAULT_ERROR_MESSAGE,
+  code: string = DEFAULT_ERROR_CODE,
+): ErrorViewState {
+  return { kind: "error", message, code };
+}
+
+export function emptyState(message = DEFAULT_EMPTY_MESSAGE): EmptyViewState {
+  return { kind: "empty", message };
+}
+
+export function staleState<T>(
+  data: T,
+  message = DEFAULT_STALE_MESSAGE,
+): StaleViewState<T> {
+  return { kind: "stale", data, message };
+}
+
+export function readyState<T>(data: T): ReadyViewState<T> {
+  return { kind: "ready", data };
+}
+
+export function isViewKind(value: string | null | undefined): value is ViewKind {
+  return value != null && (VIEW_KINDS as readonly string[]).includes(value);
+}
+
+export function parseViewKind(value: string | null | undefined): ViewKind | null {
+  if (value == null) return null;
+  return isViewKind(value) ? value : null;
+}
+
+export interface ResolveViewInput<T> {
+  loading?: boolean | undefined;
+  error?: { message: string; code?: string | undefined } | undefined;
+  data: T | null;
+  isEmpty: (data: T) => boolean;
+  isStale: (data: T) => boolean;
+  override?: ViewKind | null | undefined;
+}
+
+/**
+ * Maps adapter output (or a mock override) into one explicit view state.
+ * Override is independently exercisable via `?view=` in the hash.
+ */
+export function resolveViewState<T>(input: ResolveViewInput<T>): ViewState<T> {
+  if (input.override === "loading") return loadingState();
+  if (input.override === "error") {
+    return errorState(
+      input.error?.message ?? DEFAULT_ERROR_MESSAGE,
+      input.error?.code ?? DEFAULT_ERROR_CODE,
+    );
+  }
+  if (input.override === "empty") return emptyState();
+  if (input.override === "stale") {
+    const data = input.data;
+    if (data == null) return emptyState();
+    return staleState(data);
+  }
+  if (input.override === "ready") {
+    if (input.data == null) return emptyState();
+    return readyState(input.data);
+  }
+  if (input.loading) return loadingState();
+  if (input.error) {
+    return errorState(input.error.message, input.error.code ?? DEFAULT_ERROR_CODE);
+  }
+  if (input.data == null || input.isEmpty(input.data)) return emptyState();
+  if (input.isStale(input.data)) return staleState(input.data);
+  return readyState(input.data);
+}
+
+export function viewStateKind<T>(state: ViewState<T>): ViewKind {
+  return state.kind;
+}

--- a/control-center/apps/web-shell/tests/adapters.test.ts
+++ b/control-center/apps/web-shell/tests/adapters.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  ADAPTER_ACTIONS,
+  CHAT_SURFACE_ACTIONS,
+  FORBIDDEN_ADAPTER_ACTIONS,
+  adapterAllows,
+  createMockAdapter,
+  isForbiddenAdapterAction,
+} from "../src/adapters/index";
+import { DESTINATION_IDS } from "../src/destinations";
+import { FRESHNESS_STATUSES } from "../src/types";
+
+test("adapter contract is read-only and forbids financial/provider mutations and chat", () => {
+  assert.deepEqual([...ADAPTER_ACTIONS], ["read"]);
+  assert.equal(adapterAllows("read"), true);
+  for (const action of FORBIDDEN_ADAPTER_ACTIONS) {
+    assert.equal(adapterAllows(action), false);
+    assert.equal(isForbiddenAdapterAction(action), true);
+  }
+  for (const action of CHAT_SURFACE_ACTIONS) {
+    assert.equal(adapterAllows(action), false);
+  }
+  const adapter = createMockAdapter();
+  assert.deepEqual([...adapter.actions], ["read"]);
+  assert.equal("readDestination" in adapter, true);
+  assert.equal("charge" in adapter, false);
+  assert.equal("checkout" in adapter, false);
+  assert.equal("refund" in adapter, false);
+  assert.equal("compose" in adapter, false);
+});
+
+test("mock adapter returns fixture data for every destination without network I/O", () => {
+  const fetchCalls: unknown[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((...args: unknown[]) => {
+    fetchCalls.push(args);
+    return Promise.reject(new Error("network should not be used"));
+  }) as typeof fetch;
+  try {
+    const adapter = createMockAdapter("default");
+    assert.equal(adapter.mode, "mock");
+    assert.equal(adapter.readOperator().id, "human:operator");
+    assert.equal(adapter.readOperator().kind, "human");
+    for (const id of DESTINATION_IDS) {
+      const result = adapter.readDestination(id);
+      assert.equal(result.ok, true);
+      assert.equal(result.loading, false);
+      if (!result.ok || result.loading) throw new Error("expected page");
+      assert.equal(result.page.id, id);
+      assert.ok(result.page.generated_at.endsWith("Z"));
+      assert.equal(result.page.operator.id, "human:operator");
+    }
+    const hoje = adapter.readDestination("hoje");
+    if (!hoje.ok || hoje.loading) throw new Error("hoje page");
+    assert.ok(hoje.page.attention.length > 0);
+    assert.ok(hoje.page.priorities.length <= 3);
+    assert.equal(fetchCalls.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("finance page money is integer cents plus currency and mutations stay forbidden", () => {
+  const adapter = createMockAdapter();
+  const result = adapter.readDestination("financeiro");
+  if (!result.ok || result.loading) throw new Error("financeiro page");
+  const finance = result.page.finance;
+  assert.ok(finance);
+  assert.equal(finance.read_model_only, true);
+  assert.equal(finance.provider_mutations, "forbidden");
+  assert.equal(Number.isInteger(finance.receivables_open.amount_cents), true);
+  assert.equal(finance.receivables_open.currency, "BRL");
+  assert.equal(finance.receivables_overdue.amount_cents, 1500000);
+});
+
+test("fixture catalog covers every freshness status", () => {
+  const adapter = createMockAdapter();
+  const seen = new Set<string>();
+  for (const id of DESTINATION_IDS) {
+    const result = adapter.readDestination(id);
+    if (!result.ok || result.loading) continue;
+    for (const item of result.page.attention) {
+      seen.add(item.provenance.freshness_status);
+      assert.ok(item.provenance.source.system);
+      assert.ok(item.provenance.observed_at.endsWith("Z"));
+    }
+  }
+  for (const status of FRESHNESS_STATUSES) {
+    assert.equal(seen.has(status), true, `missing freshness ${status}`);
+  }
+});

--- a/control-center/apps/web-shell/tests/browser-entry.test.ts
+++ b/control-center/apps/web-shell/tests/browser-entry.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import {
+  applyFileProtocolGuard,
+  FILE_PROTOCOL_DEV,
+  FILE_PROTOCOL_PREVIEW,
+  installShellGlobals,
+  isFileProtocol,
+  startBrowser,
+  type ShellWindow,
+} from "../src/boot";
+import { DESTINATION_IDS, PRIMARY_SURFACE } from "../src/destinations";
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "../src");
+const rootDir = join(srcDir, "..");
+
+test("browser entry has no unguarded Node require/module.exports", () => {
+  const main = readFileSync(join(srcDir, "main.ts"), "utf8");
+  const boot = readFileSync(join(srcDir, "boot.ts"), "utf8");
+  const html = readFileSync(join(rootDir, "index.html"), "utf8");
+  for (const src of [main, boot]) {
+    assert.doesNotMatch(src, /\brequire\s*\(/);
+    assert.doesNotMatch(src, /module\.exports/);
+    assert.doesNotMatch(src, /\bexports\./);
+  }
+  assert.match(html, /location\.protocol !== "file:"|location\.protocol === "file:"/);
+  assert.match(html, /npm run dev/);
+  assert.match(html, /npm run preview/);
+});
+
+test("installShellGlobals exposes destinations and mount on window", () => {
+  const win: ShellWindow = { location: { protocol: "http:" } };
+  const globals = installShellGlobals(win);
+  assert.equal(globals.version.length > 0, true);
+  assert.deepEqual([...globals.destinations], [...DESTINATION_IDS]);
+  assert.equal(globals.primarySurface, PRIMARY_SURFACE);
+  assert.equal(typeof globals.mount, "function");
+  assert.equal(win.__CONFENGE_CONTROL_CENTER__, globals);
+});
+
+test("file: protocol is detected and shows how to run the shell", () => {
+  assert.equal(isFileProtocol("file:"), true);
+  assert.equal(isFileProtocol("http:"), false);
+  const root = { innerHTML: "" };
+  const blocked = applyFileProtocolGuard({ protocol: "file:" }, root);
+  assert.equal(blocked, true);
+  assert.match(root.innerHTML, /file:/);
+  assert.ok(root.innerHTML.includes(FILE_PROTOCOL_DEV));
+  assert.ok(root.innerHTML.includes(FILE_PROTOCOL_PREVIEW));
+  const httpRoot = { innerHTML: "" };
+  assert.equal(applyFileProtocolGuard({ protocol: "http:" }, httpRoot), false);
+  assert.equal(httpRoot.innerHTML, "");
+});
+
+test("startBrowser is a no-op without window (safe Node import) and mounts when window exists", () => {
+  startBrowser(undefined, undefined);
+  const root = { innerHTML: "" };
+  const win: ShellWindow = { location: { protocol: "file:" } };
+  startBrowser(win, { getElementById: (id: string) => (id === "root" ? root : null) });
+  assert.match(root.innerHTML, /npm run dev/);
+  assert.ok(win.__CONFENGE_CONTROL_CENTER__);
+});

--- a/control-center/apps/web-shell/tests/contract.test.ts
+++ b/control-center/apps/web-shell/tests/contract.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { createMockAdapter } from "../src/adapters/index";
+import { createMemoryRuntime, mount } from "../src/app";
+import { DIRECTIVE_FIXTURES } from "../src/fixtures/catalog";
+import { DIRECTIVE_KINDS } from "../src/types";
+import { hasChatComposer, hasMutationControls } from "../src/ui/render";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("directives carry kind, scope, status, vigência, supersedes, created_by and audit", () => {
+  const kinds = new Set(DIRECTIVE_FIXTURES.map((item) => item.kind));
+  for (const kind of DIRECTIVE_KINDS) {
+    assert.equal(kinds.has(kind), true, `missing directive kind ${kind}`);
+  }
+  for (const item of DIRECTIVE_FIXTURES) {
+    assert.ok(item.scope.length > 0);
+    assert.ok(item.status.length > 0);
+    assert.ok(item.effective_from.endsWith("Z"));
+    assert.ok(item.expires_at === null || item.expires_at.endsWith("Z"));
+    assert.ok(item.supersedes === null || Array.isArray(item.supersedes));
+    assert.ok(item.created_by.id);
+    assert.ok(item.audit.length >= 1);
+  }
+});
+
+test("mounted Hoje HTML is an attention cockpit without chat or mutation controls", () => {
+  const root = { innerHTML: "" };
+  const runtime = createMemoryRuntime("#/hoje");
+  const handle = mount(root, createMockAdapter(), runtime);
+  try {
+    assert.match(root.innerHTML, /data-destination="hoje"/);
+    assert.match(root.innerHTML, /As 3 coisas mais importantes agora/);
+    assert.match(root.innerHTML, />Exceções</);
+    assert.match(root.innerHTML, /aria-label="Áreas do Control Center"/);
+    for (const label of [
+      "Hoje",
+      "Comercial",
+      "Clientes",
+      "Financeiro",
+      "Engenharia",
+      "Infra",
+      "Memória/Decisões",
+      "Agentes",
+    ]) {
+      assert.match(root.innerHTML, new RegExp(label.replace("/", "\\/")));
+    }
+    const ranks = [...root.innerHTML.matchAll(/data-rank="(\d+)"/g)].map((m) => Number(m[1]));
+    assert.ok(ranks.length > 0);
+    assert.ok(ranks.length <= 3);
+    assert.ok(root.innerHTML.includes("data-severity="));
+    assert.equal(hasChatComposer(root.innerHTML), false);
+    assert.equal(hasMutationControls(root.innerHTML), false);
+    assert.doesNotMatch(root.innerHTML, /<textarea/i);
+    assert.doesNotMatch(root.innerHTML, /type="password"/i);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("driving a nav hash changes the visible destination", () => {
+  const root = { innerHTML: "" };
+  const runtime = createMemoryRuntime("#/hoje");
+  const handle = mount(root, createMockAdapter(), runtime);
+  try {
+    runtime.setHash("#/financeiro");
+    assert.match(root.innerHTML, /data-destination="financeiro"/);
+    assert.match(root.innerHTML, /data-amount-cents="1500000"/);
+    assert.match(root.innerHTML, /data-currency="BRL"/);
+    assert.match(root.innerHTML, /Mutações de provedor: forbidden/);
+    assert.match(root.innerHTML, /read_model_only=true/);
+    runtime.setHash("#/hoje?view=loading");
+    assert.match(root.innerHTML, /data-view-state="loading"/);
+    runtime.setHash("#/hoje?view=error");
+    assert.match(root.innerHTML, /data-view-state="error"/);
+    runtime.setHash("#/hoje?view=empty");
+    assert.match(root.innerHTML, /data-view-state="empty"/);
+    runtime.setHash("#/hoje?view=stale");
+    assert.match(root.innerHTML, /data-view-state="stale"/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("README names destinations, mock-only mode, run commands and later convergence", () => {
+  const readme = readFileSync(join(rootDir, "README.md"), "utf8");
+  for (const label of [
+    "Hoje",
+    "Comercial",
+    "Clientes",
+    "Financeiro",
+    "Engenharia",
+    "Infra",
+    "Memória/Decisões",
+    "Agentes",
+  ]) {
+    assert.ok(readme.includes(label), `README missing ${label}`);
+  }
+  assert.match(readme, /npm run dev/);
+  assert.match(readme, /npm run preview/);
+  assert.match(readme, /npm test/);
+  assert.match(readme, /nenhum|None required|Nenhuma/i);
+  assert.match(readme, /MCP/);
+  assert.match(readme, /PostgreSQL/);
+  assert.match(readme, /converg/i);
+  assert.match(readme, /mock/i);
+});

--- a/control-center/apps/web-shell/tests/destinations.test.ts
+++ b/control-center/apps/web-shell/tests/destinations.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DESTINATION_IDS,
+  DESTINATIONS,
+  PRIMARY_SURFACE,
+  destinationLabels,
+  getDestination,
+  hasChatDestination,
+  hashFor,
+  isDestinationId,
+  parseHash,
+} from "../src/destinations";
+
+test("registry exposes the eight product destinations with exact labels", () => {
+  assert.deepEqual([...DESTINATION_IDS], [
+    "hoje",
+    "comercial",
+    "clientes",
+    "financeiro",
+    "engenharia",
+    "infra",
+    "memoria",
+    "agentes",
+  ]);
+  assert.deepEqual(destinationLabels(), [
+    "Hoje",
+    "Comercial",
+    "Clientes",
+    "Financeiro",
+    "Engenharia",
+    "Infra",
+    "Memória/Decisões",
+    "Agentes",
+  ]);
+  assert.equal(DESTINATIONS.length, 8);
+  for (const id of DESTINATION_IDS) {
+    const def = getDestination(id);
+    assert.equal(def.id, id);
+    assert.ok(def.path.startsWith("#/"));
+    assert.ok(isDestinationId(id));
+  }
+});
+
+test("there is no chat destination; primary surface is the attention cockpit", () => {
+  assert.equal(hasChatDestination(), false);
+  assert.equal(PRIMARY_SURFACE, "attention-cockpit");
+});
+
+test("parseHash maps unknown paths to Hoje and reads view overrides", () => {
+  assert.deepEqual(parseHash(""), { destination: "hoje", view: null });
+  assert.deepEqual(parseHash("#/financeiro?view=stale"), {
+    destination: "financeiro",
+    view: "stale",
+  });
+  assert.deepEqual(parseHash("#/nope"), { destination: "hoje", view: null });
+  assert.equal(hashFor("agentes", "empty"), "#/agentes?view=empty");
+  assert.equal(hashFor("hoje"), "#/hoje");
+});

--- a/control-center/apps/web-shell/tests/homepage.test.ts
+++ b/control-center/apps/web-shell/tests/homepage.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ATTENTION_FIXTURES, PRIORITY_FIXTURES } from "../src/fixtures/catalog";
+import {
+  HOMEPAGE_PRIORITY_LIMIT,
+  hasOpenHighSeverity,
+  selectHojeModel,
+  selectHomepageAttention,
+  selectHomepagePriorities,
+} from "../src/homepage";
+
+test("Hoje selection yields ranked exceptions and at most three priorities", () => {
+  assert.equal(hasOpenHighSeverity(ATTENTION_FIXTURES), true);
+  const model = selectHojeModel({
+    attention: ATTENTION_FIXTURES,
+    priorities: PRIORITY_FIXTURES,
+  });
+  assert.ok(model.attention.length > 0);
+  assert.ok(model.priorities.length > 0);
+  assert.ok(model.priorities.length <= HOMEPAGE_PRIORITY_LIMIT);
+  assert.equal(HOMEPAGE_PRIORITY_LIMIT, 3);
+  assert.deepEqual(
+    model.priorities.map((item) => item.rank),
+    [1, 2, 3],
+  );
+  assert.equal(
+    model.priorities.some((item) => item.rank === 4),
+    false,
+  );
+  assert.equal(
+    model.attention.some((item) => item.status === "resolved"),
+    false,
+  );
+  assert.equal(model.attention[0]?.severity, "critical");
+  assert.equal(model.attention[1]?.severity, "high");
+  const ids = model.attention.map((item) => item.id);
+  assert.ok(ids.includes("cc:attention-item:01K3CC-OVERDUE-INVOICE"));
+  assert.ok(ids.includes("cc:attention-item:01K3CC-FAILING-CHECK"));
+});
+
+test("selectHomepageAttention and selectHomepagePriorities are the shipped ranking functions", () => {
+  const attention = selectHomepageAttention(ATTENTION_FIXTURES);
+  const priorities = selectHomepagePriorities(PRIORITY_FIXTURES);
+  assert.equal(
+    attention.every((item) => item.homepage_eligible),
+    true,
+  );
+  assert.equal(priorities.length, 3);
+  assert.equal(priorities[0]?.title.includes("inbound"), true);
+});

--- a/control-center/apps/web-shell/tests/provenance.test.ts
+++ b/control-center/apps/web-shell/tests/provenance.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { FINANCE_SNAPSHOT, FRESHNESS_SAMPLES } from "../src/fixtures/catalog";
+import { PRESENTATION_TIME_ZONE } from "../src/datetime";
+import { formatMoney } from "../src/money";
+import { mapProvenance, provenanceFromPresentation } from "../src/provenance";
+import { FRESHNESS_STATUSES } from "../src/types";
+
+test("FRESH, STALE, ERROR and UNKNOWN fixtures round-trip into the presentation model", () => {
+  for (const status of FRESHNESS_STATUSES) {
+    const fixture = FRESHNESS_SAMPLES[status];
+    const presentation = mapProvenance(fixture);
+    assert.equal(presentation.freshnessStatus, status);
+    assert.equal(presentation.sourceSystem, fixture.source.system);
+    assert.equal(presentation.sourceKind, fixture.source.kind);
+    assert.equal(presentation.sourceLocator, fixture.source.locator);
+    assert.equal(presentation.observedAtUtc, fixture.observed_at);
+    assert.ok(presentation.observedAtLocal.includes(PRESENTATION_TIME_ZONE));
+    assert.equal(presentation.confidence, fixture.confidence);
+    assert.match(presentation.confidenceLabel, /confiança/);
+    const roundTrip = provenanceFromPresentation(presentation);
+    assert.equal(roundTrip.source.system, fixture.source.system);
+    assert.equal(roundTrip.source.kind, fixture.source.kind);
+    assert.equal(roundTrip.source.locator, fixture.source.locator);
+    assert.equal(roundTrip.observed_at, fixture.observed_at);
+    assert.equal(roundTrip.freshness_status, fixture.freshness_status);
+    assert.equal(roundTrip.confidence, fixture.confidence);
+  }
+  assert.equal(FRESHNESS_SAMPLES.STALE.freshness_status, "STALE");
+  assert.equal(FRESHNESS_SAMPLES.FRESH.freshness_status, "FRESH");
+  assert.equal(FRESHNESS_SAMPLES.ERROR.freshness_status, "ERROR");
+  assert.equal(FRESHNESS_SAMPLES.UNKNOWN.freshness_status, "UNKNOWN");
+});
+
+test("finance money formats integer cents plus currency", () => {
+  const formatted = formatMoney(FINANCE_SNAPSHOT.receivables_overdue);
+  assert.equal(FINANCE_SNAPSHOT.receivables_overdue.amount_cents, 1500000);
+  assert.equal(FINANCE_SNAPSHOT.receivables_overdue.currency, "BRL");
+  assert.equal(formatted, "BRL 15.000,00");
+  assert.equal(formatMoney({ amount_cents: 0, currency: "BRL" }), "BRL 0,00");
+  assert.equal(formatMoney({ amount_cents: -250, currency: "USD" }), "-USD 2,50");
+});

--- a/control-center/apps/web-shell/tests/view-state.test.ts
+++ b/control-center/apps/web-shell/tests/view-state.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  emptyState,
+  errorState,
+  loadingState,
+  readyState,
+  resolveViewState,
+  staleState,
+  viewStateKind,
+} from "../src/view-state";
+
+test("loading, error, stale and empty helpers produce distinct explicit states", () => {
+  const loading = loadingState();
+  const error = errorState("boom", "X");
+  const empty = emptyState("nada");
+  const stale = staleState({ n: 1 }, "defasado");
+  const ready = readyState({ n: 1 });
+  const kinds = [loading, error, empty, stale, ready].map(viewStateKind);
+  assert.deepEqual(kinds, ["loading", "error", "empty", "stale", "ready"]);
+  assert.notEqual(loading.kind, error.kind);
+  assert.notEqual(error.kind, stale.kind);
+  assert.notEqual(stale.kind, empty.kind);
+  assert.notEqual(empty.kind, ready.kind);
+  assert.equal(error.message, "boom");
+  assert.equal(error.code, "X");
+  assert.equal(empty.message, "nada");
+  assert.equal(stale.data.n, 1);
+});
+
+test("resolveViewState override independently exercises each view kind", () => {
+  const base = {
+    data: { items: [1] },
+    isEmpty: (data: { items: number[] }) => data.items.length === 0,
+    isStale: () => false,
+  };
+  assert.equal(resolveViewState({ ...base, override: "loading" }).kind, "loading");
+  assert.equal(resolveViewState({ ...base, override: "error" }).kind, "error");
+  assert.equal(resolveViewState({ ...base, override: "empty" }).kind, "empty");
+  assert.equal(resolveViewState({ ...base, override: "stale" }).kind, "stale");
+  assert.equal(resolveViewState({ ...base, override: "ready" }).kind, "ready");
+  assert.equal(
+    resolveViewState({
+      data: { items: [] },
+      isEmpty: (data) => data.items.length === 0,
+      isStale: () => false,
+    }).kind,
+    "empty",
+  );
+  assert.equal(
+    resolveViewState({
+      data: { items: [1] },
+      isEmpty: () => false,
+      isStale: () => true,
+    }).kind,
+    "stale",
+  );
+  assert.equal(
+    resolveViewState({
+      loading: true,
+      data: null,
+      isEmpty: () => true,
+      isStale: () => false,
+    }).kind,
+    "loading",
+  );
+  assert.equal(
+    resolveViewState({
+      error: { message: "falha", code: "E" },
+      data: null,
+      isEmpty: () => true,
+      isStale: () => false,
+    }).kind,
+    "error",
+  );
+});

--- a/control-center/apps/web-shell/tsconfig.json
+++ b/control-center/apps/web-shell/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src", "tests", "vite.config.ts"]
+}

--- a/control-center/apps/web-shell/vite.config.ts
+++ b/control-center/apps/web-shell/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  publicDir: "public",
+  build: {
+    outDir: "dist",
+    sourcemap: true,
+    target: "es2022",
+    emptyOutDir: true,
+  },
+  server: {
+    host: "127.0.0.1",
+    port: 5173,
+    strictPort: true,
+  },
+  preview: {
+    host: "127.0.0.1",
+    port: 4173,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
Draft PR for campaign workstream **cc/16-mobile-shell**. Do not merge automatically.

## What
Adds the private Control Center visual shell exclusively under `control-center/apps/web-shell/`.

This is a mobile-first attention cockpit, not chat and not a KPI wall. Default I/O is in-repo typed mock adapters/fixtures. No live HTTP, MCP, or PostgreSQL in this campaign.

## Destinations
Chrome navigation: Hoje, Comercial, Clientes, Financeiro, Engenharia, Infra, Memória/Decisões, Agentes.

Hoje surfaces fixture exceptions plus **at most three** current priorities. Loading / error / stale / empty are independently exercisable (`?view=` and the mock state control). Aggregated records show `source`, `observed_at`, `freshness_status`, and `confidence`. Finance money is integer cents + currency. Provider mutations and commercial send are not offered.

## Out of scope (by design)
- No edits to `commercial/`, `decisions/`, `scripts/`, root README, or other Control Center workstreams.
- Does not absorb or modify PR Governance #8.
- Identity is an opaque display handle (`human:operator`); no password/secret in git or the client bundle.
- Cheap PWA manifest only (no service worker).

## Tests
From `control-center/apps/web-shell/`:
```
npm test
npm run typecheck
npm run build
npm run preview
```
21 unit/contract tests, run twice, all passing. They drive the shipped registry, mock adapters (no network), Hoje selector, view-state helpers, and provenance mapping.

Headless Playwright pixel/input readback is unavailable in this sandbox (cached Chromium missing `libnspr4.so`; no root to install). Preview HTTP 200 was confirmed; file: protocol is guarded in `index.html` + `boot.ts`.

## Convergence (later campaign)
Local types copy v1 field names (`source`, `observed_at`, `freshness_status`, `confidence`, cents+currency, directive kinds, `FRESH|STALE|UNKNOWN|ERROR`). Swap `MockControlCenterAdapter` for HTTP when the context service lands; MCP remains the agent interface and is not consumed here.

Branch: `cc/16-mobile-shell`  
SHA: `78c95dbf32ace2b58cb3b6f3e12147466f818790`
