### PR TITLE
feat(control-center): mobile-first directives memory UI

### DIFF
--- a/control-center/apps/directives-ui/.gitignore
+++ b/control-center/apps/directives-ui/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/control-center/apps/directives-ui/README.md
+++ b/control-center/apps/directives-ui/README.md
@@ -1,0 +1,72 @@
+# Control Center — Directives UI
+
+UX mobile-first para registrar memória estratégica estruturada (`control-center.directive.v1`).
+
+Não é chat. Não é ERP. Não substitui Warmbly nem os sistemas de origem. Não executa cobrança, checkout, refund, cancelamento, escrita Asaas ou envio comercial.
+
+Este pacote é autônomo: o mock vive aqui. A convergência posterior deve trocar o adapter local pelo HTTP de `control-center/services/context`, pinando `control-center/contracts/`.
+
+## Decisões
+
+1. Contrato local duplicado de `control-center.directive.v1` (kinds, statuses, campos obrigatórios, scopes string). Sibling contracts/context-service são read-only e **não** são importados.
+2. Sete kinds: `decision`, `directive`, `fact`, `constraint`, `priority`, `risk`, `hypothesis`. Não há tipo padrão no formulário — o operador escolhe e **confirma** o tipo. Decisão não pode ser gravada como fato por omissão.
+3. `hypothesis` é visualmente e textualmente distinta (não autoritativa; não é fato nem decisão). O preview de agente a separa das listas autoritativas.
+4. História nunca é reescrita em silêncio. Não existe “editar”. **Supersede** é ação explícita: o predecessor permanece legível como `superseded` (body/kind congelados) e nasce um sucessor com `supersedes`.
+5. Preview “contexto que um agente verá para scope X”: match **exato** de scope string v1. Sem dump da empresa. Sem herança `{company,domain,resource}` — isso é do context-service e fica para a convergência.
+6. Identidade single-user via handles opacos (`CONTROL_CENTER_FOUNDER_ACTOR_ID`, `CC_ACTOR_ID`, `CC_ACTOR_ROLE`). **Não é senha.** Mutação fail-closed se o ator não for o founder configurado. O HTML local só carrega handles de mock.
+7. Datas internas em UTC (`…Z`). Apresentação pode usar `America/Sao_Paulo`.
+8. Informação agregada na UI (lista/preview) carrega `source`, `observed_at`, `freshness_status`, `confidence`.
+9. Adapter desta onda: `MockDirectiveService` (`mode: "mock"`). Sem PostgreSQL, sem MCP, sem HTTP vivo.
+
+## Como rodar
+
+Node.js ≥ 20.
+
+```bash
+cd control-center/apps/directives-ui
+npm install
+npm test
+npm run typecheck
+npm start
+# http://127.0.0.1:4177/
+```
+
+`npm start` gera `dist/app.js` (IIFE, `<script src>` clássico) e serve o diretório. Abrir o `index.html` via `file:` só funciona **depois** do build; caso contrário a página explica o comando. Não há tela preta silenciosa.
+
+Scripts: `npm run build`, `npm run serve` (porta `PORT`, default `4177`, bind `127.0.0.1`).
+
+## Variáveis de ambiente
+
+Somente **nomes**. Não commitar `.env`. Nenhum valor secreto abaixo.
+
+| Variável | Obrigatória | Função |
+|---|---|---|
+| `CONTROL_CENTER_FOUNDER_ACTOR_ID` | na convergência | handle opaco do founder (não é senha) |
+| `CC_ACTOR_ID` | na convergência | handle opaco do ator da sessão |
+| `CC_ACTOR_ROLE` | na convergência | `founder` \| `operator` \| `agent` |
+| `CC_USE_MOCK_IDENTITY` | não | `0` recusa defaults de mock (fail-closed). Qualquer outro valor (incluindo ausente neste workstream) permite o handle local `human:founder` |
+| `HOST` / `PORT` | não | bind do `scripts/serve.mjs`; default `127.0.0.1:4177` |
+
+No browser, os mesmos nomes são lidos de `<meta name="cc-founder-actor-id">` etc. São handles de mock, não credenciais.
+
+## Adapter local e convergência esperada
+
+Porto atual (`src/service.ts`):
+
+- `list(filter)` — busca + filtro por `kind`, `scope`, `status`
+- `create(input)` / `createFromDraft(draft)` — exige `kindConfirm === kind`
+- `supersede(id, input)` — predecessor `superseded`, sucessor novo
+- `preview(scope)` — contexto mínimo daquele scope
+- `identity()` / founder approval
+
+Handoff posterior (não implementado aqui):
+
+1. Substituir `MockDirectiveService` por HTTP privado de `control-center/services/context` (`POST /v1/directives`, `POST /v1/directives/:id/supersede`, `GET /v1/context?…`).
+2. Pinar schemas em `control-center/contracts/` (`directive.v1`, `agent-context.v1`).
+3. Mapear scopes string v1 (`company`, `finance`, `client:slug`, …) para `{ company, domain, resource }` do context-service. Status v1 `draft`/`revoked` ↔ `inactive` do serviço. Não misturar os dois modelos neste pacote.
+4. MCP permanece a interface principal dos agentes; esta UI é humana.
+5. Não alterar `commercial/`, `decisions/`, `scripts/`, README raiz, Warmbly, nem o PR Governance #8.
+
+## Fora de escopo
+
+PostgreSQL, MCP runtime, homepage/KPI, mutações em provedores, edição in-place, auth multi-user, senha hardcoded.

--- a/control-center/apps/directives-ui/index.html
+++ b/control-center/apps/directives-ui/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#121418" />
+    <meta
+      name="description"
+      content="Confenge Control Center — registrar memória estratégica estruturada. Sem chat. Sem mutações financeiras."
+    />
+    <!-- Opaque mock handles only. Not a password. Override before any non-mock deploy. -->
+    <meta name="cc-founder-actor-id" content="human:founder" />
+    <meta name="cc-actor-id" content="human:founder" />
+    <meta name="cc-actor-role" content="founder" />
+    <meta name="cc-use-mock-identity" content="1" />
+    <link rel="stylesheet" href="./src/styles.css" />
+    <link rel="icon" href="./public/favicon.svg" type="image/svg+xml" />
+    <title>Memória estratégica — Control Center</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <noscript>
+      Este registrador precisa de JavaScript. No diretório
+      <code>control-center/apps/directives-ui</code> execute
+      <code>npm install && npm start</code>.
+    </noscript>
+    <script>
+      (function () {
+        if (typeof location === "undefined") return;
+        if (location.protocol === "file:") {
+          var note = document.createElement("p");
+          note.className = "file-hint";
+          note.setAttribute("role", "note");
+          note.textContent =
+            "file: exige npm run build (dist/app.js). Prefira npm start em http://127.0.0.1:4177/";
+          document.body.insertBefore(note, document.body.firstChild);
+        }
+        window.addEventListener("DOMContentLoaded", function () {
+          var app = document.getElementById("app");
+          if (!app) return;
+          window.setTimeout(function () {
+            if (app.getAttribute("data-ready") === "1" || app.querySelector("[data-ready='1']")) return;
+            if (app.innerHTML.trim().length > 0) return;
+            app.innerHTML =
+              '<main class="file-protocol" role="alert">' +
+              "<h1>Bundle ausente</h1>" +
+              "<p>Gere <code>dist/app.js</code> com <code>npm run build</code> ou sirva via <code>npm start</code>.</p>" +
+              "</main>";
+          }, 50);
+        });
+      })();
+    </script>
+    <script src="./dist/app.js"></script>
+  </body>
+</html>

