### PR TITLE
feat(control-center): Netcup deploy pack with encrypted backup and Caddy hooks

### DIFF
--- a/control-center/deploy/.dockerignore
+++ b/control-center/deploy/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+tests
+.env
+backups
+*.enc
+.git
+coverage

--- a/control-center/deploy/.env.example
+++ b/control-center/deploy/.env.example
@@ -1,0 +1,42 @@
+# Confenge Control Center deploy pack — names and placeholders only.
+# Copy to `.env` (gitignored) and inject values from a secret store.
+# Never commit real values. Never put secrets in git, logs, URLs, analytics, or the client bundle.
+# This file is not a production apply. CONTROL_CENTER_APPLY_PRODUCTION must stay false.
+
+COMPOSE_PROJECT_NAME=confenge-control-center
+
+# PostgreSQL (schema control_center). Password is injected; do not hardcode.
+POSTGRES_USER=control_center
+POSTGRES_PASSWORD=
+POSTGRES_DB=control_center
+
+# Later persistence/context convergence. Fill credentials locally; no password in this example.
+# Expected shape: postgres://USER@postgres:5432/control_center?sslmode=disable
+CONTROL_CENTER_DATABASE_URL=postgres://control_center@postgres:5432/control_center?sslmode=disable
+
+# 64 lowercase hex characters (32 bytes) from a secret store. Empty here on purpose.
+CONTROL_CENTER_BACKUP_KEY=
+CONTROL_CENTER_BACKUP_DIR=/var/lib/control-center/backups
+CONTROL_CENTER_BACKUP_RETAIN_DAYS=14
+CONTROL_CENTER_BACKUP_RETAIN_MIN=3
+
+# Disk guard (fail-closed). Default 1 GiB free required.
+CONTROL_CENTER_DISK_MIN_BYTES=1073741824
+CONTROL_CENTER_DISK_PATH=/var/lib/docker/volumes/confenge-control-center-postgres/_data
+
+# Opaque founder actor id (not a password, not an identity hardcode).
+CONTROL_CENTER_FOUNDER_ACTOR_ID=
+
+# MCP bearer token from a secret store. Empty here on purpose.
+CONFENGE_MCP_AUTH_TOKEN=
+
+# Caddy integration hook. High ports on loopback only — do not bind host 80/443 (Warmbly nginx).
+CONTROL_CENTER_PUBLIC_HOST=cc.internal.confenge.local
+CONTROL_CENTER_CADDY_HTTP_PORT=18080
+CONTROL_CENTER_CADDY_HTTPS_PORT=18443
+
+# Stubs for this wave. Real images are wired in the later convergence campaign.
+STUB_READY=true
+
+# Must remain false. This pack must not apply itself to the live Netcup VPS.
+CONTROL_CENTER_APPLY_PRODUCTION=false

--- a/control-center/deploy/.gitignore
+++ b/control-center/deploy/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+.env
+backups/
+*.dump
+*.dump.sql
+!fixtures/postgres.dump.sql
+*.enc
+*.enc.meta.json
+coverage/