--- a/control-center/apps/directives-ui/package-lock.json
+++ b/control-center/apps/directives-ui/package-lock.json
@@ -1,0 +1,1054 @@
+{
+  "name": "@confenge/control-center-directives-ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-directives-ui",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "esbuild": "^0.25.9",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/control-center/apps/directives-ui/package.json
+++ b/control-center/apps/directives-ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@confenge/control-center-directives-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Mobile-first UX to register structured strategic memory (directives). Local mock adapter only.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "esbuild src/main.ts --bundle --format=iife --outfile=dist/app.js --target=es2022 --legal-comments=none",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && tsx --test tests/*.test.ts",
+    "serve": "node scripts/serve.mjs",
+    "start": "npm run build && node scripts/serve.mjs"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "esbuild": "^0.25.9",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/apps/directives-ui/public/favicon.svg
+++ b/control-center/apps/directives-ui/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#121418"/>
+  <path d="M8 22V10h3.2l4.8 8.2V10H19v12h-3.2L11 13.7V22H8z" fill="#d4a656"/>
+  <rect x="21" y="10" width="3" height="12" fill="#7ec8e3"/>
+</svg>

--- a/control-center/apps/directives-ui/scripts/serve.mjs
+++ b/control-center/apps/directives-ui/scripts/serve.mjs
@@ -1,0 +1,49 @@
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+const root = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "..");
+const host = process.env.HOST ?? "127.0.0.1";
+const port = Number(process.env.PORT ?? "4177");
+
+const TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".webmanifest": "application/manifest+json; charset=utf-8",
+};
+
+function safeJoin(base, requestPath) {
+  const decoded = decodeURIComponent(requestPath.split("?")[0] ?? "/");
+  const relative = decoded === "/" ? "/index.html" : decoded;
+  const resolved = path.resolve(base, `.${relative}`);
+  if (!resolved.startsWith(base)) return null;
+  return resolved;
+}
+
+const server = http.createServer((req, res) => {
+  const filePath = safeJoin(root, req.url ?? "/");
+  if (!filePath) {
+    res.writeHead(400);
+    res.end("bad path");
+    return;
+  }
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      res.end("not found");
+      return;
+    }
+    const type = TYPES[path.extname(filePath)] ?? "application/octet-stream";
+    res.writeHead(200, { "content-type": type, "cache-control": "no-store" });
+    res.end(data);
+  });
+});
+
+server.listen(port, host, () => {
+  process.stdout.write(`directives-ui listening on http://${host}:${port}/\n`);
+});

--- a/control-center/apps/directives-ui/src/actor.ts
+++ b/control-center/apps/directives-ui/src/actor.ts
@@ -1,0 +1,154 @@
+import { ACTOR_ID_PATTERN, isSessionRole } from "./contract.ts";
+import { DirectiveUiError } from "./errors.ts";
+import type { FounderApproval, SessionIdentity, SessionRole } from "./types.ts";
+
+/**
+ * Opaque local-mock handles. Not a password, not an email, not a person name.
+ * Overridable via CONTROL_CENTER_FOUNDER_ACTOR_ID / CC_ACTOR_ID / CC_ACTOR_ROLE.
+ */
+export const LOCAL_MOCK_FOUNDER_ACTOR_ID = "human:founder";
+export const LOCAL_MOCK_ACTOR_ID = "human:founder";
+export const LOCAL_MOCK_ACTOR_ROLE: SessionRole = "founder";
+
+export const ENV_FOUNDER_ACTOR_ID = "CONTROL_CENTER_FOUNDER_ACTOR_ID";
+export const ENV_ACTOR_ID = "CC_ACTOR_ID";
+export const ENV_ACTOR_ROLE = "CC_ACTOR_ROLE";
+export const ENV_USE_MOCK_IDENTITY = "CC_USE_MOCK_IDENTITY";
+
+export interface IdentityEnv {
+  readonly [key: string]: string | undefined;
+}
+
+function readTrimmed(env: IdentityEnv, key: string): string {
+  const raw = env[key];
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function parseActorId(raw: string, field: string): string {
+  if (raw === "") {
+    throw new DirectiveUiError("invalid_actor_id", `${field} is required`);
+  }
+  if (raw.length > 128 || !ACTOR_ID_PATTERN.test(raw)) {
+    throw new DirectiveUiError("invalid_actor_id", `${field} is not a valid opaque handle`);
+  }
+  if (/password|secret|token/i.test(raw)) {
+    throw new DirectiveUiError("invalid_actor_id", `${field} looks like a secret; use an opaque handle`);
+  }
+  return raw;
+}
+
+export function mockIdentity(): SessionIdentity {
+  return {
+    actor: {
+      kind: "human",
+      id: LOCAL_MOCK_ACTOR_ID,
+      display_name: "Operador local (mock)",
+    },
+    role: LOCAL_MOCK_ACTOR_ROLE,
+    founderActorId: LOCAL_MOCK_FOUNDER_ACTOR_ID,
+    source: "mock-local",
+  };
+}
+
+/**
+ * Fail-closed identity. Mock defaults apply only when CC_USE_MOCK_IDENTITY is
+ * not "0" (this workstream is mock-only). Production convergence MUST set the
+ * founder env var and MUST NOT ship a password.
+ */
+export function resolveIdentity(env: IdentityEnv): SessionIdentity {
+  const allowMock = readTrimmed(env, ENV_USE_MOCK_IDENTITY) !== "0";
+  const founderRaw = readTrimmed(env, ENV_FOUNDER_ACTOR_ID);
+  const actorRaw = readTrimmed(env, ENV_ACTOR_ID);
+  const roleRaw = readTrimmed(env, ENV_ACTOR_ROLE);
+
+  if (founderRaw === "" && actorRaw === "" && roleRaw === "") {
+    if (!allowMock) {
+      return {
+        actor: { kind: "human", id: "human:unconfigured" },
+        role: "operator",
+        founderActorId: "",
+        source: "env",
+      };
+    }
+    return mockIdentity();
+  }
+
+  const founderActorId =
+    founderRaw === ""
+      ? allowMock
+        ? LOCAL_MOCK_FOUNDER_ACTOR_ID
+        : ""
+      : parseActorId(founderRaw, ENV_FOUNDER_ACTOR_ID);
+  const actorId =
+    actorRaw === ""
+      ? allowMock
+        ? LOCAL_MOCK_ACTOR_ID
+        : ""
+      : parseActorId(actorRaw, ENV_ACTOR_ID);
+  let role: SessionRole = allowMock ? LOCAL_MOCK_ACTOR_ROLE : "operator";
+  if (roleRaw !== "") {
+    if (!isSessionRole(roleRaw)) {
+      throw new DirectiveUiError("invalid_actor_role", `${ENV_ACTOR_ROLE} is unknown`);
+    }
+    role = roleRaw;
+  }
+
+  if (actorId === "") {
+    return {
+      actor: { kind: "human", id: "human:unconfigured" },
+      role: "operator",
+      founderActorId,
+      source: "env",
+    };
+  }
+
+  const actor: SessionIdentity["actor"] = { kind: "human", id: actorId };
+  if (allowMock && actorId === LOCAL_MOCK_ACTOR_ID) {
+    actor.display_name = "Operador local (mock)";
+  }
+  return {
+    actor,
+    role,
+    founderActorId,
+    source: founderRaw === "" && actorRaw === "" ? "mock-local" : "env",
+  };
+}
+
+export function founderApproval(identity: SessionIdentity): FounderApproval {
+  if (identity.founderActorId === "" || identity.actor.id === "human:unconfigured") {
+    return {
+      approved: false,
+      canMutate: false,
+      code: "identity_unconfigured",
+      label: "Aprovação founder: ausente — identidade não configurada (fail-closed)",
+    };
+  }
+  const approved =
+    identity.role === "founder" && identity.actor.id === identity.founderActorId;
+  if (!approved) {
+    return {
+      approved: false,
+      canMutate: false,
+      code: "not_founder",
+      label: "Aprovação founder: ausente — este ator não pode registrar memória",
+    };
+  }
+  return {
+    approved: true,
+    canMutate: true,
+    code: "founder_ok",
+    label: "Aprovação founder: este ator está autorizado a registrar memória",
+  };
+}
+
+export function assertCanMutate(identity: SessionIdentity): FounderApproval {
+  const approval = founderApproval(identity);
+  if (!approval.canMutate) {
+    throw new DirectiveUiError(
+      approval.code,
+      approval.label,
+      { actor_id: identity.actor.id, role: identity.role },
+    );
+  }
+  return approval;
+}

--- a/control-center/apps/directives-ui/src/app-state.ts
+++ b/control-center/apps/directives-ui/src/app-state.ts
@@ -1,0 +1,230 @@
+import { founderApproval } from "./actor.ts";
+import { isDirectiveKind, isScope } from "./contract.ts";
+import { type CreateDraft, draftImpact, draftToInput } from "./create.ts";
+import { isDirectiveUiError } from "./errors.ts";
+import {
+  EMPTY_FILTER,
+  parseKindFilter,
+  parseScopeFilter,
+  parseStatusFilter,
+} from "./filter.ts";
+import type { MockDirectiveService } from "./service.ts";
+import { kindOption } from "./ui/labels.ts";
+import type { DirectiveFilter, DirectiveKind, FounderApproval, ResourceId } from "./types.ts";
+
+export type Screen = "list" | "create" | "detail" | "supersede" | "preview";
+
+export interface UiState {
+  filter: DirectiveFilter;
+  screen: Screen;
+  selectedId: ResourceId | null;
+  createDraft: CreateDraft;
+  previewScope: string;
+  notice: string | null;
+  error: string | null;
+  errorCode: string | null;
+}
+
+export type Action =
+  | { type: "set-query"; query: string }
+  | { type: "set-kind-filter"; kind: string }
+  | { type: "set-scope-filter"; scope: string }
+  | { type: "set-status-filter"; status: string }
+  | { type: "open-create" }
+  | { type: "open-detail"; id: ResourceId }
+  | { type: "open-supersede"; id: ResourceId }
+  | { type: "open-preview"; scope?: string }
+  | { type: "set-preview-scope"; scope: string }
+  | { type: "back-to-list" }
+  | { type: "select-kind"; kind: string }
+  | { type: "set-kind-confirmed"; confirmed: boolean }
+  | { type: "patch-create"; patch: Partial<CreateDraft> }
+  | { type: "submit-create" }
+  | { type: "submit-supersede" };
+
+export interface AppSession {
+  service: MockDirectiveService;
+  ui: UiState;
+}
+
+export function initialUiState(service: MockDirectiveService): UiState {
+  return {
+    filter: { ...EMPTY_FILTER },
+    screen: "list",
+    selectedId: null,
+    createDraft: service.newDraft(),
+    previewScope: "company",
+    notice: null,
+    error: null,
+    errorCode: null,
+  };
+}
+
+export function approvalOf(session: AppSession): FounderApproval {
+  return founderApproval(session.service.identity());
+}
+
+export function dispatch(session: AppSession, action: Action): AppSession {
+  const ui = { ...session.ui, notice: null, error: null, errorCode: null };
+  const next: AppSession = { service: session.service, ui };
+
+  switch (action.type) {
+    case "set-query":
+      next.ui = { ...ui, filter: { ...ui.filter, query: action.query } };
+      return next;
+    case "set-kind-filter":
+      next.ui = { ...ui, filter: { ...ui.filter, kind: parseKindFilter(action.kind) } };
+      return next;
+    case "set-scope-filter":
+      next.ui = { ...ui, filter: { ...ui.filter, scope: parseScopeFilter(action.scope) } };
+      return next;
+    case "set-status-filter":
+      next.ui = { ...ui, filter: { ...ui.filter, status: parseStatusFilter(action.status) } };
+      return next;
+    case "open-create":
+      next.ui = {
+        ...ui,
+        screen: "create",
+        createDraft: session.service.newDraft(),
+        selectedId: null,
+      };
+      return next;
+    case "open-detail":
+      next.ui = { ...ui, screen: "detail", selectedId: action.id };
+      return next;
+    case "open-supersede": {
+      const predecessor = session.service.get(action.id);
+      const draft = session.service.newDraft();
+      if (predecessor) {
+        draft.kind = predecessor.kind;
+        draft.kindConfirmed = false;
+        draft.scope = predecessor.scope;
+        draft.title = predecessor.title;
+        draft.body = predecessor.body;
+        draft.supersedeId = predecessor.id;
+      }
+      next.ui = {
+        ...ui,
+        screen: "supersede",
+        selectedId: action.id,
+        createDraft: draft,
+      };
+      return next;
+    }
+    case "open-preview":
+      next.ui = {
+        ...ui,
+        screen: "preview",
+        previewScope: action.scope && isScope(action.scope) ? action.scope : ui.previewScope,
+      };
+      return next;
+    case "set-preview-scope":
+      next.ui = {
+        ...ui,
+        previewScope: isScope(action.scope) ? action.scope : ui.previewScope,
+      };
+      return next;
+    case "back-to-list":
+      next.ui = { ...ui, screen: "list", selectedId: null };
+      return next;
+    case "select-kind": {
+      if (!isDirectiveKind(action.kind)) {
+        next.ui = {
+          ...ui,
+          error: "Tipo desconhecido.",
+          errorCode: "invalid_kind",
+        };
+        return next;
+      }
+      next.ui = {
+        ...ui,
+        createDraft: { ...ui.createDraft, kind: action.kind, kindConfirmed: false },
+      };
+      return next;
+    }
+    case "set-kind-confirmed":
+      next.ui = {
+        ...ui,
+        createDraft: { ...ui.createDraft, kindConfirmed: action.confirmed },
+      };
+      return next;
+    case "patch-create":
+      next.ui = { ...ui, createDraft: { ...ui.createDraft, ...action.patch } };
+      return next;
+    case "submit-create":
+      return submit(next, "create");
+    case "submit-supersede":
+      return submit(next, "supersede");
+  }
+}
+
+function submit(session: AppSession, mode: "create" | "supersede"): AppSession {
+  const { ui, service } = session;
+  try {
+    const input = draftToInput(ui.createDraft);
+    if (mode === "create") {
+      const created = service.create(input);
+      return {
+        service,
+        ui: {
+          ...ui,
+          screen: "detail",
+          selectedId: created.id,
+          notice: `Registrado: ${kindOption(created.kind).shortName.toLowerCase()} ${created.id}`,
+          error: null,
+          errorCode: null,
+        },
+      };
+    }
+    const predecessorId = ui.selectedId ?? ui.createDraft.supersedeId;
+    if (!predecessorId) {
+      return {
+        service,
+        ui: { ...ui, error: "Selecione o registro a substituir.", errorCode: "not_found" },
+      };
+    }
+    const result = service.supersede(predecessorId, input);
+    return {
+      service,
+      ui: {
+        ...ui,
+        screen: "detail",
+        selectedId: result.successor.id,
+        notice: `Supersede explícito: ${result.predecessor.id} ficou superseded; sucessor ${result.successor.id}`,
+        error: null,
+        errorCode: null,
+      },
+    };
+  } catch (error) {
+    if (isDirectiveUiError(error)) {
+      return {
+        service,
+        ui: { ...ui, error: error.message, errorCode: error.code },
+      };
+    }
+    return {
+      service,
+      ui: {
+        ...ui,
+        error: "Falha inesperada ao gravar.",
+        errorCode: "unknown",
+      },
+    };
+  }
+}
+
+export function selectedRecord(session: AppSession) {
+  if (!session.ui.selectedId) return undefined;
+  return session.service.get(session.ui.selectedId);
+}
+
+export function currentImpact(session: AppSession) {
+  return draftImpact(session.ui.createDraft);
+}
+
+export function confirmLabel(kind: DirectiveKind | ""): string {
+  if (kind === "") {
+    return "Escolha o tipo antes de confirmar. Sem confirmação, nada é gravado.";
+  }
+  return kindOption(kind).confirmHint;
+}

--- a/control-center/apps/directives-ui/src/contract.ts
+++ b/control-center/apps/directives-ui/src/contract.ts
@@ -1,0 +1,95 @@
+import {
+  AUTHORITATIVE_KINDS,
+  CREATE_STATUSES,
+  DIRECTIVE_KINDS,
+  DIRECTIVE_STATUSES,
+  FORBIDDEN_MUTATIONS,
+  ORIENTATIVE_KINDS,
+  SCOPE_LITERALS,
+  SESSION_ROLES,
+  type AuthoritativeKind,
+  type CreateStatus,
+  type DirectiveKind,
+  type DirectiveStatus,
+  type ForbiddenMutation,
+  type Scope,
+  type SessionRole,
+} from "./types.ts";
+
+export const UTC_DATETIME_PATTERN =
+  /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,9})?Z$/;
+
+export const RESOURCE_ID_PATTERN = /^cc:[a-z][a-z0-9-]*:[A-Za-z0-9._~-]+$/;
+
+export const SCOPE_PATTERN =
+  /^(company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?|client:[a-z0-9]+(?:-[a-z0-9]+)*|[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)$/;
+
+export const ACTOR_ID_PATTERN = /^[A-Za-z0-9._:@-]+$/;
+
+export const TAG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+export const TITLE_MAX = 200;
+export const BODY_MAX = 8000;
+
+export const FORBIDDEN_SECRET_KEY_REGEX =
+  /^(secret|token|password|authorization|api[_-]?key|cookie|credential|private[_-]?key)$/i;
+
+export function isDirectiveKind(value: string): value is DirectiveKind {
+  return (DIRECTIVE_KINDS as readonly string[]).includes(value);
+}
+
+export function isDirectiveStatus(value: string): value is DirectiveStatus {
+  return (DIRECTIVE_STATUSES as readonly string[]).includes(value);
+}
+
+export function isCreateStatus(value: string): value is CreateStatus {
+  return (CREATE_STATUSES as readonly string[]).includes(value);
+}
+
+export function isSessionRole(value: string): value is SessionRole {
+  return (SESSION_ROLES as readonly string[]).includes(value);
+}
+
+export function isAuthoritativeKind(kind: DirectiveKind): kind is AuthoritativeKind {
+  return (AUTHORITATIVE_KINDS as readonly string[]).includes(kind);
+}
+
+export function isHypothesisKind(kind: DirectiveKind): boolean {
+  return kind === "hypothesis";
+}
+
+export function isOrientativeKind(kind: DirectiveKind): boolean {
+  return (ORIENTATIVE_KINDS as readonly string[]).includes(kind);
+}
+
+export function isUtcDateTime(value: string): boolean {
+  return UTC_DATETIME_PATTERN.test(value);
+}
+
+export function isResourceId(value: string): boolean {
+  return RESOURCE_ID_PATTERN.test(value);
+}
+
+export function isScope(value: string): value is Scope {
+  return value.length >= 2 && value.length <= 128 && SCOPE_PATTERN.test(value);
+}
+
+export function isScopeLiteral(value: string): boolean {
+  return (SCOPE_LITERALS as readonly string[]).includes(value);
+}
+
+export function isForbiddenMutation(value: string): value is ForbiddenMutation {
+  return (FORBIDDEN_MUTATIONS as readonly string[]).includes(value);
+}
+
+export function looksLikeSecretKey(key: string): boolean {
+  return FORBIDDEN_SECRET_KEY_REGEX.test(key);
+}
+
+export function authorityClass(
+  kind: DirectiveKind,
+): "authoritative" | "orientative" | "hypothesis" {
+  if (isHypothesisKind(kind)) return "hypothesis";
+  if (isAuthoritativeKind(kind)) return "authoritative";
+  return "orientative";
+}

--- a/control-center/apps/directives-ui/src/create.ts
+++ b/control-center/apps/directives-ui/src/create.ts
@@ -1,0 +1,219 @@
+import {
+  BODY_MAX,
+  TITLE_MAX,
+  isCreateStatus,
+  isDirectiveKind,
+  isResourceId,
+  isScope,
+  isUtcDateTime,
+} from "./contract.ts";
+import { parseUtcDateTime, toUtcDateTime } from "./datetime.ts";
+import { DirectiveUiError } from "./errors.ts";
+import { describeSaveImpact, type SaveImpact } from "./impact.ts";
+import { newDirectiveId } from "./ids.ts";
+import type {
+  ActorRef,
+  Clock,
+  CreateDirectiveInput,
+  CreateStatus,
+  Directive,
+  DirectiveKind,
+  Scope,
+} from "./types.ts";
+import { SCHEMA_VERSION } from "./types.ts";
+
+export interface CreateDraft {
+  kind: DirectiveKind | "";
+  kindConfirmed: boolean;
+  title: string;
+  body: string;
+  scope: Scope;
+  status: CreateStatus;
+  effective_from: string;
+  expires_at: string;
+  supersedeId: string;
+}
+
+export function defaultCreateDraft(now: Date, defaultScope: Scope = "company"): CreateDraft {
+  return {
+    kind: "",
+    kindConfirmed: false,
+    title: "",
+    body: "",
+    scope: defaultScope,
+    status: "active",
+    effective_from: toUtcDateTime(now),
+    expires_at: "",
+    supersedeId: "",
+  };
+}
+
+export function parseExpiresAt(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  return trimmed;
+}
+
+export function draftToInput(draft: CreateDraft): CreateDirectiveInput {
+  if (draft.kind === "") {
+    throw new DirectiveUiError(
+      "kind_required",
+      "Escolha o tipo da memória. Não há tipo padrão — decisão e fato são escolhas distintas.",
+    );
+  }
+  if (!draft.kindConfirmed) {
+    throw new DirectiveUiError(
+      "kind_not_confirmed",
+      `Confirme explicitamente que o tipo é ${draft.kind}. Sem essa confirmação o registro não é gravado.`,
+      { kind: draft.kind },
+    );
+  }
+  const expires = parseExpiresAt(draft.expires_at);
+  const supersedes =
+    draft.supersedeId.trim() === "" ? null : [draft.supersedeId.trim()];
+  return {
+    kind: draft.kind,
+    kindConfirm: draft.kind,
+    title: draft.title,
+    body: draft.body,
+    scope: draft.scope,
+    status: draft.status,
+    effective_from: draft.effective_from,
+    expires_at: expires,
+    supersedes,
+  };
+}
+
+export function draftImpact(draft: CreateDraft): SaveImpact {
+  return describeSaveImpact(draft.scope, parseExpiresAt(draft.expires_at), draft.status);
+}
+
+function requireKind(value: string, field: string): DirectiveKind {
+  if (!isDirectiveKind(value)) {
+    throw new DirectiveUiError("invalid_kind", `${field} must be a known directive kind`, {
+      field,
+    });
+  }
+  return value;
+}
+
+export function assertKindConfirmed(kind: DirectiveKind, kindConfirm: string): void {
+  const confirmed = requireKind(kindConfirm, "kindConfirm");
+  if (confirmed !== kind) {
+    throw new DirectiveUiError(
+      "kind_mismatch",
+      `Confirmação de tipo (${confirmed}) não coincide com o tipo escolhido (${kind}). Uma decisão não pode ser gravada como fato.`,
+      { kind, kindConfirm: confirmed },
+    );
+  }
+}
+
+export function validateCreateInput(input: CreateDirectiveInput): CreateDirectiveInput {
+  const kind = requireKind(input.kind, "kind");
+  assertKindConfirmed(kind, input.kindConfirm);
+  if (!isScope(input.scope)) {
+    throw new DirectiveUiError("invalid_scope", "scope is not a v1 scope string", {
+      scope: input.scope,
+    });
+  }
+  if (!isCreateStatus(input.status)) {
+    throw new DirectiveUiError(
+      "invalid_status",
+      "create only accepts draft or active; superseded/revoked/expired are lifecycle results",
+    );
+  }
+  const title = input.title.trim();
+  const body = input.body.trim();
+  if (title.length < 1 || title.length > TITLE_MAX) {
+    throw new DirectiveUiError("invalid_title", `title must be 1–${TITLE_MAX} characters`);
+  }
+  if (body.length < 1 || body.length > BODY_MAX) {
+    throw new DirectiveUiError("invalid_body", `body must be 1–${BODY_MAX} characters`);
+  }
+  if (!isUtcDateTime(input.effective_from)) {
+    throw new DirectiveUiError("invalid_effective_from", "effective_from must be UTC with Z");
+  }
+  if (input.expires_at !== null) {
+    if (!isUtcDateTime(input.expires_at)) {
+      throw new DirectiveUiError("invalid_expires_at", "expires_at must be UTC with Z or null");
+    }
+    const from = parseUtcDateTime(input.effective_from, "effective_from");
+    const until = parseUtcDateTime(input.expires_at, "expires_at");
+    if (until.getTime() <= from.getTime()) {
+      throw new DirectiveUiError("invalid_expires_at", "expires_at must be after effective_from");
+    }
+  }
+  let supersedes: string[] | null = null;
+  if (input.supersedes !== null) {
+    if (input.supersedes.length === 0) {
+      supersedes = null;
+    } else {
+      const unique = [...new Set(input.supersedes)];
+      for (const id of unique) {
+        if (!isResourceId(id)) {
+          throw new DirectiveUiError("invalid_supersedes", "supersedes ids must be resource ids");
+        }
+      }
+      supersedes = unique;
+    }
+  }
+  return {
+    kind,
+    kindConfirm: kind,
+    title,
+    body,
+    scope: input.scope,
+    status: input.status,
+    effective_from: input.effective_from,
+    expires_at: input.expires_at,
+    supersedes,
+    ...(input.tags ? { tags: input.tags } : {}),
+  };
+}
+
+export function buildDirective(
+  input: CreateDirectiveInput,
+  actor: ActorRef,
+  clock: Clock,
+): Directive {
+  const valid = validateCreateInput(input);
+  const now = toUtcDateTime(clock.now());
+  const id = newDirectiveId(clock.now());
+  const record: Directive = {
+    schema_version: SCHEMA_VERSION,
+    id,
+    kind: valid.kind,
+    scope: valid.scope,
+    status: valid.status,
+    title: valid.title,
+    body: valid.body,
+    effective_from: valid.effective_from,
+    expires_at: valid.expires_at,
+    supersedes: valid.supersedes,
+    created_by: { kind: actor.kind, id: actor.id },
+    created_at: now,
+    updated_at: now,
+    audit: [
+      {
+        at: now,
+        actor: { kind: actor.kind, id: actor.id },
+        action: "created",
+        to_status: valid.status,
+      },
+    ],
+  };
+  if (actor.display_name) {
+    record.created_by = { ...record.created_by, display_name: actor.display_name };
+    const first = record.audit[0];
+    if (first) {
+      record.audit[0] = {
+        ...first,
+        actor: { ...first.actor, display_name: actor.display_name },
+      };
+    }
+  }
+  if (valid.tags && valid.tags.length > 0) {
+    record.tags = valid.tags;
+  }
+  return record;
+}

--- a/control-center/apps/directives-ui/src/datetime.ts
+++ b/control-center/apps/directives-ui/src/datetime.ts
@@ -1,0 +1,57 @@
+import { UTC_DATETIME_PATTERN } from "./contract.ts";
+
+export const PRESENTATION_TIME_ZONE = "America/Sao_Paulo";
+
+export function toUtcDateTime(date: Date): string {
+  const iso = date.toISOString();
+  const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?Z$/.exec(iso);
+  if (!match) {
+    throw new Error("clock produced a non-UTC timestamp");
+  }
+  return `${match[1]}Z`;
+}
+
+export function parseUtcDateTime(value: string, field: string): Date {
+  if (!UTC_DATETIME_PATTERN.test(value)) {
+    throw new Error(`${field} must be UTC RFC3339 with a Z suffix`);
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${field} is not a valid instant`);
+  }
+  return date;
+}
+
+export function formatLocal(value: string, timeZone = PRESENTATION_TIME_ZONE): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  const formatted = new Intl.DateTimeFormat("pt-BR", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(date);
+  return `${formatted} (${timeZone})`;
+}
+
+export function frozenClock(iso: string): { now(): Date } {
+  const date = parseUtcDateTime(iso, "clock");
+  return {
+    now() {
+      return new Date(date.getTime());
+    },
+  };
+}
+
+export function systemClock(): { now(): Date } {
+  return {
+    now() {
+      return new Date();
+    },
+  };
+}

--- a/control-center/apps/directives-ui/src/errors.ts
+++ b/control-center/apps/directives-ui/src/errors.ts
@@ -1,0 +1,15 @@
+export class DirectiveUiError extends Error {
+  readonly code: string;
+  readonly fields: Readonly<Record<string, string>>;
+
+  constructor(code: string, message: string, fields: Record<string, string> = {}) {
+    super(message);
+    this.name = "DirectiveUiError";
+    this.code = code;
+    this.fields = fields;
+  }
+}
+
+export function isDirectiveUiError(error: unknown): error is DirectiveUiError {
+  return error instanceof DirectiveUiError;
+}

--- a/control-center/apps/directives-ui/src/escape.ts
+++ b/control-center/apps/directives-ui/src/escape.ts
@@ -1,0 +1,12 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function escapeAttr(value: string): string {
+  return escapeHtml(value);
+}

--- a/control-center/apps/directives-ui/src/filter.ts
+++ b/control-center/apps/directives-ui/src/filter.ts
@@ -1,0 +1,59 @@
+import { isDirectiveKind, isDirectiveStatus, isScope } from "./contract.ts";
+import type { Directive, DirectiveFilter, DirectiveKind, DirectiveStatus } from "./types.ts";
+
+export const EMPTY_FILTER: DirectiveFilter = {
+  query: "",
+  kind: "all",
+  scope: "all",
+  status: "all",
+};
+
+export function parseKindFilter(value: string): DirectiveKind | "all" {
+  if (value === "all" || value === "") return "all";
+  if (!isDirectiveKind(value)) return "all";
+  return value;
+}
+
+export function parseStatusFilter(value: string): DirectiveStatus | "all" {
+  if (value === "all" || value === "") return "all";
+  if (!isDirectiveStatus(value)) return "all";
+  return value;
+}
+
+export function parseScopeFilter(value: string): string | "all" {
+  if (value === "all" || value === "") return "all";
+  if (!isScope(value)) return "all";
+  return value;
+}
+
+export function matchesQuery(record: Directive, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === "") return true;
+  const tags = record.tags ?? [];
+  const hay = [record.title, record.body, record.id, record.scope, record.kind, record.status, ...tags]
+    .join("\n")
+    .toLowerCase();
+  return hay.includes(q);
+}
+
+export function matchesFilter(record: Directive, filter: DirectiveFilter): boolean {
+  if (filter.kind !== "all" && record.kind !== filter.kind) return false;
+  if (filter.scope !== "all" && record.scope !== filter.scope) return false;
+  if (filter.status !== "all" && record.status !== filter.status) return false;
+  return matchesQuery(record, filter.query);
+}
+
+export function filterDirectives(
+  records: readonly Directive[],
+  filter: DirectiveFilter,
+): Directive[] {
+  return records.filter((record) => matchesFilter(record, filter));
+}
+
+export function uniqueScopes(records: readonly Directive[]): string[] {
+  const set = new Set<string>();
+  for (const record of records) {
+    set.add(record.scope);
+  }
+  return [...set].sort((a, b) => a.localeCompare(b));
+}

--- a/control-center/apps/directives-ui/src/fixtures.ts
+++ b/control-center/apps/directives-ui/src/fixtures.ts
@@ -1,0 +1,180 @@
+import type { ActorRef, Directive, DirectiveKind } from "./types.ts";
+import { SCHEMA_VERSION } from "./types.ts";
+
+export const FIXTURE_NOW = "2026-08-20T15:00:00Z";
+
+export const FIXTURE_ACTOR: ActorRef = {
+  kind: "human",
+  id: "human:founder",
+  display_name: "Operador local (mock)",
+};
+
+function entry(
+  partial: Omit<Directive, "schema_version" | "created_by" | "created_at" | "updated_at" | "audit"> & {
+    created_at?: string;
+    updated_at?: string;
+    note?: string;
+  },
+): Directive {
+  const createdAt = partial.created_at ?? "2026-08-20T12:00:00Z";
+  const updatedAt = partial.updated_at ?? createdAt;
+  return {
+    schema_version: SCHEMA_VERSION,
+    id: partial.id,
+    kind: partial.kind,
+    scope: partial.scope,
+    status: partial.status,
+    title: partial.title,
+    body: partial.body,
+    effective_from: partial.effective_from,
+    expires_at: partial.expires_at,
+    supersedes: partial.supersedes,
+    created_by: FIXTURE_ACTOR,
+    created_at: createdAt,
+    updated_at: updatedAt,
+    audit: [
+      {
+        at: createdAt,
+        actor: FIXTURE_ACTOR,
+        action: "created",
+        to_status: partial.status === "superseded" ? "active" : partial.status,
+      },
+      ...(partial.status === "superseded"
+        ? [
+            {
+              at: updatedAt,
+              actor: FIXTURE_ACTOR,
+              action: "superseded" as const,
+              from_status: "active" as const,
+              to_status: "superseded" as const,
+              ...(partial.note ? { note: partial.note } : {}),
+            },
+          ]
+        : []),
+    ],
+    ...(partial.tags ? { tags: partial.tags } : {}),
+  };
+}
+
+export const FIXTURE_DIRECTIVES: Directive[] = [
+  entry({
+    id: "cc:directive:01K3CC-NO-PROVIDER-MUTATION",
+    kind: "constraint",
+    scope: "finance",
+    status: "active",
+    title: "No provider financial mutations in Control Center",
+    body: "Control Center collectors and agents MUST NOT execute cobrança, checkout, refund, cancelamento, Asaas writes, or commercial send. Those remain in origin systems under separate authority.",
+    effective_from: "2026-08-20T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    tags: ["fail-closed", "finance"],
+  }),
+  entry({
+    id: "cc:directive:01K3CC-GOV-CANONICAL",
+    kind: "decision",
+    scope: "company",
+    status: "active",
+    title: "Governance is canonical for strategic memory",
+    body: "Governance holds strategic/canonical authority. Warmbly remains commercial/CRM operational authority. Control Center aggregates; it does not replace origin systems.",
+    effective_from: "2026-08-19T00:00:00Z",
+    expires_at: null,
+    supersedes: ["cc:directive:01K3CC-GOV-CANONICAL-OLD"],
+    tags: ["authority"],
+  }),
+  entry({
+    id: "cc:directive:01K3CC-GOV-CANONICAL-OLD",
+    kind: "decision",
+    scope: "company",
+    status: "superseded",
+    title: "Draft: dual authority unresolved",
+    body: "Earlier unresolved wording. Kept readable after supersede; do not treat as current.",
+    effective_from: "2026-08-01T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    updated_at: "2026-08-19T00:00:00Z",
+    note: "succeeded by cc:directive:01K3CC-GOV-CANONICAL",
+    tags: ["authority"],
+  }),
+  entry({
+    id: "cc:directive:01K3CC-MCP-INTERFACE",
+    kind: "directive",
+    scope: "company",
+    status: "active",
+    title: "MCP is the principal agent interface",
+    body: "Agents consume Control Center through MCP. HTTP is an internal companion. Agents query by scope; they do not receive a whole-company dump.",
+    effective_from: "2026-08-20T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    tags: ["agents"],
+  }),
+  entry({
+    id: "cc:directive:01K3CC-WARMBLY-CRM",
+    kind: "fact",
+    scope: "commercial",
+    status: "active",
+    title: "Warmbly is the commercial operational runtime",
+    body: "Commercial pipeline, inbound, and CRM mutations stay in Warmbly. Control Center commercial snapshots are read models.",
+    effective_from: "2026-08-18T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    tags: ["warmbly"],
+  }),
+  entry({
+    id: "cc:directive:01K3CC-HOMEPAGE-THREE",
+    kind: "priority",
+    scope: "company",
+    status: "active",
+    title: "Homepage shows exceptions and three now-items",
+    body: "The cockpit homepage privileges exceptions and at most three current priorities. It is not a KPI wall.",
+    effective_from: "2026-08-20T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    tags: ["homepage"],
+  }),
+  entry({
+    id: "cc:directive:01K3CC-STALE-COLLECTOR",
+    kind: "risk",
+    scope: "infrastructure",
+    status: "active",
+    title: "Stale collectors hide operational truth",
+    body: "If github/asaas/warmbly collectors stop, freshness becomes STALE or ERROR. Agents must not treat last-known as current.",
+    effective_from: "2026-08-20T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    tags: ["freshness"],
+  }),
+  entry({
+    id: "cc:directive:01K3CC-OFFER-HYPOTHESIS",
+    kind: "hypothesis",
+    scope: "commercial",
+    status: "active",
+    title: "Partner-program offer may convert better with founder-approved copy",
+    body: "Hypothesis only. Not a fact and not a decision. Do not mix into authoritative commercial memory until evidence and a decision exist.",
+    effective_from: "2026-08-20T00:00:00Z",
+    expires_at: "2026-09-30T00:00:00Z",
+    supersedes: null,
+    tags: ["hypothesis"],
+  }),
+  entry({
+    id: "cc:directive:01K3CC-DRAFT-INBOUND",
+    kind: "directive",
+    scope: "inbound",
+    status: "draft",
+    title: "Inbound SLA wording (draft)",
+    body: "Draft wording for inbound response expectations. Not yet active; agents must not receive this as current context.",
+    effective_from: "2026-08-21T00:00:00Z",
+    expires_at: null,
+    supersedes: null,
+    tags: ["draft"],
+  }),
+];
+
+export const FIXTURE_KIND_COVERAGE: readonly DirectiveKind[] = [
+  "decision",
+  "directive",
+  "fact",
+  "constraint",
+  "priority",
+  "risk",
+  "hypothesis",
+];

--- a/control-center/apps/directives-ui/src/ids.ts
+++ b/control-center/apps/directives-ui/src/ids.ts
@@ -1,0 +1,20 @@
+import { isResourceId } from "./contract.ts";
+
+let seq = 0;
+
+export function resetIdSeq(value = 0): void {
+  seq = value;
+}
+
+/**
+ * `cc:directive:<slug>` matching contracts v1. No ULID dependency in this package.
+ */
+export function newDirectiveId(now: Date): string {
+  seq += 1;
+  const stamp = now.toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+  const id = `cc:directive:${stamp}-${seq.toString(36)}`;
+  if (!isResourceId(id)) {
+    throw new Error("generated id does not match resource_id pattern");
+  }
+  return id;
+}

--- a/control-center/apps/directives-ui/src/impact.ts
+++ b/control-center/apps/directives-ui/src/impact.ts
@@ -1,0 +1,74 @@
+import { isScopeLiteral } from "./contract.ts";
+import { formatLocal } from "./datetime.ts";
+import type { CreateStatus, Scope } from "./types.ts";
+
+export interface SaveImpact {
+  scope: Scope;
+  expires_at: string | null;
+  status: CreateStatus;
+  scopeSummary: string;
+  expirationSummary: string;
+  combined: string;
+}
+
+const SCOPE_BLURBS: Record<string, string> = {
+  company:
+    "Escopo company: um agente só vê este registro se consultar company. Isto não despeja a memória inteira da empresa em qualquer sessão.",
+  commercial:
+    "Escopo commercial: visível apenas para consultas commercial. Recortes finance/clients/infra não recebem este registro nesta UI.",
+  finance:
+    "Escopo finance: visível apenas para consultas finance. Nenhuma mutação de provedor (cobrança, checkout, refund, Asaas) é acionada daqui.",
+  clients:
+    "Escopo clients: visível apenas para o recorte de clientes. Não vaza para commercial ou finance.",
+  infrastructure:
+    "Escopo infrastructure: visível apenas para o recorte de infraestrutura.",
+  inbound:
+    "Escopo inbound: visível apenas para o recorte de inbound.",
+};
+
+export function describeScopeImpact(scope: Scope): string {
+  const known = SCOPE_BLURBS[scope];
+  if (known) return known;
+  if (scope.startsWith("client:")) {
+    return `Escopo ${scope}: um agente vê este registro só se consultar exatamente este cliente. Irmãos não recebem o contexto.`;
+  }
+  if (scope.startsWith("repo:")) {
+    return `Escopo ${scope}: um agente vê este registro só se consultar exatamente este repositório.`;
+  }
+  if (isScopeLiteral(scope)) {
+    return `Escopo ${scope}: visível apenas para consultas nesse recorte.`;
+  }
+  return `Escopo ${scope}: tratado como namespace opaco. Agentes não o recebem por omissão; só quem consultar exatamente este escopo.`;
+}
+
+export function describeExpirationImpact(expiresAt: string | null): string {
+  if (expiresAt === null) {
+    return "Sem expiração: permanece vigente até um supersede ou revogação explícitos. História antiga não será reescrita.";
+  }
+  return `Expira em ${expiresAt} UTC / ${formatLocal(expiresAt)}. Depois disso um agente não deve tratar o registro como vigente.`;
+}
+
+export function describeStatusImpact(status: CreateStatus): string {
+  if (status === "draft") {
+    return "Status draft: operadores veem o rascunho; o preview de agente não inclui drafts.";
+  }
+  return "Status active: entra no preview de agente do escopo escolhido (se ainda vigente).";
+}
+
+export function describeSaveImpact(
+  scope: Scope,
+  expiresAt: string | null,
+  status: CreateStatus,
+): SaveImpact {
+  const scopeSummary = describeScopeImpact(scope);
+  const expirationSummary = describeExpirationImpact(expiresAt);
+  const statusSummary = describeStatusImpact(status);
+  return {
+    scope,
+    expires_at: expiresAt,
+    status,
+    scopeSummary,
+    expirationSummary,
+    combined: `${scopeSummary} ${expirationSummary} ${statusSummary}`,
+  };
+}

--- a/control-center/apps/directives-ui/src/index.ts
+++ b/control-center/apps/directives-ui/src/index.ts
@@ -1,0 +1,9 @@
+export { resolveIdentity, founderApproval, assertCanMutate } from "./actor.ts";
+export { dispatch, initialUiState } from "./app-state.ts";
+export { buildDirective, defaultCreateDraft, draftToInput, draftImpact } from "./create.ts";
+export { filterDirectives, EMPTY_FILTER } from "./filter.ts";
+export { previewAgentContext, previewTitle } from "./preview.ts";
+export { createMockService, MockDirectiveService } from "./service.ts";
+export { supersedeDirective } from "./supersede.ts";
+export { renderApp } from "./ui/render.ts";
+export { DIRECTIVE_KINDS, DIRECTIVE_STATUSES } from "./types.ts";

--- a/control-center/apps/directives-ui/src/log.ts
+++ b/control-center/apps/directives-ui/src/log.ts
@@ -1,0 +1,34 @@
+import { looksLikeSecretKey } from "./contract.ts";
+
+export type LogFields = Record<string, string | number | boolean | null>;
+
+const FORBIDDEN_FIELD_NAMES = new Set([
+  "body",
+  "title",
+  "password",
+  "token",
+  "secret",
+  "authorization",
+  "cookie",
+  "credential",
+]);
+
+export function sanitizeLogFields(fields: LogFields): LogFields {
+  const out: LogFields = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (looksLikeSecretKey(key) || FORBIDDEN_FIELD_NAMES.has(key.toLowerCase())) {
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+export function logEvent(event: string, fields: LogFields = {}): string {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    event,
+    ...sanitizeLogFields(fields),
+  });
+  return line;
+}

--- a/control-center/apps/directives-ui/src/main.ts
+++ b/control-center/apps/directives-ui/src/main.ts
@@ -1,0 +1,64 @@
+import { initialUiState } from "./app-state.ts";
+import { createLiveClockService } from "./service.ts";
+import { mount } from "./ui/bind.ts";
+
+declare global {
+  interface Window {
+    __CC_DIRECTIVES_UI__?: { mounted: boolean };
+  }
+}
+
+function readMeta(name: string): string {
+  if (typeof document === "undefined") return "";
+  const el = document.querySelector(`meta[name="${name}"]`);
+  return el?.getAttribute("content")?.trim() ?? "";
+}
+
+function showFileProtocolHelp(root: HTMLElement): void {
+  root.innerHTML = `
+    <main class="file-protocol" role="alert">
+      <h1>Memória estratégica precisa de um servidor local ou do bundle gerado</h1>
+      <p>Abrir via <code>file:</code> só funciona depois de <code>npm run build</code> (script clássico, não módulo ES).</p>
+      <p>No diretório <code>control-center/apps/directives-ui</code> execute:</p>
+      <pre>npm install
+npm run build
+npm start
+# http://127.0.0.1:4177/</pre>
+    </main>
+  `;
+}
+
+function boot(): void {
+  const root = document.getElementById("app");
+  if (!root) return;
+
+  if (typeof location !== "undefined" && location.protocol === "file:") {
+    const script = document.querySelector("script[src$='dist/app.js']");
+    if (!script) {
+      showFileProtocolHelp(root);
+      return;
+    }
+  }
+
+  const env = {
+    CONTROL_CENTER_FOUNDER_ACTOR_ID: readMeta("cc-founder-actor-id"),
+    CC_ACTOR_ID: readMeta("cc-actor-id"),
+    CC_ACTOR_ROLE: readMeta("cc-actor-role"),
+    CC_USE_MOCK_IDENTITY: readMeta("cc-use-mock-identity") || "1",
+  };
+
+  const service = createLiveClockService(env);
+  const session = { service, ui: initialUiState(service) };
+  mount(root, session);
+  if (typeof window !== "undefined") {
+    window.__CC_DIRECTIVES_UI__ = { mounted: true };
+  }
+}
+
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+}

--- a/control-center/apps/directives-ui/src/observe.ts
+++ b/control-center/apps/directives-ui/src/observe.ts
@@ -1,0 +1,20 @@
+import { authorityClass } from "./contract.ts";
+import type { Directive, ObservedDirective } from "./types.ts";
+
+export const MOCK_SOURCE_SYSTEM = "governance";
+
+export function observeDirective(record: Directive, observedAt: string): ObservedDirective {
+  const authority = authorityClass(record.kind);
+  const confidence = authority === "hypothesis" ? 0.4 : authority === "orientative" ? 0.8 : 1;
+  return {
+    record,
+    source: MOCK_SOURCE_SYSTEM,
+    observed_at: observedAt,
+    freshness_status: "FRESH",
+    confidence,
+  };
+}
+
+export function observeAll(records: readonly Directive[], observedAt: string): ObservedDirective[] {
+  return records.map((record) => observeDirective(record, observedAt));
+}

--- a/control-center/apps/directives-ui/src/preview.ts
+++ b/control-center/apps/directives-ui/src/preview.ts
@@ -1,0 +1,112 @@
+import { parseUtcDateTime, toUtcDateTime } from "./datetime.ts";
+import { DirectiveUiError } from "./errors.ts";
+import { isScope } from "./contract.ts";
+import { observeDirective } from "./observe.ts";
+import type {
+  AgentScopePreview,
+  Clock,
+  Directive,
+  ObservedDirective,
+  Scope,
+} from "./types.ts";
+
+export function isEffectiveAt(record: Directive, now: Date): boolean {
+  if (record.status !== "active") return false;
+  const effective = parseUtcDateTime(record.effective_from, "effective_from");
+  if (effective.getTime() > now.getTime()) return false;
+  if (record.expires_at !== null) {
+    const expires = parseUtcDateTime(record.expires_at, "expires_at");
+    if (expires.getTime() <= now.getTime()) return false;
+  }
+  return true;
+}
+
+export function previewTitle(scope: Scope): string {
+  return `contexto que um agente verá para scope ${scope}`;
+}
+
+/**
+ * Exact-scope preview. v1 string scopes have no ancestor inheritance in this UI.
+ * Hypotheses are never mixed into decisions/facts. Other company memory is excluded.
+ */
+export function previewAgentContext(
+  records: readonly Directive[],
+  scope: string,
+  clock: Clock,
+): AgentScopePreview {
+  if (!isScope(scope)) {
+    throw new DirectiveUiError("invalid_scope", "preview requires a v1 scope string");
+  }
+  const now = clock.now();
+  const asOf = toUtcDateTime(now);
+  let excludedOther = 0;
+  let excludedInactive = 0;
+  const inScope: Directive[] = [];
+  for (const record of records) {
+    if (record.scope !== scope) {
+      excludedOther += 1;
+      continue;
+    }
+    if (!isEffectiveAt(record, now)) {
+      excludedInactive += 1;
+      continue;
+    }
+    inScope.push(record);
+  }
+
+  const bucket = {
+    decisions: [] as ObservedDirective[],
+    directives: [] as ObservedDirective[],
+    facts: [] as ObservedDirective[],
+    constraints: [] as ObservedDirective[],
+    priorities: [] as ObservedDirective[],
+    risks: [] as ObservedDirective[],
+    hypotheses: [] as ObservedDirective[],
+  };
+  for (const record of inScope) {
+    const observed = observeDirective(record, asOf);
+    switch (record.kind) {
+      case "decision":
+        bucket.decisions.push(observed);
+        break;
+      case "directive":
+        bucket.directives.push(observed);
+        break;
+      case "fact":
+        bucket.facts.push(observed);
+        break;
+      case "constraint":
+        bucket.constraints.push(observed);
+        break;
+      case "priority":
+        bucket.priorities.push(observed);
+        break;
+      case "risk":
+        bucket.risks.push(observed);
+        break;
+      case "hypothesis":
+        bucket.hypotheses.push(observed);
+        break;
+    }
+  }
+
+  return {
+    title: previewTitle(scope),
+    scope,
+    as_of: asOf,
+    granted_scopes: [scope],
+    ...bucket,
+    excluded_other_scopes: excludedOther,
+    excluded_inactive: excludedInactive,
+  };
+}
+
+export function previewHasHypothesisMixedIntoAuthoritative(preview: AgentScopePreview): boolean {
+  const authoritative = [
+    ...preview.decisions,
+    ...preview.directives,
+    ...preview.facts,
+    ...preview.constraints,
+  ];
+  return authoritative.some((item) => item.record.kind === "hypothesis");
+}

--- a/control-center/apps/directives-ui/src/service.ts
+++ b/control-center/apps/directives-ui/src/service.ts
@@ -1,0 +1,140 @@
+import { assertCanMutate, type IdentityEnv, resolveIdentity } from "./actor.ts";
+import { isForbiddenMutation } from "./contract.ts";
+import { buildDirective, type CreateDraft, defaultCreateDraft, draftToInput } from "./create.ts";
+import { frozenClock, systemClock, toUtcDateTime } from "./datetime.ts";
+import { DirectiveUiError } from "./errors.ts";
+import { EMPTY_FILTER, filterDirectives } from "./filter.ts";
+import { FIXTURE_DIRECTIVES, FIXTURE_NOW } from "./fixtures.ts";
+import { logEvent } from "./log.ts";
+import { observeDirective } from "./observe.ts";
+import { previewAgentContext } from "./preview.ts";
+import { MemoryDirectiveStore } from "./store.ts";
+import { supersedeDirective } from "./supersede.ts";
+import type {
+  AgentScopePreview,
+  Clock,
+  CreateDirectiveInput,
+  Directive,
+  DirectiveFilter,
+  ObservedDirective,
+  ResourceId,
+  SessionIdentity,
+} from "./types.ts";
+
+/**
+ * Local mock port. Later convergence replaces this class with HTTP to
+ * `control-center/services/context` while keeping the same method names.
+ */
+export interface DirectiveMemoryPort {
+  readonly mode: "mock";
+  list(filter?: DirectiveFilter): Directive[];
+  get(id: ResourceId): Directive | undefined;
+  create(input: CreateDirectiveInput): Directive;
+  createFromDraft(draft: CreateDraft): Directive;
+  supersede(predecessorId: ResourceId, input: CreateDirectiveInput): {
+    predecessor: Directive;
+    successor: Directive;
+  };
+  preview(scope: string): AgentScopePreview;
+  identity(): SessionIdentity;
+}
+
+export interface ServiceOptions {
+  store?: MemoryDirectiveStore;
+  clock?: Clock;
+  identity?: SessionIdentity;
+  env?: IdentityEnv;
+}
+
+export class MockDirectiveService implements DirectiveMemoryPort {
+  readonly mode = "mock" as const;
+  private readonly store: MemoryDirectiveStore;
+  private readonly clock: Clock;
+  private readonly session: SessionIdentity;
+
+  constructor(options: ServiceOptions = {}) {
+    this.store = options.store ?? new MemoryDirectiveStore(FIXTURE_DIRECTIVES);
+    this.clock = options.clock ?? frozenClock(FIXTURE_NOW);
+    this.session = options.identity ?? resolveIdentity(options.env ?? {});
+  }
+
+  identity(): SessionIdentity {
+    return this.session;
+  }
+
+  list(filter: DirectiveFilter = EMPTY_FILTER): Directive[] {
+    return filterDirectives(this.store.list(), filter);
+  }
+
+  get(id: ResourceId): Directive | undefined {
+    return this.store.get(id);
+  }
+
+  observe(id: ResourceId): ObservedDirective | undefined {
+    const record = this.store.get(id);
+    if (!record) return undefined;
+    return observeDirective(record, toUtcDateTime(this.clock.now()));
+  }
+
+  create(input: CreateDirectiveInput): Directive {
+    assertCanMutate(this.session);
+    const record = buildDirective(input, this.session.actor, this.clock);
+    this.store.insert(record);
+    logEvent("directive.create", {
+      id: record.id,
+      kind: record.kind,
+      scope: record.scope,
+      status: record.status,
+    });
+    return record;
+  }
+
+  createFromDraft(draft: CreateDraft): Directive {
+    return this.create(draftToInput(draft));
+  }
+
+  supersede(predecessorId: ResourceId, input: CreateDirectiveInput): {
+    predecessor: Directive;
+    successor: Directive;
+  } {
+    assertCanMutate(this.session);
+    const current = this.store.get(predecessorId);
+    if (!current) {
+      throw new DirectiveUiError("not_found", "predecessor does not exist", { id: predecessorId });
+    }
+    const result = supersedeDirective(current, input, this.session.actor, this.clock);
+    this.store.replace(result.predecessor);
+    this.store.insert(result.successor);
+    logEvent("directive.supersede", {
+      predecessor_id: result.predecessor.id,
+      successor_id: result.successor.id,
+      kind: result.successor.kind,
+      scope: result.successor.scope,
+    });
+    return result;
+  }
+
+  preview(scope: string): AgentScopePreview {
+    return previewAgentContext(this.store.list(), scope, this.clock);
+  }
+
+  newDraft(): CreateDraft {
+    return defaultCreateDraft(this.clock.now());
+  }
+
+  refusesForbiddenMutation(action: string): boolean {
+    return isForbiddenMutation(action);
+  }
+}
+
+export function createMockService(options: ServiceOptions = {}): MockDirectiveService {
+  return new MockDirectiveService(options);
+}
+
+export function createLiveClockService(env: IdentityEnv): MockDirectiveService {
+  return new MockDirectiveService({
+    clock: systemClock(),
+    env,
+    store: new MemoryDirectiveStore(FIXTURE_DIRECTIVES),
+  });
+}

--- a/control-center/apps/directives-ui/src/store.ts
+++ b/control-center/apps/directives-ui/src/store.ts
@@ -1,0 +1,55 @@
+import { DirectiveUiError } from "./errors.ts";
+import type { Directive, ResourceId } from "./types.ts";
+
+export class MemoryDirectiveStore {
+  private readonly records = new Map<ResourceId, Directive>();
+
+  constructor(seed: readonly Directive[] = []) {
+    for (const record of seed) {
+      this.records.set(record.id, cloneDirective(record));
+    }
+  }
+
+  list(): Directive[] {
+    return [...this.records.values()]
+      .map(cloneDirective)
+      .sort((a, b) => b.updated_at.localeCompare(a.updated_at) || a.id.localeCompare(b.id));
+  }
+
+  get(id: ResourceId): Directive | undefined {
+    const found = this.records.get(id);
+    return found ? cloneDirective(found) : undefined;
+  }
+
+  insert(record: Directive): void {
+    if (this.records.has(record.id)) {
+      throw new DirectiveUiError("duplicate_id", "directive id already exists", { id: record.id });
+    }
+    this.records.set(record.id, cloneDirective(record));
+  }
+
+  /**
+   * Replace is only for explicit lifecycle (supersede marks the predecessor).
+   * Callers must not use this to silently rewrite body/kind.
+   */
+  replace(record: Directive): void {
+    if (!this.records.has(record.id)) {
+      throw new DirectiveUiError("not_found", "directive does not exist", { id: record.id });
+    }
+    this.records.set(record.id, cloneDirective(record));
+  }
+}
+
+function cloneDirective(record: Directive): Directive {
+  return {
+    ...record,
+    created_by: { ...record.created_by },
+    supersedes: record.supersedes ? [...record.supersedes] : null,
+    audit: record.audit.map((entry) => ({
+      ...entry,
+      actor: { ...entry.actor },
+    })),
+    ...(record.tags ? { tags: [...record.tags] } : {}),
+    ...(record.related_ids ? { related_ids: [...record.related_ids] } : {}),
+  };
+}

--- a/control-center/apps/directives-ui/src/styles.css
+++ b/control-center/apps/directives-ui/src/styles.css
@@ -1,0 +1,230 @@
+:root {
+  color-scheme: dark;
+  --bg: #121418;
+  --bg-elev: #1b1f27;
+  --ink: #f4f1ea;
+  --muted: #b7b2a6;
+  --line: #2c3340;
+  --gold: #d4a656;
+  --hypothesis: #7ec8e3;
+  --danger: #e07a5f;
+  --ok: #8fbf8f;
+  --focus: #f2e6c9;
+  font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--ink);
+}
+
+body {
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+#app { min-height: 100vh; }
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+}
+.skip-link:focus {
+  left: 0.5rem;
+  background: var(--gold);
+  color: #111;
+  padding: 0.5rem 0.75rem;
+  z-index: 2;
+}
+
+.app {
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 1rem 1rem 3rem;
+}
+
+.top {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.brand {
+  margin: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--gold);
+}
+
+.founder {
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+  font-size: 0.9rem;
+}
+.founder[data-founder="yes"] {
+  border-color: var(--ok);
+}
+.founder[data-founder="no"] {
+  border-color: var(--danger);
+}
+
+.tabs {
+  display: flex;
+  gap: 0.4rem;
+  margin: 0.75rem 0 1rem;
+}
+.tabs button {
+  flex: 1;
+  min-height: 44px;
+}
+
+button, select, input, textarea {
+  font: inherit;
+  color: inherit;
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+  padding: 0.55rem 0.7rem;
+}
+
+button {
+  min-height: 44px;
+  cursor: pointer;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+button[type="submit"],
+button[data-action="open-create"] {
+  background: var(--gold);
+  color: #1a1408;
+  border-color: var(--gold);
+  font-weight: 650;
+}
+
+h1, h2 { line-height: 1.2; }
+h1 { font-size: 1.55rem; margin: 0 0 0.4rem; }
+h2 { font-size: 1.05rem; }
+
+.lede, .meta, .count, .empty, .kind-help { color: var(--muted); }
+
+.filters, .create {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.field { display: grid; gap: 0.3rem; }
+.field label { font-size: 0.92rem; }
+
+.cards {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.card, .panel, .impact, .kind-option {
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  border-radius: 0.6rem;
+  padding: 0.9rem;
+}
+
+.card.authority-authoritative,
+.kind-option.authority-authoritative {
+  border-left: 4px solid var(--gold);
+}
+
+.card.authority-hypothesis,
+.kind-option.authority-hypothesis,
+.preview-group[data-preview-group="hypotheses"] {
+  border: 1px dashed var(--hypothesis);
+  background: #152028;
+}
+
+.badge[data-authority="authoritative"] { color: var(--gold); }
+.badge[data-authority="hypothesis"] { color: var(--hypothesis); }
+
+.kicker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0 0 0.4rem;
+  font-size: 0.82rem;
+}
+
+.pill, .scope {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.notice { color: var(--ok); }
+.error { color: var(--danger); }
+.warn { color: var(--gold); }
+
+.kinds {
+  border: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.kind-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.2rem 0.55rem;
+  min-height: 44px;
+}
+.kind-option input { grid-row: 1 / span 2; }
+.kind-name { font-weight: 650; }
+
+.facts { display: grid; gap: 0.4rem; }
+.facts div { display: grid; gap: 0.1rem; }
+dt { color: var(--muted); font-size: 0.8rem; }
+dd { margin: 0; word-break: break-word; }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+.file-protocol {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 1.5rem;
+}
+.file-protocol pre {
+  background: var(--bg-elev);
+  padding: 0.8rem;
+  overflow: auto;
+}
+
+@media (min-width: 720px) {
+  .filters { grid-template-columns: 1fr 1fr; }
+}

--- a/control-center/apps/directives-ui/src/supersede.ts
+++ b/control-center/apps/directives-ui/src/supersede.ts
@@ -1,0 +1,86 @@
+import { toUtcDateTime } from "./datetime.ts";
+import { DirectiveUiError } from "./errors.ts";
+import { buildDirective } from "./create.ts";
+import type { ActorRef, Clock, CreateDirectiveInput, Directive } from "./types.ts";
+
+export interface SupersedeResult {
+  predecessor: Directive;
+  successor: Directive;
+}
+
+function cloneActor(actor: ActorRef): ActorRef {
+  const cloned: ActorRef = { kind: actor.kind, id: actor.id };
+  if (actor.display_name) cloned.display_name = actor.display_name;
+  return cloned;
+}
+
+/**
+ * Explicit supersede: the prior record stays readable as `superseded` with
+ * body/kind frozen. A successor is appended and references the predecessor.
+ * There is no in-place history rewrite.
+ */
+export function supersedeDirective(
+  predecessor: Directive,
+  input: CreateDirectiveInput,
+  actor: ActorRef,
+  clock: Clock,
+): SupersedeResult {
+  if (predecessor.status === "superseded") {
+    throw new DirectiveUiError(
+      "already_superseded",
+      "this record is already superseded; supersede the current successor instead",
+      { id: predecessor.id },
+    );
+  }
+  if (predecessor.status === "revoked") {
+    throw new DirectiveUiError("already_revoked", "revoked records cannot be superseded", {
+      id: predecessor.id,
+    });
+  }
+
+  const now = toUtcDateTime(clock.now());
+  const linked: CreateDirectiveInput = {
+    ...input,
+    supersedes: mergeSupersedes(input.supersedes, predecessor.id),
+  };
+  const successor = buildDirective(linked, actor, clock);
+
+  const frozenBody = predecessor.body;
+  const frozenKind = predecessor.kind;
+  const frozenTitle = predecessor.title;
+
+  const updated: Directive = {
+    ...predecessor,
+    status: "superseded",
+    updated_at: now,
+    body: frozenBody,
+    kind: frozenKind,
+    title: frozenTitle,
+    audit: [
+      ...predecessor.audit,
+      {
+        at: now,
+        actor: cloneActor(actor),
+        action: "superseded",
+        from_status: predecessor.status,
+        to_status: "superseded",
+        note: `succeeded by ${successor.id}`,
+      },
+    ],
+  };
+
+  if (updated.body !== frozenBody || updated.kind !== frozenKind || updated.title !== frozenTitle) {
+    throw new DirectiveUiError("history_rewrite", "supersede must not rewrite predecessor body/kind");
+  }
+
+  return { predecessor: updated, successor };
+}
+
+function mergeSupersedes(
+  existing: string[] | null,
+  predecessorId: string,
+): string[] {
+  const set = new Set(existing ?? []);
+  set.add(predecessorId);
+  return [...set];
+}

--- a/control-center/apps/directives-ui/src/types.ts
+++ b/control-center/apps/directives-ui/src/types.ts
@@ -1,0 +1,178 @@
+/**
+ * Local copy of control-center.directive.v1 field/enum contract.
+ * Sibling `control-center/contracts/` is read-only and not on this branch.
+ * Convergence must pin the schema `$id` rather than this duplicate.
+ */
+
+export const SCHEMA_VERSION = "control-center.directive.v1" as const;
+
+export const DIRECTIVE_KINDS = [
+  "decision",
+  "directive",
+  "fact",
+  "constraint",
+  "priority",
+  "risk",
+  "hypothesis",
+] as const;
+export type DirectiveKind = (typeof DIRECTIVE_KINDS)[number];
+
+export const AUTHORITATIVE_KINDS = ["decision", "directive", "fact", "constraint"] as const;
+export type AuthoritativeKind = (typeof AUTHORITATIVE_KINDS)[number];
+
+export const ORIENTATIVE_KINDS = ["priority", "risk"] as const;
+export type OrientativeKind = (typeof ORIENTATIVE_KINDS)[number];
+
+export const DIRECTIVE_STATUSES = [
+  "draft",
+  "active",
+  "superseded",
+  "revoked",
+  "expired",
+] as const;
+export type DirectiveStatus = (typeof DIRECTIVE_STATUSES)[number];
+
+export const CREATE_STATUSES = ["draft", "active"] as const;
+export type CreateStatus = (typeof CREATE_STATUSES)[number];
+
+export const SCOPE_LITERALS = [
+  "company",
+  "commercial",
+  "finance",
+  "clients",
+  "infrastructure",
+  "inbound",
+] as const;
+export type ScopeLiteral = (typeof SCOPE_LITERALS)[number];
+
+export const ACTOR_KINDS = ["human", "agent", "system"] as const;
+export type ActorKind = (typeof ACTOR_KINDS)[number];
+
+export const SESSION_ROLES = ["founder", "operator", "agent"] as const;
+export type SessionRole = (typeof SESSION_ROLES)[number];
+
+export const AUDIT_ACTIONS = [
+  "created",
+  "updated",
+  "status_changed",
+  "superseded",
+  "revoked",
+] as const;
+export type AuditAction = (typeof AUDIT_ACTIONS)[number];
+
+export const FRESHNESS_STATUSES = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const FORBIDDEN_MUTATIONS = [
+  "cobranca",
+  "checkout",
+  "refund",
+  "cancelamento",
+  "asaas_write",
+  "commercial_send",
+] as const;
+export type ForbiddenMutation = (typeof FORBIDDEN_MUTATIONS)[number];
+
+export type UtcDateTime = string;
+export type ResourceId = string;
+export type Scope = string;
+
+export interface ActorRef {
+  kind: ActorKind;
+  id: string;
+  display_name?: string;
+}
+
+export interface DirectiveAuditEntry {
+  at: UtcDateTime;
+  actor: ActorRef;
+  action: AuditAction;
+  from_status?: DirectiveStatus;
+  to_status?: DirectiveStatus;
+  note?: string;
+}
+
+export interface Directive {
+  schema_version: typeof SCHEMA_VERSION;
+  id: ResourceId;
+  kind: DirectiveKind;
+  scope: Scope;
+  status: DirectiveStatus;
+  title: string;
+  body: string;
+  effective_from: UtcDateTime;
+  expires_at: UtcDateTime | null;
+  supersedes: ResourceId[] | null;
+  created_by: ActorRef;
+  created_at: UtcDateTime;
+  updated_at: UtcDateTime;
+  audit: DirectiveAuditEntry[];
+  tags?: string[];
+  related_ids?: ResourceId[];
+}
+
+/**
+ * Aggregated view wrapper. Directives as stored do not carry provenance;
+ * any list/preview shown to an operator or agent MUST.
+ */
+export interface ObservedDirective {
+  record: Directive;
+  source: string;
+  observed_at: UtcDateTime;
+  freshness_status: FreshnessStatus;
+  confidence: number;
+}
+
+export interface SessionIdentity {
+  actor: ActorRef;
+  role: SessionRole;
+  founderActorId: string;
+  source: "env" | "mock-local";
+}
+
+export interface FounderApproval {
+  approved: boolean;
+  canMutate: boolean;
+  label: string;
+  code: "founder_ok" | "not_founder" | "identity_unconfigured";
+}
+
+export interface DirectiveFilter {
+  query: string;
+  kind: DirectiveKind | "all";
+  scope: string | "all";
+  status: DirectiveStatus | "all";
+}
+
+export interface CreateDirectiveInput {
+  kind: DirectiveKind;
+  kindConfirm: DirectiveKind;
+  title: string;
+  body: string;
+  scope: Scope;
+  status: CreateStatus;
+  effective_from: UtcDateTime;
+  expires_at: UtcDateTime | null;
+  supersedes: ResourceId[] | null;
+  tags?: string[];
+}
+
+export interface Clock {
+  now(): Date;
+}
+
+export interface AgentScopePreview {
+  title: string;
+  scope: Scope;
+  as_of: UtcDateTime;
+  granted_scopes: Scope[];
+  decisions: ObservedDirective[];
+  directives: ObservedDirective[];
+  facts: ObservedDirective[];
+  constraints: ObservedDirective[];
+  priorities: ObservedDirective[];
+  risks: ObservedDirective[];
+  hypotheses: ObservedDirective[];
+  excluded_other_scopes: number;
+  excluded_inactive: number;
+}

--- a/control-center/apps/directives-ui/src/ui/bind.ts
+++ b/control-center/apps/directives-ui/src/ui/bind.ts
@@ -1,0 +1,168 @@
+import { dispatch, type Action, type AppSession } from "../app-state.ts";
+import { isCreateStatus } from "../contract.ts";
+import { renderApp } from "./render.ts";
+
+function targetElement(event: Event): HTMLElement | null {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  return target instanceof HTMLElement ? target : target.parentElement;
+}
+
+function closestAction(el: HTMLElement | null): HTMLElement | null {
+  if (!el) return null;
+  return el.closest("[data-action]");
+}
+
+export function mount(root: HTMLElement, session: AppSession): () => void {
+  let current = session;
+
+  const paint = (): void => {
+    const hasDomConstructors = typeof HTMLElement !== "undefined";
+    const active = typeof document !== "undefined" ? document.activeElement : null;
+    const activeId =
+      hasDomConstructors && active instanceof HTMLElement ? active.id : "";
+    const selection =
+      hasDomConstructors &&
+      (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement)
+        ? { start: active.selectionStart, end: active.selectionEnd }
+        : null;
+    root.innerHTML = renderApp(current);
+    root.setAttribute("data-ready", "1");
+    root.setAttribute("data-screen", current.ui.screen);
+    if (activeId) {
+      const restored = root.querySelector(`[id=${JSON.stringify(activeId)}]`);
+      if (hasDomConstructors && restored instanceof HTMLElement) {
+        restored.focus();
+        if (
+          selection &&
+          (restored instanceof HTMLInputElement || restored instanceof HTMLTextAreaElement) &&
+          selection.start !== null &&
+          selection.end !== null
+        ) {
+          restored.setSelectionRange(selection.start, selection.end);
+        }
+      }
+    }
+  };
+
+  const apply = (action: Action): void => {
+    current = dispatch(current, action);
+    paint();
+  };
+
+  const onClick = (event: Event): void => {
+    const actionEl = closestAction(targetElement(event));
+    if (!actionEl) return;
+    const action = actionEl.getAttribute("data-action");
+    const id = actionEl.getAttribute("data-id") ?? "";
+    const scope = actionEl.getAttribute("data-scope") ?? undefined;
+    if (action === "open-list") {
+      event.preventDefault();
+      apply({ type: "back-to-list" });
+    } else if (action === "open-create") {
+      event.preventDefault();
+      apply({ type: "open-create" });
+    } else if (action === "open-preview") {
+      event.preventDefault();
+      apply({ type: "open-preview", ...(scope ? { scope } : {}) });
+    } else if (action === "open-detail" && id) {
+      event.preventDefault();
+      apply({ type: "open-detail", id });
+    } else if (action === "open-supersede" && id) {
+      event.preventDefault();
+      apply({ type: "open-supersede", id });
+    } else if (action === "submit-create" || action === "submit-supersede") {
+      // submit handler takes this
+    }
+  };
+
+  const onChange = (event: Event): void => {
+    const el = targetElement(event);
+    if (!el) return;
+    if (el instanceof HTMLSelectElement || el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+      const name = el.name;
+      if (el.id === "filter-query" || name === "query") {
+        apply({ type: "set-query", query: el.value });
+        return;
+      }
+      if (el.id === "filter-kind" || (name === "kind" && el.id === "filter-kind")) {
+        apply({ type: "set-kind-filter", kind: el.value });
+        return;
+      }
+      if (el.id === "filter-scope") {
+        apply({ type: "set-scope-filter", scope: el.value });
+        return;
+      }
+      if (el.id === "filter-status") {
+        apply({ type: "set-status-filter", status: el.value });
+        return;
+      }
+      if (el.id === "preview-scope") {
+        apply({ type: "set-preview-scope", scope: el.value });
+        return;
+      }
+      if (name === "kind" && el instanceof HTMLInputElement && el.type === "radio") {
+        apply({ type: "select-kind", kind: el.value });
+        return;
+      }
+      if (el.id === "kind-confirm") {
+        apply({ type: "set-kind-confirmed", confirmed: el instanceof HTMLInputElement && el.checked });
+        return;
+      }
+      if (el.id === "create-title") {
+        apply({ type: "patch-create", patch: { title: el.value } });
+        return;
+      }
+      if (el.id === "create-body") {
+        apply({ type: "patch-create", patch: { body: el.value } });
+        return;
+      }
+      if (el.id === "create-scope") {
+        apply({ type: "patch-create", patch: { scope: el.value } });
+        return;
+      }
+      if (el.id === "create-status" && isCreateStatus(el.value)) {
+        apply({ type: "patch-create", patch: { status: el.value } });
+        return;
+      }
+      if (el.id === "create-effective") {
+        apply({ type: "patch-create", patch: { effective_from: el.value } });
+        return;
+      }
+      if (el.id === "create-expires") {
+        apply({ type: "patch-create", patch: { expires_at: el.value } });
+        return;
+      }
+    }
+  };
+
+  const onSubmit = (event: Event): void => {
+    const el = targetElement(event);
+    if (!el) return;
+    const form = el.closest("form");
+    if (!form) return;
+    const formName = form.getAttribute("data-form");
+    if (formName === "create") {
+      event.preventDefault();
+      apply({ type: "submit-create" });
+    } else if (formName === "supersede") {
+      event.preventDefault();
+      apply({ type: "submit-supersede" });
+    } else if (formName === "filters" || formName === "preview-scope") {
+      event.preventDefault();
+    }
+  };
+
+  root.addEventListener("click", onClick);
+  root.addEventListener("change", onChange);
+  root.addEventListener("input", onChange);
+  root.addEventListener("submit", onSubmit);
+  paint();
+
+  return () => {
+    root.removeEventListener("click", onClick);
+    root.removeEventListener("change", onChange);
+    root.removeEventListener("input", onChange);
+    root.removeEventListener("submit", onSubmit);
+  };
+}

--- a/control-center/apps/directives-ui/src/ui/labels.ts
+++ b/control-center/apps/directives-ui/src/ui/labels.ts
@@ -1,0 +1,97 @@
+import { authorityClass } from "../contract.ts";
+import type { DirectiveKind, DirectiveStatus } from "../types.ts";
+
+export interface KindOption {
+  kind: DirectiveKind;
+  name: string;
+  shortName: string;
+  authority: "authoritative" | "orientative" | "hypothesis";
+  confirmHint: string;
+  description: string;
+}
+
+export const KIND_OPTIONS: readonly KindOption[] = [
+  {
+    kind: "decision",
+    name: "Decisão (autoritativa)",
+    shortName: "Decisão",
+    authority: "authoritative",
+    confirmHint: "Confirmo que isto é uma DECISÃO — não um fato observável e não uma hipótese.",
+    description:
+      "Escolha humana que passa a valer. Agentes devem tratar como autoridade. Não use para registrar um fato ou uma hipótese.",
+  },
+  {
+    kind: "directive",
+    name: "Diretiva (autoritativa)",
+    shortName: "Diretiva",
+    authority: "authoritative",
+    confirmHint: "Confirmo que isto é uma DIRETIVA autoritativa — não uma hipótese.",
+    description: "Instrução vigente sobre como operar. Autoridade, não chat.",
+  },
+  {
+    kind: "fact",
+    name: "Fato (autoritativo)",
+    shortName: "Fato",
+    authority: "authoritative",
+    confirmHint: "Confirmo que isto é um FATO — não uma decisão e não uma hipótese.",
+    description:
+      "Afirmação considerada verdadeira neste recorte. Escolha distinta de decisão. Não use para decidir o que fazer.",
+  },
+  {
+    kind: "constraint",
+    name: "Restrição (autoritativa)",
+    shortName: "Restrição",
+    authority: "authoritative",
+    confirmHint: "Confirmo que isto é uma RESTRIÇÃO autoritativa.",
+    description: "Limite que não pode ser cruzado (ex.: nenhuma mutação financeira de provedor).",
+  },
+  {
+    kind: "priority",
+    name: "Prioridade",
+    shortName: "Prioridade",
+    authority: "orientative",
+    confirmHint: "Confirmo que isto é uma PRIORIDADE, não um fato nem uma decisão.",
+    description: "O que importa agora. Não substitui uma decisão.",
+  },
+  {
+    kind: "risk",
+    name: "Risco",
+    shortName: "Risco",
+    authority: "orientative",
+    confirmHint: "Confirmo que isto é um RISCO, não um fato fechado.",
+    description: "Ameaça ou incerteza operacional. Não é autoridade canônica.",
+  },
+  {
+    kind: "hypothesis",
+    name: "Hipótese (não autoritativa — não é fato nem decisão)",
+    shortName: "Hipótese",
+    authority: "hypothesis",
+    confirmHint:
+      "Confirmo que isto é uma HIPÓTESE — não autoritativa; agentes a verão separada de fatos e decisões.",
+    description:
+      "Crença ainda não promovida. Distinta de fato e de decisão. Nunca misturada no contexto autoritativo.",
+  },
+];
+
+export const STATUS_LABELS: Record<DirectiveStatus, string> = {
+  draft: "Rascunho",
+  active: "Ativa",
+  superseded: "Substituta / superseded",
+  revoked: "Revogada",
+  expired: "Expirada",
+};
+
+export function kindOption(kind: DirectiveKind): KindOption {
+  const found = KIND_OPTIONS.find((item) => item.kind === kind);
+  if (!found) {
+    throw new Error(`unknown kind ${kind}`);
+  }
+  return found;
+}
+
+export function authorityLabel(kind: DirectiveKind): string {
+  const cls = authorityClass(kind);
+  if (cls === "hypothesis") return "Hipótese — não autoritativa (não é fato nem decisão)";
+  if (cls === "authoritative") return "Autoritativa";
+  return "Orientativa (não é fato nem decisão)";
+}

--- a/control-center/apps/directives-ui/src/ui/render.ts
+++ b/control-center/apps/directives-ui/src/ui/render.ts
@@ -1,0 +1,358 @@
+import { approvalOf, confirmLabel, currentImpact, selectedRecord, type AppSession } from "../app-state.ts";
+import { authorityClass } from "../contract.ts";
+import { formatLocal } from "../datetime.ts";
+import { escapeHtml } from "../escape.ts";
+import { uniqueScopes } from "../filter.ts";
+import { previewTitle } from "../preview.ts";
+import type { AgentScopePreview, Directive, ObservedDirective } from "../types.ts";
+import { DIRECTIVE_KINDS, DIRECTIVE_STATUSES, SCOPE_LITERALS } from "../types.ts";
+import { KIND_OPTIONS, STATUS_LABELS, authorityLabel, kindOption } from "./labels.ts";
+
+export function renderApp(session: AppSession): string {
+  const approval = approvalOf(session);
+  const { ui } = session;
+  const records = session.service.list(ui.filter);
+  return `
+    <a class="skip-link" href="#conteudo">Saltar para o conteúdo</a>
+    <div class="app" data-screen="${escapeHtml(ui.screen)}" data-ready="1">
+      <header class="top">
+        <p class="brand">Control Center · Memória estratégica</p>
+        <p
+          class="founder"
+          data-founder="${approval.approved ? "yes" : "no"}"
+          data-founder-code="${escapeHtml(approval.code)}"
+          role="status"
+          aria-label="${escapeHtml(approval.label)}"
+        >${escapeHtml(approval.label)}</p>
+      </header>
+      <nav class="tabs" aria-label="Fluxos">
+        <button type="button" data-action="open-list" aria-current="${ui.screen === "list" ? "page" : "false"}">Lista</button>
+        <button type="button" data-action="open-create" aria-current="${ui.screen === "create" ? "page" : "false"}">Registrar</button>
+        <button type="button" data-action="open-preview" aria-current="${ui.screen === "preview" ? "page" : "false"}">Preview de agente</button>
+      </nav>
+      <main id="conteudo">
+        ${ui.notice ? `<p class="notice" role="status">${escapeHtml(ui.notice)}</p>` : ""}
+        ${ui.error ? `<p class="error" role="alert" data-error-code="${escapeHtml(ui.errorCode ?? "")}">${escapeHtml(ui.error)}</p>` : ""}
+        ${ui.screen === "list" ? renderList(session, records) : ""}
+        ${ui.screen === "create" ? renderCreate(session, "create") : ""}
+        ${ui.screen === "supersede" ? renderCreate(session, "supersede") : ""}
+        ${ui.screen === "detail" ? renderDetail(session) : ""}
+        ${ui.screen === "preview" ? renderPreview(session) : ""}
+      </main>
+    </div>
+  `;
+}
+
+function renderList(session: AppSession, records: Directive[]): string {
+  const scopes = uniqueScopes(session.service.list());
+  const { filter } = session.ui;
+  return `
+    <section class="panel" aria-labelledby="lista-titulo">
+      <h1 id="lista-titulo">Memória estruturada</h1>
+      <p class="lede">Registre decisões, diretivas, fatos, restrições, prioridades, riscos e hipóteses. Isto não é chat e não é ERP.</p>
+      <form class="filters" data-form="filters" aria-label="Filtros da memória">
+        <div class="field">
+          <label for="filter-query">Buscar</label>
+          <input id="filter-query" name="query" type="search" value="${escapeHtml(filter.query)}" autocomplete="off" placeholder="título, corpo, id, escopo" />
+        </div>
+        <div class="field">
+          <label for="filter-kind">Tipo</label>
+          <select id="filter-kind" name="kind">
+            <option value="all" ${filter.kind === "all" ? "selected" : ""}>Todos os tipos</option>
+            ${KIND_OPTIONS.map(
+              (opt) =>
+                `<option value="${opt.kind}" ${filter.kind === opt.kind ? "selected" : ""}>${escapeHtml(opt.name)}</option>`,
+            ).join("")}
+          </select>
+        </div>
+        <div class="field">
+          <label for="filter-scope">Escopo</label>
+          <select id="filter-scope" name="scope">
+            <option value="all" ${filter.scope === "all" ? "selected" : ""}>Todos os escopos</option>
+            ${SCOPE_LITERALS.map(
+              (scope) =>
+                `<option value="${scope}" ${filter.scope === scope ? "selected" : ""}>${scope}</option>`,
+            ).join("")}
+            ${scopes
+              .filter((scope) => !(SCOPE_LITERALS as readonly string[]).includes(scope))
+              .map(
+                (scope) =>
+                  `<option value="${escapeHtml(scope)}" ${filter.scope === scope ? "selected" : ""}>${escapeHtml(scope)}</option>`,
+              )
+              .join("")}
+          </select>
+        </div>
+        <div class="field">
+          <label for="filter-status">Status</label>
+          <select id="filter-status" name="status">
+            <option value="all" ${filter.status === "all" ? "selected" : ""}>Todos os status</option>
+            ${DIRECTIVE_STATUSES.map(
+              (status) =>
+                `<option value="${status}" ${filter.status === status ? "selected" : ""}>${escapeHtml(STATUS_LABELS[status])}</option>`,
+            ).join("")}
+          </select>
+        </div>
+      </form>
+      <p class="count" role="status">${records.length} registro(s)</p>
+      <ul class="cards">
+        ${records.map((record) => renderCard(record)).join("")}
+      </ul>
+      ${records.length === 0 ? `<p class="empty">Nenhum registro neste recorte.</p>` : ""}
+    </section>
+  `;
+}
+
+function renderCard(record: Directive): string {
+  const authority = authorityClass(record.kind);
+  const option = kindOption(record.kind);
+  return `
+    <li>
+      <article
+        class="card authority-${authority}"
+        data-id="${escapeHtml(record.id)}"
+        data-kind="${escapeHtml(record.kind)}"
+        data-scope="${escapeHtml(record.scope)}"
+        data-status="${escapeHtml(record.status)}"
+        data-authority="${authority}"
+      >
+        <p class="kicker">
+          <span class="badge" data-authority="${authority}">${escapeHtml(option.name)}</span>
+          <span class="pill">${escapeHtml(STATUS_LABELS[record.status])}</span>
+          <span class="scope">${escapeHtml(record.scope)}</span>
+        </p>
+        <h2>${escapeHtml(record.title)}</h2>
+        <p class="body">${escapeHtml(truncate(record.body, 180))}</p>
+        <p class="meta">
+          <span>UTC ${escapeHtml(record.effective_from)}</span>
+          <span class="sr-only">apresentação ${escapeHtml(formatLocal(record.effective_from))}</span>
+        </p>
+        <div class="row">
+          <button type="button" data-action="open-detail" data-id="${escapeHtml(record.id)}">Abrir</button>
+          <button type="button" data-action="open-supersede" data-id="${escapeHtml(record.id)}">Supersede explícito</button>
+        </div>
+      </article>
+    </li>
+  `;
+}
+
+function renderCreate(session: AppSession, mode: "create" | "supersede"): string {
+  const draft = session.ui.createDraft;
+  const impact = currentImpact(session);
+  const kind = draft.kind;
+  const heading = mode === "supersede" ? "Supersede explícito" : "Registrar memória";
+  const submitAction = mode === "supersede" ? "submit-supersede" : "submit-create";
+  const submitLabel = mode === "supersede" ? "Criar sucessor e marcar a anterior como superseded" : "Salvar memória";
+  return `
+    <section class="panel" aria-labelledby="form-titulo">
+      <h1 id="form-titulo">${heading}</h1>
+      <p class="lede">Preencha título e corpo. Tipo não tem padrão silencioso: decisão e fato são escolhas distintas e exigem confirmação explícita.</p>
+      ${mode === "supersede" ? `<p class="warn" role="note">A história anterior permanece legível como superseded. O corpo e o tipo antigos não serão reescritos.</p>` : ""}
+      <form class="create" data-form="${mode}" novalidate>
+        <fieldset class="kinds" data-name="create-kind">
+          <legend id="create-kind-legend">Tipo desta memória</legend>
+          ${KIND_OPTIONS.map((opt) => {
+            const checked = kind === opt.kind;
+            return `
+              <label class="kind-option authority-${opt.authority}" data-authority="${opt.authority}">
+                <input
+                  type="radio"
+                  name="kind"
+                  id="create-kind-${opt.kind}"
+                  value="${opt.kind}"
+                  ${checked ? "checked" : ""}
+                  aria-describedby="kind-help-${opt.kind}"
+                />
+                <span class="kind-name">${escapeHtml(opt.name)}</span>
+                <span id="kind-help-${opt.kind}" class="kind-help">${escapeHtml(opt.description)}</span>
+              </label>
+            `;
+          }).join("")}
+        </fieldset>
+        <div class="field">
+          <label for="kind-confirm">
+            <input id="kind-confirm" name="kindConfirm" type="checkbox" ${draft.kindConfirmed ? "checked" : ""} ${kind === "" ? "disabled" : ""} />
+            <span data-confirm-for="${escapeHtml(kind || "none")}">${escapeHtml(confirmLabel(kind))}</span>
+          </label>
+        </div>
+        <div class="field">
+          <label for="create-title">Título</label>
+          <input id="create-title" name="title" maxlength="200" required value="${escapeHtml(draft.title)}" />
+        </div>
+        <div class="field">
+          <label for="create-body">Corpo</label>
+          <textarea id="create-body" name="body" maxlength="8000" required rows="6">${escapeHtml(draft.body)}</textarea>
+        </div>
+        <div class="field">
+          <label for="create-scope">Escopo</label>
+          <select id="create-scope" name="scope">
+            ${SCOPE_LITERALS.map(
+              (scope) =>
+                `<option value="${scope}" ${draft.scope === scope ? "selected" : ""}>${scope}</option>`,
+            ).join("")}
+          </select>
+        </div>
+        <div class="field">
+          <label for="create-status">Status inicial</label>
+          <select id="create-status" name="status">
+            <option value="active" ${draft.status === "active" ? "selected" : ""}>Ativa</option>
+            <option value="draft" ${draft.status === "draft" ? "selected" : ""}>Rascunho</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="create-effective">Vigente a partir de (UTC)</label>
+          <input id="create-effective" name="effective_from" value="${escapeHtml(draft.effective_from)}" />
+        </div>
+        <div class="field">
+          <label for="create-expires">Expira em (UTC, vazio = sem expiração)</label>
+          <input id="create-expires" name="expires_at" value="${escapeHtml(draft.expires_at)}" placeholder="2026-12-31T00:00:00Z" />
+        </div>
+        <aside id="save-impact" class="impact" data-scope="${escapeHtml(impact.scope)}" data-expires="${escapeHtml(impact.expires_at ?? "null")}" aria-live="polite">
+          <h2>Impacto de escopo e expiração (antes de salvar)</h2>
+          <p data-impact="scope">${escapeHtml(impact.scopeSummary)}</p>
+          <p data-impact="expiration">${escapeHtml(impact.expirationSummary)}</p>
+          <p data-impact="status">${escapeHtml(impact.combined)}</p>
+        </aside>
+        <div class="row">
+          <button type="submit" name="save-memory" data-action="${submitAction}">${submitLabel}</button>
+          <button type="button" data-action="open-list">Cancelar</button>
+        </div>
+      </form>
+    </section>
+  `;
+}
+
+function renderDetail(session: AppSession): string {
+  const record = selectedRecord(session);
+  if (!record) {
+    return `<section class="panel"><h1>Registro não encontrado</h1><button type="button" data-action="open-list">Voltar</button></section>`;
+  }
+  const authority = authorityClass(record.kind);
+  const option = kindOption(record.kind);
+  return `
+    <section class="panel" aria-labelledby="detalhe-titulo">
+      <p class="kicker">
+        <span class="badge" data-authority="${authority}">${escapeHtml(option.name)}</span>
+        <span class="pill">${escapeHtml(STATUS_LABELS[record.status])}</span>
+        <span class="scope">${escapeHtml(record.scope)}</span>
+      </p>
+      <h1 id="detalhe-titulo">${escapeHtml(record.title)}</h1>
+      <p class="authority-text">${escapeHtml(authorityLabel(record.kind))}</p>
+      <p class="body">${escapeHtml(record.body)}</p>
+      <dl class="facts">
+        <div><dt>id</dt><dd>${escapeHtml(record.id)}</dd></div>
+        <div><dt>created_by</dt><dd>${escapeHtml(record.created_by.id)}</dd></div>
+        <div><dt>effective_from</dt><dd><time datetime="${escapeHtml(record.effective_from)}">${escapeHtml(record.effective_from)} · ${escapeHtml(formatLocal(record.effective_from))}</time></dd></div>
+        <div><dt>expires_at</dt><dd>${record.expires_at ? escapeHtml(record.expires_at) : "null"}</dd></div>
+        <div><dt>supersedes</dt><dd>${record.supersedes ? escapeHtml(record.supersedes.join(", ")) : "null"}</dd></div>
+      </dl>
+      <h2>Trilha de auditoria</h2>
+      <ol class="audit">
+        ${record.audit
+          .map(
+            (entry) =>
+              `<li>${escapeHtml(entry.at)} · ${escapeHtml(entry.action)} · ${escapeHtml(entry.actor.id)}${entry.note ? ` · ${escapeHtml(entry.note)}` : ""}</li>`,
+          )
+          .join("")}
+      </ol>
+      <div class="row">
+        <button type="button" data-action="open-supersede" data-id="${escapeHtml(record.id)}">Supersede explícito</button>
+        <button type="button" data-action="open-preview" data-scope="${escapeHtml(record.scope)}">Ver preview de agente deste escopo</button>
+        <button type="button" data-action="open-list">Voltar</button>
+      </div>
+    </section>
+  `;
+}
+
+function renderPreview(session: AppSession): string {
+  const preview = session.service.preview(session.ui.previewScope);
+  return `
+    <section class="panel preview-panel" aria-labelledby="preview-titulo" data-preview-scope="${escapeHtml(preview.scope)}">
+      <h1 id="preview-titulo">${escapeHtml(preview.title)}</h1>
+      <p class="lede">Agentes consultam por escopo. Hipóteses ficam numa lista própria e não entram em fatos/decisões. ${escapeHtml(String(preview.excluded_other_scopes))} registro(s) de outros escopos foram excluídos. ${escapeHtml(String(preview.excluded_inactive))} inativos/não vigentes excluídos.</p>
+      <form class="filters" data-form="preview-scope">
+        <div class="field">
+          <label for="preview-scope">Escopo do preview</label>
+          <select id="preview-scope" name="previewScope">
+            ${SCOPE_LITERALS.map(
+              (scope) =>
+                `<option value="${scope}" ${preview.scope === scope ? "selected" : ""}>${scope}</option>`,
+            ).join("")}
+          </select>
+        </div>
+      </form>
+      ${renderPreviewGroup("Decisões (autoritativas)", "decisions", preview.decisions)}
+      ${renderPreviewGroup("Diretivas (autoritativas)", "directives", preview.directives)}
+      ${renderPreviewGroup("Fatos (autoritativos)", "facts", preview.facts)}
+      ${renderPreviewGroup("Restrições (autoritativas)", "constraints", preview.constraints)}
+      ${renderPreviewGroup("Prioridades", "priorities", preview.priorities)}
+      ${renderPreviewGroup("Riscos", "risks", preview.risks)}
+      ${renderPreviewGroup("Hipóteses (não autoritativas — não é fato nem decisão)", "hypotheses", preview.hypotheses)}
+      <p class="meta">as_of ${escapeHtml(preview.as_of)} · granted_scopes ${escapeHtml(preview.granted_scopes.join(", "))}</p>
+    </section>
+  `;
+}
+
+function renderPreviewGroup(
+  heading: string,
+  key: keyof Pick<
+    AgentScopePreview,
+    "decisions" | "directives" | "facts" | "constraints" | "priorities" | "risks" | "hypotheses"
+  >,
+  items: ObservedDirective[],
+): string {
+  return `
+    <section class="preview-group" data-preview-group="${key}" aria-labelledby="pg-${key}">
+      <h2 id="pg-${key}">${escapeHtml(heading)}</h2>
+      ${
+        items.length === 0
+          ? `<p class="empty">Nenhum item neste grupo para o escopo.</p>`
+          : `<ul>${items
+              .map((item) => {
+                const rec = item.record;
+                return `<li data-kind="${escapeHtml(rec.kind)}" data-authority="${authorityClass(rec.kind)}" data-source="${escapeHtml(item.source)}" data-freshness="${escapeHtml(item.freshness_status)}" data-confidence="${item.confidence}">
+                  <strong>${escapeHtml(rec.title)}</strong>
+                  <span> · ${escapeHtml(rec.kind)} · source=${escapeHtml(item.source)} · observed_at=${escapeHtml(item.observed_at)} · freshness=${escapeHtml(item.freshness_status)} · confidence=${item.confidence}</span>
+                </li>`;
+              })
+              .join("")}</ul>`
+      }
+    </section>
+  `;
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
+export function renderHasLabeledFilters(html: string): boolean {
+  return (
+    html.includes('for="filter-query"') &&
+    html.includes('for="filter-kind"') &&
+    html.includes('for="filter-scope"') &&
+    html.includes('for="filter-status"')
+  );
+}
+
+export function renderHasNamedKinds(html: string): boolean {
+  return DIRECTIVE_KINDS.every((kind) => html.includes(`id="create-kind-${kind}"`));
+}
+
+export function renderHasHypothesisDistinction(html: string): boolean {
+  return (
+    html.includes("não autoritativa — não é fato nem decisão") ||
+    html.includes("Hipótese — não autoritativa")
+  );
+}
+
+export function renderHasSaveImpact(html: string): boolean {
+  return html.includes('id="save-impact"') && html.includes("Impacto de escopo e expiração");
+}
+
+export function renderHasPreviewTitle(html: string, scope: string): boolean {
+  return html.includes(previewTitle(scope));
+}
+
+export function renderHasSecretLeak(html: string): boolean {
+  return /password\s*=|api[_-]?key|authorization:\s*bearer/i.test(html);
+}

--- a/control-center/apps/directives-ui/tests/a11y.test.ts
+++ b/control-center/apps/directives-ui/tests/a11y.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { dispatch } from "../src/app-state.ts";
+import {
+  renderApp,
+  renderHasHypothesisDistinction,
+  renderHasLabeledFilters,
+  renderHasNamedKinds,
+  renderHasPreviewTitle,
+  renderHasSaveImpact,
+  renderHasSecretLeak,
+} from "../src/ui/render.ts";
+import { DIRECTIVE_KINDS } from "../src/types.ts";
+import { makeSession } from "./helpers.ts";
+
+test("list filters are labeled", () => {
+  const html = renderApp(makeSession());
+  assert.equal(renderHasLabeledFilters(html), true);
+  assert.match(html, /<label for="filter-query">Buscar<\/label>/);
+  assert.match(html, /<label for="filter-kind">Tipo<\/label>/);
+  assert.match(html, /<label for="filter-scope">Escopo<\/label>/);
+  assert.match(html, /<label for="filter-status">Status<\/label>/);
+  for (const kind of DIRECTIVE_KINDS) {
+    assert.match(html, new RegExp(`<option value="${kind}"`));
+  }
+});
+
+test("create form names every kind, requires confirmation, and shows scope/expiry impact", () => {
+  let session = makeSession();
+  session = dispatch(session, { type: "open-create" });
+  session = dispatch(session, { type: "select-kind", kind: "decision" });
+  const html = renderApp(session);
+  assert.equal(renderHasNamedKinds(html), true);
+  assert.match(html, /id="create-kind-decision"/);
+  assert.match(html, /id="create-kind-fact"/);
+  assert.match(html, /id="create-kind-hypothesis"/);
+  assert.match(html, /Decisão \(autoritativa\)/);
+  assert.match(html, /Fato \(autoritativo\)/);
+  assert.match(html, /id="kind-confirm"/);
+  assert.match(html, /Confirmo que isto é uma DECISÃO/);
+  assert.equal(renderHasSaveImpact(html), true);
+  assert.match(html, /id="save-impact"/);
+  assert.match(html, /Impacto de escopo e expiração \(antes de salvar\)/);
+  assert.match(html, /data-impact="scope"/);
+  assert.match(html, /data-impact="expiration"/);
+  assert.equal(renderHasHypothesisDistinction(html), true);
+});
+
+test("hypothesis is distinguishable from authoritative kinds by accessible text, not color-only", () => {
+  const session = makeSession();
+  const list = renderApp(session);
+  assert.match(list, /data-authority="hypothesis"/);
+  assert.match(list, /data-authority="authoritative"/);
+  assert.match(list, /Hipótese \(não autoritativa — não é fato nem decisão\)/);
+  let creating = dispatch(session, { type: "open-create" });
+  creating = dispatch(creating, { type: "select-kind", kind: "hypothesis" });
+  const form = renderApp(creating);
+  assert.match(form, /data-authority="hypothesis"/);
+  assert.match(form, /não autoritativa/);
+  assert.match(form, /não é fato nem decisão/i);
+});
+
+test("founder approval indicator is exposed as a status with an accessible name", () => {
+  const html = renderApp(makeSession());
+  assert.match(html, /role="status"/);
+  assert.match(html, /aria-label="Aprovação founder:/);
+  assert.match(html, /data-founder="yes"/);
+});
+
+test("agent preview heading uses the required scope title", () => {
+  let session = makeSession();
+  session = dispatch(session, { type: "open-preview", scope: "finance" });
+  const html = renderApp(session);
+  assert.equal(renderHasPreviewTitle(html, "finance"), true);
+  assert.match(html, /contexto que um agente verá para scope finance/);
+  assert.match(html, /data-preview-group="hypotheses"/);
+  assert.match(html, /data-preview-group="decisions"/);
+  assert.match(html, /data-preview-group="facts"/);
+});
+
+test("rendered HTML does not leak secrets", () => {
+  const session = dispatch(makeSession(), { type: "open-create" });
+  const html = renderApp(session);
+  assert.equal(renderHasSecretLeak(html), false);
+});

--- a/control-center/apps/directives-ui/tests/actor.test.ts
+++ b/control-center/apps/directives-ui/tests/actor.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { founderApproval, resolveIdentity } from "../src/actor.ts";
+import { FORBIDDEN_MUTATIONS } from "../src/types.ts";
+import { makeSession } from "./helpers.ts";
+
+test("mock identity is an opaque handle, not a password", () => {
+  const identity = resolveIdentity({});
+  assert.equal(identity.actor.id, "human:founder");
+  assert.equal(identity.role, "founder");
+  assert.doesNotMatch(identity.actor.id, /password|secret|token/i);
+  const approval = founderApproval(identity);
+  assert.equal(approval.canMutate, true);
+  assert.equal(approval.code, "founder_ok");
+});
+
+test("CC_USE_MOCK_IDENTITY=0 without env is fail-closed", () => {
+  const identity = resolveIdentity({ CC_USE_MOCK_IDENTITY: "0" });
+  const approval = founderApproval(identity);
+  assert.equal(approval.canMutate, false);
+  assert.equal(approval.code, "identity_unconfigured");
+});
+
+test("mock service refuses forbidden provider mutations", () => {
+  const session = makeSession();
+  for (const action of FORBIDDEN_MUTATIONS) {
+    assert.equal(session.service.refusesForbiddenMutation(action), true);
+  }
+  assert.equal(session.service.refusesForbiddenMutation("create"), false);
+});

--- a/control-center/apps/directives-ui/tests/app-state.test.ts
+++ b/control-center/apps/directives-ui/tests/app-state.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { dispatch } from "../src/app-state.ts";
+import { renderApp } from "../src/ui/render.ts";
+import { makeSession } from "./helpers.ts";
+
+test("decision create path: pick kind, confirm, title, body — defaults fill the rest", () => {
+  let session = makeSession();
+  session = dispatch(session, { type: "open-create" });
+  session = dispatch(session, { type: "select-kind", kind: "decision" });
+  session = dispatch(session, { type: "set-kind-confirmed", confirmed: true });
+  session = dispatch(session, {
+    type: "patch-create",
+    patch: { title: "Congelar mutações Asaas", body: "Nenhuma escrita Asaas neste cockpit." },
+  });
+  const before = session.service.list().length;
+  session = dispatch(session, { type: "submit-create" });
+  assert.equal(session.ui.error, null);
+  assert.equal(session.ui.errorCode, null);
+  assert.equal(session.ui.screen, "detail");
+  assert.ok(session.ui.selectedId);
+  const created = session.service.get(session.ui.selectedId ?? "");
+  assert.equal(created?.kind, "decision");
+  assert.equal(created?.scope, "company");
+  assert.equal(created?.status, "active");
+  assert.equal(created?.expires_at, null);
+  assert.equal(created?.title, "Congelar mutações Asaas");
+  assert.equal(session.service.list().length, before + 1);
+});
+
+test("submitting a decision without kind confirmation fails and writes nothing", () => {
+  let session = makeSession();
+  const before = session.service.list().length;
+  session = dispatch(session, { type: "open-create" });
+  session = dispatch(session, { type: "select-kind", kind: "decision" });
+  session = dispatch(session, {
+    type: "patch-create",
+    patch: { title: "Sem confirmação", body: "Não deve gravar." },
+  });
+  session = dispatch(session, { type: "submit-create" });
+  assert.equal(session.ui.errorCode, "kind_not_confirmed");
+  assert.match(session.ui.error ?? "", /Confirme explicitamente que o tipo é decision/);
+  assert.equal(session.service.list().length, before);
+});
+
+test("changing the kind filter updates the rendered list through the shipped units", () => {
+  let session = makeSession();
+  session = dispatch(session, { type: "set-kind-filter", kind: "hypothesis" });
+  const html = renderApp(session);
+  assert.match(html, /cc:directive:01K3CC-OFFER-HYPOTHESIS/);
+  assert.doesNotMatch(html, /cc:directive:01K3CC-NO-PROVIDER-MUTATION/);
+  assert.match(html, /1 registro/);
+});
+
+test("explicit supersede from the UI leaves the prior record superseded", () => {
+  let session = makeSession();
+  session = dispatch(session, { type: "open-supersede", id: "cc:directive:01K3CC-WARMBLY-CRM" });
+  session = dispatch(session, { type: "select-kind", kind: "fact" });
+  session = dispatch(session, { type: "set-kind-confirmed", confirmed: true });
+  session = dispatch(session, {
+    type: "patch-create",
+    patch: {
+      title: "Warmbly continua o CRM",
+      body: "Sucessor do fato comercial. História anterior permanece.",
+    },
+  });
+  session = dispatch(session, { type: "submit-supersede" });
+  assert.equal(session.ui.error, null);
+  const old = session.service.get("cc:directive:01K3CC-WARMBLY-CRM");
+  assert.equal(old?.status, "superseded");
+  assert.match(old?.body ?? "", /Commercial pipeline/);
+  const successor = session.service.get(session.ui.selectedId ?? "");
+  assert.ok(successor?.supersedes?.includes("cc:directive:01K3CC-WARMBLY-CRM"));
+  assert.equal(successor?.kind, "fact");
+});

--- a/control-center/apps/directives-ui/tests/bundle.test.ts
+++ b/control-center/apps/directives-ui/tests/bundle.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("page artifact uses a classic script and documents file: serving", () => {
+  const html = fs.readFileSync(path.join(root, "index.html"), "utf8");
+  assert.match(html, /<script src="\.\/dist\/app\.js"><\/script>/);
+  assert.doesNotMatch(html, /<script type="module"/);
+  assert.match(html, /file:/);
+  assert.match(html, /npm start/);
+  assert.doesNotMatch(html, /type="password"/);
+  assert.doesNotMatch(html, /password=/i);
+});
+
+test("built IIFE runs with window and without Node require", () => {
+  const bundlePath = path.join(root, "dist/app.js");
+  assert.equal(fs.existsSync(bundlePath), true, "dist/app.js must exist after npm run build");
+  const code = fs.readFileSync(bundlePath, "utf8");
+  assert.doesNotMatch(code, /\brequire\s*\(/);
+  assert.doesNotMatch(code, /module\.exports/);
+  assert.doesNotMatch(code, /process\.env\.(PASSWORD|SECRET|TOKEN|DATABASE_URL)/);
+  assert.doesNotMatch(code, /password\s*[:=]/i);
+
+  const listeners = new Map<string, Array<(ev: { type: string }) => void>>();
+  const app = {
+    innerHTML: "",
+    id: "app",
+    attributes: new Map<string, string>(),
+    setAttribute(name: string, value: string) {
+      this.attributes.set(name, value);
+    },
+    getAttribute(name: string) {
+      return this.attributes.get(name) ?? null;
+    },
+    addEventListener() {},
+    removeEventListener() {},
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+  };
+
+  const document = {
+    getElementById(id: string) {
+      return id === "app" ? app : null;
+    },
+    querySelector(sel: string) {
+      if (typeof sel === "string" && sel.startsWith("meta[name=")) {
+        const name = sel.slice('meta[name="'.length, -2);
+        const content: Record<string, string> = {
+          "cc-founder-actor-id": "human:founder",
+          "cc-actor-id": "human:founder",
+          "cc-actor-role": "founder",
+          "cc-use-mock-identity": "1",
+        };
+        return {
+          getAttribute(attr: string) {
+            return attr === "content" ? content[name] ?? "" : null;
+          },
+        };
+      }
+      if (sel.includes("dist/app.js")) return { src: "./dist/app.js" };
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    addEventListener(type: string, fn: (ev: { type: string }) => void) {
+      const list = listeners.get(type) ?? [];
+      list.push(fn);
+      listeners.set(type, list);
+    },
+    readyState: "complete",
+    body: { insertBefore() {} },
+  };
+
+  const window = {
+    document,
+    location: { protocol: "http:" },
+    addEventListener() {},
+    __CC_DIRECTIVES_UI__: undefined as { mounted: boolean } | undefined,
+  };
+
+  const sandbox = {
+    window,
+    document,
+    location: window.location,
+    setTimeout,
+    clearTimeout,
+    Intl,
+    Date,
+    console,
+  };
+  vm.runInNewContext(code, sandbox, { filename: "dist/app.js" });
+  assert.equal(window.__CC_DIRECTIVES_UI__?.mounted, true);
+  assert.ok(app.innerHTML.length > 400, "mounted surface must be substantially filled");
+  assert.match(app.innerHTML, /Memória estratégica/);
+  assert.match(app.innerHTML, /filter-kind/);
+});

--- a/control-center/apps/directives-ui/tests/create.test.ts
+++ b/control-center/apps/directives-ui/tests/create.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { draftImpact, draftToInput } from "../src/create.ts";
+import { isDirectiveUiError } from "../src/errors.ts";
+import { DIRECTIVE_KINDS } from "../src/types.ts";
+import { createInput, makeSession } from "./helpers.ts";
+
+test("creates all seven kinds with required fields and defaults from the service", () => {
+  const session = makeSession();
+  for (const kind of DIRECTIVE_KINDS) {
+    const rec = session.service.create(
+      createInput(kind, `Registro ${kind}`, { scope: "company", body: `corpo ${kind}` }),
+    );
+    assert.equal(rec.schema_version, "control-center.directive.v1");
+    assert.equal(rec.kind, kind);
+    assert.equal(rec.scope, "company");
+    assert.equal(rec.status, "active");
+    assert.ok(rec.effective_from.endsWith("Z"));
+    assert.equal(rec.expires_at, null);
+    assert.equal(rec.supersedes, null);
+    assert.equal(rec.created_by.id, "human:founder");
+    assert.ok(rec.audit.length >= 1);
+    assert.equal(rec.audit[0]?.action, "created");
+    assert.match(rec.id, /^cc:directive:/);
+    assert.equal(session.service.get(rec.id)?.kind, kind);
+  }
+});
+
+test("create refuses an unconfirmed kind", () => {
+  const session = makeSession();
+  assert.throws(
+    () => session.service.create(createInput("decision", "Ops", { kindConfirm: "fact" })),
+    (error: unknown) => isDirectiveUiError(error) && error.code === "kind_mismatch",
+  );
+});
+
+test("create refuses a missing kind confirmation from the draft", () => {
+  const session = makeSession();
+  const draft = session.service.newDraft();
+  draft.kind = "decision";
+  draft.kindConfirmed = false;
+  draft.title = "Uma decisão";
+  draft.body = "Texto da decisão";
+  assert.throws(
+    () => draftToInput(draft),
+    (error: unknown) => isDirectiveUiError(error) && error.code === "kind_not_confirmed",
+  );
+});
+
+test("saving a decision requires confirming decision; saving a fact is a different explicit choice", () => {
+  const session = makeSession();
+  assert.throws(() =>
+    session.service.create({
+      ...createInput("decision", "Não é fato"),
+      kindConfirm: "fact",
+    }),
+  );
+  const decision = session.service.create({
+    ...createInput("decision", "Esta é a decisão"),
+    kindConfirm: "decision",
+  });
+  assert.equal(decision.kind, "decision");
+  const fact = session.service.create({
+    ...createInput("fact", "Este é o fato", { scope: "commercial" }),
+    kindConfirm: "fact",
+  });
+  assert.equal(fact.kind, "fact");
+  assert.notEqual(decision.kind, fact.kind);
+});
+
+test("new drafts fill scope, status, UTC effective_from and empty expiration", () => {
+  const session = makeSession();
+  const draft = session.service.newDraft();
+  assert.equal(draft.kind, "");
+  assert.equal(draft.kindConfirmed, false);
+  assert.equal(draft.scope, "company");
+  assert.equal(draft.status, "active");
+  assert.equal(draft.effective_from, "2026-08-20T15:00:00Z");
+  assert.equal(draft.expires_at, "");
+  assert.equal(draft.title, "");
+  assert.equal(draft.body, "");
+  const impact = draftImpact(draft);
+  assert.match(impact.scopeSummary, /company/i);
+  assert.match(impact.expirationSummary, /Sem expiração/);
+});
+
+test("mutate is fail-closed when identity is not founder", () => {
+  const session = makeSession({
+    CONTROL_CENTER_FOUNDER_ACTOR_ID: "human:founder",
+    CC_ACTOR_ID: "agent:cc-context",
+    CC_ACTOR_ROLE: "agent",
+    CC_USE_MOCK_IDENTITY: "0",
+  });
+  assert.throws(
+    () => session.service.create(createInput("risk", "Não deve gravar")),
+    (error: unknown) => isDirectiveUiError(error) && error.code === "not_founder",
+  );
+});

--- a/control-center/apps/directives-ui/tests/filter.test.ts
+++ b/control-center/apps/directives-ui/tests/filter.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { EMPTY_FILTER, filterDirectives } from "../src/filter.ts";
+import { FIXTURE_DIRECTIVES } from "../src/fixtures.ts";
+import { makeSession } from "./helpers.ts";
+
+test("lists fixtures from the mock store start state", () => {
+  const session = makeSession();
+  const listed = session.service.list();
+  assert.equal(listed.length, FIXTURE_DIRECTIVES.length);
+  assert.ok(listed.some((row) => row.kind === "decision"));
+  assert.ok(listed.some((row) => row.kind === "hypothesis"));
+});
+
+test("filters by kind, scope, and status from the real list", () => {
+  const session = makeSession();
+  const decisions = session.service.list({ ...EMPTY_FILTER, kind: "decision" });
+  assert.ok(decisions.length >= 1);
+  assert.ok(decisions.every((row) => row.kind === "decision"));
+
+  const finance = session.service.list({ ...EMPTY_FILTER, scope: "finance" });
+  assert.ok(finance.length >= 1);
+  assert.ok(finance.every((row) => row.scope === "finance"));
+  assert.ok(finance.some((row) => row.id === "cc:directive:01K3CC-NO-PROVIDER-MUTATION"));
+
+  const superseded = session.service.list({ ...EMPTY_FILTER, status: "superseded" });
+  assert.ok(superseded.length >= 1);
+  assert.ok(superseded.every((row) => row.status === "superseded"));
+  assert.ok(superseded.some((row) => row.id === "cc:directive:01K3CC-GOV-CANONICAL-OLD"));
+});
+
+test("search matches title and body via shipped filterDirectives", () => {
+  const byBody = filterDirectives(FIXTURE_DIRECTIVES, {
+    ...EMPTY_FILTER,
+    query: "read models",
+  });
+  assert.equal(byBody.length, 1);
+  assert.equal(byBody[0]?.kind, "fact");
+  assert.equal(byBody[0]?.scope, "commercial");
+  assert.equal(byBody[0]?.id, "cc:directive:01K3CC-WARMBLY-CRM");
+
+  const byId = filterDirectives(FIXTURE_DIRECTIVES, {
+    ...EMPTY_FILTER,
+    query: "01K3CC-NO-PROVIDER-MUTATION",
+  });
+  assert.equal(byId.length, 1);
+  assert.equal(byId[0]?.kind, "constraint");
+});
+
+test("combined filters do not leak other kinds or scopes", () => {
+  const session = makeSession();
+  const rows = session.service.list({
+    query: "hipótese",
+    kind: "hypothesis",
+    scope: "commercial",
+    status: "active",
+  });
+  assert.equal(rows.length, 0);
+  const byKind = session.service.list({
+    ...EMPTY_FILTER,
+    kind: "hypothesis",
+    scope: "commercial",
+    status: "active",
+  });
+  assert.equal(byKind.length, 1);
+  assert.equal(byKind[0]?.id, "cc:directive:01K3CC-OFFER-HYPOTHESIS");
+});

--- a/control-center/apps/directives-ui/tests/helpers.ts
+++ b/control-center/apps/directives-ui/tests/helpers.ts
@@ -1,0 +1,37 @@
+import { initialUiState, type AppSession } from "../src/app-state.ts";
+import { frozenClock } from "../src/datetime.ts";
+import { resetIdSeq } from "../src/ids.ts";
+import { FIXTURE_DIRECTIVES, FIXTURE_NOW } from "../src/fixtures.ts";
+import { createMockService } from "../src/service.ts";
+import { MemoryDirectiveStore } from "../src/store.ts";
+import type { IdentityEnv } from "../src/actor.ts";
+import type { CreateDirectiveInput, DirectiveKind } from "../src/types.ts";
+
+export function makeSession(env?: IdentityEnv): AppSession {
+  resetIdSeq();
+  const service = createMockService({
+    store: new MemoryDirectiveStore(FIXTURE_DIRECTIVES),
+    clock: frozenClock(FIXTURE_NOW),
+    ...(env ? { env } : {}),
+  });
+  return { service, ui: initialUiState(service) };
+}
+
+export function createInput(
+  kind: DirectiveKind,
+  title: string,
+  extra: Partial<CreateDirectiveInput> = {},
+): CreateDirectiveInput {
+  return {
+    kind,
+    kindConfirm: extra.kindConfirm ?? kind,
+    title,
+    body: extra.body ?? `Body for ${title}`,
+    scope: extra.scope ?? "company",
+    status: extra.status ?? "active",
+    effective_from: extra.effective_from ?? "2026-08-20T15:00:00Z",
+    expires_at: extra.expires_at === undefined ? null : extra.expires_at,
+    supersedes: extra.supersedes === undefined ? null : extra.supersedes,
+    ...(extra.tags ? { tags: extra.tags } : {}),
+  };
+}

--- a/control-center/apps/directives-ui/tests/preview.test.ts
+++ b/control-center/apps/directives-ui/tests/preview.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  previewAgentContext,
+  previewHasHypothesisMixedIntoAuthoritative,
+  previewTitle,
+} from "../src/preview.ts";
+import { FIXTURE_DIRECTIVES, FIXTURE_NOW } from "../src/fixtures.ts";
+import { frozenClock } from "../src/datetime.ts";
+import { makeSession } from "./helpers.ts";
+
+test("preview is titled for the requested scope and is not a company dump", () => {
+  const session = makeSession();
+  const preview = session.service.preview("commercial");
+  assert.equal(preview.title, previewTitle("commercial"));
+  assert.equal(preview.scope, "commercial");
+  assert.deepEqual(preview.granted_scopes, ["commercial"]);
+  assert.ok(preview.excluded_other_scopes > 0);
+  const ids = [
+    ...preview.decisions,
+    ...preview.directives,
+    ...preview.facts,
+    ...preview.constraints,
+    ...preview.priorities,
+    ...preview.risks,
+    ...preview.hypotheses,
+  ].map((item) => item.record.scope);
+  assert.ok(ids.every((scope) => scope === "commercial"));
+});
+
+test("hypotheses are not mixed into facts or decisions", () => {
+  const preview = previewAgentContext(
+    FIXTURE_DIRECTIVES,
+    "commercial",
+    frozenClock(FIXTURE_NOW),
+  );
+  assert.equal(preview.facts.length, 1);
+  assert.equal(preview.facts[0]?.record.kind, "fact");
+  assert.equal(preview.hypotheses.length, 1);
+  assert.equal(preview.hypotheses[0]?.record.kind, "hypothesis");
+  assert.equal(preview.decisions.length, 0);
+  assert.equal(previewHasHypothesisMixedIntoAuthoritative(preview), false);
+  assert.equal(preview.facts[0]?.source, "governance");
+  assert.ok(preview.facts[0]?.observed_at.endsWith("Z"));
+  assert.equal(preview.facts[0]?.freshness_status, "FRESH");
+  assert.ok(typeof preview.hypotheses[0]?.confidence === "number");
+  assert.ok((preview.hypotheses[0]?.confidence ?? 1) < (preview.facts[0]?.confidence ?? 0));
+});
+
+test("drafts and other scopes stay out of the agent preview", () => {
+  const session = makeSession();
+  const inbound = session.service.preview("inbound");
+  assert.equal(inbound.directives.length, 0);
+  assert.ok(inbound.excluded_inactive >= 1);
+  const company = session.service.preview("company");
+  assert.ok(company.decisions.some((item) => item.record.id === "cc:directive:01K3CC-GOV-CANONICAL"));
+  assert.ok(
+    company.decisions.every((item) => item.record.id !== "cc:directive:01K3CC-GOV-CANONICAL-OLD"),
+  );
+});

--- a/control-center/apps/directives-ui/tests/supersede.test.ts
+++ b/control-center/apps/directives-ui/tests/supersede.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createInput, makeSession } from "./helpers.ts";
+
+test("supersede leaves the predecessor readable as superseded and does not rewrite body or kind", () => {
+  const session = makeSession();
+  const original = session.service.create(
+    createInput("decision", "Decisão v1", { body: "Texto original da decisão." }),
+  );
+  const originalBody = original.body;
+  const originalKind = original.kind;
+
+  const result = session.service.supersede(
+    original.id,
+    createInput("decision", "Decisão v2", { body: "Texto sucessor." }),
+  );
+
+  assert.equal(result.predecessor.id, original.id);
+  assert.equal(result.predecessor.status, "superseded");
+  assert.equal(result.predecessor.body, originalBody);
+  assert.equal(result.predecessor.kind, originalKind);
+  assert.equal(result.predecessor.title, "Decisão v1");
+  assert.ok(result.predecessor.audit.some((entry) => entry.action === "superseded"));
+
+  assert.notEqual(result.successor.id, original.id);
+  assert.equal(result.successor.status, "active");
+  assert.ok(result.successor.supersedes?.includes(original.id));
+  assert.equal(result.successor.body, "Texto sucessor.");
+
+  const storedOld = session.service.get(original.id);
+  assert.equal(storedOld?.status, "superseded");
+  assert.equal(storedOld?.body, originalBody);
+  assert.equal(storedOld?.kind, originalKind);
+
+  const storedNew = session.service.get(result.successor.id);
+  assert.equal(storedNew?.supersedes?.[0], original.id);
+
+  const listedOld = session.service.list({
+    query: "",
+    kind: "all",
+    scope: "all",
+    status: "superseded",
+  });
+  assert.ok(listedOld.some((row) => row.id === original.id));
+});
+
+test("fixture predecessor remains readable after the seeded supersede", () => {
+  const session = makeSession();
+  const old = session.service.get("cc:directive:01K3CC-GOV-CANONICAL-OLD");
+  const current = session.service.get("cc:directive:01K3CC-GOV-CANONICAL");
+  assert.equal(old?.status, "superseded");
+  assert.equal(old?.kind, "decision");
+  assert.match(old?.body ?? "", /Earlier unresolved/);
+  assert.ok(current?.supersedes?.includes("cc:directive:01K3CC-GOV-CANONICAL-OLD"));
+});

--- a/control-center/apps/directives-ui/tsconfig.json
+++ b/control-center/apps/directives-ui/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "useUnknownInCatchVariables": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds the Confenge Control Center **directives UI** under `control-center/apps/directives-ui/` (this campaign's exclusive path). Mobile-first UX to register structured strategic memory against a **local mock** — not chat, not ERP, not live HTTP/MCP/PostgreSQL.

## What this ships

- List / search / filter by `kind`, `scope`, and `status` (`draft|active|superseded|revoked|expired`).
- Create all seven kinds (`decision`, `directive`, `fact`, `constraint`, `priority`, `risk`, `hypothesis`) with required v1 fields and sensible defaults (scope `company`, status `active`, UTC `effective_from`, `expires_at` null).
- **Explicit kind confirmation** so a decision cannot be saved as a fact by accident.
- Scope + expiration **impact shown before save**.
- **Explicit supersede** (predecessor stays readable as `superseded`; body/kind frozen; successor references it).
- Authoritative vs **hypothesis** distinguished by accessible text/role, not color-only.
- Founder approval indicator (opaque actor handles, no password).
- Preview titled **“contexto que um agente verá para scope X”** (exact scope; hypotheses not mixed into facts/decisions).

## Tests

`cd control-center/apps/directives-ui && npm test` (builds IIFE + `tsx --test`). 30 tests covering list/filter/create/supersede/preview, kind confirmation, and a11y labels.

Playwright Chromium could not start in this sandbox (`libnspr4.so` missing). Fallback: page artifact + IIFE `window` load without Node `require` (see `tests/bundle.test.ts`).

## Convergence (later campaign)

Replace `MockDirectiveService` with HTTP to `control-center/services/context`. Pin `control-center/contracts/` `directive.v1`. Map string scopes ↔ `{company,domain,resource}` and `draft|revoked` ↔ `inactive`. Do not merge those models in this PR.

## Out of scope

No edits to `commercial/`, `decisions/`, `scripts/`, root README, PR #8, Warmbly, or other `control-center/` workstreams.