--- a/control-center/deploy/Caddyfile
+++ b/control-center/deploy/Caddyfile
@@ -1,0 +1,59 @@
+# Confenge Control Center — Caddy 2 integration hook.
+#
+# This wave does NOT bind host :80 or :443. Warmbly keeps the existing host
+# nginx on those ports. Compose publishes Caddy only on 127.0.0.1:18080 and
+# 127.0.0.1:18443.
+#
+# Automatic HTTPS (later convergence campaign):
+# Caddy 2 enables automatic HTTPS (ACME) when a site address is a public
+# hostname served on ports 80/443. Do not switch this file to
+# `{$CONTROL_CENTER_PUBLIC_HOST}` on 80/443 until a dedicated vhost exists
+# and nginx is no longer occupying those ports for this hostname.
+# Until then, keep `tls internal` on the high HTTPS port so `/data` still
+# stores certificates (volume confenge-control-center-caddy-data).
+#
+# MCP and the cockpit UI are not a public internet surface in this wave.
+
+{
+	admin off
+	persist_config off
+}
+
+(cc_handlers) {
+  encode gzip
+  log {
+    output stdout
+    format json
+  }
+
+  handle /healthz {
+    reverse_proxy context:8080
+  }
+
+  handle /ready {
+    reverse_proxy context:8080
+  }
+
+  handle /mcp* {
+    reverse_proxy mcp:8080
+  }
+
+  handle /v1/* {
+    reverse_proxy context:8080
+  }
+
+  handle {
+    reverse_proxy web-shell:8080
+  }
+}
+
+http://:{$CONTROL_CENTER_CADDY_HTTP_PORT:18080} {
+  import cc_handlers
+}
+
+# HTTPS hook with locally issued certs. Replace `tls internal` with Caddy
+# automatic HTTPS in the convergence campaign, not in this wave.
+:{$CONTROL_CENTER_CADDY_HTTPS_PORT:18443} {
+  tls internal
+  import cc_handlers
+}

--- a/control-center/deploy/README.md
+++ b/control-center/deploy/README.md
@@ -1,0 +1,154 @@
+# Control Center deploy pack
+
+Reproducible reference pack for running Confenge Control Center on a Linux VPS (Netcup) with Docker Compose, Caddy hooks, PostgreSQL, encrypted backups, retention, and a fail-closed disk guard.
+
+This workstream is **not** chat, **not** an ERP, and **not** a replacement for Warmbly or origin systems. It does **not** apply itself to production. It does **not** bind host ports 80/443. Warmbly keeps the existing host nginx.
+
+Write path: `control-center/deploy/` only.
+
+## Decisions
+
+1. Governance remains the strategic/canonical authority; Warmbly remains the operational commercial/CRM authority. This pack only hosts the Control Center aggregate.
+2. Persistence of aggregated state is PostgreSQL 16, schema `control_center`. This pack provisions the cluster and schema; tables come from `control-center/persistence` in a later convergence campaign.
+3. Sibling images (context, MCP, web-shell) are not in this tree yet. Compose runs **stubs** that expose `/healthz` (liveness) and `/ready` (readiness). Convergence replaces build contexts; it does not require rewriting backup, Caddy hooks, or the runbook.
+4. Caddy is an **integration hook**: `reverse_proxy` to `context`, `mcp`, and `web-shell`, JSON logs, cert volume `/data`. Automatic HTTPS (ACME on 80/443) is documented for later. This wave uses `tls internal` on loopback high ports (`127.0.0.1:18080` / `18443`) so nginx is not stolen.
+5. Aggregated artifacts (backup meta, stub health bodies) carry `source`, `observed_at` (UTC `Z`), `freshness_status`, and `confidence` when applicable.
+6. Backup is AES-256-GCM with a 32-byte key from `CONTROL_CENTER_BACKUP_KEY` (64 hex chars). Missing, placeholder, or short keys **fail closed**. Ciphertext is not a dump. Restore verifies the SHA-256 of plaintext against the sidecar meta.
+7. Retention keeps copies for `CONTROL_CENTER_BACKUP_RETAIN_DAYS` **and** at least `CONTROL_CENTER_BACKUP_RETAIN_MIN` newest files. Unknown files without meta are not deleted blindly — prune **fails closed** if a `.dump.enc` lacks sidecar meta.
+8. Disk guard fails closed when the path is missing or free bytes are below `CONTROL_CENTER_DISK_MIN_BYTES`.
+9. Restart policy is `unless-stopped`. Resource limits and json-file log rotation (`max-size: 10m`, `max-file: 5`) are declared on every always-on service. Host logrotate snippet lives at `docker/logrotate.control-center.conf` (not applied this wave).
+10. Single-user human initially. No identity or password is hardcoded. Secrets are injected from a secret store into a gitignored `.env`.
+11. Fail-closed security. No secrets in git, logs, URLs, analytics, or a client bundle. Structured logs are JSON with UTC timestamps and refuse secret-bearing field names.
+12. No Kubernetes, Swarm, or cluster orchestrator. No cobranca, checkout, refund, cancelamento, Asaas writes, or commercial send.
+13. `CONTROL_CENTER_APPLY_PRODUCTION` must stay false. There is no Netcup SSH/apply command. A green deploy to the live VPS in this wave is a violation.
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `docker-compose.yml` | Project `confenge-control-center`, stubs, Postgres volume `confenge-control-center-postgres`, Caddy hook |
+| `Caddyfile` | reverse_proxy + automatic HTTPS notes + `tls internal` |
+| `docker/*.Dockerfile` | stub, postgres, caddy, ops (backup CLI + `pg_dump` client) |
+| `src/` | validate, backup/restore/verify, retention, disk guard, stub server, CLI |
+| `fixtures/postgres.dump.sql` | PII-free dump for the restore drill |
+| `RUNBOOK.md` | deploy / rollback / restore without relying on human memory |
+| `.env.example` | variable **names** and placeholders only |
+
+## Run (local, no production)
+
+Requires Node.js ≥ 20. Docker is optional for file/CLI verification.
+
+```bash
+cd control-center/deploy
+npm install
+npm test
+npm run typecheck
+npm run validate
+```
+
+Encrypted backup + restore drill (throwaway key, never a production secret):
+
+```bash
+export CONTROL_CENTER_BACKUP_KEY="$(openssl rand -hex 32)"
+npm run restore-drill -- --out /tmp/cc-restore-drill
+```
+
+Stub liveness/readiness (distinguishes ready vs not-ready):
+
+```bash
+HOST=127.0.0.1 PORT=18081 CONTROL_CENTER_STUB_SERVICE=context STUB_READY=true npm run stub
+# GET /healthz  → 200  live=true
+# GET /ready    → 200  ready=true
+
+STUB_READY=false npm run stub
+# GET /healthz  → 200  live=true
+# GET /ready    → 503  ready=false
+```
+
+Compose config (does **not** start production, does **not** SSH):
+
+```bash
+cp .env.example .env   # then inject secrets locally
+# Interpolation-only placeholders are fine for `config`; they must not be used to up a live host.
+POSTGRES_PASSWORD=interpolation-only \
+CONTROL_CENTER_BACKUP_KEY=0000000000000000000000000000000000000000000000000000000000000001 \
+docker compose -f docker-compose.yml config
+```
+
+If a Docker daemon is available, stubs can be brought up on loopback. This is still not a Netcup apply:
+
+```bash
+docker compose up --build -d postgres context mcp web-shell caddy
+curl -sS http://127.0.0.1:18080/healthz
+curl -sS http://127.0.0.1:18080/ready
+docker compose down
+```
+
+Do **not** run `docker compose up` against the live Netcup VPS from this wave.
+
+## Environment
+
+Names only; real values come from a secret store. See `.env.example`.
+
+| Variable | Required at runtime | Purpose |
+| --- | --- | --- |
+| `POSTGRES_USER` / `POSTGRES_DB` | yes | Role and database (`control_center`) |
+| `POSTGRES_PASSWORD` | yes | Inject; compose fails closed if empty |
+| `CONTROL_CENTER_DATABASE_URL` | later convergence | `postgres://USER@postgres:5432/control_center` — persistence/context |
+| `CONTROL_CENTER_BACKUP_KEY` | backup/restore | 64 hex chars; fail-closed if missing/placeholder |
+| `CONTROL_CENTER_BACKUP_DIR` | ops | Where encrypted copies land |
+| `CONTROL_CENTER_BACKUP_RETAIN_DAYS` | no (14) | Age window |
+| `CONTROL_CENTER_BACKUP_RETAIN_MIN` | no (3) | Always keep this many newest |
+| `CONTROL_CENTER_DISK_MIN_BYTES` | no (1 GiB) | Disk guard threshold |
+| `CONTROL_CENTER_DISK_PATH` | disk guard | Path that must exist and have space |
+| `CONTROL_CENTER_FOUNDER_ACTOR_ID` | later context | Opaque actor id, not a password |
+| `CONFENGE_MCP_AUTH_TOKEN` | later MCP | Bearer token from a secret store |
+| `CONTROL_CENTER_PUBLIC_HOST` | Caddy hook | Placeholder hostname |
+| `CONTROL_CENTER_CADDY_HTTP_PORT` | no (18080) | Loopback HTTP |
+| `CONTROL_CENTER_CADDY_HTTPS_PORT` | no (18443) | Loopback HTTPS (`tls internal`) |
+| `STUB_READY` | no (true) | Stub readiness flip |
+| `CONTROL_CENTER_APPLY_PRODUCTION` | must be false | Validate refuses to run if truthy |
+| `COMPOSE_PROJECT_NAME` | no | `confenge-control-center` |
+
+Dates inside the pack are UTC. Operators may display backup windows in `America/Sao_Paulo` (see runbook). Money in origin systems stays integer cents + currency; this pack does not store ledgers.
+
+## Backup CLI
+
+```bash
+export CONTROL_CENTER_BACKUP_KEY="$(openssl rand -hex 32)"
+npx tsx src/cli.ts backup --in fixtures/postgres.dump.sql --out ./backups
+npx tsx src/cli.ts verify --in ./backups/cc-pg-....dump.enc
+npx tsx src/cli.ts restore --in ./backups/cc-pg-....dump.enc --out ./restored.dump.sql
+npx tsx src/cli.ts retain --dir ./backups --now 2026-08-20T06:00:00Z
+npx tsx src/cli.ts disk-guard --path ./backups
+```
+
+After convergence, take a live dump without leaving the Compose network:
+
+```bash
+docker compose exec -T postgres pg_dump -U control_center -d control_center --schema=control_center \
+  | npx tsx src/cli.ts backup --in /dev/stdin --out "$CONTROL_CENTER_BACKUP_DIR"
+```
+
+(`backup --in` needs a seekable file today; write the dump to a temp file first, then encrypt. The runbook spells the drill.)
+
+## Expected later convergence
+
+Do **not** edit sibling trees from this workstream. Wire later:
+
+| Later workstream | Expected swap |
+| --- | --- |
+| `control-center/persistence` | Apply migrations into schema `control_center` using `CONTROL_CENTER_DATABASE_URL`. Volume `confenge-control-center-postgres` stays. |
+| `control-center/services/context` | Replace stub build with that Dockerfile. Keep `/healthz`; add `/ready` if not already present. |
+| `control-center/services/mcp` | Replace stub. Keep `CONFENGE_MCP_AUTH_TOKEN` injection. Caddy already `reverse_proxy`s `/mcp*` to `mcp:8080`. |
+| `control-center/apps/web-shell` | Replace stub. Caddy default handler already `reverse_proxy`s to `web-shell:8080`. |
+| Collectors / read models | Continue to write into Postgres; this pack does not mutate Warmbly, Asaas, or GitHub. |
+| Host nginx | Add a dedicated vhost or hand 80/443 to Caddy automatic HTTPS **only** when Warmbly’s vhost is preserved. |
+
+## Limits of this wave
+
+- No production apply, no ACME against real DNS, no Netcup SSH.
+- No Kubernetes manifests.
+- Stubs only for HTTP live/ready. They do not implement context, MCP protocol, or the cockpit UI.
+- Backup encryption is local-key GCM, not an offsite SaaS.
+- MCP/UI stay on loopback. Not a public internet surface.

--- a/control-center/deploy/RUNBOOK.md
+++ b/control-center/deploy/RUNBOOK.md
@@ -1,0 +1,159 @@
+# Runbook — Control Center deploy, rollback, restore
+
+Operators should be able to deploy, roll back, and restore **from this file**, not from memory. This wave ships the procedures and a local restore drill. It does **not** change the live Netcup VPS.
+
+Internal clocks are UTC. Display times below also show `America/Sao_Paulo`.
+
+## Never in this wave
+
+- SSH to Netcup to apply this pack.
+- Bind host 80/443 (Warmbly nginx).
+- `kubectl apply`, Helm, Swarm.
+- Cobranca, checkout, refund, cancelamento, Asaas writes, commercial send.
+- Set `CONTROL_CENTER_APPLY_PRODUCTION=true` (validate fails closed).
+
+## Prerequisites (after convergence)
+
+- Docker Compose v2 on the Linux VPS.
+- Secrets in a file **not** in git: `POSTGRES_PASSWORD`, `CONTROL_CENTER_BACKUP_KEY` (64 hex chars), later `CONFENGE_MCP_AUTH_TOKEN` and `CONTROL_CENTER_FOUNDER_ACTOR_ID`.
+- Disk guard path exists (Postgres volume and/or backup dir).
+- Copy `.env.example` → `.env` and inject secrets.
+
+Check the pack before any change:
+
+```bash
+cd control-center/deploy
+npm run validate
+```
+
+Expected primary line:
+
+```
+Control Center deploy pack: project=confenge-control-center postgres_volume=confenge-control-center-postgres caddy_hook=reverse_proxy backup=encrypted-aes-256-gcm restore=fixture-drill retention=age-and-min-count disk_guard=fail-closed kubernetes=absent production_apply=refused
+```
+
+## Deploy (reference, not executed here)
+
+1. `npm run validate` must succeed.
+2. `npx tsx src/cli.ts disk-guard --path "$CONTROL_CENTER_DISK_PATH"`.
+3. Record the current image tags (`docker compose images`) as the rollback point.
+4. `docker compose build`.
+5. `docker compose up -d postgres` and wait until `pg_isready` (Compose healthcheck).
+6. Later convergence: run `control-center/persistence` migrations against `CONTROL_CENTER_DATABASE_URL` (schema `control_center`).
+7. `docker compose up -d context mcp web-shell caddy`.
+8. Probe twice:
+   - `curl -sS http://127.0.0.1:18080/healthz`
+   - `curl -sS http://127.0.0.1:18080/ready`
+   Ready body must be non-empty JSON with `"ready": true`. Not-ready is `"ready": false` and HTTP 503.
+9. Confirm Caddy does **not** listen on host 80/443 (`ss -lntp` / existing nginx still owns those ports).
+
+## Rollback
+
+1. `docker compose images` / the notes from step 3 of deploy identify the previous tags (`confenge-control-center-stub`, `confenge-control-center-postgres:16`, `confenge-control-center-caddy`).
+2. `docker compose down` (volumes **stay**; `confenge-control-center-postgres` is the data).
+3. Set image tags back (or `git checkout` the previous compose/Dockerfiles on this path only).
+4. `docker compose up -d`.
+5. Probe `/healthz` and `/ready` twice again.
+6. If the schema migration in a later campaign is the failure, roll the persistence package forward/back with its own `migrate:down` / `migrate:up`. This pack does not own SQL tables.
+
+Rolling back does **not** delete `confenge-control-center-postgres` or `confenge-control-center-backups`.
+
+## Backup (encrypted)
+
+Preferred window: 03:00 America/Sao_Paulo (06:00 UTC).
+
+1. Disk guard.
+2. Dump (after convergence; fixture dump in this wave):
+
+```bash
+docker compose exec -T postgres \
+  pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --schema=control_center \
+  > /tmp/cc-pg.dump.sql
+```
+
+3. Encrypt + verify + retain (shipped CLI):
+
+```bash
+npx tsx src/cli.ts backup --in /tmp/cc-pg.dump.sql --out "$CONTROL_CENTER_BACKUP_DIR"
+npx tsx src/cli.ts verify --in "$CONTROL_CENTER_BACKUP_DIR"/cc-pg-*.dump.enc
+npx tsx src/cli.ts retain --dir "$CONTROL_CENTER_BACKUP_DIR"
+shred -u /tmp/cc-pg.dump.sql
+```
+
+4. Confirm ciphertext is not the SQL text (`grep CC_FIXTURE_SENTINEL` on the `.enc` file must miss; on a live dump, `grep CREATE` must miss).
+5. Sidecar `*.dump.enc.meta.json` records `source`, `observed_at`, `freshness_status`, `sha256_plaintext`.
+
+Fail closed if the key is missing. Do not log the key.
+
+## Restore drill (this wave — no Netcup)
+
+Uses `fixtures/postgres.dump.sql`. Run **twice**. Both restored files must match the fixture byte-for-byte.
+
+```bash
+export CONTROL_CENTER_BACKUP_KEY="$(openssl rand -hex 32)"
+npx tsx src/cli.ts restore-drill --out ./backups/drill
+cmp fixtures/postgres.dump.sql ./backups/drill/run-1/restored.dump.sql
+cmp fixtures/postgres.dump.sql ./backups/drill/run-2/restored.dump.sql
+```
+
+## Restore (after convergence, still not a live apply from this wave)
+
+1. Disk guard on the data directory.
+2. `docker compose stop context mcp web-shell caddy`.
+3. Decrypt:
+
+```bash
+npx tsx src/cli.ts restore --in "$CONTROL_CENTER_BACKUP_DIR"/cc-pg-WHEN.dump.enc --out /tmp/cc-pg.restore.sql
+```
+
+4. Recreate or apply into Postgres (operator choice; prefer a new database then swap):
+
+```bash
+docker compose exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" < /tmp/cc-pg.restore.sql
+```
+
+5. Start dependents, probe `/healthz` and `/ready` twice.
+6. Shred the plaintext restore file.
+
+If restore produces empty or unencrypted output, treat it as a **pack defect**, not an environment skip.
+
+## Retention
+
+Default: 14 days **and** at least 3 newest copies. Prune is `npx tsx src/cli.ts retain --dir "$CONTROL_CENTER_BACKUP_DIR"`. A `.dump.enc` without `.meta.json` fails closed (nothing is deleted blindly).
+
+## Disk guard
+
+Default 1 GiB (`1073741824` bytes) on `CONTROL_CENTER_DISK_PATH`. Backup, restore, and validate-time ops refuse to proceed when space is insufficient.
+
+## Log rotation
+
+- Docker `json-file`: `max-size: 10m`, `max-file: 5` (compose).
+- Optional host hook: `docker/logrotate.control-center.conf` — **not** installed by this wave.
+
+Logs are JSON. Do not attach secrets, tokens, `DATABASE_URL`, or dump contents to log fields.
+
+## Caddy / nginx coexistence
+
+| Port | Owner this wave |
+| --- | --- |
+| host 80/443 | Warmbly nginx — do not steal |
+| 127.0.0.1:18080 | Caddy HTTP hook → reverse_proxy |
+| 127.0.0.1:18443 | Caddy HTTPS hook, `tls internal`, certs in `confenge-control-center-caddy-data` |
+
+Automatic HTTPS (ACME) is the later campaign, after a dedicated hostname exists.
+
+## Health vs ready
+
+| Path | Meaning | Stub not-ready |
+| --- | --- | --- |
+| `GET /healthz` | process live | 200, `live: true` |
+| `GET /ready` | safe to receive traffic | 503, `ready: false`, non-empty JSON |
+
+## Contacts for later wiring
+
+- Postgres volume: `confenge-control-center-postgres`
+- Schema: `control_center`
+- URL env: `CONTROL_CENTER_DATABASE_URL`
+- MCP: Caddy `/mcp*` → `mcp:8080`
+- Cockpit: Caddy default → `web-shell:8080`
+- Context HTTP: Caddy `/v1/*`, `/healthz`, `/ready` → `context:8080`

--- a/control-center/deploy/docker-compose.yml
+++ b/control-center/deploy/docker-compose.yml
@@ -1,0 +1,231 @@
+# Confenge Control Center — reference Compose pack for a Linux VPS (Netcup).
+# Project: confenge-control-center
+# This file does NOT apply itself to production. Do not bind host 80/443:
+# Warmbly continues to use the existing host nginx on those ports.
+# Sibling services (context, MCP, web-shell, persistence) are not in this
+# tree yet. Stubs satisfy health/readiness. Later convergence replaces
+# build contexts, for example:
+#   context:   ../services/context
+#   mcp:       ../services/mcp
+#   web-shell: ../apps/web-shell
+# Persistence applies migrations into schema control_center on `postgres`.
+# No Kubernetes. No Swarm. No production apply from this wave.
+
+name: confenge-control-center
+
+x-logging: &cc-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
+x-stub-base: &stub-base
+  build:
+    context: .
+    dockerfile: docker/stub.Dockerfile
+  image: confenge-control-center-stub:local
+  restart: unless-stopped
+  logging: *cc-logging
+  mem_limit: 256m
+  cpus: 0.50
+  deploy:
+    resources:
+      limits:
+        cpus: "0.50"
+        memory: 256M
+      reservations:
+        cpus: "0.10"
+        memory: 64M
+  networks:
+    - ccnet
+  expose:
+    - "8080"
+  healthcheck:
+    test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/healthz && wget -qO- http://127.0.0.1:8080/ready"]
+    interval: 10s
+    timeout: 3s
+    retries: 5
+    start_period: 8s
+  security_opt:
+    - no-new-privileges:true
+
+services:
+  postgres:
+    build:
+      context: .
+      dockerfile: docker/postgres.Dockerfile
+    image: confenge-control-center-postgres:16
+    restart: unless-stopped
+    logging: *cc-logging
+    mem_limit: 1g
+    cpus: 1.0
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+        reservations:
+          cpus: "0.25"
+          memory: 256M
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER:-control_center}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set from a secret store}"
+      POSTGRES_DB: "${POSTGRES_DB:-control_center}"
+      TZ: UTC
+      PGTZ: UTC
+    volumes:
+      - cc_postgres_data:/var/lib/postgresql/data
+    networks:
+      - ccnet
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    command:
+      - postgres
+      - -c
+      - listen_addresses=*
+      - -c
+      - timezone=UTC
+      - -c
+      - log_timezone=UTC
+    security_opt:
+      - no-new-privileges:true
+
+  context:
+    <<: *stub-base
+    environment:
+      CONTROL_CENTER_STUB_SERVICE: context
+      HOST: 0.0.0.0
+      PORT: "8080"
+      STUB_READY: "${STUB_READY:-true}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  mcp:
+    <<: *stub-base
+    environment:
+      CONTROL_CENTER_STUB_SERVICE: mcp
+      HOST: 0.0.0.0
+      PORT: "8080"
+      STUB_READY: "${STUB_READY:-true}"
+    depends_on:
+      context:
+        condition: service_healthy
+
+  web-shell:
+    <<: *stub-base
+    environment:
+      CONTROL_CENTER_STUB_SERVICE: web-shell
+      HOST: 0.0.0.0
+      PORT: "8080"
+      STUB_READY: "${STUB_READY:-true}"
+    depends_on:
+      context:
+        condition: service_healthy
+
+  caddy:
+    build:
+      context: .
+      dockerfile: docker/caddy.Dockerfile
+    image: confenge-control-center-caddy:local
+    restart: unless-stopped
+    logging: *cc-logging
+    mem_limit: 128m
+    cpus: 0.50
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 128M
+        reservations:
+          cpus: "0.05"
+          memory: 32M
+    environment:
+      CONTROL_CENTER_PUBLIC_HOST: "${CONTROL_CENTER_PUBLIC_HOST:-cc.internal.confenge.local}"
+      CONTROL_CENTER_CADDY_HTTP_PORT: "${CONTROL_CENTER_CADDY_HTTP_PORT:-18080}"
+      CONTROL_CENTER_CADDY_HTTPS_PORT: "${CONTROL_CENTER_CADDY_HTTPS_PORT:-18443}"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - cc_caddy_data:/data
+      - cc_caddy_config:/config
+    ports:
+      - target: 18080
+        published: "${CONTROL_CENTER_CADDY_HTTP_PORT:-18080}"
+        protocol: tcp
+        host_ip: "127.0.0.1"
+      - target: 18443
+        published: "${CONTROL_CENTER_CADDY_HTTPS_PORT:-18443}"
+        protocol: tcp
+        host_ip: "127.0.0.1"
+    networks:
+      - ccnet
+    depends_on:
+      context:
+        condition: service_healthy
+      mcp:
+        condition: service_healthy
+      web-shell:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:18080/healthz && wget -qO- http://127.0.0.1:18080/ready"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    security_opt:
+      - no-new-privileges:true
+
+  backup-ops:
+    profiles: ["ops"]
+    build:
+      context: .
+      dockerfile: docker/ops.Dockerfile
+    image: confenge-control-center-ops:local
+    restart: "no"
+    logging: *cc-logging
+    mem_limit: 256m
+    cpus: 0.50
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 256M
+        reservations:
+          cpus: "0.10"
+          memory: 64M
+    environment:
+      CONTROL_CENTER_BACKUP_KEY: "${CONTROL_CENTER_BACKUP_KEY:?CONTROL_CENTER_BACKUP_KEY must be set from a secret store}"
+      CONTROL_CENTER_BACKUP_DIR: /backups
+      CONTROL_CENTER_BACKUP_RETAIN_DAYS: "${CONTROL_CENTER_BACKUP_RETAIN_DAYS:-14}"
+      CONTROL_CENTER_BACKUP_RETAIN_MIN: "${CONTROL_CENTER_BACKUP_RETAIN_MIN:-3}"
+      CONTROL_CENTER_DISK_MIN_BYTES: "${CONTROL_CENTER_DISK_MIN_BYTES:-1073741824}"
+      CONTROL_CENTER_DISK_PATH: /backups
+      CONTROL_CENTER_DATABASE_URL: "${CONTROL_CENTER_DATABASE_URL:-postgres://control_center@postgres:5432/control_center}"
+    volumes:
+      - cc_backup_data:/backups
+    networks:
+      - ccnet
+    depends_on:
+      postgres:
+        condition: service_healthy
+    security_opt:
+      - no-new-privileges:true
+
+volumes:
+  cc_postgres_data:
+    name: confenge-control-center-postgres
+  cc_caddy_data:
+    name: confenge-control-center-caddy-data
+  cc_caddy_config:
+    name: confenge-control-center-caddy-config
+  cc_backup_data:
+    name: confenge-control-center-backups
+
+networks:
+  ccnet:
+    name: confenge-control-center
+    driver: bridge

--- a/control-center/deploy/docker/caddy.Dockerfile
+++ b/control-center/deploy/docker/caddy.Dockerfile
@@ -1,0 +1,6 @@
+FROM caddy:2.8-alpine
+
+RUN apk add --no-cache wget
+
+# Default hook; compose also bind-mounts Caddyfile so operators can edit without rebuild.
+COPY Caddyfile /etc/caddy/Caddyfile

--- a/control-center/deploy/docker/logrotate.control-center.conf
+++ b/control-center/deploy/docker/logrotate.control-center.conf
@@ -1,0 +1,15 @@
+# Host-side logrotate hook for any Control Center files written outside Docker
+# json-file logs. Docker json-file rotation is configured in docker-compose.yml
+# (max-size 10m, max-file 5). This file is not applied to the live Netcup host
+# in this wave.
+
+/var/log/control-center/*.log {
+    daily
+    rotate 14
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}

--- a/control-center/deploy/docker/ops.Dockerfile
+++ b/control-center/deploy/docker/ops.Dockerfile
@@ -1,0 +1,18 @@
+FROM node:20-alpine
+
+RUN apk add --no-cache postgresql-client wget
+
+WORKDIR /app
+
+COPY package.json tsconfig.json ./
+COPY src ./src
+COPY fixtures ./fixtures
+COPY Caddyfile docker-compose.yml .env.example ./
+
+RUN npm install \
+  && npm cache clean --force
+
+USER node
+
+ENTRYPOINT ["npx", "tsx", "src/cli.ts"]
+CMD ["validate"]

--- a/control-center/deploy/docker/postgres.Dockerfile
+++ b/control-center/deploy/docker/postgres.Dockerfile
@@ -1,0 +1,7 @@
+FROM postgres:16-alpine
+
+# UTC internally. Presentation (America/Sao_Paulo) belongs to consumers, not this cluster.
+ENV TZ=UTC
+ENV PGTZ=UTC
+
+COPY docker/postgres/init-control-center.sql /docker-entrypoint-initdb.d/001-control-center.sql

--- a/control-center/deploy/docker/postgres/init-control-center.sql
+++ b/control-center/deploy/docker/postgres/init-control-center.sql
@@ -1,0 +1,7 @@
+-- Control Center PostgreSQL bootstrap (deploy pack).
+-- Tables are owned by control-center/persistence (later convergence).
+-- This file only reserves the schema so the cluster is ready for migrations.
+
+CREATE SCHEMA IF NOT EXISTS control_center;
+COMMENT ON SCHEMA control_center IS
+  'Aggregated operational state and structured strategic memory. Persistence workstream owns tables.';

--- a/control-center/deploy/docker/stub.Dockerfile
+++ b/control-center/deploy/docker/stub.Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine
+
+RUN apk add --no-cache wget
+
+WORKDIR /app
+
+COPY package.json tsconfig.json ./
+COPY src ./src
+
+RUN npm install --omit=dev \
+  && npm install tsx@4.20.5 typescript@5.9.2 \
+  && npm cache clean --force
+
+ENV HOST=0.0.0.0
+ENV PORT=8080
+ENV STUB_READY=true
+ENV CONTROL_CENTER_STUB_SERVICE=control-center-stub
+
+EXPOSE 8080
+
+USER node
+
+CMD ["npx", "tsx", "src/stub-health-server.ts"]

--- a/control-center/deploy/fixtures/postgres.dump.sql
+++ b/control-center/deploy/fixtures/postgres.dump.sql
@@ -1,0 +1,11 @@
+-- Confenge Control Center fixture dump (synthetic, PII-free).
+-- Used by the encrypted backup → verify → restore drill. Not production data.
+-- source=control-center.deploy.fixture observed_at=2026-01-01T00:00:00Z freshness_status=fresh
+
+CREATE SCHEMA IF NOT EXISTS control_center;
+
+-- Sentinel used by contract tests to prove round-trip restore equality.
+-- CC_FIXTURE_SENTINEL_9f3c2a7b1e44
+
+INSERT INTO control_center.directives (id, kind, scope, status)
+VALUES ('cc:directive:fixture-01', 'priority', 'company', 'active');

--- a/control-center/deploy/package-lock.json
+++ b/control-center/deploy/package-lock.json
@@ -1,0 +1,590 @@
+{
+  "name": "@confenge/control-center-deploy",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@confenge/control-center-deploy",
+      "version": "0.1.0",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      },
+      "bin": {
+        "cc-deploy": "src/cli.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/control-center/deploy/package.json
+++ b/control-center/deploy/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@confenge/control-center-deploy",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Reproducible Netcup deploy pack for Confenge Control Center: Compose, Caddy hooks, encrypted backup, retention, disk guard. Does not apply itself to production.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "bin": {
+    "cc-deploy": "./src/cli.ts"
+  },
+  "scripts": {
+    "test": "tsx --test tests/*.test.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "validate": "tsx src/cli.ts validate",
+    "backup": "tsx src/cli.ts backup",
+    "restore": "tsx src/cli.ts restore",
+    "verify": "tsx src/cli.ts verify",
+    "retain": "tsx src/cli.ts retain",
+    "disk-guard": "tsx src/cli.ts disk-guard",
+    "restore-drill": "tsx src/cli.ts restore-drill",
+    "stub": "tsx src/stub-health-server.ts"
+  },
+  "dependencies": {
+    "yaml": "^2.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/control-center/deploy/src/backup.ts
+++ b/control-center/deploy/src/backup.ts
@@ -1,0 +1,199 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { failClosed } from "./fail-closed.ts";
+
+export const BACKUP_MAGIC = Buffer.from("CCBK01");
+export const BACKUP_ALGORITHM = "aes-256-gcm";
+const IV_LEN = 12;
+const TAG_LEN = 16;
+
+export interface BackupMeta {
+  schema_version: "control-center.backup.v1";
+  source: string;
+  observed_at: string;
+  freshness_status: "fresh" | "stale" | "unknown" | "expired";
+  confidence: number;
+  algorithm: typeof BACKUP_ALGORITHM;
+  sha256_plaintext: string;
+  bytes_plaintext: number;
+  bytes_ciphertext: number;
+  filename: string;
+}
+
+export function parseBackupKey(raw: string | undefined): Buffer {
+  if (raw === undefined || raw.trim() === "") {
+    failClosed("CONTROL_CENTER_BACKUP_KEY is missing");
+  }
+  const key = raw.trim();
+  if (/change-?me|placeholder|example|insert|todo|xxx|your-?key/i.test(key)) {
+    failClosed("CONTROL_CENTER_BACKUP_KEY looks like a placeholder");
+  }
+  if (!/^[0-9a-fA-F]{64}$/.test(key)) {
+    failClosed("CONTROL_CENTER_BACKUP_KEY must be 64 hex characters");
+  }
+  return Buffer.from(key, "hex");
+}
+
+export function sha256Hex(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+export function encryptDump(plaintext: Buffer, key: Buffer): Buffer {
+  if (plaintext.length === 0) {
+    failClosed("refusing to encrypt empty dump");
+  }
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(BACKUP_ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([BACKUP_MAGIC, iv, tag, ciphertext]);
+}
+
+export function decryptDump(blob: Buffer, key: Buffer): Buffer {
+  const min = BACKUP_MAGIC.length + IV_LEN + TAG_LEN + 1;
+  if (blob.length < min) {
+    failClosed("ciphertext too short");
+  }
+  if (!blob.subarray(0, BACKUP_MAGIC.length).equals(BACKUP_MAGIC)) {
+    failClosed("missing CCBK01 magic; refusing unencrypted or foreign blob");
+  }
+  const ivStart = BACKUP_MAGIC.length;
+  const tagStart = ivStart + IV_LEN;
+  const dataStart = tagStart + TAG_LEN;
+  const iv = blob.subarray(ivStart, tagStart);
+  const tag = blob.subarray(tagStart, dataStart);
+  const ciphertext = blob.subarray(dataStart);
+  const decipher = createDecipheriv(BACKUP_ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  try {
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch {
+    failClosed("backup authentication failed");
+  }
+}
+
+function assertUtcIso(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/.test(value)) {
+    failClosed("observed_at must be UTC ISO-8601 ending with Z");
+  }
+}
+
+export function writeEncryptedBackup(opts: {
+  plaintext: Buffer;
+  key: Buffer;
+  outDir: string;
+  observedAt: string;
+  source?: string;
+}): { encPath: string; metaPath: string; meta: BackupMeta; ciphertext: Buffer } {
+  assertUtcIso(opts.observedAt);
+  mkdirSync(opts.outDir, { recursive: true });
+  const ciphertext = encryptDump(opts.plaintext, opts.key);
+  if (ciphertext.equals(opts.plaintext)) {
+    failClosed("encryption produced ciphertext identical to plaintext");
+  }
+  const stamp = opts.observedAt.replace(/[:.]/g, "-");
+  const filename = `cc-pg-${stamp}.dump.enc`;
+  const encPath = join(opts.outDir, filename);
+  const meta: BackupMeta = {
+    schema_version: "control-center.backup.v1",
+    source: opts.source ?? "postgres.control_center",
+    observed_at: opts.observedAt,
+    freshness_status: "fresh",
+    confidence: 1,
+    algorithm: BACKUP_ALGORITHM,
+    sha256_plaintext: sha256Hex(opts.plaintext),
+    bytes_plaintext: opts.plaintext.length,
+    bytes_ciphertext: ciphertext.length,
+    filename,
+  };
+  writeFileSync(encPath, ciphertext);
+  const metaPath = `${encPath}.meta.json`;
+  writeFileSync(metaPath, `${JSON.stringify(meta, null, 2)}\n`);
+  return { encPath, metaPath, meta, ciphertext };
+}
+
+export function parseBackupMeta(raw: string): BackupMeta {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    failClosed("backup meta is not valid JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    failClosed("backup meta is not an object");
+  }
+  const rec = parsed as Record<string, unknown>;
+  if (rec.schema_version !== "control-center.backup.v1") {
+    failClosed("backup meta schema_version mismatch");
+  }
+  if (typeof rec.source !== "string" || rec.source.length === 0) {
+    failClosed("backup meta source missing");
+  }
+  if (typeof rec.observed_at !== "string") {
+    failClosed("backup meta observed_at missing");
+  }
+  assertUtcIso(rec.observed_at);
+  if (typeof rec.sha256_plaintext !== "string" || rec.sha256_plaintext.length !== 64) {
+    failClosed("backup meta sha256_plaintext missing");
+  }
+  if (rec.algorithm !== BACKUP_ALGORITHM) {
+    failClosed("backup meta algorithm mismatch");
+  }
+  if (typeof rec.filename !== "string") {
+    failClosed("backup meta filename missing");
+  }
+  const freshness = rec.freshness_status;
+  if (
+    freshness !== "fresh" &&
+    freshness !== "stale" &&
+    freshness !== "unknown" &&
+    freshness !== "expired"
+  ) {
+    failClosed("backup meta freshness_status invalid");
+  }
+  const confidence = rec.confidence;
+  if (typeof confidence !== "number" || confidence < 0 || confidence > 1) {
+    failClosed("backup meta confidence invalid");
+  }
+  const bytesPlain = rec.bytes_plaintext;
+  const bytesCipher = rec.bytes_ciphertext;
+  if (typeof bytesPlain !== "number" || typeof bytesCipher !== "number") {
+    failClosed("backup meta byte counts missing");
+  }
+  return {
+    schema_version: "control-center.backup.v1",
+    source: rec.source,
+    observed_at: rec.observed_at,
+    freshness_status: freshness,
+    confidence,
+    algorithm: BACKUP_ALGORITHM,
+    sha256_plaintext: rec.sha256_plaintext,
+    bytes_plaintext: bytesPlain,
+    bytes_ciphertext: bytesCipher,
+    filename: rec.filename,
+  };
+}
+
+export function verifyEncryptedBackup(encPath: string, key: Buffer): Buffer {
+  const blob = readFileSync(encPath);
+  const meta = parseBackupMeta(readFileSync(`${encPath}.meta.json`, "utf8"));
+  const plain = decryptDump(blob, key);
+  if (sha256Hex(plain) !== meta.sha256_plaintext) {
+    failClosed("backup verification hash mismatch");
+  }
+  if (blob.equals(plain)) {
+    failClosed("ciphertext equals plaintext");
+  }
+  return plain;
+}
+
+export function restoreEncryptedBackup(
+  encPath: string,
+  key: Buffer,
+  outFile: string,
+): Buffer {
+  const plain = verifyEncryptedBackup(encPath, key);
+  writeFileSync(outFile, plain);
+  return plain;
+}

--- a/control-center/deploy/src/caddy.ts
+++ b/control-center/deploy/src/caddy.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { failClosed } from "./fail-closed.ts";
+import { CADDY_FILE } from "./paths.ts";
+
+export interface CaddyReverseProxy {
+  path: string;
+  upstream: string;
+}
+
+export interface CaddyHook {
+  reverseProxies: CaddyReverseProxy[];
+  documentsAutomaticHttps: boolean;
+  usesTlsInternal: boolean;
+  adminOff: boolean;
+  jsonLogs: boolean;
+}
+
+const REQUIRED_UPSTREAMS = ["context:8080", "mcp:8080", "web-shell:8080"] as const;
+
+export function parseCaddyfile(text: string): CaddyHook {
+  const reverseProxies: CaddyReverseProxy[] = [];
+  let currentPath = "/";
+  for (const raw of text.split(/\n/)) {
+    const line = raw.trim();
+    const handle = line.match(/^handle\s+(\S+)\s*\{?$/);
+    if (handle) {
+      currentPath = handle[1] ?? "/";
+    } else if (line === "handle {") {
+      currentPath = "/";
+    }
+    const proxy = line.match(/^reverse_proxy\s+(\S+)/);
+    if (proxy && proxy[1]) {
+      reverseProxies.push({ path: currentPath, upstream: proxy[1] });
+    }
+  }
+  const documentsAutomaticHttps =
+    /automatic HTTPS/i.test(text) && /ACME/i.test(text) && /80\/443/.test(text);
+  return {
+    reverseProxies,
+    documentsAutomaticHttps,
+    usesTlsInternal: /tls\s+internal/.test(text),
+    adminOff: /admin\s+off/.test(text),
+    jsonLogs: /format\s+json/.test(text),
+  };
+}
+
+export function loadCaddy(path = CADDY_FILE): { text: string; hook: CaddyHook } {
+  const text = readFileSync(path, "utf8");
+  return { text, hook: parseCaddyfile(text) };
+}
+
+export function assertCaddyHook(hook: CaddyHook): void {
+  const upstreams = new Set(hook.reverseProxies.map((p) => p.upstream));
+  for (const required of REQUIRED_UPSTREAMS) {
+    if (!upstreams.has(required)) {
+      failClosed(`Caddyfile missing reverse_proxy ${required}`);
+    }
+  }
+  const paths = hook.reverseProxies.map((p) => p.path);
+  if (!paths.includes("/healthz") || !paths.includes("/ready")) {
+    failClosed("Caddyfile must reverse_proxy /healthz and /ready");
+  }
+  if (!hook.documentsAutomaticHttps) {
+    failClosed("Caddyfile must document automatic HTTPS for later convergence");
+  }
+  if (!hook.usesTlsInternal) {
+    failClosed("Caddyfile must use tls internal on the high HTTPS port this wave");
+  }
+  if (!hook.adminOff) {
+    failClosed("Caddy admin API must be off");
+  }
+}

--- a/control-center/deploy/src/cli.ts
+++ b/control-center/deploy/src/cli.ts
@@ -1,0 +1,189 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { createLogger } from "./log.ts";
+import { parseBackupKey, restoreEncryptedBackup, verifyEncryptedBackup } from "./backup.ts";
+import { assertDiskSpace, parseMinBytes } from "./disk-guard.ts";
+import { FailClosedError } from "./fail-closed.ts";
+import { FIXTURE_DUMP } from "./paths.ts";
+import { runBackupPipeline } from "./pipeline.ts";
+import { parseRetainDays, parseRetainMin, pruneBackupDir } from "./retention.ts";
+import { runRestoreDrill } from "./restore-drill.ts";
+import { formatValidateReport, validatePack } from "./validate.ts";
+
+const logger = createLogger("control-center-deploy");
+
+function flag(name: string): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1) {
+    return undefined;
+  }
+  const value = process.argv[idx + 1];
+  if (value === undefined || value.startsWith("--")) {
+    return undefined;
+  }
+  return value;
+}
+
+function requiredFlag(name: string): string {
+  const value = flag(name);
+  if (value === undefined || value.trim() === "") {
+    throw new FailClosedError(`missing --${name}`);
+  }
+  return value;
+}
+
+function usage(): string {
+  return [
+    "cc-deploy <validate|backup|restore|verify|retain|disk-guard|restore-drill>",
+    "  validate",
+    "  backup --in <dump> --out <dir>",
+    "  restore --in <enc> --out <file>",
+    "  verify --in <enc>",
+    "  retain --dir <dir>",
+    "  disk-guard --path <dir>",
+    "  restore-drill --out <dir>",
+  ].join("\n");
+}
+
+function main(): void {
+  const cmd = process.argv[2];
+  if (cmd === undefined || cmd === "--help" || cmd === "help") {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  if (cmd === "validate") {
+    const report = validatePack(process.env);
+    process.stdout.write(formatValidateReport(report));
+    logger.info("validate.ok", {
+      project: report.project,
+      postgres_volume: report.postgres_volume,
+      caddy_hook: report.caddy_hook,
+      backup: report.backup,
+      restore: report.restore,
+      retention: report.retention,
+      disk_guard: report.disk_guard,
+    });
+    return;
+  }
+  if (cmd === "backup") {
+    const input = requiredFlag("in");
+    const outDir = requiredFlag("out");
+    mkdirSync(outDir, { recursive: true });
+    const result = runBackupPipeline({
+      plaintext: readFileSync(input),
+      keyRaw: process.env.CONTROL_CENTER_BACKUP_KEY,
+      outDir,
+      observedAt: flag("observed-at") ?? new Date().toISOString(),
+      diskPath: process.env.CONTROL_CENTER_DISK_PATH ?? outDir,
+      ...(process.env.CONTROL_CENTER_DISK_MIN_BYTES
+        ? { minBytesRaw: process.env.CONTROL_CENTER_DISK_MIN_BYTES }
+        : {}),
+      ...(process.env.CONTROL_CENTER_BACKUP_RETAIN_DAYS
+        ? { retainDaysRaw: process.env.CONTROL_CENTER_BACKUP_RETAIN_DAYS }
+        : {}),
+      ...(process.env.CONTROL_CENTER_BACKUP_RETAIN_MIN
+        ? { retainMinRaw: process.env.CONTROL_CENTER_BACKUP_RETAIN_MIN }
+        : {}),
+    });
+    logger.info("backup.ok", {
+      filename: result.meta.filename,
+      bytes_plaintext: result.meta.bytes_plaintext,
+      bytes_ciphertext: result.meta.bytes_ciphertext,
+      source: result.meta.source,
+      observed_at: result.meta.observed_at,
+      freshness_status: result.meta.freshness_status,
+    });
+    process.stdout.write(`${result.encPath}\n`);
+    return;
+  }
+  if (cmd === "restore") {
+    const encPath = requiredFlag("in");
+    const outFile = requiredFlag("out");
+    const outDir = dirname(outFile);
+    mkdirSync(outDir === "" ? "." : outDir, { recursive: true });
+    const diskPath = process.env.CONTROL_CENTER_DISK_PATH ?? (outDir === "" ? "." : outDir);
+    assertDiskSpace({
+      path: diskPath,
+      minBytes: parseMinBytes(process.env.CONTROL_CENTER_DISK_MIN_BYTES),
+    });
+    restoreEncryptedBackup(encPath, parseBackupKey(process.env.CONTROL_CENTER_BACKUP_KEY), outFile);
+    logger.info("restore.ok", { out: outFile });
+    return;
+  }
+  if (cmd === "verify") {
+    const encPath = requiredFlag("in");
+    const plain = verifyEncryptedBackup(
+      encPath,
+      parseBackupKey(process.env.CONTROL_CENTER_BACKUP_KEY),
+    );
+    logger.info("verify.ok", { bytes: plain.length });
+    return;
+  }
+  if (cmd === "retain") {
+    const dir = requiredFlag("dir");
+    const nowRaw = flag("now");
+    const now = nowRaw ? new Date(nowRaw) : new Date();
+    const result = pruneBackupDir(
+      dir,
+      now,
+      parseRetainDays(process.env.CONTROL_CENTER_BACKUP_RETAIN_DAYS),
+      parseRetainMin(process.env.CONTROL_CENTER_BACKUP_RETAIN_MIN),
+    );
+    logger.info("retain.ok", { kept: result.kept.length, dropped: result.dropped.length });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  if (cmd === "disk-guard") {
+    const path = requiredFlag("path");
+    const result = assertDiskSpace({
+      path,
+      minBytes: parseMinBytes(process.env.CONTROL_CENTER_DISK_MIN_BYTES ?? flag("min-bytes")),
+    });
+    logger.info("disk_guard.ok", {
+      path: result.path,
+      free_bytes: result.freeBytes,
+      min_bytes: result.minBytes,
+    });
+    return;
+  }
+  if (cmd === "restore-drill") {
+    const outDir = requiredFlag("out");
+    const result = runRestoreDrill({
+      fixturePath: flag("fixture") ?? FIXTURE_DUMP,
+      outDir,
+      keyRaw: process.env.CONTROL_CENTER_BACKUP_KEY,
+    });
+    writeFileSync(
+      `${outDir}/drill-summary.json`,
+      `${JSON.stringify(
+        {
+          fixturePath: result.fixturePath,
+          fixtureBytes: result.fixtureBytes,
+          sameContent: result.sameContent,
+          run1: result.run1.restoredPath,
+          run2: result.run2.restoredPath,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    logger.info("restore_drill.ok", {
+      fixture_bytes: result.fixtureBytes,
+      same_content: true,
+    });
+    process.stdout.write(
+      `restore-drill ok fixture_bytes=${result.fixtureBytes} same_content=true\n`,
+    );
+    return;
+  }
+  throw new FailClosedError(`unknown command ${cmd}\n${usage()}`);
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : "internal error";
+  logger.error("cli.fail_closed", { err: message });
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}

--- a/control-center/deploy/src/compose.ts
+++ b/control-center/deploy/src/compose.ts
@@ -1,0 +1,322 @@
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+import { failClosed } from "./fail-closed.ts";
+import { COMPOSE_FILE } from "./paths.ts";
+
+export interface ResourceLimits {
+  cpus?: string;
+  memory?: string;
+}
+
+export interface ComposeHealthcheck {
+  test?: unknown;
+  interval?: string;
+  timeout?: string;
+  retries?: number;
+  start_period?: string;
+}
+
+export interface ComposePort {
+  target?: number | string;
+  published?: number | string;
+  protocol?: string;
+  host_ip?: string;
+}
+
+export interface ComposeService {
+  restart?: string;
+  image?: string;
+  build?: { context?: string; dockerfile?: string };
+  healthcheck?: ComposeHealthcheck;
+  deploy?: { resources?: { limits?: ResourceLimits; reservations?: ResourceLimits } };
+  mem_limit?: string | number;
+  cpus?: string | number;
+  logging?: { driver?: string; options?: Record<string, string> };
+  volumes?: unknown[];
+  ports?: unknown[];
+  environment?: unknown;
+  profiles?: unknown[];
+}
+
+export interface ComposeVolume {
+  name?: string;
+}
+
+export interface ComposeDocument {
+  name?: string;
+  services?: Record<string, ComposeService>;
+  volumes?: Record<string, ComposeVolume | null>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asResourceLimits(value: unknown): ResourceLimits | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const limits: ResourceLimits = {};
+  if (typeof value.cpus === "string" || typeof value.cpus === "number") {
+    limits.cpus = String(value.cpus);
+  }
+  if (typeof value.memory === "string") {
+    limits.memory = value.memory;
+  }
+  return limits;
+}
+
+function asService(value: unknown): ComposeService {
+  if (!isRecord(value)) {
+    failClosed("compose service is not a mapping");
+  }
+  const svc: ComposeService = {};
+  if (typeof value.restart === "string") {
+    svc.restart = value.restart;
+  }
+  if (typeof value.image === "string") {
+    svc.image = value.image;
+  }
+  if (isRecord(value.build)) {
+    svc.build = {
+      ...(typeof value.build.context === "string" ? { context: value.build.context } : {}),
+      ...(typeof value.build.dockerfile === "string"
+        ? { dockerfile: value.build.dockerfile }
+        : {}),
+    };
+  }
+  if (isRecord(value.healthcheck)) {
+    const hc: ComposeHealthcheck = {};
+    if (value.healthcheck.test !== undefined) {
+      hc.test = value.healthcheck.test;
+    }
+    if (typeof value.healthcheck.interval === "string") {
+      hc.interval = value.healthcheck.interval;
+    }
+    if (typeof value.healthcheck.timeout === "string") {
+      hc.timeout = value.healthcheck.timeout;
+    }
+    if (typeof value.healthcheck.retries === "number") {
+      hc.retries = value.healthcheck.retries;
+    }
+    if (typeof value.healthcheck.start_period === "string") {
+      hc.start_period = value.healthcheck.start_period;
+    }
+    svc.healthcheck = hc;
+  }
+  if (isRecord(value.deploy) && isRecord(value.deploy.resources)) {
+    const limits = asResourceLimits(value.deploy.resources.limits);
+    const reservations = asResourceLimits(value.deploy.resources.reservations);
+    svc.deploy = {
+      resources: {
+        ...(limits ? { limits } : {}),
+        ...(reservations ? { reservations } : {}),
+      },
+    };
+  }
+  if (typeof value.mem_limit === "string" || typeof value.mem_limit === "number") {
+    svc.mem_limit = value.mem_limit;
+  }
+  if (typeof value.cpus === "string" || typeof value.cpus === "number") {
+    svc.cpus = value.cpus;
+  }
+  if (isRecord(value.logging)) {
+    const options: Record<string, string> = {};
+    if (isRecord(value.logging.options)) {
+      for (const [k, v] of Object.entries(value.logging.options)) {
+        if (typeof v === "string") {
+          options[k] = v;
+        }
+      }
+    }
+    svc.logging = {
+      ...(typeof value.logging.driver === "string" ? { driver: value.logging.driver } : {}),
+      ...(Object.keys(options).length > 0 ? { options } : {}),
+    };
+  }
+  if (Array.isArray(value.volumes)) {
+    svc.volumes = value.volumes;
+  }
+  if (Array.isArray(value.ports)) {
+    svc.ports = value.ports;
+  }
+  if (value.environment !== undefined) {
+    svc.environment = value.environment;
+  }
+  if (Array.isArray(value.profiles)) {
+    svc.profiles = value.profiles;
+  }
+  return svc;
+}
+
+export function parseComposeText(text: string): ComposeDocument {
+  const parsed: unknown = parseYaml(text, { merge: true });
+  if (!isRecord(parsed)) {
+    failClosed("compose file is not a mapping");
+  }
+  const doc: ComposeDocument = {};
+  if (typeof parsed.name === "string") {
+    doc.name = parsed.name;
+  }
+  if (isRecord(parsed.services)) {
+    const services: Record<string, ComposeService> = {};
+    for (const [name, svc] of Object.entries(parsed.services)) {
+      services[name] = asService(svc);
+    }
+    doc.services = services;
+  }
+  if (isRecord(parsed.volumes)) {
+    const volumes: Record<string, ComposeVolume | null> = {};
+    for (const [name, vol] of Object.entries(parsed.volumes)) {
+      if (vol === null) {
+        volumes[name] = null;
+      } else if (isRecord(vol)) {
+        volumes[name] = typeof vol.name === "string" ? { name: vol.name } : {};
+      } else {
+        failClosed(`compose volume ${name} is invalid`);
+      }
+    }
+    doc.volumes = volumes;
+  }
+  return doc;
+}
+
+export function loadCompose(path = COMPOSE_FILE): { text: string; doc: ComposeDocument } {
+  const text = readFileSync(path, "utf8");
+  return { text, doc: parseComposeText(text) };
+}
+
+export function healthcheckText(svc: ComposeService | undefined): string {
+  const test = svc?.healthcheck?.test;
+  if (typeof test === "string") {
+    return test;
+  }
+  if (Array.isArray(test)) {
+    return test.map(String).join(" ");
+  }
+  return "";
+}
+
+export function parsePort(entry: unknown): ComposePort | undefined {
+  if (typeof entry === "string") {
+    const parts = entry.split(":");
+    if (parts.length === 3) {
+      return { host_ip: parts[0], published: parts[1], target: parts[2] };
+    }
+    if (parts.length === 2) {
+      return { published: parts[0], target: parts[1] };
+    }
+    return { target: entry };
+  }
+  if (!isRecord(entry)) {
+    return undefined;
+  }
+  const port: ComposePort = {};
+  if (typeof entry.target === "number" || typeof entry.target === "string") {
+    port.target = entry.target;
+  }
+  if (typeof entry.published === "number" || typeof entry.published === "string") {
+    port.published = entry.published;
+  }
+  if (typeof entry.protocol === "string") {
+    port.protocol = entry.protocol;
+  }
+  if (typeof entry.host_ip === "string") {
+    port.host_ip = entry.host_ip;
+  }
+  return port;
+}
+
+export function defaultPublishedPort(published: string | number | undefined): number | undefined {
+  if (typeof published === "number") {
+    return published;
+  }
+  if (typeof published !== "string") {
+    return undefined;
+  }
+  const match = published.match(/:-(\d+)\}/);
+  if (match) {
+    return Number(match[1]);
+  }
+  if (/^\d+$/.test(published)) {
+    return Number(published);
+  }
+  return undefined;
+}
+
+export function serviceVolumeNames(svc: ComposeService | undefined): string[] {
+  const vols = svc?.volumes ?? [];
+  const names: string[] = [];
+  for (const item of vols) {
+    if (typeof item === "string") {
+      const left = item.split(":")[0];
+      if (left) {
+        names.push(left);
+      }
+    } else if (isRecord(item) && typeof item.source === "string") {
+      names.push(item.source);
+    }
+  }
+  return names;
+}
+
+export function hasResourceLimits(svc: ComposeService | undefined): boolean {
+  if (!svc) {
+    return false;
+  }
+  const limits = svc.deploy?.resources?.limits;
+  const mem = svc.mem_limit !== undefined || typeof limits?.memory === "string";
+  const cpu = svc.cpus !== undefined || typeof limits?.cpus === "string";
+  return mem && cpu;
+}
+
+export function hasLogRotation(svc: ComposeService | undefined): boolean {
+  const logging = svc?.logging;
+  if (!logging || logging.driver !== "json-file") {
+    return false;
+  }
+  const maxSize = logging.options?.["max-size"];
+  const maxFile = logging.options?.["max-file"];
+  return typeof maxSize === "string" && typeof maxFile === "string";
+}
+
+export function requireService(
+  doc: ComposeDocument,
+  name: string,
+): ComposeService {
+  const svc = doc.services?.[name];
+  if (!svc) {
+    failClosed(`compose missing service ${name}`);
+  }
+  return svc;
+}
+
+export function inspectCompose(doc: ComposeDocument): {
+  project: string;
+  postgresVolume: string;
+  services: string[];
+} {
+  const project = asString(doc.name);
+  if (project !== "confenge-control-center") {
+    failClosed("compose name must be confenge-control-center");
+  }
+  const postgres = requireService(doc, "postgres");
+  const volKey = "cc_postgres_data";
+  if (!serviceVolumeNames(postgres).includes(volKey)) {
+    failClosed("postgres is missing persistent volume cc_postgres_data");
+  }
+  const named = doc.volumes?.[volKey];
+  const postgresVolume = named?.name ?? volKey;
+  if (postgresVolume !== "confenge-control-center-postgres") {
+    failClosed("postgres volume name must be confenge-control-center-postgres");
+  }
+  return {
+    project,
+    postgresVolume,
+    services: Object.keys(doc.services ?? {}),
+  };
+}

--- a/control-center/deploy/src/disk-guard.ts
+++ b/control-center/deploy/src/disk-guard.ts
@@ -1,0 +1,47 @@
+import { existsSync, statfsSync } from "node:fs";
+import { failClosed } from "./fail-closed.ts";
+
+export interface DiskStat {
+  bavail: number;
+  bsize: number;
+}
+
+export type DiskStatFn = (path: string) => DiskStat;
+
+export function parseMinBytes(raw: string | undefined, fallback = 1_073_741_824): number {
+  const n = raw === undefined || raw.trim() === "" ? fallback : Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    failClosed("CONTROL_CENTER_DISK_MIN_BYTES must be an integer >= 1");
+  }
+  return n;
+}
+
+export function freeBytes(stat: DiskStat): number {
+  if (stat.bavail < 0 || stat.bsize <= 0) {
+    failClosed("disk stat is invalid");
+  }
+  return stat.bavail * stat.bsize;
+}
+
+export function defaultStatFn(path: string): DiskStat {
+  const stat = statfsSync(path);
+  return { bavail: stat.bavail, bsize: stat.bsize };
+}
+
+export function assertDiskSpace(opts: {
+  path: string;
+  minBytes: number;
+  statFn?: DiskStatFn;
+}): { ok: true; path: string; freeBytes: number; minBytes: number } {
+  if (!existsSync(opts.path)) {
+    failClosed(`disk path missing: ${opts.path}`);
+  }
+  const statFn = opts.statFn ?? defaultStatFn;
+  const free = freeBytes(statFn(opts.path));
+  if (free < opts.minBytes) {
+    failClosed(
+      `insufficient disk: ${free} bytes free at ${opts.path}, need ${opts.minBytes}`,
+    );
+  }
+  return { ok: true, path: opts.path, freeBytes: free, minBytes: opts.minBytes };
+}

--- a/control-center/deploy/src/env-file.ts
+++ b/control-center/deploy/src/env-file.ts
@@ -1,0 +1,113 @@
+import { failClosed } from "./fail-closed.ts";
+
+export interface EnvAssignment {
+  name: string;
+  value: string;
+  line: number;
+}
+
+const REQUIRED_NAMES = [
+  "COMPOSE_PROJECT_NAME",
+  "POSTGRES_USER",
+  "POSTGRES_PASSWORD",
+  "POSTGRES_DB",
+  "CONTROL_CENTER_DATABASE_URL",
+  "CONTROL_CENTER_BACKUP_KEY",
+  "CONTROL_CENTER_BACKUP_DIR",
+  "CONTROL_CENTER_BACKUP_RETAIN_DAYS",
+  "CONTROL_CENTER_BACKUP_RETAIN_MIN",
+  "CONTROL_CENTER_DISK_MIN_BYTES",
+  "CONTROL_CENTER_DISK_PATH",
+  "CONTROL_CENTER_FOUNDER_ACTOR_ID",
+  "CONFENGE_MCP_AUTH_TOKEN",
+  "CONTROL_CENTER_PUBLIC_HOST",
+  "CONTROL_CENTER_CADDY_HTTP_PORT",
+  "CONTROL_CENTER_CADDY_HTTPS_PORT",
+  "STUB_READY",
+  "CONTROL_CENTER_APPLY_PRODUCTION",
+] as const;
+
+export const ENV_EXAMPLE_REQUIRED_NAMES: readonly string[] = REQUIRED_NAMES;
+
+export function parseEnvExample(text: string): EnvAssignment[] {
+  const out: EnvAssignment[] = [];
+  const lines = text.split(/\n/);
+  for (const [index, raw] of lines.entries()) {
+    const line = raw.trim();
+    if (line === "" || line.startsWith("#")) {
+      continue;
+    }
+    const eq = line.indexOf("=");
+    if (eq <= 0) {
+      failClosed(`invalid .env.example line ${index + 1}`);
+    }
+    const name = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1);
+    const hash = value.indexOf(" #");
+    if (hash >= 0) {
+      value = value.slice(0, hash);
+    }
+    value = value.trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out.push({ name, value, line: index + 1 });
+  }
+  return out;
+}
+
+export function looksLikeSecret(value: string): boolean {
+  const v = value.trim();
+  if (v.length === 0) {
+    return false;
+  }
+  if (/^postgres:\/\//i.test(v)) {
+    return /:([^:@/]+)@/.test(v);
+  }
+  if (/^[0-9]+$/.test(v)) {
+    return false;
+  }
+  if (/^(true|false)$/i.test(v)) {
+    return false;
+  }
+  if (v.startsWith("eyJ")) {
+    return true;
+  }
+  if (/^[0-9a-f]{32,}$/i.test(v)) {
+    return true;
+  }
+  if (/^[A-Za-z0-9+/]{40,}={0,2}$/.test(v) && /[A-Z]/.test(v) && /[a-z]/.test(v) && /\d/.test(v)) {
+    return true;
+  }
+  if (v.length >= 24 && /[A-Za-z]/.test(v) && /\d/.test(v) && !/[./:_-]/.test(v)) {
+    return true;
+  }
+  return false;
+}
+
+export function assertEnvExampleSafe(text: string): EnvAssignment[] {
+  const assignments = parseEnvExample(text);
+  const names = new Set(assignments.map((a) => a.name));
+  for (const required of REQUIRED_NAMES) {
+    if (!names.has(required)) {
+      failClosed(`.env.example missing ${required}`);
+    }
+  }
+  for (const row of assignments) {
+    if (looksLikeSecret(row.value)) {
+      failClosed(`.env.example line ${row.line} looks like a live secret (${row.name})`);
+    }
+  }
+  const apply = assignments.find((a) => a.name === "CONTROL_CENTER_APPLY_PRODUCTION");
+  if (apply && apply.value !== "false" && apply.value !== "0") {
+    failClosed("CONTROL_CENTER_APPLY_PRODUCTION must be false in .env.example");
+  }
+  const project = assignments.find((a) => a.name === "COMPOSE_PROJECT_NAME");
+  if (project && project.value !== "confenge-control-center") {
+    failClosed("COMPOSE_PROJECT_NAME must be confenge-control-center");
+  }
+  return assignments;
+}

--- a/control-center/deploy/src/fail-closed.ts
+++ b/control-center/deploy/src/fail-closed.ts
@@ -1,0 +1,16 @@
+export class FailClosedError extends Error {
+  readonly code = "fail_closed";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "FailClosedError";
+  }
+}
+
+export function failClosed(message: string): never {
+  throw new FailClosedError(message);
+}
+
+export function isFailClosed(err: unknown): err is FailClosedError {
+  return err instanceof FailClosedError;
+}

--- a/control-center/deploy/src/index.ts
+++ b/control-center/deploy/src/index.ts
@@ -1,0 +1,12 @@
+export { parseBackupKey, encryptDump, decryptDump, writeEncryptedBackup, verifyEncryptedBackup, restoreEncryptedBackup } from "./backup.ts";
+export { parseCaddyfile, loadCaddy, assertCaddyHook } from "./caddy.ts";
+export { loadCompose, parseComposeText, inspectCompose } from "./compose.ts";
+export { assertDiskSpace, parseMinBytes } from "./disk-guard.ts";
+export { assertEnvExampleSafe, parseEnvExample } from "./env-file.ts";
+export { FailClosedError, failClosed } from "./fail-closed.ts";
+export { createLogger } from "./log.ts";
+export { runBackupPipeline, runRestorePipeline } from "./pipeline.ts";
+export { planRetention, pruneBackupDir } from "./retention.ts";
+export { runRestoreDrill } from "./restore-drill.ts";
+export { createStubListener, startStubServer, configFromEnv } from "./stub-server.ts";
+export { validatePack, formatValidateReport } from "./validate.ts";

--- a/control-center/deploy/src/k8s.ts
+++ b/control-center/deploy/src/k8s.ts
@@ -1,0 +1,73 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { failClosed } from "./fail-closed.ts";
+import { PACK_ROOT } from "./paths.ts";
+
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "backups", "coverage"]);
+
+const WORKLOAD_KIND =
+  /kind:\s*(Deployment|StatefulSet|DaemonSet|ReplicaSet|Job|CronJob|Pod|Service|Ingress|HelmChart)\b/;
+
+export function isKubernetesWorkload(text: string): boolean {
+  return /apiVersion:\s*\S+/.test(text) && WORKLOAD_KIND.test(text);
+}
+
+export function walkPackFiles(root = PACK_ROOT): string[] {
+  const out: string[] = [];
+  const visit = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      if (SKIP_DIRS.has(name)) {
+        continue;
+      }
+      const full = join(dir, name);
+      const st = statSync(full);
+      if (st.isDirectory()) {
+        visit(full);
+        continue;
+      }
+      out.push(full);
+    }
+  };
+  visit(root);
+  return out;
+}
+
+export function findKubernetesManifests(root = PACK_ROOT): string[] {
+  const hits: string[] = [];
+  for (const file of walkPackFiles(root)) {
+    if (!/\.(ya?ml|json)$/i.test(file)) {
+      continue;
+    }
+    const text = readFileSync(file, "utf8");
+    if (isKubernetesWorkload(text)) {
+      hits.push(file);
+    }
+  }
+  return hits;
+}
+
+export function assertNoKubernetes(root = PACK_ROOT): void {
+  const hits = findKubernetesManifests(root);
+  if (hits.length > 0) {
+    failClosed(`kubernetes workload manifests are forbidden: ${hits.join(", ")}`);
+  }
+}
+
+export function assertNoProductionApplyScripts(root = PACK_ROOT): void {
+  const forbidden = [
+    /kubectl\s+apply/,
+    /helm\s+upgrade/,
+    /ssh\s+[^\n]*netcup/i,
+  ];
+  for (const file of walkPackFiles(root)) {
+    if (!/\.(sh|ts|yml|yaml|md)$/i.test(file)) {
+      continue;
+    }
+    const text = readFileSync(file, "utf8");
+    for (const re of forbidden) {
+      if (re.test(text) && !/must not|do not|forbidden|never/i.test(text)) {
+        failClosed(`production-apply marker in ${file}`);
+      }
+    }
+  }
+}

--- a/control-center/deploy/src/log.ts
+++ b/control-center/deploy/src/log.ts
@@ -1,0 +1,70 @@
+export type LogLevel = "info" | "warn" | "error";
+
+export type LogScalar = string | number | boolean | null;
+
+export interface Logger {
+  info(msg: string, fields?: Record<string, LogScalar>): void;
+  warn(msg: string, fields?: Record<string, LogScalar>): void;
+  error(msg: string, fields?: Record<string, LogScalar>): void;
+}
+
+const SECRET_KEY =
+  /pass(word)?|secret|token|authorization|cookie|database_url|dsn|private[_-]?key|api[_-]?key|backup_key/i;
+
+export function assertSafeLogFields(
+  fields: Record<string, LogScalar> | undefined,
+): void {
+  if (!fields) {
+    return;
+  }
+  for (const key of Object.keys(fields)) {
+    if (SECRET_KEY.test(key)) {
+      throw new Error("refusing to log a secret-bearing field name");
+    }
+  }
+}
+
+export function createLogger(
+  service = "control-center-deploy",
+  write?: (line: string, level: LogLevel) => void,
+): Logger {
+  const emit = (
+    level: LogLevel,
+    msg: string,
+    fields?: Record<string, LogScalar>,
+  ): void => {
+    assertSafeLogFields(fields);
+    const rec: Record<string, LogScalar> = {
+      level,
+      msg,
+      service,
+      ts: new Date().toISOString(),
+    };
+    if (fields) {
+      for (const [k, v] of Object.entries(fields)) {
+        rec[k] = v;
+      }
+    }
+    const line = JSON.stringify(rec);
+    if (write) {
+      write(line, level);
+      return;
+    }
+    if (level === "error") {
+      process.stderr.write(`${line}\n`);
+    } else {
+      process.stdout.write(`${line}\n`);
+    }
+  };
+  return {
+    info: (msg, fields) => emit("info", msg, fields),
+    warn: (msg, fields) => emit("warn", msg, fields),
+    error: (msg, fields) => emit("error", msg, fields),
+  };
+}
+
+export const silentLogger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+};

--- a/control-center/deploy/src/paths.ts
+++ b/control-center/deploy/src/paths.ts
@@ -1,0 +1,11 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const SRC_DIR = dirname(fileURLToPath(import.meta.url));
+export const PACK_ROOT = dirname(SRC_DIR);
+
+export const COMPOSE_FILE = join(PACK_ROOT, "docker-compose.yml");
+export const CADDY_FILE = join(PACK_ROOT, "Caddyfile");
+export const ENV_EXAMPLE = join(PACK_ROOT, ".env.example");
+export const FIXTURE_DUMP = join(PACK_ROOT, "fixtures", "postgres.dump.sql");
+export const LOGROTATE_FILE = join(PACK_ROOT, "docker", "logrotate.control-center.conf");

--- a/control-center/deploy/src/pipeline.ts
+++ b/control-center/deploy/src/pipeline.ts
@@ -1,0 +1,127 @@
+import { mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  parseBackupKey,
+  restoreEncryptedBackup,
+  verifyEncryptedBackup,
+  writeEncryptedBackup,
+  type BackupMeta,
+} from "./backup.ts";
+import { assertDiskSpace, parseMinBytes, type DiskStatFn } from "./disk-guard.ts";
+import { failClosed } from "./fail-closed.ts";
+import { parseRetainDays, parseRetainMin, pruneBackupDir } from "./retention.ts";
+
+export interface BackupPipelineResult {
+  encPath: string;
+  metaPath: string;
+  meta: BackupMeta;
+  restoredEqualsPlaintext: true;
+  ciphertextDiffers: true;
+  kept: string[];
+  dropped: string[];
+}
+
+export function runBackupPipeline(opts: {
+  plaintext: Buffer;
+  keyRaw: string | undefined;
+  outDir: string;
+  observedAt: string;
+  diskPath?: string;
+  minBytesRaw?: string;
+  retainDaysRaw?: string;
+  retainMinRaw?: string;
+  now?: Date;
+  statFn?: DiskStatFn;
+  source?: string;
+}): BackupPipelineResult {
+  const key = parseBackupKey(opts.keyRaw);
+  mkdirSync(opts.outDir, { recursive: true });
+  assertDiskSpace({
+    path: opts.diskPath ?? opts.outDir,
+    minBytes: parseMinBytes(opts.minBytesRaw),
+    ...(opts.statFn ? { statFn: opts.statFn } : {}),
+  });
+  const written = writeEncryptedBackup({
+    plaintext: opts.plaintext,
+    key,
+    outDir: opts.outDir,
+    observedAt: opts.observedAt,
+    ...(opts.source ? { source: opts.source } : {}),
+  });
+  const verified = verifyEncryptedBackup(written.encPath, key);
+  if (!verified.equals(opts.plaintext)) {
+    failClosed("verified backup does not match source dump");
+  }
+  if (written.ciphertext.equals(opts.plaintext)) {
+    failClosed("ciphertext equals plaintext");
+  }
+  const pruned = pruneBackupDir(
+    opts.outDir,
+    opts.now ?? new Date(opts.observedAt),
+    parseRetainDays(opts.retainDaysRaw),
+    parseRetainMin(opts.retainMinRaw),
+  );
+  return {
+    encPath: written.encPath,
+    metaPath: written.metaPath,
+    meta: written.meta,
+    restoredEqualsPlaintext: true,
+    ciphertextDiffers: true,
+    kept: pruned.kept,
+    dropped: pruned.dropped,
+  };
+}
+
+export function runRestorePipeline(opts: {
+  encPath: string;
+  keyRaw: string | undefined;
+  outFile: string;
+  diskPath: string;
+  minBytesRaw?: string;
+  statFn?: DiskStatFn;
+}): Buffer {
+  parseBackupKey(opts.keyRaw);
+  assertDiskSpace({
+    path: opts.diskPath,
+    minBytes: parseMinBytes(opts.minBytesRaw),
+    ...(opts.statFn ? { statFn: opts.statFn } : {}),
+  });
+  return restoreEncryptedBackup(opts.encPath, parseBackupKey(opts.keyRaw), opts.outFile);
+}
+
+export function backupFixtureDump(fixturePath: string, opts: {
+  keyRaw: string | undefined;
+  outDir: string;
+  observedAt: string;
+  diskPath?: string;
+  minBytesRaw?: string;
+  retainDaysRaw?: string;
+  retainMinRaw?: string;
+  now?: Date;
+  statFn?: DiskStatFn;
+}): BackupPipelineResult {
+  const plaintext = readFileSync(fixturePath);
+  return runBackupPipeline({
+    plaintext,
+    keyRaw: opts.keyRaw,
+    outDir: opts.outDir,
+    observedAt: opts.observedAt,
+    source: "control-center.deploy.fixture",
+    ...(opts.diskPath ? { diskPath: opts.diskPath } : {}),
+    ...(opts.minBytesRaw ? { minBytesRaw: opts.minBytesRaw } : {}),
+    ...(opts.retainDaysRaw ? { retainDaysRaw: opts.retainDaysRaw } : {}),
+    ...(opts.retainMinRaw ? { retainMinRaw: opts.retainMinRaw } : {}),
+    ...(opts.now ? { now: opts.now } : {}),
+    ...(opts.statFn ? { statFn: opts.statFn } : {}),
+  });
+}
+
+export function restoreTo(outDir: string, encPath: string, keyRaw: string | undefined, name: string): Buffer {
+  const outFile = join(outDir, name);
+  return runRestorePipeline({
+    encPath,
+    keyRaw,
+    outFile,
+    diskPath: outDir,
+  });
+}

--- a/control-center/deploy/src/restore-drill.ts
+++ b/control-center/deploy/src/restore-drill.ts
@@ -1,0 +1,95 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { failClosed } from "./fail-closed.ts";
+import { FIXTURE_DUMP } from "./paths.ts";
+import { backupFixtureDump, restoreTo } from "./pipeline.ts";
+
+export interface DrillRun {
+  encPath: string;
+  restoredPath: string;
+  restored: Buffer;
+  sha256: string;
+}
+
+export interface DrillResult {
+  fixturePath: string;
+  fixtureBytes: number;
+  run1: DrillRun;
+  run2: DrillRun;
+  sameContent: true;
+}
+
+function isoZ(d: Date): string {
+  return d.toISOString();
+}
+
+export function runRestoreDrill(opts: {
+  fixturePath?: string;
+  outDir: string;
+  keyRaw: string | undefined;
+  now?: Date;
+}): DrillResult {
+  const fixturePath = opts.fixturePath ?? FIXTURE_DUMP;
+  const fixture = readFileSync(fixturePath);
+  if (fixture.length === 0) {
+    failClosed("fixture dump is empty");
+  }
+  mkdirSync(opts.outDir, { recursive: true });
+  const baseNow = opts.now ?? new Date();
+  const runs: DrillRun[] = [];
+  for (const [index, offsetMs] of [0, 1000].entries()) {
+    const runDir = join(opts.outDir, `run-${index + 1}`);
+    mkdirSync(runDir, { recursive: true });
+    const observedAt = isoZ(new Date(baseNow.getTime() + offsetMs));
+    const backup = backupFixtureDump(fixturePath, {
+      keyRaw: opts.keyRaw,
+      outDir: join(runDir, "backups"),
+      observedAt,
+      diskPath: runDir,
+      minBytesRaw: "1",
+      retainDaysRaw: "14",
+      retainMinRaw: "3",
+    });
+    const restored = restoreTo(runDir, backup.encPath, opts.keyRaw, "restored.dump.sql");
+    if (!restored.equals(fixture)) {
+      failClosed(`restore drill run ${index + 1} does not match fixture`);
+    }
+    if (readFileSync(backup.encPath).equals(fixture)) {
+      failClosed("restore drill wrote unencrypted archive");
+    }
+    writeFileSync(
+      join(runDir, "drill.meta.json"),
+      `${JSON.stringify(
+        {
+          source: "control-center.deploy.restore-drill",
+          observed_at: observedAt,
+          freshness_status: "fresh",
+          encPath: backup.encPath,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    runs.push({
+      encPath: backup.encPath,
+      restoredPath: join(runDir, "restored.dump.sql"),
+      restored,
+      sha256: backup.meta.sha256_plaintext,
+    });
+  }
+  const run1 = runs[0];
+  const run2 = runs[1];
+  if (!run1 || !run2) {
+    failClosed("restore drill did not produce two runs");
+  }
+  if (!run1.restored.equals(run2.restored)) {
+    failClosed("restore drill runs restored different bytes");
+  }
+  return {
+    fixturePath,
+    fixtureBytes: fixture.length,
+    run1,
+    run2,
+    sameContent: true,
+  };
+}

--- a/control-center/deploy/src/retention.ts
+++ b/control-center/deploy/src/retention.ts
@@ -1,0 +1,97 @@
+import { readdirSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { parseBackupMeta } from "./backup.ts";
+import { failClosed } from "./fail-closed.ts";
+
+export interface RetentionEntry {
+  encPath: string;
+  metaPath: string;
+  observedAt: Date;
+}
+
+export interface RetentionPlan {
+  keep: RetentionEntry[];
+  drop: RetentionEntry[];
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function parseRetainDays(raw: string | undefined, fallback = 14): number {
+  const n = raw === undefined || raw.trim() === "" ? fallback : Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    failClosed("CONTROL_CENTER_BACKUP_RETAIN_DAYS must be an integer >= 1");
+  }
+  return n;
+}
+
+export function parseRetainMin(raw: string | undefined, fallback = 3): number {
+  const n = raw === undefined || raw.trim() === "" ? fallback : Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    failClosed("CONTROL_CENTER_BACKUP_RETAIN_MIN must be an integer >= 1");
+  }
+  return n;
+}
+
+export function planRetention(
+  entries: RetentionEntry[],
+  now: Date,
+  retainDays: number,
+  retainMin: number,
+): RetentionPlan {
+  if (retainDays < 1 || retainMin < 1) {
+    failClosed("retention retainDays and retainMin must be >= 1");
+  }
+  const sorted = [...entries].sort(
+    (a, b) => b.observedAt.getTime() - a.observedAt.getTime(),
+  );
+  const cutoff = now.getTime() - retainDays * MS_PER_DAY;
+  const keep = new Set<RetentionEntry>();
+  for (const [index, entry] of sorted.entries()) {
+    if (index < retainMin || entry.observedAt.getTime() >= cutoff) {
+      keep.add(entry);
+    }
+  }
+  return {
+    keep: sorted.filter((e) => keep.has(e)),
+    drop: sorted.filter((e) => !keep.has(e)),
+  };
+}
+
+export function listBackupEntries(dir: string): RetentionEntry[] {
+  const names = readdirSync(dir);
+  const entries: RetentionEntry[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".dump.enc")) {
+      continue;
+    }
+    const encPath = join(dir, name);
+    const metaPath = `${encPath}.meta.json`;
+    if (!names.includes(`${name}.meta.json`)) {
+      failClosed(`backup missing meta sidecar: ${name}`);
+    }
+    const meta = parseBackupMeta(readFileSync(metaPath, "utf8"));
+    const observedAt = new Date(meta.observed_at);
+    if (Number.isNaN(observedAt.getTime())) {
+      failClosed(`backup meta observed_at is not a date: ${name}`);
+    }
+    entries.push({ encPath, metaPath, observedAt });
+  }
+  return entries;
+}
+
+export function pruneBackupDir(
+  dir: string,
+  now: Date,
+  retainDays: number,
+  retainMin: number,
+): { kept: string[]; dropped: string[] } {
+  const plan = planRetention(listBackupEntries(dir), now, retainDays, retainMin);
+  for (const entry of plan.drop) {
+    unlinkSync(entry.encPath);
+    unlinkSync(entry.metaPath);
+  }
+  return {
+    kept: plan.keep.map((e) => e.encPath),
+    dropped: plan.drop.map((e) => e.encPath),
+  };
+}

--- a/control-center/deploy/src/stub-health-server.ts
+++ b/control-center/deploy/src/stub-health-server.ts
@@ -1,0 +1,10 @@
+import { configFromEnv, startStubServer } from "./stub-server.ts";
+
+const server = startStubServer(configFromEnv(process.env));
+
+function shutdown(): void {
+  server.close(() => process.exit(0));
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/control-center/deploy/src/stub-server.ts
+++ b/control-center/deploy/src/stub-server.ts
@@ -1,0 +1,131 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { failClosed } from "./fail-closed.ts";
+import { createLogger, type Logger } from "./log.ts";
+
+export interface StubConfig {
+  service: string;
+  ready: boolean;
+  host: string;
+  port: number;
+  now?: () => string;
+  logger?: Logger;
+}
+
+export interface HealthBody {
+  ok: boolean;
+  live: boolean;
+  service: string;
+  source: string;
+  observed_at: string;
+  freshness_status: "fresh" | "stale";
+}
+
+export interface ReadyBody {
+  ok: boolean;
+  ready: boolean;
+  service: string;
+  source: string;
+  observed_at: string;
+  freshness_status: "fresh" | "stale";
+  reason?: string;
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.setHeader("cache-control", "no-store");
+  res.setHeader("content-length", Buffer.byteLength(payload).toString());
+  res.end(payload);
+}
+
+export function parseReadyFlag(raw: string | undefined): boolean {
+  if (raw === undefined || raw.trim() === "") {
+    return true;
+  }
+  const v = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(v)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(v)) {
+    return false;
+  }
+  failClosed("STUB_READY must be a boolean-like value");
+}
+
+export function configFromEnv(env: NodeJS.ProcessEnv = process.env): StubConfig {
+  const portRaw = env.PORT ?? "8080";
+  const port = Number(portRaw);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    failClosed("PORT is invalid");
+  }
+  return {
+    service: env.CONTROL_CENTER_STUB_SERVICE ?? "control-center-stub",
+    ready: parseReadyFlag(env.STUB_READY),
+    host: env.HOST ?? "127.0.0.1",
+    port,
+  };
+}
+
+export function createStubListener(config: StubConfig): (req: IncomingMessage, res: ServerResponse) => void {
+  const now = config.now ?? (() => new Date().toISOString());
+  const source = `control-center.deploy.stub.${config.service}`;
+  return (req, res) => {
+    const host = req.headers.host ?? "127.0.0.1";
+    const url = new URL(req.url ?? "/", `http://${host}`);
+    const method = req.method ?? "GET";
+    const observed_at = now();
+    if (method === "GET" && url.pathname === "/healthz") {
+      const body: HealthBody = {
+        ok: true,
+        live: true,
+        service: config.service,
+        source,
+        observed_at,
+        freshness_status: "fresh",
+      };
+      json(res, 200, body);
+      return;
+    }
+    if (method === "GET" && url.pathname === "/ready") {
+      if (config.ready) {
+        const body: ReadyBody = {
+          ok: true,
+          ready: true,
+          service: config.service,
+          source,
+          observed_at,
+          freshness_status: "fresh",
+        };
+        json(res, 200, body);
+        return;
+      }
+      const body: ReadyBody = {
+        ok: false,
+        ready: false,
+        service: config.service,
+        source,
+        observed_at,
+        freshness_status: "stale",
+        reason: "stub_not_ready",
+      };
+      json(res, 503, body);
+      return;
+    }
+    json(res, 404, { error: "not_found", service: config.service });
+  };
+}
+
+export function startStubServer(config: StubConfig): Server {
+  const logger = config.logger ?? createLogger(`control-center-stub-${config.service}`);
+  const server = createServer(createStubListener(config));
+  server.listen(config.port, config.host, () => {
+    logger.info("stub.listen", {
+      service: config.service,
+      host: config.host,
+      port: config.port,
+      ready: config.ready,
+    });
+  });
+  return server;
+}

--- a/control-center/deploy/src/validate.ts
+++ b/control-center/deploy/src/validate.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from "node:fs";
+import { assertCaddyHook, loadCaddy } from "./caddy.ts";
+import {
+  defaultPublishedPort,
+  hasLogRotation,
+  hasResourceLimits,
+  healthcheckText,
+  inspectCompose,
+  loadCompose,
+  parsePort,
+  requireService,
+} from "./compose.ts";
+import { assertEnvExampleSafe } from "./env-file.ts";
+import { failClosed } from "./fail-closed.ts";
+import { assertNoKubernetes, assertNoProductionApplyScripts } from "./k8s.ts";
+import { CADDY_FILE, COMPOSE_FILE, ENV_EXAMPLE, PACK_ROOT } from "./paths.ts";
+
+export interface ValidateReport {
+  ok: true;
+  project: string;
+  postgres_volume: string;
+  caddy_hook: string;
+  backup: string;
+  restore: string;
+  retention: string;
+  disk_guard: string;
+  kubernetes: "absent";
+  production_apply: "refused";
+  services: string[];
+  summary: string;
+}
+
+const STUB_SERVICES = ["context", "mcp", "web-shell"] as const;
+const ALWAYS_ON = ["postgres", "context", "mcp", "web-shell", "caddy"] as const;
+
+function truthy(raw: string | undefined): boolean {
+  if (raw === undefined) {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
+}
+
+export function assertNoHostPrivilegedPorts(doc: ReturnType<typeof loadCompose>["doc"]): void {
+  for (const [name, svc] of Object.entries(doc.services ?? {})) {
+    for (const entry of svc.ports ?? []) {
+      const port = parsePort(entry);
+      if (!port) {
+        continue;
+      }
+      if (port.host_ip && port.host_ip !== "127.0.0.1") {
+        failClosed(`service ${name} publishes on ${port.host_ip}; loopback only this wave`);
+      }
+      const published = defaultPublishedPort(port.published);
+      if (published === 80 || published === 443) {
+        failClosed(`service ${name} publishes host port ${published}; Warmbly nginx owns 80/443`);
+      }
+      const target = typeof port.target === "number" ? port.target : Number(port.target);
+      if (target === 80 || target === 443) {
+        failClosed(`service ${name} container port ${target} would steal 80/443`);
+      }
+    }
+  }
+}
+
+export function assertComposeInvariants(doc: ReturnType<typeof loadCompose>["doc"]): ReturnType<typeof inspectCompose> {
+  const inspected = inspectCompose(doc);
+  for (const name of ALWAYS_ON) {
+    const svc = requireService(doc, name);
+    if (svc.restart !== "unless-stopped") {
+      failClosed(`service ${name} must restart unless-stopped`);
+    }
+    if (!hasResourceLimits(svc)) {
+      failClosed(`service ${name} must declare CPU and memory limits`);
+    }
+    if (!hasLogRotation(svc)) {
+      failClosed(`service ${name} must use json-file log rotation`);
+    }
+    const hc = healthcheckText(svc);
+    if (hc.length === 0) {
+      failClosed(`service ${name} missing healthcheck`);
+    }
+  }
+  const pg = healthcheckText(requireService(doc, "postgres"));
+  if (!pg.includes("pg_isready")) {
+    failClosed("postgres healthcheck must use pg_isready");
+  }
+  for (const name of STUB_SERVICES) {
+    const hc = healthcheckText(requireService(doc, name));
+    if (!hc.includes("/healthz") || !hc.includes("/ready")) {
+      failClosed(`service ${name} healthcheck must probe /healthz and /ready`);
+    }
+  }
+  const caddyHc = healthcheckText(requireService(doc, "caddy"));
+  if (!caddyHc.includes("/healthz") || !caddyHc.includes("/ready")) {
+    failClosed("caddy healthcheck must probe /healthz and /ready");
+  }
+  requireService(doc, "backup-ops");
+  assertNoHostPrivilegedPorts(doc);
+  return inspected;
+}
+
+export function validatePack(env: NodeJS.ProcessEnv = process.env): ValidateReport {
+  if (truthy(env.CONTROL_CENTER_APPLY_PRODUCTION)) {
+    failClosed("CONTROL_CENTER_APPLY_PRODUCTION is set; this pack refuses to apply to production");
+  }
+  const { doc } = loadCompose(COMPOSE_FILE);
+  const inspected = assertComposeInvariants(doc);
+  const { hook } = loadCaddy(CADDY_FILE);
+  assertCaddyHook(hook);
+  assertEnvExampleSafe(readFileSync(ENV_EXAMPLE, "utf8"));
+  assertNoKubernetes(PACK_ROOT);
+  assertNoProductionApplyScripts(PACK_ROOT);
+  const summary =
+    `Control Center deploy pack: project=${inspected.project} ` +
+    `postgres_volume=${inspected.postgresVolume} ` +
+    `caddy_hook=reverse_proxy ` +
+    `backup=encrypted-aes-256-gcm ` +
+    `restore=fixture-drill ` +
+    `retention=age-and-min-count ` +
+    `disk_guard=fail-closed ` +
+    `kubernetes=absent ` +
+    `production_apply=refused`;
+  return {
+    ok: true,
+    project: inspected.project,
+    postgres_volume: inspected.postgresVolume,
+    caddy_hook: "reverse_proxy",
+    backup: "encrypted-aes-256-gcm",
+    restore: "fixture-drill",
+    retention: "age-and-min-count",
+    disk_guard: "fail-closed",
+    kubernetes: "absent",
+    production_apply: "refused",
+    services: inspected.services,
+    summary,
+  };
+}
+
+export function formatValidateReport(report: ValidateReport): string {
+  const { summary, ...rest } = report;
+  return `${JSON.stringify(rest, null, 2)}\n${summary}\n`;
+}

--- a/control-center/deploy/tests/backup.test.ts
+++ b/control-center/deploy/tests/backup.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  decryptDump,
+  encryptDump,
+  parseBackupKey,
+  restoreEncryptedBackup,
+  verifyEncryptedBackup,
+  writeEncryptedBackup,
+} from "../src/backup.ts";
+import { FailClosedError } from "../src/fail-closed.ts";
+import { FIXTURE_DUMP } from "../src/paths.ts";
+import { runBackupPipeline } from "../src/pipeline.ts";
+import { tempDir, testKey } from "./helpers.ts";
+
+test("backup encrypt/verify/restore round-trip drives shipped functions on the fixture dump", () => {
+  const fixture = readFileSync(FIXTURE_DUMP);
+  assert.ok(fixture.includes("CC_FIXTURE_SENTINEL_9f3c2a7b1e44"));
+  const key = parseBackupKey(testKey());
+  const ciphertext = encryptDump(fixture, key);
+  assert.notEqual(ciphertext.equals(fixture), true);
+  assert.equal(ciphertext.includes(Buffer.from("CC_FIXTURE_SENTINEL_9f3c2a7b1e44")), false);
+  const plain = decryptDump(ciphertext, key);
+  assert.equal(Buffer.compare(plain, fixture), 0);
+
+  const outDir = tempDir("cc-backup-");
+  const written = writeEncryptedBackup({
+    plaintext: fixture,
+    key,
+    outDir,
+    observedAt: "2026-08-20T06:00:00Z",
+    source: "control-center.deploy.fixture",
+  });
+  assert.equal(written.meta.source, "control-center.deploy.fixture");
+  assert.equal(written.meta.observed_at, "2026-08-20T06:00:00Z");
+  assert.equal(written.meta.freshness_status, "fresh");
+  assert.equal(written.meta.confidence, 1);
+  const onDisk = readFileSync(written.encPath);
+  assert.notEqual(Buffer.compare(onDisk, fixture), 0);
+  const verified = verifyEncryptedBackup(written.encPath, key);
+  assert.equal(Buffer.compare(verified, fixture), 0);
+  const restoredPath = join(outDir, "restored.dump.sql");
+  const restored = restoreEncryptedBackup(written.encPath, key, restoredPath);
+  assert.equal(Buffer.compare(restored, fixture), 0);
+  assert.equal(Buffer.compare(readFileSync(restoredPath), fixture), 0);
+});
+
+test("backup pipeline fails closed without a key, on placeholders, and on unencrypted blobs", () => {
+  const fixture = readFileSync(FIXTURE_DUMP);
+  const outDir = tempDir("cc-backup-fail-");
+  assert.throws(
+    () =>
+      runBackupPipeline({
+        plaintext: fixture,
+        keyRaw: undefined,
+        outDir,
+        observedAt: "2026-08-20T06:00:00Z",
+        minBytesRaw: "1",
+      }),
+    FailClosedError,
+  );
+  assert.throws(() => parseBackupKey("change-me"), FailClosedError);
+  assert.throws(() => parseBackupKey("abcd"), FailClosedError);
+  const key = parseBackupKey(testKey());
+  assert.throws(() => decryptDump(fixture, key), FailClosedError);
+  const encPath = join(outDir, "foreign.dump.enc");
+  writeFileSync(encPath, fixture);
+  writeFileSync(
+    `${encPath}.meta.json`,
+    `${JSON.stringify({
+      schema_version: "control-center.backup.v1",
+      source: "x",
+      observed_at: "2026-08-20T06:00:00Z",
+      freshness_status: "fresh",
+      confidence: 1,
+      algorithm: "aes-256-gcm",
+      sha256_plaintext: "00".repeat(32),
+      bytes_plaintext: fixture.length,
+      bytes_ciphertext: fixture.length,
+      filename: "foreign.dump.enc",
+    })}\n`,
+  );
+  assert.throws(() => verifyEncryptedBackup(encPath, key), FailClosedError);
+});

--- a/control-center/deploy/tests/caddy.test.ts
+++ b/control-center/deploy/tests/caddy.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { assertCaddyHook, loadCaddy } from "../src/caddy.ts";
+import { CADDY_FILE } from "../src/paths.ts";
+
+test("shipped Caddyfile reverse_proxies Control Center services and documents automatic HTTPS", () => {
+  const { text, hook } = loadCaddy(CADDY_FILE);
+  assertCaddyHook(hook);
+  const upstreams = hook.reverseProxies.map((p) => p.upstream);
+  assert.ok(upstreams.includes("context:8080"));
+  assert.ok(upstreams.includes("mcp:8080"));
+  assert.ok(upstreams.includes("web-shell:8080"));
+  const paths = hook.reverseProxies.map((p) => p.path);
+  assert.ok(paths.includes("/healthz"));
+  assert.ok(paths.includes("/ready"));
+  assert.ok(hook.documentsAutomaticHttps);
+  assert.ok(hook.usesTlsInternal);
+  assert.ok(hook.adminOff);
+  assert.ok(hook.jsonLogs);
+  assert.match(text, /reverse_proxy context:8080/);
+  assert.match(text, /reverse_proxy mcp:8080/);
+  assert.match(text, /reverse_proxy web-shell:8080/);
+  assert.match(text, /automatic HTTPS/i);
+  assert.match(text, /ACME/);
+  assert.doesNotMatch(text, /^\s*:\s*80\s*\{/m);
+  assert.doesNotMatch(text, /^\s*:\s*443\s*\{/m);
+});

--- a/control-center/deploy/tests/cli-entry.test.ts
+++ b/control-center/deploy/tests/cli-entry.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import { FIXTURE_DUMP } from "../src/paths.ts";
+import { runCli, tempDir, testKey } from "./helpers.ts";
+
+test("validate CLI entry succeeds twice and names compose, volume, caddy, backup, disk guard", () => {
+  const first = runCli(["validate"], { CONTROL_CENTER_APPLY_PRODUCTION: "false" });
+  const second = runCli(["validate"], { CONTROL_CENTER_APPLY_PRODUCTION: "false" });
+  assert.equal(first.status, 0, first.stderr);
+  assert.equal(second.status, 0, second.stderr);
+  for (const out of [first.stdout, second.stdout]) {
+    assert.match(out, /project=confenge-control-center/);
+    assert.match(out, /postgres_volume=confenge-control-center-postgres/);
+    assert.match(out, /caddy_hook=reverse_proxy/);
+    assert.match(out, /backup=encrypted-aes-256-gcm/);
+    assert.match(out, /restore=fixture-drill/);
+    assert.match(out, /retention=age-and-min-count/);
+    assert.match(out, /disk_guard=fail-closed/);
+  }
+  const blocked = runCli(["validate"], { CONTROL_CENTER_APPLY_PRODUCTION: "true" });
+  assert.notEqual(blocked.status, 0);
+  assert.match(blocked.stderr, /refuses to apply to production/);
+});
+
+test("restore-drill CLI entry restores the fixture twice with ciphertext != plaintext", () => {
+  const key = testKey();
+  const outDir = tempDir("cc-drill-");
+  const result = runCli(["restore-drill", "--out", outDir], {
+    CONTROL_CENTER_BACKUP_KEY: key,
+    CONTROL_CENTER_DISK_MIN_BYTES: "1",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /restore-drill ok/);
+  const fixture = readFileSync(FIXTURE_DUMP);
+  const run1 = readFileSync(join(outDir, "run-1", "restored.dump.sql"));
+  const run2 = readFileSync(join(outDir, "run-2", "restored.dump.sql"));
+  assert.equal(Buffer.compare(run1, fixture), 0);
+  assert.equal(Buffer.compare(run2, fixture), 0);
+  for (const run of ["run-1", "run-2"]) {
+    const backups = join(outDir, run, "backups");
+    const encName = readdirSync(backups).find((name) => name.endsWith(".dump.enc"));
+    assert.ok(encName, `${run} missing ciphertext`);
+    const enc = readFileSync(join(backups, encName));
+    assert.notEqual(Buffer.compare(enc, fixture), 0);
+    assert.equal(enc.includes(Buffer.from("CC_FIXTURE_SENTINEL_9f3c2a7b1e44")), false);
+  }
+  const drill = JSON.parse(readFileSync(join(outDir, "drill-summary.json"), "utf8")) as {
+    sameContent: boolean;
+    fixtureBytes: number;
+  };
+  assert.equal(drill.sameContent, true);
+  assert.equal(drill.fixtureBytes, fixture.length);
+});

--- a/control-center/deploy/tests/compose.test.ts
+++ b/control-center/deploy/tests/compose.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import {
+  defaultPublishedPort,
+  hasLogRotation,
+  hasResourceLimits,
+  healthcheckText,
+  inspectCompose,
+  loadCompose,
+  parsePort,
+  requireService,
+  serviceVolumeNames,
+} from "../src/compose.ts";
+import { COMPOSE_FILE, PACK_ROOT } from "../src/paths.ts";
+import { isKubernetesWorkload } from "../src/k8s.ts";
+
+test("shipped compose names the Control Center project, postgres volume, health+readiness, restart, limits, log rotation", () => {
+  const { text, doc } = loadCompose(COMPOSE_FILE);
+  const inspected = inspectCompose(doc);
+  assert.equal(inspected.project, "confenge-control-center");
+  assert.equal(inspected.postgresVolume, "confenge-control-center-postgres");
+  assert.ok(inspected.services.includes("postgres"));
+  assert.ok(inspected.services.includes("context"));
+  assert.ok(inspected.services.includes("mcp"));
+  assert.ok(inspected.services.includes("web-shell"));
+  assert.ok(inspected.services.includes("caddy"));
+  assert.ok(inspected.services.includes("backup-ops"));
+
+  const postgres = requireService(doc, "postgres");
+  assert.equal(postgres.restart, "unless-stopped");
+  assert.ok(hasResourceLimits(postgres));
+  assert.ok(hasLogRotation(postgres));
+  assert.ok(serviceVolumeNames(postgres).includes("cc_postgres_data"));
+  assert.ok(healthcheckText(postgres).includes("pg_isready"));
+  assert.equal(postgres.build?.dockerfile, "docker/postgres.Dockerfile");
+
+  for (const name of ["context", "mcp", "web-shell"] as const) {
+    const svc = requireService(doc, name);
+    assert.equal(svc.restart, "unless-stopped");
+    assert.ok(hasResourceLimits(svc));
+    assert.ok(hasLogRotation(svc));
+    const hc = healthcheckText(svc);
+    assert.ok(hc.includes("/healthz"), `${name} healthcheck must include /healthz`);
+    assert.ok(hc.includes("/ready"), `${name} healthcheck must include /ready`);
+    assert.equal(svc.build?.dockerfile, "docker/stub.Dockerfile");
+  }
+
+  const caddy = requireService(doc, "caddy");
+  assert.equal(caddy.restart, "unless-stopped");
+  assert.ok(hasResourceLimits(caddy));
+  assert.ok(hasLogRotation(caddy));
+  const caddyHc = healthcheckText(caddy);
+  assert.ok(caddyHc.includes("/healthz"));
+  assert.ok(caddyHc.includes("/ready"));
+  assert.equal(caddy.build?.dockerfile, "docker/caddy.Dockerfile");
+
+  for (const entry of caddy.ports ?? []) {
+    const port = parsePort(entry);
+    assert.ok(port);
+    assert.equal(port.host_ip, "127.0.0.1");
+    const published = defaultPublishedPort(port.published);
+    assert.ok(published !== 80 && published !== 443);
+    const target = typeof port.target === "number" ? port.target : Number(port.target);
+    assert.ok(target !== 80 && target !== 443);
+  }
+
+  assert.equal(isKubernetesWorkload(text), false);
+  assert.doesNotMatch(text, /apiVersion:\s/);
+  assert.match(text, /json-file/);
+  assert.match(text, /max-size/);
+  assert.equal(COMPOSE_FILE.startsWith(PACK_ROOT), true);
+  assert.ok(readFileSync(COMPOSE_FILE, "utf8").includes("confenge-control-center-postgres"));
+});

--- a/control-center/deploy/tests/disk-guard.test.ts
+++ b/control-center/deploy/tests/disk-guard.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { assertDiskSpace } from "../src/disk-guard.ts";
+import { FailClosedError } from "../src/fail-closed.ts";
+import { tempDir } from "./helpers.ts";
+
+test("disk guard fails closed on injected low free space and succeeds when space is present", () => {
+  const dir = tempDir("cc-disk-");
+  assert.throws(
+    () =>
+      assertDiskSpace({
+        path: dir,
+        minBytes: 1_073_741_824,
+        statFn: () => ({ bavail: 0, bsize: 4096 }),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof FailClosedError);
+      assert.match(err.message, /insufficient disk/);
+      return true;
+    },
+  );
+  assert.throws(
+    () =>
+      assertDiskSpace({
+        path: joinMissing(),
+        minBytes: 1,
+      }),
+    FailClosedError,
+  );
+  const ok = assertDiskSpace({
+    path: dir,
+    minBytes: 1,
+    statFn: () => ({ bavail: 1024, bsize: 4096 }),
+  });
+  assert.equal(ok.ok, true);
+  assert.equal(ok.freeBytes, 1024 * 4096);
+  assert.equal(ok.path, dir);
+});
+
+function joinMissing(): string {
+  return `${tempDir("cc-disk-missing-")}-does-not-exist`;
+}

--- a/control-center/deploy/tests/docs.test.ts
+++ b/control-center/deploy/tests/docs.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import { PACK_ROOT } from "../src/paths.ts";
+
+test("README and runbook document decisions, run, env, rollback, restore, and later wiring", () => {
+  const readme = readFileSync(join(PACK_ROOT, "README.md"), "utf8");
+  assert.match(readme, /## Decisions/);
+  assert.match(readme, /## Run/);
+  assert.match(readme, /## Environment/);
+  assert.match(readme, /control-center\/persistence/);
+  assert.match(readme, /control-center\/services\/context/);
+  assert.match(readme, /control-center\/services\/mcp/);
+  assert.match(readme, /control-center\/apps\/web-shell/);
+  assert.match(readme, /CONTROL_CENTER_BACKUP_KEY/);
+  assert.match(readme, /CONTROL_CENTER_DATABASE_URL/);
+  assert.match(readme, /Warmbly/);
+  assert.match(readme, /does \*\*not\*\* apply itself to production/);
+
+  const runbook = readFileSync(join(PACK_ROOT, "RUNBOOK.md"), "utf8");
+  assert.match(runbook, /## Deploy/);
+  assert.match(runbook, /## Rollback/);
+  assert.match(runbook, /## Restore/);
+  assert.match(runbook, /## Backup/);
+  assert.match(runbook, /America\/Sao_Paulo/);
+  assert.match(runbook, /confenge-control-center-postgres/);
+  assert.match(runbook, /disk-guard/);
+  assert.match(runbook, /tls internal/);
+});

--- a/control-center/deploy/tests/env.test.ts
+++ b/control-center/deploy/tests/env.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import {
+  ENV_EXAMPLE_REQUIRED_NAMES,
+  assertEnvExampleSafe,
+  looksLikeSecret,
+} from "../src/env-file.ts";
+import { ENV_EXAMPLE } from "../src/paths.ts";
+
+test("shipped .env.example has required names and no high-entropy secrets", () => {
+  const text = readFileSync(ENV_EXAMPLE, "utf8");
+  const rows = assertEnvExampleSafe(text);
+  const names = new Set(rows.map((r) => r.name));
+  for (const required of ENV_EXAMPLE_REQUIRED_NAMES) {
+    assert.ok(names.has(required), `missing ${required}`);
+  }
+  const secrets = ["POSTGRES_PASSWORD", "CONTROL_CENTER_BACKUP_KEY", "CONFENGE_MCP_AUTH_TOKEN"];
+  for (const name of secrets) {
+    const row = rows.find((r) => r.name === name);
+    assert.ok(row);
+    assert.equal(row.value, "");
+    assert.equal(looksLikeSecret(row.value), false);
+  }
+  const url = rows.find((r) => r.name === "CONTROL_CENTER_DATABASE_URL");
+  assert.ok(url);
+  assert.doesNotMatch(url.value, /:[^:@/]+@/);
+  const apply = rows.find((r) => r.name === "CONTROL_CENTER_APPLY_PRODUCTION");
+  assert.equal(apply?.value, "false");
+  assert.equal(looksLikeSecret("cc.internal.confenge.local"), false);
+  assert.equal(looksLikeSecret("0123456789abcdef0123456789abcdef"), true);
+  assert.equal(looksLikeSecret("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc"), true);
+  assert.doesNotMatch(text, /sk_live|sk_test/);
+});

--- a/control-center/deploy/tests/helpers.ts
+++ b/control-center/deploy/tests/helpers.ts
@@ -1,0 +1,25 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { PACK_ROOT } from "../src/paths.ts";
+
+export function runCli(
+  args: string[],
+  env: NodeJS.ProcessEnv = {},
+): SpawnSyncReturns<string> {
+  return spawnSync("npx", ["tsx", "src/cli.ts", ...args], {
+    cwd: PACK_ROOT,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+export function tempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+export function testKey(): string {
+  return randomBytes(32).toString("hex");
+}

--- a/control-center/deploy/tests/k8s.test.ts
+++ b/control-center/deploy/tests/k8s.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { findKubernetesManifests, isKubernetesWorkload } from "../src/k8s.ts";
+import { PACK_ROOT } from "../src/paths.ts";
+
+test("deploy pack contains no Kubernetes workload manifests", () => {
+  assert.equal(findKubernetesManifests(PACK_ROOT).length, 0);
+  assert.equal(
+    isKubernetesWorkload("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: x\n"),
+    true,
+  );
+  assert.equal(isKubernetesWorkload("name: confenge-control-center\nservices:\n  postgres: {}\n"), false);
+});

--- a/control-center/deploy/tests/log.test.ts
+++ b/control-center/deploy/tests/log.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { assertSafeLogFields, createLogger } from "../src/log.ts";
+
+test("structured logger writes JSON UTC records and refuses secret field names", () => {
+  const lines: string[] = [];
+  const logger = createLogger("control-center-deploy", (line) => {
+    lines.push(line);
+  });
+  logger.info("backup.ok", {
+    source: "postgres.control_center",
+    observed_at: "2026-08-20T06:00:00Z",
+    freshness_status: "fresh",
+    bytes_plaintext: 12,
+  });
+  assert.equal(lines.length, 1);
+  const rec = JSON.parse(lines[0] ?? "{}") as {
+    ts: string;
+    level: string;
+    msg: string;
+    service: string;
+  };
+  assert.equal(rec.level, "info");
+  assert.equal(rec.msg, "backup.ok");
+  assert.equal(rec.service, "control-center-deploy");
+  assert.match(rec.ts, /Z$/);
+  assert.throws(() => assertSafeLogFields({ password: "x" }), /secret-bearing/);
+  assert.throws(() => logger.error("nope", { CONTROL_CENTER_BACKUP_KEY: "x" }), /secret-bearing/);
+});

--- a/control-center/deploy/tests/retention.test.ts
+++ b/control-center/deploy/tests/retention.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { test } from "node:test";
+import { parseBackupKey, writeEncryptedBackup } from "../src/backup.ts";
+import { pruneBackupDir } from "../src/retention.ts";
+import { FIXTURE_DUMP } from "../src/paths.ts";
+import { tempDir, testKey } from "./helpers.ts";
+
+test("retention prune removes expired copies and keeps current plus the minimum newest", () => {
+  const fixture = readFileSync(FIXTURE_DUMP);
+  const key = parseBackupKey(testKey());
+  const dir = tempDir("cc-retain-");
+  const current = writeEncryptedBackup({
+    plaintext: fixture,
+    key,
+    outDir: dir,
+    observedAt: "2026-08-20T06:00:00Z",
+  });
+  const recent = writeEncryptedBackup({
+    plaintext: fixture,
+    key,
+    outDir: dir,
+    observedAt: "2026-08-18T06:00:00Z",
+  });
+  const expired = writeEncryptedBackup({
+    plaintext: fixture,
+    key,
+    outDir: dir,
+    observedAt: "2026-07-01T06:00:00Z",
+  });
+  const alsoExpired = writeEncryptedBackup({
+    plaintext: fixture,
+    key,
+    outDir: dir,
+    observedAt: "2026-06-01T06:00:00Z",
+  });
+
+  const result = pruneBackupDir(dir, new Date("2026-08-20T12:00:00Z"), 14, 3);
+  assert.equal(existsSync(current.encPath), true);
+  assert.equal(existsSync(recent.encPath), true);
+  assert.equal(existsSync(expired.encPath), true);
+  assert.equal(existsSync(alsoExpired.encPath), false);
+  assert.equal(existsSync(alsoExpired.metaPath), false);
+  assert.ok(result.kept.includes(current.encPath));
+  assert.ok(result.dropped.includes(alsoExpired.encPath));
+  assert.equal(result.kept.length, 3);
+  assert.equal(result.dropped.length, 1);
+
+  const second = pruneBackupDir(dir, new Date("2026-08-20T12:00:00Z"), 1, 2);
+  assert.equal(existsSync(current.encPath), true);
+  assert.equal(existsSync(recent.encPath), true);
+  assert.equal(existsSync(expired.encPath), false);
+  assert.equal(second.kept.length, 2);
+});

--- a/control-center/deploy/tests/stub-health.test.ts
+++ b/control-center/deploy/tests/stub-health.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { test } from "node:test";
+import { createStubListener } from "../src/stub-server.ts";
+
+async function withStub(
+  ready: boolean,
+  fn: (base: string) => Promise<void>,
+): Promise<void> {
+  const server = createServer(
+    createStubListener({
+      service: "context",
+      ready,
+      host: "127.0.0.1",
+      port: 0,
+      now: () => "2026-08-20T06:00:00.000Z",
+    }),
+  );
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object");
+  const base = `http://127.0.0.1:${addr.port}`;
+  try {
+    await fn(base);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+test("stub /healthz and /ready bodies are non-empty and distinguish ready vs not-ready", async () => {
+  await withStub(true, async (base) => {
+    const live = await fetch(`${base}/healthz`);
+    assert.equal(live.status, 200);
+    const liveBody = (await live.json()) as {
+      ok: boolean;
+      live: boolean;
+      ready?: boolean;
+      service: string;
+      source: string;
+      observed_at: string;
+      freshness_status: string;
+    };
+    assert.equal(liveBody.ok, true);
+    assert.equal(liveBody.live, true);
+    assert.equal(liveBody.service, "context");
+    assert.equal(liveBody.source, "control-center.deploy.stub.context");
+    assert.equal(liveBody.observed_at, "2026-08-20T06:00:00.000Z");
+    assert.equal(liveBody.freshness_status, "fresh");
+    assert.ok(JSON.stringify(liveBody).length > 0);
+
+    const ready = await fetch(`${base}/ready`);
+    assert.equal(ready.status, 200);
+    const readyBody = (await ready.json()) as { ok: boolean; ready: boolean };
+    assert.equal(readyBody.ok, true);
+    assert.equal(readyBody.ready, true);
+    assert.ok(JSON.stringify(readyBody).length > 0);
+  });
+
+  await withStub(false, async (base) => {
+    const live = await fetch(`${base}/healthz`);
+    assert.equal(live.status, 200);
+    const liveBody = (await live.json()) as { live: boolean; ready?: boolean };
+    assert.equal(liveBody.live, true);
+    assert.notEqual(liveBody.ready, false);
+
+    const ready = await fetch(`${base}/ready`);
+    assert.equal(ready.status, 503);
+    const readyBody = (await ready.json()) as {
+      ok: boolean;
+      ready: boolean;
+      reason: string;
+      freshness_status: string;
+    };
+    assert.equal(readyBody.ok, false);
+    assert.equal(readyBody.ready, false);
+    assert.equal(readyBody.reason, "stub_not_ready");
+    assert.equal(readyBody.freshness_status, "stale");
+    assert.ok(JSON.stringify(readyBody).length > 0);
+    assert.notEqual(JSON.stringify(readyBody), JSON.stringify(liveBody));
+  });
+});

--- a/control-center/deploy/tests/validate.test.ts
+++ b/control-center/deploy/tests/validate.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { FailClosedError } from "../src/fail-closed.ts";
+import { formatValidateReport, validatePack } from "../src/validate.ts";
+
+test("validatePack reports compose project, postgres volume, caddy, backup, retention, disk guard", () => {
+  const report = validatePack({ CONTROL_CENTER_APPLY_PRODUCTION: "false" });
+  assert.equal(report.ok, true);
+  assert.equal(report.project, "confenge-control-center");
+  assert.equal(report.postgres_volume, "confenge-control-center-postgres");
+  assert.equal(report.caddy_hook, "reverse_proxy");
+  assert.equal(report.backup, "encrypted-aes-256-gcm");
+  assert.equal(report.restore, "fixture-drill");
+  assert.equal(report.retention, "age-and-min-count");
+  assert.equal(report.disk_guard, "fail-closed");
+  assert.equal(report.kubernetes, "absent");
+  assert.equal(report.production_apply, "refused");
+  assert.match(report.summary, /project=confenge-control-center/);
+  assert.match(report.summary, /postgres_volume=confenge-control-center-postgres/);
+  assert.match(report.summary, /caddy_hook=reverse_proxy/);
+  assert.match(report.summary, /backup=encrypted-aes-256-gcm/);
+  assert.match(report.summary, /restore=fixture-drill/);
+  assert.match(report.summary, /retention=age-and-min-count/);
+  assert.match(report.summary, /disk_guard=fail-closed/);
+  const rendered = formatValidateReport(report);
+  assert.match(rendered, /confenge-control-center/);
+  assert.throws(
+    () => validatePack({ CONTROL_CENTER_APPLY_PRODUCTION: "true" }),
+    FailClosedError,
+  );
+});

--- a/control-center/deploy/tsconfig.json
+++ b/control-center/deploy/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "useUnknownInCatchVariables": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds the Confenge Control Center deploy pack under `control-center/deploy/` only. This is a reference Compose/Caddy pack for a Linux VPS (Netcup). It does **not** apply itself to production and does **not** bind host 80/443 (Warmbly nginx stays).

- Docker Compose project `confenge-control-center` with stub `context` / `mcp` / `web-shell`, PostgreSQL 16 (volume `confenge-control-center-postgres`), Caddy reverse-proxy hook on loopback 18080/18443 (`tls internal`, automatic HTTPS documented for later convergence).
- Health (`/healthz`) and readiness (`/ready`) on stubs; restart `unless-stopped`; CPU/memory limits; json-file log rotation.
- AES-256-GCM encrypted backup, verify, restore, retention prune, fail-closed disk guard, restore drill.
- `.env.example` with names/placeholders only (no live secrets, no hardcoded identity/password).
- Local README + RUNBOOK so deploy/rollback/restore after convergence does not depend on human memory.
- No Kubernetes. `CONTROL_CENTER_APPLY_PRODUCTION=true` is refused.

Sibling Control Center images are not in this tree yet; stubs/contracts document the later swap to `control-center/persistence`, `services/context`, `services/mcp`, and `apps/web-shell` without editing those trees in this wave.

## Tests

```bash
cd control-center/deploy
npm install
npm test
npm run validate
CONTROL_CENTER_BACKUP_KEY=$(openssl rand -hex 32) npm run restore-drill -- --out ./backups/drill
```

14/14 tests passed twice. Validate CLI succeeded twice. Restore drill restored the fixture twice with ciphertext ≠ plaintext. Docker CLI was not available in the verification environment (`docker-unavailable.log`).

## Risk

Do not merge this into a live Netcup apply. Convergence still needs real service Dockerfiles, persistence migrations, and a dedicated vhost plan that preserves Warmbly nginx.