### PR TITLE
fix(control-center): ship fail-closed production canaries for residual connectors

### DIFF
--- a/control-center/connectors/asaas/config/production.json
+++ b/control-center/connectors/asaas/config/production.json
@@ -1,0 +1,20 @@
+{
+  "collector": "asaas",
+  "mode": "read-only",
+  "egress": "https",
+  "environment": "SANDBOX XOR PRODUCTION",
+  "required_secrets": ["ASAAS_ENVIRONMENT", "ASAAS_API_KEY"],
+  "secret_aliases": {
+    "ASAAS_API_KEY": ["ASAAS_API_KEY_SANDBOX", "ASAAS_API_KEY_PRODUCTION"]
+  },
+  "confirmed_lifecycle": "paid-not-received",
+  "forbidden": [
+    "checkout",
+    "charge-create",
+    "customer-create",
+    "subscription-create",
+    "webhook-register",
+    "refund",
+    "cancel"
+  ]
+}

--- a/control-center/connectors/asaas/package.json
+++ b/control-center/connectors/asaas/package.json
@@ -21,10 +21,15 @@
     "fixtures",
     "README.md"
   ],
+  "bin": {
+    "cc-connector-canary": "./src/canary.ts"
+  },
   "scripts": {
     "test": "tsx --test tests/*.test.ts",
     "consumer": "tsx scripts/consumer.ts",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "canary": "tsx src/canary.ts",
+    "cc-connector-canary": "tsx src/canary.ts"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/control-center/connectors/asaas/src/canary.ts
+++ b/control-center/connectors/asaas/src/canary.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+import { collectFinanceSnapshot } from "./collect.js";
+import { ASAAS_GET_ALLOWLIST_PATHS, assertGetAllowed, isMutationMethod } from "./allowlist.js";
+import { AsaasHttpError, AsaasMutationForbiddenError } from "./errors.js";
+import {
+  buildEnvelope,
+  mapAsaasFreshness,
+  toCanaryReport,
+  type CanonicalFreshness,
+  type CanaryReport,
+} from "./envelope.js";
+import { DefaultFetchTransport, GetOnlyAsaasClient } from "./http-client.js";
+import { createLogger, redactDeep } from "./log.js";
+import {
+  ASAAS_REQUIRED_SECRETS,
+  loadAsaasProductionConfig,
+  resolveAsaasProductionConfig,
+} from "./production-config.js";
+import { mapChargeLifecycle } from "./status.js";
+import type { HttpTransport } from "./types.js";
+
+export interface AsaasCanaryOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly now?: Date;
+  readonly transport?: HttpTransport;
+  readonly log?: (line: string) => void;
+}
+
+function confidenceFor(status: CanonicalFreshness): number {
+  switch (status) {
+    case "FRESH":
+      return 0.9;
+    case "STALE":
+      return 0.5;
+    case "UNKNOWN":
+      return 0;
+    case "ERROR":
+      return 0;
+  }
+}
+
+function locatorFor(envName: string | undefined, baseUrl: string | undefined): string {
+  if (baseUrl) {
+    return baseUrl;
+  }
+  if (envName === "production") {
+    return "https://api.asaas.com";
+  }
+  if (envName === "sandbox") {
+    return "https://api-sandbox.asaas.com";
+  }
+  return "ASAAS_ENVIRONMENT";
+}
+
+function httpStatusCapability(status: number): { freshness: CanonicalFreshness; code: string } {
+  if (status === 401 || status === 403) {
+    return { freshness: "ERROR", code: "UPSTREAM_AUTH" };
+  }
+  if (status === 429) {
+    return { freshness: "ERROR", code: "UPSTREAM_RATE_LIMIT" };
+  }
+  if (status >= 500) {
+    return { freshness: "ERROR", code: "UPSTREAM_5XX" };
+  }
+  return { freshness: "ERROR", code: "UPSTREAM" };
+}
+
+export async function runAsaasCanary(options: AsaasCanaryOptions = {}): Promise<CanaryReport> {
+  const now = options.now ?? new Date();
+  const observedAt = now.toISOString();
+  const env = options.env ?? process.env;
+  const log = options.log ?? ((line: string) => process.stderr.write(`${line}\n`));
+  loadAsaasProductionConfig();
+  const resolved = resolveAsaasProductionConfig(env);
+
+  if (!resolved.ok) {
+    const blocked = resolved.code === "CREDENTIAL_MISSING";
+    const envelope = buildEnvelope({
+      collector: "asaas",
+      freshness_status: blocked ? "UNKNOWN" : "ERROR",
+      observed_at: observedAt,
+      source: {
+        system: "asaas",
+        kind: "finance-api",
+        locator: locatorFor(env.ASAAS_ENVIRONMENT, undefined),
+      },
+      confidence: 0,
+      error: { code: resolved.code, message: resolved.message },
+      payload: {
+        required_secrets: [...ASAAS_REQUIRED_SECRETS],
+        secret_aliases: {
+          ASAAS_API_KEY: ["ASAAS_API_KEY_SANDBOX", "ASAAS_API_KEY_PRODUCTION"],
+        },
+        missing: resolved.missing,
+      },
+    });
+    log(JSON.stringify({ event: "asaas.canary.blocked", code: resolved.code, missing: resolved.missing }));
+    return toCanaryReport(envelope, blocked ? "BLOCKED_BY_SECRET" : "ERROR");
+  }
+
+  const logger = createLogger(resolved.config.apiKey, (row) => log(JSON.stringify(row)));
+  try {
+    const snapshot = await collectFinanceSnapshot({
+      config: resolved.config,
+      now,
+      transport: options.transport ?? new DefaultFetchTransport(),
+      logSink: (row) => logger.info(String(row.event ?? "asaas"), row),
+    });
+    const freshness = mapAsaasFreshness(snapshot.freshness_status);
+    const confirmedIds = snapshot.entities.charges
+      .filter((charge) => charge.provider_status === "CONFIRMED")
+      .map((charge) => charge.provider_id);
+    const envelope = buildEnvelope({
+      collector: "asaas",
+      freshness_status: freshness,
+      observed_at: observedAt,
+      source: {
+        system: "asaas",
+        kind: "finance-api",
+        locator: resolved.config.baseUrl,
+      },
+      confidence: confidenceFor(freshness),
+      error: freshness === "FRESH" ? null : { code: "ASAAS_NOT_FRESH", message: `snapshot freshness=${freshness}` },
+      payload: {
+        environment: snapshot.environment,
+        charge_count: snapshot.entities.charges.length,
+        customer_count: snapshot.entities.customers.length,
+        paid_cents: snapshot.buckets.paid.cents,
+        received_cents: snapshot.buckets.received.cents,
+        confirmed_not_in_received: confirmedIds.every(
+          (id) => !snapshot.buckets.received.provider_ids.includes(id),
+        ),
+        allowlisted_gets: [...ASAAS_GET_ALLOWLIST_PATHS],
+      },
+    });
+    const capability = freshness === "FRESH" ? "AVAILABLE" : freshness === "STALE" ? "PARTIAL" : "ERROR";
+    return toCanaryReport(envelope, capability);
+  } catch (err) {
+    if (err instanceof AsaasMutationForbiddenError) {
+      const envelope = buildEnvelope({
+        collector: "asaas",
+        freshness_status: "ERROR",
+        observed_at: observedAt,
+        source: { system: "asaas", kind: "finance-api", locator: resolved.config.baseUrl },
+        confidence: 0,
+        error: { code: "MUTATION_FORBIDDEN", message: err.message },
+        payload: { required_secrets: [...ASAAS_REQUIRED_SECRETS] },
+      });
+      return toCanaryReport(envelope, "ERROR");
+    }
+    if (err instanceof AsaasHttpError) {
+      const mapped = httpStatusCapability(err.status);
+      const envelope = buildEnvelope({
+        collector: "asaas",
+        freshness_status: mapped.freshness,
+        observed_at: observedAt,
+        source: { system: "asaas", kind: "finance-api", locator: resolved.config.baseUrl },
+        confidence: 0,
+        error: { code: mapped.code, message: err.message },
+        payload: { http_status: err.status },
+      });
+      return toCanaryReport(envelope, "ERROR");
+    }
+    const message = err instanceof Error ? err.message : "asaas canary failed";
+    const timedOut = /timeout|abort/i.test(message);
+    const envelope = buildEnvelope({
+      collector: "asaas",
+      freshness_status: "ERROR",
+      observed_at: observedAt,
+      source: { system: "asaas", kind: "finance-api", locator: resolved.config.baseUrl },
+      confidence: 0,
+      error: { code: timedOut ? "TIMEOUT" : "ERROR", message },
+      payload: {},
+    });
+    return toCanaryReport(envelope, "ERROR");
+  }
+}
+
+export function parseCanaryArgs(argv: readonly string[]): { collector: "asaas"; now?: Date } {
+  let now: Date | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--help" || token === "-h") {
+      throw new Error("usage: cc-connector-canary asaas [--now UTC-Z]");
+    }
+    if (token === "--now") {
+      const raw = argv[i + 1];
+      i += 1;
+      if (!raw) {
+        throw new Error("--now requires a UTC timestamp");
+      }
+      const parsed = new Date(raw);
+      if (Number.isNaN(parsed.getTime())) {
+        throw new Error(`invalid --now: ${raw}`);
+      }
+      now = parsed;
+      continue;
+    }
+    if (token === "asaas") {
+      continue;
+    }
+    if (token === "warmbly" || token === "pncp" || token === "infra") {
+      throw new Error(`this package canary only accepts asaas, got ${token}`);
+    }
+  }
+  return now ? { collector: "asaas", now } : { collector: "asaas" };
+}
+
+export async function runCli(
+  argv: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  io: { stdout: (line: string) => void; stderr: (line: string) => void } = {
+    stdout: (line) => process.stdout.write(`${line}\n`),
+    stderr: (line) => process.stderr.write(`${line}\n`),
+  },
+): Promise<{ code: number; report?: CanaryReport }> {
+  try {
+    const args = parseCanaryArgs(argv);
+    const report = await runAsaasCanary({ env, now: args.now, log: io.stderr });
+    io.stdout(JSON.stringify(redactDeep(report, env.ASAAS_API_KEY ?? ""), null, 2));
+    return { code: 0, report };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "canary failed";
+    io.stderr(JSON.stringify({ event: "asaas.canary.error", error: message }));
+    return { code: 2 };
+  }
+}
+
+export function denyAsaasMutation(method: string, path: string): void {
+  if (isMutationMethod(method)) {
+    throw new AsaasMutationForbiddenError(method, path);
+  }
+  assertGetAllowed(method, path);
+}
+
+export { mapChargeLifecycle, GetOnlyAsaasClient };
+
+const isDirect =
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith("/canary.ts") || process.argv[1].endsWith("/canary.js"));
+
+if (isDirect) {
+  void runCli().then((outcome) => {
+    process.exitCode = outcome.code;
+  });
+}

--- a/control-center/connectors/asaas/src/envelope.ts
+++ b/control-center/connectors/asaas/src/envelope.ts
@@ -1,0 +1,103 @@
+import { createHash } from "node:crypto";
+
+export const CANARY_COLLECTORS = ["warmbly", "asaas", "pncp", "infra"] as const;
+export type CanaryCollector = (typeof CANARY_COLLECTORS)[number];
+
+export const CANONICAL_FRESHNESS = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+export type CanonicalFreshness = (typeof CANONICAL_FRESHNESS)[number];
+
+export const CAPABILITIES = [
+  "AVAILABLE",
+  "PARTIAL",
+  "BLOCKED_BY_SECRET",
+  "BLOCKED_UPSTREAM",
+  "CONTRACT_DRIFT",
+  "ERROR",
+] as const;
+export type Capability = (typeof CAPABILITIES)[number];
+
+export interface CanaryError {
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface CanaryEnvelope {
+  readonly collector: CanaryCollector;
+  readonly freshness_status: CanonicalFreshness;
+  readonly observed_at: string;
+  readonly source: {
+    readonly system: string;
+    readonly kind: string;
+    readonly locator: string;
+  };
+  readonly confidence: number;
+  readonly error: CanaryError | null;
+  readonly payload: Record<string, unknown>;
+  readonly idempotency_key: string;
+}
+
+export interface CanaryReport extends CanaryEnvelope {
+  readonly capability: Capability;
+}
+
+export function stableIdempotencyKey(parts: {
+  readonly collector: CanaryCollector;
+  readonly kind: string;
+  readonly locator: string;
+  readonly observedAt: string;
+}): string {
+  const digest = createHash("sha256")
+    .update(`${parts.collector}|${parts.kind}|${parts.locator}|${parts.observedAt}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `${parts.collector}:${parts.kind}:${digest}:${parts.observedAt}`;
+}
+
+export function buildEnvelope(input: {
+  readonly collector: CanaryCollector;
+  readonly freshness_status: CanonicalFreshness;
+  readonly observed_at: string;
+  readonly source: CanaryEnvelope["source"];
+  readonly confidence: number;
+  readonly error: CanaryError | null;
+  readonly payload: Record<string, unknown>;
+}): CanaryEnvelope {
+  return {
+    collector: input.collector,
+    freshness_status: input.freshness_status,
+    observed_at: input.observed_at,
+    source: input.source,
+    confidence: input.confidence,
+    error: input.error,
+    payload: input.payload,
+    idempotency_key: stableIdempotencyKey({
+      collector: input.collector,
+      kind: input.source.kind,
+      locator: input.source.locator,
+      observedAt: input.observed_at,
+    }),
+  };
+}
+
+export function toCanaryReport(envelope: CanaryEnvelope, capability: Capability): CanaryReport {
+  return { ...envelope, capability };
+}
+
+export function mapAsaasFreshness(status: string): CanonicalFreshness {
+  if (status === "fresh") {
+    return "FRESH";
+  }
+  if (status === "stale") {
+    return "STALE";
+  }
+  if (status === "absent") {
+    return "UNKNOWN";
+  }
+  if (status === "inconsistent") {
+    return "ERROR";
+  }
+  if ((CANONICAL_FRESHNESS as readonly string[]).includes(status)) {
+    return status as CanonicalFreshness;
+  }
+  return "ERROR";
+}

--- a/control-center/connectors/asaas/src/http-client.ts
+++ b/control-center/connectors/asaas/src/http-client.ts
@@ -29,7 +29,10 @@ export class RecordingTransport implements HttpTransport {
 }
 
 export class DefaultFetchTransport implements HttpTransport {
-  constructor(private readonly fetchImpl: typeof fetch = fetch) {}
+  constructor(
+    private readonly fetchImpl: typeof fetch = fetch,
+    private readonly timeoutMs: number = 8_000,
+  ) {}
 
   async request(req: HttpRequest): Promise<HttpResponse> {
     if (req.method.toUpperCase() !== "GET" || isMutationMethod(req.method)) {
@@ -43,6 +46,7 @@ export class DefaultFetchTransport implements HttpTransport {
       method: "GET",
       headers: req.headers,
       redirect: "error",
+      signal: AbortSignal.timeout(this.timeoutMs),
     });
     const bodyText = await res.text();
     const headers: Record<string, string> = {};

--- a/control-center/connectors/asaas/src/index.ts
+++ b/control-center/connectors/asaas/src/index.ts
@@ -60,3 +60,12 @@ export {
   AsaasHttpError,
   AsaasSecretInUrlError,
 } from "./errors.js";
+export { parseCanaryArgs, runAsaasCanary, runCli as runCanaryCli } from "./canary.js";
+export { CAPABILITIES, CANARY_COLLECTORS, buildEnvelope, mapAsaasFreshness } from "./envelope.js";
+export type { Capability, CanaryReport } from "./envelope.js";
+export {
+  ASAAS_REQUIRED_SECRETS,
+  loadAsaasProductionConfig,
+  missingAsaasSecretNames,
+  resolveAsaasProductionConfig,
+} from "./production-config.js";

--- a/control-center/connectors/asaas/src/production-config.ts
+++ b/control-center/connectors/asaas/src/production-config.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { AsaasConfigError } from "./errors.js";
+import { parseAsaasConfig } from "./config.js";
+import type { AsaasConfig } from "./types.js";
+
+export const ASAAS_REQUIRED_SECRETS = ["ASAAS_ENVIRONMENT", "ASAAS_API_KEY"] as const;
+
+export interface AsaasProductionConfig {
+  readonly collector: "asaas";
+  readonly mode: "read-only";
+  readonly egress: "https";
+  readonly required_secrets: readonly string[];
+}
+
+export function productionConfigPath(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "..", "config", "production.json");
+}
+
+export function loadAsaasProductionConfig(): AsaasProductionConfig {
+  const raw = JSON.parse(readFileSync(productionConfigPath(), "utf8")) as AsaasProductionConfig;
+  if (raw.collector !== "asaas" || raw.mode !== "read-only" || raw.egress !== "https") {
+    throw new Error("asaas production config must be HTTPS read-only");
+  }
+  return raw;
+}
+
+export function missingAsaasSecretNames(env: NodeJS.ProcessEnv): string[] {
+  const missing: string[] = [];
+  if ((env.ASAAS_ENVIRONMENT ?? "").trim() === "") {
+    missing.push("ASAAS_ENVIRONMENT");
+  }
+  const key =
+    (env.ASAAS_API_KEY ?? "").trim() ||
+    (env.ASAAS_API_KEY_SANDBOX ?? "").trim() ||
+    (env.ASAAS_API_KEY_PRODUCTION ?? "").trim();
+  if (key === "") {
+    missing.push("ASAAS_API_KEY");
+  }
+  return missing;
+}
+
+export function resolveAsaasProductionConfig(
+  env: NodeJS.ProcessEnv,
+):
+  | { ok: true; config: AsaasConfig }
+  | { ok: false; missing: string[]; message: string; code: "CREDENTIAL_MISSING" | "CONFIG" } {
+  const missing = missingAsaasSecretNames(env);
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      missing,
+      code: "CREDENTIAL_MISSING",
+      message: `Missing ${missing.join(", ")} (XOR sandbox/production key slots: ASAAS_API_KEY_SANDBOX / ASAAS_API_KEY_PRODUCTION)`,
+    };
+  }
+  try {
+    return { ok: true, config: parseAsaasConfig(env) };
+  } catch (err) {
+    const message = err instanceof AsaasConfigError ? err.message : "asaas config rejected";
+    return {
+      ok: false,
+      missing: [],
+      code: "CONFIG",
+      message,
+    };
+  }
+}

--- a/control-center/connectors/asaas/tests/canary.test.ts
+++ b/control-center/connectors/asaas/tests/canary.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  AsaasMutationForbiddenError,
+  DefaultFetchTransport,
+  GetOnlyAsaasClient,
+  MUTATION_METHODS,
+  RecordingTransport,
+  collectFinanceSnapshot,
+  createFixtureTransport,
+  mapChargeLifecycle,
+  parseAsaasConfig,
+  recordsContainSecret,
+  runAsaasCanary,
+  runCanaryCli,
+} from "../src/index.js";
+import { CAPABILITIES, CANARY_COLLECTORS } from "../src/envelope.js";
+import { ASAAS_REQUIRED_SECRETS } from "../src/production-config.js";
+import type { HttpRequest, HttpResponse, HttpTransport } from "../src/index.js";
+
+const NOW = new Date("2026-08-21T12:00:00.000Z");
+const KEY = "fixture-local-key-do-not-send";
+const LIVE_LOOKING_KEY = "$aact_UNITTESTONLY_NOT_A_REAL_KEY";
+
+class BoomTransport implements HttpTransport {
+  calls = 0;
+  async request(_req: HttpRequest): Promise<HttpResponse> {
+    this.calls += 1;
+    throw new Error("transport must not be reached");
+  }
+}
+
+class ScriptedTransport implements HttpTransport {
+  readonly calls: HttpRequest[] = [];
+  constructor(private readonly handler: (req: HttpRequest) => HttpResponse | Promise<HttpResponse>) {}
+  async request(req: HttpRequest): Promise<HttpResponse> {
+    this.calls.push(req);
+    return this.handler(req);
+  }
+}
+
+function emptyPage(): unknown {
+  return { object: "list", hasMore: false, totalCount: 0, limit: 100, offset: 0, data: [] };
+}
+
+function jsonResponse(status: number, body: unknown): HttpResponse {
+  return {
+    status,
+    headers: { "content-type": "application/json" },
+    bodyText: JSON.stringify(body),
+  };
+}
+
+function assertEnvelope(report: Awaited<ReturnType<typeof runAsaasCanary>>): void {
+  assert.equal(report.collector, "asaas");
+  assert.ok((CANARY_COLLECTORS as readonly string[]).includes(report.collector));
+  assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(report.freshness_status));
+  assert.ok(report.observed_at.endsWith("Z"));
+  assert.equal(typeof report.source.system, "string");
+  assert.equal(typeof report.source.kind, "string");
+  assert.equal(typeof report.source.locator, "string");
+  assert.equal(typeof report.confidence, "number");
+  assert.ok(
+    report.error === null ||
+      (typeof report.error.code === "string" && typeof report.error.message === "string"),
+  );
+  assert.equal(typeof report.payload, "object");
+  assert.equal(typeof report.idempotency_key, "string");
+  assert.ok((CAPABILITIES as readonly string[]).includes(report.capability));
+}
+
+describe("asaas production canary", () => {
+  it("missing secrets yield CREDENTIAL_MISSING / BLOCKED_BY_SECRET and never open a socket", async () => {
+    const boom = new BoomTransport();
+    const report = await runAsaasCanary({ env: {}, now: NOW, transport: boom });
+    assertEnvelope(report);
+    assert.equal(report.capability, "BLOCKED_BY_SECRET");
+    assert.equal(report.error?.code, "CREDENTIAL_MISSING");
+    assert.equal(report.confidence, 0);
+    assert.notEqual(report.freshness_status, "FRESH");
+    assert.ok((report.payload.required_secrets as string[]).includes("ASAAS_ENVIRONMENT"));
+    assert.ok((report.payload.required_secrets as string[]).includes("ASAAS_API_KEY"));
+    assert.deepEqual([...ASAAS_REQUIRED_SECRETS], ["ASAAS_ENVIRONMENT", "ASAAS_API_KEY"]);
+    assert.equal(boom.calls, 0);
+  });
+
+  it("two pinned-clock blocked runs share idempotency_key", async () => {
+    const first = await runAsaasCanary({ env: {}, now: NOW, transport: new BoomTransport() });
+    const second = await runAsaasCanary({ env: {}, now: NOW, transport: new BoomTransport() });
+    assert.equal(first.idempotency_key, second.idempotency_key);
+    assert.equal(first.capability, second.capability);
+  });
+
+  it("empty 200 lists are success, not error; 401/403/429/5xx stay ERROR", async () => {
+    const empty = new ScriptedTransport(() => jsonResponse(200, emptyPage()));
+    const emptyReport = await runAsaasCanary({
+      env: { ASAAS_ENVIRONMENT: "sandbox", ASAAS_API_KEY: KEY },
+      now: NOW,
+      transport: empty,
+    });
+    assertEnvelope(emptyReport);
+    assert.notEqual(emptyReport.freshness_status, "ERROR");
+    assert.ok(empty.calls.length > 0);
+
+    for (const status of [401, 403, 429, 500, 503]) {
+      const failing = new ScriptedTransport(() => jsonResponse(status, { errors: [{ code: "x" }] }));
+      const report = await runAsaasCanary({
+        env: { ASAAS_ENVIRONMENT: "sandbox", ASAAS_API_KEY: KEY },
+        now: NOW,
+        transport: failing,
+      });
+      assertEnvelope(report);
+      assert.notEqual(report.freshness_status, "FRESH");
+      assert.equal(report.freshness_status, "ERROR");
+    }
+  });
+
+  it("timeout is ERROR not empty FRESH", async () => {
+    let fetchCalls = 0;
+    const transport = new DefaultFetchTransport(async () => {
+      fetchCalls += 1;
+      const err = new Error("This operation was aborted");
+      err.name = "TimeoutError";
+      throw err;
+    }, 20);
+    const report = await runAsaasCanary({
+      env: { ASAAS_ENVIRONMENT: "sandbox", ASAAS_API_KEY: KEY },
+      now: NOW,
+      transport,
+    });
+    assertEnvelope(report);
+    assert.notEqual(report.freshness_status, "FRESH");
+    assert.ok(fetchCalls >= 1);
+  });
+
+  it("POST/PUT/PATCH/DELETE and mutation paths never hit transport; CONFIRMED is not received", async () => {
+    const boom = new BoomTransport();
+    const config = parseAsaasConfig({ ASAAS_ENVIRONMENT: "sandbox", ASAAS_API_KEY: KEY });
+    const client = new GetOnlyAsaasClient(config, boom);
+    for (const method of MUTATION_METHODS) {
+      await assert.rejects(() => client.request(method, "/v3/payments"), AsaasMutationForbiddenError);
+    }
+    assert.throws(() => client.post("/v3/checkouts"), AsaasMutationForbiddenError);
+    assert.equal(boom.calls, 0);
+    assert.equal(mapChargeLifecycle("CONFIRMED", false), "paid");
+    assert.notEqual(mapChargeLifecycle("CONFIRMED", false), "received");
+
+    const recording = new RecordingTransport(createFixtureTransport());
+    const snapshot = await collectFinanceSnapshot({ config, transport: recording, now: NOW });
+    const confirmed = snapshot.entities.charges.find((c) => c.provider_status === "CONFIRMED");
+    assert.ok(confirmed);
+    assert.equal(confirmed.lifecycle, "paid");
+    assert.ok(!snapshot.buckets.received.provider_ids.includes(confirmed.provider_id));
+    for (const entry of recording.log) {
+      assert.equal(entry.method, "GET");
+    }
+  });
+
+  it("redacts API keys and does not put PII into canary JSON", async () => {
+    const logs: Record<string, unknown>[] = [];
+    const report = await runAsaasCanary({
+      env: { ASAAS_ENVIRONMENT: "sandbox", ASAAS_API_KEY: LIVE_LOOKING_KEY },
+      now: NOW,
+      transport: createFixtureTransport(),
+      log: (line) => logs.push(JSON.parse(line) as Record<string, unknown>),
+    });
+    const blob = `${JSON.stringify(report)}\n${JSON.stringify(logs)}`;
+    assert.equal(blob.includes(LIVE_LOOKING_KEY), false);
+    assert.equal(/\$aact_/i.test(blob), false);
+    assert.equal(/@/.test(blob) && /email/i.test(blob), false);
+    assert.equal(recordsContainSecret(logs, LIVE_LOOKING_KEY), false);
+    assert.equal(
+      JSON.stringify(report.payload).includes("cpf") || JSON.stringify(report.payload).includes("email"),
+      false,
+    );
+  });
+
+  it("CLI entry emits BLOCKED_BY_SECRET without secrets", async () => {
+    const lines: string[] = [];
+    const outcome = await runCanaryCli(["asaas", "--now", NOW.toISOString()], {}, {
+      stdout: (line) => lines.push(line),
+      stderr: () => undefined,
+    });
+    assert.equal(outcome.code, 0);
+    const parsed = JSON.parse(lines.join("\n")) as Awaited<ReturnType<typeof runAsaasCanary>>;
+    assertEnvelope(parsed);
+    assert.equal(parsed.capability, "BLOCKED_BY_SECRET");
+  });
+});

--- a/control-center/connectors/infrastructure/config/allowlist.production.json
+++ b/control-center/connectors/infrastructure/config/allowlist.production.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "collector_id": "infrastructure.netcup",
+  "source": "infrastructure",
+  "default_timeout_ms": 5000,
+  "thresholds": {
+    "stale_after_seconds": 300,
+    "disk_warn_pct": 80,
+    "disk_crit_pct": 90,
+    "mem_warn_pct": 90,
+    "backup_max_age_seconds": 86400,
+    "tls_warn_days": 21,
+    "tls_crit_days": 7
+  },
+  "targets": [
+    {
+      "id": "netcup-vps-tcp",
+      "display_name": "Netcup VPS TCP",
+      "host": "159.195.18.88",
+      "connect_host": "159.195.18.88",
+      "port": 443,
+      "checks": ["reachability"]
+    },
+    {
+      "id": "netcup-api-tls",
+      "display_name": "Confenge API TLS",
+      "host": "159.195.18.88",
+      "connect_host": "159.195.18.88",
+      "tls_server_name": "api.confenge.com.br",
+      "port": 443,
+      "checks": ["tls"]
+    },
+    {
+      "id": "confenge-api-http",
+      "display_name": "Confenge API inbound health",
+      "url": "https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health",
+      "connect_host": "159.195.18.88",
+      "http_host": "api.confenge.com.br",
+      "tls_server_name": "api.confenge.com.br",
+      "expect_status": 200,
+      "checks": ["http"]
+    }
+  ]
+}

--- a/control-center/connectors/infrastructure/package.json
+++ b/control-center/connectors/infrastructure/package.json
@@ -7,11 +7,16 @@
   "engines": {
     "node": ">=20"
   },
+  "bin": {
+    "cc-connector-canary": "./dist/src/canary.js"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json --pretty false",
     "typecheck": "tsc -p tsconfig.json --pretty false --noEmit",
     "test": "tsc -p tsconfig.json --pretty false && node --test dist/tests/*.test.js",
-    "collect": "tsc -p tsconfig.json --pretty false && node dist/src/cli.js"
+    "collect": "tsc -p tsconfig.json --pretty false && node dist/src/cli.js",
+    "canary": "tsc -p tsconfig.json --pretty false && node dist/src/canary.js",
+    "cc-connector-canary": "tsc -p tsconfig.json --pretty false && node dist/src/canary.js"
   },
   "exports": {
     ".": "./dist/src/index.js"

--- a/control-center/connectors/infrastructure/src/allowlist.ts
+++ b/control-center/connectors/infrastructure/src/allowlist.ts
@@ -109,13 +109,18 @@ function parseTarget(raw: unknown, index: number): AllowlistTarget {
   };
 
   if (raw.host !== undefined) {
-    if (typeof raw.host !== "string" || raw.host.trim().length === 0) {
-      throw new AllowlistError(`${path}.host must be a hostname`);
-    }
-    if (raw.host.includes("@") || raw.host.includes("/")) {
-      throw new AllowlistError(`${path}.host must not contain credentials or paths`);
-    }
-    Object.assign(target, { host: raw.host.trim() });
+    Object.assign(target, { host: parseHostField(raw.host, `${path}.host`) });
+  }
+  if (raw.connect_host !== undefined) {
+    Object.assign(target, { connect_host: parseHostField(raw.connect_host, `${path}.connect_host`) });
+  }
+  if (raw.tls_server_name !== undefined) {
+    Object.assign(target, {
+      tls_server_name: parseServerName(raw.tls_server_name, `${path}.tls_server_name`),
+    });
+  }
+  if (raw.http_host !== undefined) {
+    Object.assign(target, { http_host: parseServerName(raw.http_host, `${path}.http_host`) });
   }
   if (raw.port !== undefined) {
     const port = asPositiveInt(raw.port, `${path}.port`);
@@ -151,10 +156,33 @@ function parseTarget(raw: unknown, index: number): AllowlistTarget {
   if (checks.includes("http") && !target.url) {
     throw new AllowlistError(`${path} http check requires url`);
   }
-  if ((checks.includes("reachability") || checks.includes("tls")) && !target.host) {
-    throw new AllowlistError(`${path} reachability/tls checks require host`);
+  if (
+    (checks.includes("reachability") || checks.includes("tls")) &&
+    !target.host &&
+    !target.connect_host
+  ) {
+    throw new AllowlistError(`${path} reachability/tls checks require host or connect_host`);
   }
   return target;
+}
+
+function parseHostField(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new AllowlistError(`${path} must be a hostname or IP`);
+  }
+  const host = value.trim();
+  if (host.includes("@") || host.includes("/")) {
+    throw new AllowlistError(`${path} must not contain credentials or paths`);
+  }
+  return host;
+}
+
+function parseServerName(value: unknown, path: string): string {
+  const host = parseHostField(value, path);
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) {
+    throw new AllowlistError(`${path} must be a DNS name, not an IP (SNI/Host identity)`);
+  }
+  return host;
 }
 
 export function parseAllowlist(input: unknown): Allowlist {

--- a/control-center/connectors/infrastructure/src/canary.ts
+++ b/control-center/connectors/infrastructure/src/canary.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import { collect } from "./collect.js";
+import {
+  buildEnvelope,
+  toCanaryReport,
+  type Capability,
+  type CanaryReport,
+} from "./envelope.js";
+import { worstFreshness } from "./freshness.js";
+import {
+  CANONICAL_HEALTH_URL,
+  CANONICAL_HTTP_HOST,
+  loadProductionAllowlist,
+} from "./production-config.js";
+import { createLivePorts } from "./live-ports.js";
+import { logEvent, redact } from "./log.js";
+import type { ProbePorts } from "./ports.js";
+import type { CollectResult, FreshnessStatus } from "./types.js";
+import { toUtcIso } from "./ids.js";
+
+export interface InfraCanaryOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly now?: Date;
+  readonly ports?: ProbePorts;
+  readonly allowlist?: unknown;
+  readonly log?: (line: string) => void;
+}
+
+function confidenceFor(status: FreshnessStatus): number {
+  switch (status) {
+    case "FRESH":
+      return 0.9;
+    case "STALE":
+      return 0.5;
+    case "UNKNOWN":
+      return 0;
+    case "ERROR":
+      return 0;
+  }
+}
+
+function capabilityFor(result: CollectResult): Capability {
+  const statuses = result.observations.map((row) => row.freshness_status);
+  if (statuses.length === 0) {
+    return "ERROR";
+  }
+  const unique = new Set(statuses);
+  if (unique.size === 1 && unique.has("FRESH")) {
+    return "AVAILABLE";
+  }
+  if (unique.has("FRESH") || unique.has("STALE")) {
+    return "PARTIAL";
+  }
+  return "ERROR";
+}
+
+export async function runInfraCanary(options: InfraCanaryOptions = {}): Promise<CanaryReport> {
+  const now = options.now ?? new Date();
+  const observedAt = toUtcIso(now);
+  const log = options.log ?? ((line: string) => process.stderr.write(`${line}\n`));
+  const allowlist = options.allowlist ?? loadProductionAllowlist();
+  const ports =
+    options.ports ??
+    createLivePorts({
+      now: () => now,
+      ...(options.env?.CONTROL_CENTER_INFRA_AGENT_URL
+        ? { agentBaseUrl: options.env.CONTROL_CENTER_INFRA_AGENT_URL }
+        : {}),
+    });
+
+  logEvent("infra_canary_start", {
+    collector: "infra",
+    health_url: CANONICAL_HEALTH_URL,
+    http_host: CANONICAL_HTTP_HOST,
+  });
+
+  try {
+    const result = await collect({ allowlist, ports });
+    const freshness = worstFreshness(result.observations.map((row) => row.freshness_status));
+    const httpObs = result.observations.find((row) => row.check === "http");
+    const tcpObs = result.observations.find((row) => row.check === "reachability");
+    const tlsObs = result.observations.find((row) => row.check === "tls");
+    const httpError =
+      httpObs && httpObs.freshness_status !== "FRESH"
+        ? {
+            code: "HTTP_OBSERVATION",
+            message: String(httpObs.summary),
+          }
+        : null;
+    const envelopeError =
+      freshness === "FRESH"
+        ? null
+        : httpError ?? {
+            code: "INFRA_UNHEALTHY",
+            message: "one or more infrastructure observations are not FRESH",
+          };
+    const envelope = buildEnvelope({
+      collector: "infra",
+      freshness_status: freshness,
+      observed_at: observedAt,
+      source: {
+        system: "infrastructure",
+        kind: "netcup-http-tls-tcp",
+        locator: CANONICAL_HEALTH_URL,
+      },
+      confidence: confidenceFor(freshness),
+      error: envelopeError,
+      payload: {
+        health_url: CANONICAL_HEALTH_URL,
+        http_host: CANONICAL_HTTP_HOST,
+        observations: result.observations.map((row) => ({
+          target_id: row.target_id,
+          check: row.check,
+          freshness_status: row.freshness_status,
+          summary: row.summary,
+          connect_host: row.payload.connect_host ?? null,
+          tls_server_name: row.payload.tls_server_name ?? null,
+          http_host: row.payload.http_host ?? null,
+        })),
+        tcp_freshness: tcpObs?.freshness_status ?? "UNKNOWN",
+        tls_freshness: tlsObs?.freshness_status ?? "UNKNOWN",
+        http_freshness: httpObs?.freshness_status ?? "UNKNOWN",
+        exception_count: result.exceptions.length,
+      },
+    });
+    const report = toCanaryReport(envelope, capabilityFor(result));
+    log(
+      JSON.stringify(
+        redact({
+          event: "infra_canary_finish",
+          collector: report.collector,
+          capability: report.capability,
+          freshness_status: report.freshness_status,
+        }),
+      ),
+    );
+    return report;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "infra canary failed";
+    const envelope = buildEnvelope({
+      collector: "infra",
+      freshness_status: "ERROR",
+      observed_at: observedAt,
+      source: {
+        system: "infrastructure",
+        kind: "netcup-http-tls-tcp",
+        locator: CANONICAL_HEALTH_URL,
+      },
+      confidence: 0,
+      error: { code: "ERROR", message },
+      payload: {},
+    });
+    return toCanaryReport(envelope, "ERROR");
+  }
+}
+
+export function parseCanaryArgs(argv: readonly string[]): { collector: "infra"; now?: Date } {
+  let now: Date | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--help" || token === "-h") {
+      throw new Error("usage: cc-connector-canary infra [--now UTC-Z]");
+    }
+    if (token === "--now") {
+      const raw = argv[i + 1];
+      i += 1;
+      if (!raw) {
+        throw new Error("--now requires a UTC timestamp");
+      }
+      const parsed = new Date(raw);
+      if (Number.isNaN(parsed.getTime())) {
+        throw new Error(`invalid --now: ${raw}`);
+      }
+      now = parsed;
+      continue;
+    }
+    if (token === "infra") {
+      continue;
+    }
+    if (token === "warmbly" || token === "asaas" || token === "pncp") {
+      throw new Error(`this package canary only accepts infra, got ${token}`);
+    }
+  }
+  return now ? { collector: "infra", now } : { collector: "infra" };
+}
+
+export async function runCli(
+  argv: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  io: { stdout: (line: string) => void; stderr: (line: string) => void } = {
+    stdout: (line) => process.stdout.write(`${line}\n`),
+    stderr: (line) => process.stderr.write(`${line}\n`),
+  },
+): Promise<{ code: number; report?: CanaryReport }> {
+  try {
+    const args = parseCanaryArgs(argv);
+    const report = await runInfraCanary({
+      env,
+      ...(args.now ? { now: args.now } : {}),
+      log: (line) => io.stderr(line),
+    });
+    io.stdout(JSON.stringify(redact(report), null, 2));
+    return { code: 0, report };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "canary failed";
+    io.stderr(JSON.stringify({ event: "infra_canary_error", error: message }));
+    return { code: 2 };
+  }
+}
+
+function isMain(): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isMain()) {
+  void runCli().then((outcome) => {
+    process.exitCode = outcome.code;
+  });
+}

--- a/control-center/connectors/infrastructure/src/envelope.ts
+++ b/control-center/connectors/infrastructure/src/envelope.ts
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+import type { FreshnessStatus } from "./types.js";
+
+export const CANARY_COLLECTORS = ["warmbly", "asaas", "pncp", "infra"] as const;
+export type CanaryCollector = (typeof CANARY_COLLECTORS)[number];
+
+export const CAPABILITIES = [
+  "AVAILABLE",
+  "PARTIAL",
+  "BLOCKED_BY_SECRET",
+  "BLOCKED_UPSTREAM",
+  "CONTRACT_DRIFT",
+  "ERROR",
+] as const;
+export type Capability = (typeof CAPABILITIES)[number];
+
+export interface CanaryError {
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface CanaryEnvelope {
+  readonly collector: CanaryCollector;
+  readonly freshness_status: FreshnessStatus;
+  readonly observed_at: string;
+  readonly source: {
+    readonly system: string;
+    readonly kind: string;
+    readonly locator: string;
+  };
+  readonly confidence: number;
+  readonly error: CanaryError | null;
+  readonly payload: Record<string, unknown>;
+  readonly idempotency_key: string;
+}
+
+export interface CanaryReport extends CanaryEnvelope {
+  readonly capability: Capability;
+}
+
+export function isCanaryCollector(value: string): value is CanaryCollector {
+  return (CANARY_COLLECTORS as readonly string[]).includes(value);
+}
+
+export function isCapability(value: string): value is Capability {
+  return (CAPABILITIES as readonly string[]).includes(value);
+}
+
+export function stableIdempotencyKey(parts: {
+  readonly collector: CanaryCollector;
+  readonly kind: string;
+  readonly locator: string;
+  readonly observedAt: string;
+}): string {
+  const digest = createHash("sha256")
+    .update(`${parts.collector}|${parts.kind}|${parts.locator}|${parts.observedAt}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `${parts.collector}:${parts.kind}:${digest}:${parts.observedAt}`;
+}
+
+export function buildEnvelope(input: {
+  readonly collector: CanaryCollector;
+  readonly freshness_status: FreshnessStatus;
+  readonly observed_at: string;
+  readonly source: CanaryEnvelope["source"];
+  readonly confidence: number;
+  readonly error: CanaryError | null;
+  readonly payload: Record<string, unknown>;
+}): CanaryEnvelope {
+  return {
+    collector: input.collector,
+    freshness_status: input.freshness_status,
+    observed_at: input.observed_at,
+    source: input.source,
+    confidence: input.confidence,
+    error: input.error,
+    payload: input.payload,
+    idempotency_key: stableIdempotencyKey({
+      collector: input.collector,
+      kind: input.source.kind,
+      locator: input.source.locator,
+      observedAt: input.observed_at,
+    }),
+  };
+}
+
+export function toCanaryReport(envelope: CanaryEnvelope, capability: Capability): CanaryReport {
+  return { ...envelope, capability };
+}

--- a/control-center/connectors/infrastructure/src/identity.ts
+++ b/control-center/connectors/infrastructure/src/identity.ts
@@ -1,0 +1,137 @@
+import type { ConnectionIdentity } from "./ports.js";
+import type { AllowlistTarget } from "./types.js";
+
+export const CANONICAL_CONNECT_HOST = "159.195.18.88";
+export const CANONICAL_TLS_SERVER_NAME = "api.confenge.com.br";
+export const CANONICAL_HTTP_HOST = "api.confenge.com.br";
+export const CANONICAL_HEALTH_URL =
+  "https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health";
+
+export function connectHostOf(target: AllowlistTarget): string {
+  return (target.connect_host ?? target.host ?? "").trim();
+}
+
+export function tlsServerNameOf(target: AllowlistTarget): string {
+  const named = target.tls_server_name ?? target.http_host;
+  if (named && named.trim() !== "") {
+    return named.trim();
+  }
+  return connectHostOf(target);
+}
+
+export function httpHostOf(target: AllowlistTarget): string {
+  if (target.http_host && target.http_host.trim() !== "") {
+    return target.http_host.trim();
+  }
+  if (target.url) {
+    try {
+      const hostname = new URL(target.url).hostname;
+      if (hostname) {
+        return hostname;
+      }
+    } catch {
+      // fall through
+    }
+  }
+  if (target.tls_server_name && target.tls_server_name.trim() !== "") {
+    return target.tls_server_name.trim();
+  }
+  return connectHostOf(target);
+}
+
+export function identityFor(target: AllowlistTarget): ConnectionIdentity {
+  const identity: ConnectionIdentity = {};
+  const connectHost = connectHostOf(target);
+  if (connectHost) {
+    Object.assign(identity, { connectHost });
+  }
+  const tlsServerName = tlsServerNameOf(target);
+  if (tlsServerName) {
+    Object.assign(identity, { tlsServerName });
+  }
+  const httpHost = httpHostOf(target);
+  if (httpHost) {
+    Object.assign(identity, { httpHost });
+  }
+  return identity;
+}
+
+export interface TlsConnectOptions {
+  readonly host: string;
+  readonly port: number;
+  readonly servername: string;
+  readonly rejectUnauthorized: false;
+}
+
+/** TCP host vs SNI servername. SNI mismatch must not be used as the TCP host. */
+export function buildTlsConnectOptions(input: {
+  readonly connectHost: string;
+  readonly port: number;
+  readonly tlsServerName?: string;
+}): TlsConnectOptions {
+  return {
+    host: input.connectHost,
+    port: input.port,
+    servername: input.tlsServerName && input.tlsServerName.trim() !== ""
+      ? input.tlsServerName.trim()
+      : input.connectHost,
+    rejectUnauthorized: false,
+  };
+}
+
+export interface BuiltHttpRequest {
+  readonly protocol: "http:" | "https:";
+  readonly connectHost: string;
+  readonly httpHost: string;
+  readonly tlsServerName: string;
+  readonly port: number;
+  readonly method: "GET";
+  readonly path: string;
+  readonly headers: { readonly Host: string; readonly Accept: string; readonly "User-Agent": string };
+  readonly timeoutMs: number;
+  readonly rejectUnauthorized: boolean;
+}
+
+/**
+ * HTTP identity: connect to connectHost (IP allowed), present Host + SNI as
+ * the HTTP/TLS name. A non-SAN connect hostname must not become SNI/Host.
+ */
+export function buildHttpRequestOptions(input: {
+  readonly url: string;
+  readonly timeoutMs: number;
+  readonly connectHost?: string;
+  readonly httpHost?: string;
+  readonly tlsServerName?: string;
+}): BuiltHttpRequest {
+  const url = new URL(input.url);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("http probe URL must be http(s)");
+  }
+  const urlHost = url.hostname;
+  const httpHost = (input.httpHost && input.httpHost.trim() !== "" ? input.httpHost : urlHost).trim();
+  const connectHost = (input.connectHost && input.connectHost.trim() !== ""
+    ? input.connectHost
+    : urlHost
+  ).trim();
+  const tlsServerName = (input.tlsServerName && input.tlsServerName.trim() !== ""
+    ? input.tlsServerName
+    : httpHost
+  ).trim();
+  const port = url.port ? Number(url.port) : url.protocol === "https:" ? 443 : 80;
+  return {
+    protocol: url.protocol,
+    connectHost,
+    httpHost,
+    tlsServerName,
+    port,
+    method: "GET",
+    path: `${url.pathname}${url.search}`,
+    headers: {
+      Host: httpHost,
+      Accept: "application/json, text/plain, */*",
+      "User-Agent": "ConfengeControlCenter-InfraCollector/1.0",
+    },
+    timeoutMs: input.timeoutMs,
+    rejectUnauthorized: url.protocol === "https:",
+  };
+}

--- a/control-center/connectors/infrastructure/src/index.ts
+++ b/control-center/connectors/infrastructure/src/index.ts
@@ -1,10 +1,32 @@
 export { parseAllowlist } from "./allowlist.js";
 export { collect, mapCollectResult, type CollectInput } from "./collect.js";
 export { collectFromFixtureFile, parseCliArgs, runCli } from "./cli.js";
+export { parseCanaryArgs, runCli as runCanaryCli, runInfraCanary } from "./canary.js";
 export { deriveExceptions } from "./exceptions.js";
 export { createFixturePorts, parseFixture } from "./fixture-ports.js";
+export {
+  buildEnvelope,
+  CAPABILITIES,
+  CANARY_COLLECTORS,
+  stableIdempotencyKey,
+  toCanaryReport,
+} from "./envelope.js";
+export type { Capability, CanaryEnvelope, CanaryReport } from "./envelope.js";
+export {
+  buildHttpRequestOptions,
+  buildTlsConnectOptions,
+  CANONICAL_CONNECT_HOST,
+  CANONICAL_HEALTH_URL,
+  CANONICAL_HTTP_HOST,
+  CANONICAL_TLS_SERVER_NAME,
+  identityFor,
+} from "./identity.js";
 export { createLivePorts } from "./live-ports.js";
 export { mapCollectRecords, mapObservation, mapServiceHealth } from "./map.js";
+export {
+  assertProductionIdentity,
+  loadProductionAllowlist,
+} from "./production-config.js";
 export { runProbes } from "./probes.js";
 export type {
   ActionableException,

--- a/control-center/connectors/infrastructure/src/live-ports.ts
+++ b/control-center/connectors/infrastructure/src/live-ports.ts
@@ -1,7 +1,10 @@
+import http from "node:http";
+import https from "node:https";
 import net from "node:net";
 import tls from "node:tls";
 import { parseAgentPayload } from "./agent.js";
-import type { ProbePorts } from "./ports.js";
+import { buildHttpRequestOptions, buildTlsConnectOptions } from "./identity.js";
+import type { ConnectionIdentity, ProbePorts } from "./ports.js";
 import type { AgentPayload, HttpSample, ReachabilitySample, TlsSample } from "./types.js";
 
 export interface LivePortOptions {
@@ -28,8 +31,8 @@ export function createLivePorts(options: LivePortOptions = {}): ProbePorts {
   return {
     now: () => (options.now ? options.now() : new Date()),
     reachHost: (host, port, timeoutMs) => tcpReach(host, port, timeoutMs),
-    httpGet: (url, timeoutMs) => httpProbe(url, timeoutMs, fetchImpl),
-    readTls: (host, port, timeoutMs) => tlsProbe(host, port, timeoutMs),
+    httpGet: (url, timeoutMs, identity) => httpProbe(url, timeoutMs, identity),
+    readTls: (host, port, timeoutMs, identity) => tlsProbe(host, port, timeoutMs, identity),
     readAgent: (targetId) => readAgent(targetId, agentBase, fetchImpl),
   };
 }
@@ -50,24 +53,81 @@ function tcpReach(host: string, port: number, timeoutMs: number): Promise<Reacha
   });
 }
 
-async function httpProbe(url: string, timeoutMs: number, fetchImpl: typeof fetch): Promise<HttpSample> {
+function httpProbe(
+  url: string,
+  timeoutMs: number,
+  identity?: ConnectionIdentity,
+): Promise<HttpSample> {
   const started = Date.now();
+  let built: ReturnType<typeof buildHttpRequestOptions>;
   try {
-    const response = await fetchImpl(url, {
-      method: "GET",
-      redirect: "manual",
-      signal: AbortSignal.timeout(timeoutMs),
+    built = buildHttpRequestOptions({
+      url,
+      timeoutMs,
+      ...(identity?.connectHost ? { connectHost: identity.connectHost } : {}),
+      ...(identity?.httpHost ? { httpHost: identity.httpHost } : {}),
+      ...(identity?.tlsServerName ? { tlsServerName: identity.tlsServerName } : {}),
     });
-    return { status: response.status, elapsed_ms: Date.now() - started };
   } catch (err) {
     const message = err instanceof Error ? err.message : "http error";
-    return { status: 0, elapsed_ms: Date.now() - started, error: message };
+    return Promise.resolve({ status: 0, elapsed_ms: Date.now() - started, error: message });
   }
+  const lib = built.protocol === "https:" ? https : http;
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (sample: HttpSample): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(sample);
+    };
+    const req = lib.request(
+      {
+        hostname: built.connectHost,
+        port: built.port,
+        method: built.method,
+        path: built.path,
+        headers: {
+          Host: built.headers.Host,
+          Accept: built.headers.Accept,
+          "User-Agent": built.headers["User-Agent"],
+        },
+        timeout: built.timeoutMs,
+        ...(built.protocol === "https:"
+          ? { servername: built.tlsServerName, rejectUnauthorized: built.rejectUnauthorized }
+          : {}),
+      },
+      (res) => {
+        res.resume();
+        finish({ status: res.statusCode ?? 0, elapsed_ms: Date.now() - started });
+      },
+    );
+    req.setTimeout(timeoutMs, () => {
+      req.destroy();
+      finish({ status: 0, elapsed_ms: Date.now() - started, error: "http timeout" });
+    });
+    req.on("error", (err) => {
+      finish({ status: 0, elapsed_ms: Date.now() - started, error: err.message });
+    });
+    req.end();
+  });
 }
 
-function tlsProbe(host: string, port: number, timeoutMs: number): Promise<TlsSample> {
+function tlsProbe(
+  host: string,
+  port: number,
+  timeoutMs: number,
+  identity?: ConnectionIdentity,
+): Promise<TlsSample> {
+  const connectHost = identity?.connectHost ?? host;
+  const tlsOpts = buildTlsConnectOptions({
+    connectHost,
+    port,
+    ...(identity?.tlsServerName ? { tlsServerName: identity.tlsServerName } : {}),
+  });
   return new Promise((resolve) => {
-    const socket = tls.connect({ host, port, servername: host, rejectUnauthorized: false });
+    const socket = tls.connect(tlsOpts);
     const finish = (sample: TlsSample): void => {
       socket.removeAllListeners();
       socket.destroy();

--- a/control-center/connectors/infrastructure/src/ports.ts
+++ b/control-center/connectors/infrastructure/src/ports.ts
@@ -1,11 +1,18 @@
 import type { AgentPayload, HttpSample, ReachabilitySample, TlsSample } from "./types.js";
 
+/** Split connection identity (TCP) from TLS SNI / HTTP Host. */
+export interface ConnectionIdentity {
+  readonly connectHost?: string;
+  readonly tlsServerName?: string;
+  readonly httpHost?: string;
+}
+
 /** Injected I/O. Tests and `--fixture` supply recordings; `--live` uses TCP/HTTP/TLS only. */
 export interface ProbePorts {
   now(): Date;
   reachHost(host: string, port: number, timeoutMs: number): Promise<ReachabilitySample>;
-  httpGet(url: string, timeoutMs: number): Promise<HttpSample>;
-  readTls(host: string, port: number, timeoutMs: number): Promise<TlsSample>;
+  httpGet(url: string, timeoutMs: number, identity?: ConnectionIdentity): Promise<HttpSample>;
+  readTls(host: string, port: number, timeoutMs: number, identity?: ConnectionIdentity): Promise<TlsSample>;
   readAgent(targetId: string): Promise<AgentPayload | null>;
 }
 

--- a/control-center/connectors/infrastructure/src/probes.ts
+++ b/control-center/connectors/infrastructure/src/probes.ts
@@ -1,5 +1,6 @@
 import { parseAgentPayload } from "./agent.js";
 import { timeoutFor } from "./allowlist.js";
+import { connectHostOf, httpHostOf, identityFor, tlsServerNameOf } from "./identity.js";
 import { toUtcIso } from "./ids.js";
 import type { ProbePorts } from "./ports.js";
 import { withTimeout } from "./timeout.js";
@@ -56,12 +57,13 @@ async function probeReachability(
   now: Date,
   timeoutMs: number,
 ): Promise<ProbeResult> {
-  const host = target.host ?? "";
+  const host = connectHostOf(target);
   const port = target.port ?? 443;
   const outcome = await timed(ports.reachHost(host, port, timeoutMs), timeoutMs);
   if (outcome.status === "timeout") {
     return baseResult(target, "reachability", now, "timeout", `host reachability timed out after ${timeoutMs}ms`, {
       host,
+      connect_host: host,
       port,
       timed_out: true,
     });
@@ -69,6 +71,7 @@ async function probeReachability(
   if (outcome.status === "error") {
     return baseResult(target, "reachability", now, "error", `host reachability error: ${outcome.error}`, {
       host,
+      connect_host: host,
       port,
       error: outcome.error,
     });
@@ -81,10 +84,10 @@ async function probeReachability(
       now,
       "error",
       `host ${host}:${port} unreachable${sample.error ? `: ${sample.error}` : ""}`,
-      { host, port, ok: false, error: sample.error ?? "unreachable" },
+      { host, connect_host: host, port, ok: false, error: sample.error ?? "unreachable" },
     );
   }
-  const payload: Record<string, unknown> = { host, port, ok: true };
+  const payload: Record<string, unknown> = { host, connect_host: host, port, ok: true };
   if (sample.latency_ms !== undefined) {
     payload.latency_ms = sample.latency_ms;
   }
@@ -99,33 +102,42 @@ async function probeHttp(
 ): Promise<ProbeResult> {
   const url = target.url ?? "";
   const expect = target.expect_status ?? 200;
-  const outcome = await timed(ports.httpGet(url, timeoutMs), timeoutMs);
+  const identity = identityFor(target);
+  const httpHost = httpHostOf(target);
+  const tlsServerName = tlsServerNameOf(target);
+  const connectHost = identity.connectHost;
+  const identityFields: Record<string, unknown> = {
+    url,
+    expect_status: expect,
+    http_host: httpHost,
+    tls_server_name: tlsServerName,
+  };
+  if (connectHost) {
+    identityFields.connect_host = connectHost;
+  }
+  const outcome = await timed(ports.httpGet(url, timeoutMs, identity), timeoutMs);
   if (outcome.status === "timeout") {
     return baseResult(target, "http", now, "timeout", `HTTP health timed out after ${timeoutMs}ms`, {
-      url,
+      ...identityFields,
       timed_out: true,
-      expect_status: expect,
     });
   }
   if (outcome.status === "error") {
     return baseResult(target, "http", now, "error", `HTTP health error: ${outcome.error}`, {
-      url,
+      ...identityFields,
       error: outcome.error,
-      expect_status: expect,
     });
   }
   const sample = outcome.value;
   if (sample.error && sample.status === 0) {
     return baseResult(target, "http", now, "error", `HTTP health error: ${sample.error}`, {
-      url,
+      ...identityFields,
       error: sample.error,
-      expect_status: expect,
     });
   }
   const payload: Record<string, unknown> = {
-    url,
+    ...identityFields,
     status: sample.status,
-    expect_status: expect,
   };
   if (sample.elapsed_ms !== undefined) {
     payload.elapsed_ms = sample.elapsed_ms;
@@ -149,34 +161,38 @@ async function probeTls(
   now: Date,
   timeoutMs: number,
 ): Promise<ProbeResult> {
-  const host = target.host ?? "";
+  const host = connectHostOf(target);
   const port = target.port ?? 443;
-  const outcome = await timed(ports.readTls(host, port, timeoutMs), timeoutMs);
+  const identity = identityFor(target);
+  const tlsServerName = tlsServerNameOf(target);
+  const identityFields: Record<string, unknown> = {
+    host,
+    connect_host: host,
+    tls_server_name: tlsServerName,
+    port,
+  };
+  const outcome = await timed(ports.readTls(host, port, timeoutMs, identity), timeoutMs);
   if (outcome.status === "timeout") {
     return baseResult(target, "tls", now, "timeout", `TLS probe timed out after ${timeoutMs}ms`, {
-      host,
-      port,
+      ...identityFields,
       timed_out: true,
     });
   }
   if (outcome.status === "error") {
     return baseResult(target, "tls", now, "error", `TLS probe error: ${outcome.error}`, {
-      host,
-      port,
+      ...identityFields,
       error: outcome.error,
     });
   }
   const sample = outcome.value;
   if (sample.error) {
     return baseResult(target, "tls", now, "error", `TLS probe error: ${sample.error}`, {
-      host,
-      port,
+      ...identityFields,
       error: sample.error,
     });
   }
-  return baseResult(target, "tls", now, "ok", `TLS certificate observed for ${host}`, {
-    host,
-    port,
+  return baseResult(target, "tls", now, "ok", `TLS certificate observed for ${tlsServerName} via ${host}`, {
+    ...identityFields,
     not_after: sample.not_after,
   });
 }

--- a/control-center/connectors/infrastructure/src/production-config.ts
+++ b/control-center/connectors/infrastructure/src/production-config.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseAllowlist } from "./allowlist.js";
+import {
+  CANONICAL_CONNECT_HOST,
+  CANONICAL_HEALTH_URL,
+  CANONICAL_HTTP_HOST,
+  CANONICAL_TLS_SERVER_NAME,
+  connectHostOf,
+  httpHostOf,
+  tlsServerNameOf,
+} from "./identity.js";
+import { findPackageRoot } from "./paths.js";
+import type { Allowlist } from "./types.js";
+
+export {
+  CANONICAL_CONNECT_HOST,
+  CANONICAL_HEALTH_URL,
+  CANONICAL_HTTP_HOST,
+  CANONICAL_TLS_SERVER_NAME,
+} from "./identity.js";
+
+export const PRODUCTION_ALLOWLIST_RELATIVE = "config/allowlist.production.json";
+
+export function productionAllowlistPath(): string {
+  return join(findPackageRoot(), PRODUCTION_ALLOWLIST_RELATIVE);
+}
+
+export function loadProductionAllowlist(): Allowlist {
+  const raw: unknown = JSON.parse(readFileSync(productionAllowlistPath(), "utf8"));
+  const allowlist = parseAllowlist(raw);
+  assertProductionIdentity(allowlist);
+  return allowlist;
+}
+
+export function assertProductionIdentity(allowlist: Allowlist): void {
+  const tcp = allowlist.targets.find((target) => target.checks.includes("reachability"));
+  const tls = allowlist.targets.find((target) => target.checks.includes("tls"));
+  const http = allowlist.targets.find((target) => target.checks.includes("http"));
+  if (!tcp || !tls || !http) {
+    throw new Error("production allowlist must include reachability, tls, and http targets");
+  }
+  if (connectHostOf(tcp) !== CANONICAL_CONNECT_HOST) {
+    throw new Error(`TCP connect_host must be ${CANONICAL_CONNECT_HOST}`);
+  }
+  if (tlsServerNameOf(tls) !== CANONICAL_TLS_SERVER_NAME) {
+    throw new Error(`TLS servername must be ${CANONICAL_TLS_SERVER_NAME}`);
+  }
+  if (connectHostOf(tls) === CANONICAL_TLS_SERVER_NAME) {
+    throw new Error("TLS connect host must stay independent of tls_server_name");
+  }
+  if (http.url !== CANONICAL_HEALTH_URL) {
+    throw new Error(`HTTP health URL must be ${CANONICAL_HEALTH_URL}`);
+  }
+  if (httpHostOf(http) !== CANONICAL_HTTP_HOST || tlsServerNameOf(http) !== CANONICAL_TLS_SERVER_NAME) {
+    throw new Error(`HTTP Host/SNI must be ${CANONICAL_HTTP_HOST}`);
+  }
+  if (http.url.includes("happysrv.de") || httpHostOf(http) === "happysrv.de") {
+    throw new Error("HTTP identity must not use happysrv.de");
+  }
+}

--- a/control-center/connectors/infrastructure/src/types.ts
+++ b/control-center/connectors/infrastructure/src/types.ts
@@ -111,6 +111,12 @@ export interface AllowlistTarget {
   readonly display_name: string;
   readonly checks: readonly CheckKind[];
   readonly host?: string;
+  /** TCP connect address (IP or hostname). Independent of TLS/HTTP identity. */
+  readonly connect_host?: string;
+  /** SNI servername for TLS. Independent of connect_host. */
+  readonly tls_server_name?: string;
+  /** HTTP Host header. Independent of connect_host. */
+  readonly http_host?: string;
   readonly port?: number;
   readonly url?: string;
   readonly expect_status?: number;

--- a/control-center/connectors/infrastructure/tests/sni-identity.test.ts
+++ b/control-center/connectors/infrastructure/tests/sni-identity.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseAllowlist } from "../src/allowlist.js";
+import { runInfraCanary } from "../src/canary.js";
+import { collect } from "../src/collect.js";
+import { CAPABILITIES, CANARY_COLLECTORS } from "../src/envelope.js";
+import {
+  buildHttpRequestOptions,
+  buildTlsConnectOptions,
+  CANONICAL_CONNECT_HOST,
+  CANONICAL_HEALTH_URL,
+  CANONICAL_HTTP_HOST,
+  CANONICAL_TLS_SERVER_NAME,
+  identityFor,
+} from "../src/identity.js";
+import { loadProductionAllowlist } from "../src/production-config.js";
+import type { ConnectionIdentity, ProbePorts } from "../src/ports.js";
+import { runProbes } from "../src/probes.js";
+import type { AgentPayload, HttpSample, ReachabilitySample, TlsSample } from "../src/types.js";
+
+const NOW = new Date("2026-08-21T12:00:00.000Z");
+
+function recordingPorts(input: {
+  tcp?: ReachabilitySample;
+  http?: HttpSample;
+  tls?: TlsSample;
+}): ProbePorts & {
+  httpCalls: Array<{ url: string; identity?: ConnectionIdentity }>;
+  tlsCalls: Array<{ host: string; port: number; identity?: ConnectionIdentity }>;
+  tcpCalls: Array<{ host: string; port: number }>;
+} {
+  const httpCalls: Array<{ url: string; identity?: ConnectionIdentity }> = [];
+  const tlsCalls: Array<{ host: string; port: number; identity?: ConnectionIdentity }> = [];
+  const tcpCalls: Array<{ host: string; port: number }> = [];
+  const ports: ProbePorts & {
+    httpCalls: typeof httpCalls;
+    tlsCalls: typeof tlsCalls;
+    tcpCalls: typeof tcpCalls;
+  } = {
+    now: () => NOW,
+    async reachHost(host, port) {
+      tcpCalls.push({ host, port });
+      return input.tcp ?? { ok: true, latency_ms: 5 };
+    },
+    async httpGet(url, _timeoutMs, identity) {
+      httpCalls.push(identity ? { url, identity } : { url });
+      return input.http ?? { status: 200, elapsed_ms: 10 };
+    },
+    async readTls(host, port, _timeoutMs, identity) {
+      tlsCalls.push(identity ? { host, port, identity } : { host, port });
+      return input.tls ?? { not_after: "2027-08-21T00:00:00.000Z" };
+    },
+    async readAgent(_targetId): Promise<AgentPayload | null> {
+      return null;
+    },
+    httpCalls,
+    tlsCalls,
+    tcpCalls,
+  };
+  return ports;
+}
+
+test("shipped HTTP options keep Host/SNI as api.confenge.com.br when connect host is the IP", () => {
+  const built = buildHttpRequestOptions({
+    url: CANONICAL_HEALTH_URL,
+    timeoutMs: 1000,
+    connectHost: CANONICAL_CONNECT_HOST,
+    httpHost: CANONICAL_HTTP_HOST,
+    tlsServerName: CANONICAL_TLS_SERVER_NAME,
+  });
+  assert.equal(built.connectHost, CANONICAL_CONNECT_HOST);
+  assert.equal(built.headers.Host, CANONICAL_HTTP_HOST);
+  assert.equal(built.tlsServerName, CANONICAL_TLS_SERVER_NAME);
+  assert.equal(built.path, "/api/v1/webhooks/confenge/inbound/health");
+  assert.notEqual(built.tlsServerName, CANONICAL_CONNECT_HOST);
+  assert.notEqual(built.headers.Host, "happysrv.de");
+});
+
+test("shipped HTTP options override a non-SAN URL hostname with canonical Host/SNI", () => {
+  const built = buildHttpRequestOptions({
+    url: "https://happysrv.de/api/v1/webhooks/confenge/inbound/health",
+    timeoutMs: 1000,
+    connectHost: CANONICAL_CONNECT_HOST,
+    httpHost: CANONICAL_HTTP_HOST,
+    tlsServerName: CANONICAL_TLS_SERVER_NAME,
+  });
+  assert.equal(built.connectHost, CANONICAL_CONNECT_HOST);
+  assert.equal(built.headers.Host, "api.confenge.com.br");
+  assert.equal(built.tlsServerName, "api.confenge.com.br");
+  assert.notEqual(built.tlsServerName, "happysrv.de");
+});
+
+test("shipped TLS options split connect host from SNI servername", () => {
+  const opts = buildTlsConnectOptions({
+    connectHost: CANONICAL_CONNECT_HOST,
+    port: 443,
+    tlsServerName: CANONICAL_TLS_SERVER_NAME,
+  });
+  assert.equal(opts.host, CANONICAL_CONNECT_HOST);
+  assert.equal(opts.servername, CANONICAL_TLS_SERVER_NAME);
+  assert.notEqual(opts.servername, opts.host);
+});
+
+test("production allowlist binds canonical health URL and split identity", () => {
+  const allowlist = loadProductionAllowlist();
+  const http = allowlist.targets.find((target) => target.checks.includes("http"));
+  const tls = allowlist.targets.find((target) => target.checks.includes("tls"));
+  const tcp = allowlist.targets.find((target) => target.checks.includes("reachability"));
+  assert.ok(http && tls && tcp);
+  assert.equal(http.url, CANONICAL_HEALTH_URL);
+  assert.equal(http.http_host, CANONICAL_HTTP_HOST);
+  assert.equal(http.tls_server_name, CANONICAL_TLS_SERVER_NAME);
+  assert.equal(http.connect_host, CANONICAL_CONNECT_HOST);
+  assert.equal(tls.tls_server_name, CANONICAL_TLS_SERVER_NAME);
+  assert.equal(tls.connect_host, CANONICAL_CONNECT_HOST);
+  assert.equal(tcp.connect_host, CANONICAL_CONNECT_HOST);
+  assert.equal(http.url?.includes("happysrv.de"), false);
+  const identity = identityFor(http);
+  assert.equal(identity.httpHost, CANONICAL_HTTP_HOST);
+  assert.equal(identity.tlsServerName, CANONICAL_TLS_SERVER_NAME);
+  assert.equal(identity.connectHost, CANONICAL_CONNECT_HOST);
+});
+
+test("runProbes passes canonical Host/SNI even when connect host is the raw IP", async () => {
+  const allowlist = parseAllowlist({
+    version: 1,
+    collector_id: "infrastructure.netcup",
+    source: "infrastructure",
+    default_timeout_ms: 50,
+    targets: [
+      {
+        id: "netcup-vps-tcp",
+        display_name: "tcp",
+        connect_host: CANONICAL_CONNECT_HOST,
+        host: CANONICAL_CONNECT_HOST,
+        port: 443,
+        checks: ["reachability"],
+      },
+      {
+        id: "netcup-api-tls",
+        display_name: "tls",
+        connect_host: CANONICAL_CONNECT_HOST,
+        host: CANONICAL_CONNECT_HOST,
+        tls_server_name: CANONICAL_TLS_SERVER_NAME,
+        port: 443,
+        checks: ["tls"],
+      },
+      {
+        id: "confenge-api-http",
+        display_name: "http",
+        url: CANONICAL_HEALTH_URL,
+        connect_host: CANONICAL_CONNECT_HOST,
+        http_host: CANONICAL_HTTP_HOST,
+        tls_server_name: CANONICAL_TLS_SERVER_NAME,
+        expect_status: 200,
+        checks: ["http"],
+      },
+    ],
+  });
+  const ports = recordingPorts({});
+  const probes = await runProbes(allowlist, ports);
+  assert.equal(ports.tcpCalls[0]?.host, CANONICAL_CONNECT_HOST);
+  assert.equal(ports.tlsCalls[0]?.identity?.tlsServerName, CANONICAL_TLS_SERVER_NAME);
+  assert.equal(ports.tlsCalls[0]?.host, CANONICAL_CONNECT_HOST);
+  assert.equal(ports.httpCalls[0]?.identity?.httpHost, CANONICAL_HTTP_HOST);
+  assert.equal(ports.httpCalls[0]?.identity?.tlsServerName, CANONICAL_TLS_SERVER_NAME);
+  assert.equal(ports.httpCalls[0]?.identity?.connectHost, CANONICAL_CONNECT_HOST);
+  const httpProbe = probes.find((row) => row.check === "http");
+  assert.equal(httpProbe?.payload.http_host, CANONICAL_HTTP_HOST);
+  assert.equal(httpProbe?.payload.tls_server_name, CANONICAL_TLS_SERVER_NAME);
+});
+
+test("SNI/HTTP error is not classified as whole-host TCP unavailability", async () => {
+  const allowlist = loadProductionAllowlist();
+  const ports = recordingPorts({
+    tcp: { ok: true, latency_ms: 8 },
+    tls: { not_after: "1970-01-01T00:00:00.000Z", error: "hostname/IP does not match certificate's altnames" },
+    http: { status: 0, error: "Hostname/IP does not match certificate's altnames" },
+  });
+  const result = await collect({ allowlist, ports });
+  const tcp = result.observations.find((row) => row.check === "reachability");
+  const http = result.observations.find((row) => row.check === "http");
+  const tls = result.observations.find((row) => row.check === "tls");
+  assert.ok(tcp && http && tls);
+  assert.equal(tcp.freshness_status, "FRESH");
+  assert.equal(tcp.payload.ok, true);
+  assert.equal(http.freshness_status, "ERROR");
+  assert.equal(tls.freshness_status, "ERROR");
+  assert.notEqual(tcp.freshness_status, "ERROR");
+});
+
+test("infra canary envelope, capability enum, and pinned-clock idempotency", async () => {
+  const ports = recordingPorts({
+    tcp: { ok: true, latency_ms: 4 },
+    tls: { not_after: "2027-08-21T00:00:00.000Z" },
+    http: { status: 200, elapsed_ms: 12 },
+  });
+  const first = await runInfraCanary({ now: NOW, ports });
+  const second = await runInfraCanary({ now: NOW, ports });
+  for (const report of [first, second]) {
+    assert.equal(report.collector, "infra");
+    assert.ok((CANARY_COLLECTORS as readonly string[]).includes(report.collector));
+    assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(report.freshness_status));
+    assert.equal(report.observed_at, NOW.toISOString());
+    assert.ok(report.observed_at.endsWith("Z"));
+    assert.equal(report.source.system, "infrastructure");
+    assert.equal(typeof report.source.kind, "string");
+    assert.equal(report.source.locator, CANONICAL_HEALTH_URL);
+    assert.equal(typeof report.confidence, "number");
+    assert.ok(report.error === null || (typeof report.error.code === "string" && typeof report.error.message === "string"));
+    assert.equal(typeof report.payload, "object");
+    assert.equal(typeof report.idempotency_key, "string");
+    assert.ok((CAPABILITIES as readonly string[]).includes(report.capability));
+    assert.equal(report.source.locator.includes("happysrv.de"), false);
+    const blob = JSON.stringify(report);
+    assert.equal(/\$aact_|Bearer |api[_-]?key/i.test(blob), false);
+  }
+  assert.equal(first.idempotency_key, second.idempotency_key);
+  assert.equal(first.capability, second.capability);
+  assert.equal(first.freshness_status, "FRESH");
+  assert.equal(first.capability, "AVAILABLE");
+  assert.equal(first.error, null);
+});

--- a/control-center/connectors/infrastructure/tsconfig.json
+++ b/control-center/connectors/infrastructure/tsconfig.json
@@ -20,7 +20,8 @@
     "sourceMap": true,
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/control-center/connectors/pncp/config/production.json
+++ b/control-center/connectors/pncp/config/production.json
@@ -1,0 +1,22 @@
+{
+  "collector": "pncp",
+  "mode": "read-only",
+  "contract": "PNCP_CONTRACT_FRESHNESS/1.0",
+  "bindings": {
+    "file": "PNCP_CONTRACT_PATH",
+    "http": "PNCP_CONTRACT_HTTP_URL"
+  },
+  "forbidden": [
+    "--live",
+    "ingest",
+    "recrawl",
+    "backfill",
+    "host-python",
+    "repo-fixture-as-production"
+  ],
+  "netcup_candidates": [
+    "/var/lib/extra-cli/pncp/PNCP_CONTRACT_FRESHNESS.json",
+    "/var/lib/extra-cli/pncp-contract-freshness.json",
+    "/opt/extra-cli/var/PNCP_CONTRACT_FRESHNESS.json"
+  ]
+}

--- a/control-center/connectors/pncp/package.json
+++ b/control-center/connectors/pncp/package.json
@@ -11,10 +11,15 @@
   "engines": {
     "node": ">=20"
   },
+  "bin": {
+    "cc-connector-canary": "./src/canary.ts"
+  },
   "scripts": {
     "test": "tsx --test tests/*.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "evaluate": "tsx src/cli.ts"
+    "evaluate": "tsx src/cli.ts",
+    "canary": "tsx src/canary.ts",
+    "cc-connector-canary": "tsx src/canary.ts"
   },
   "dependencies": {
     "zod": "^3.24.4"

--- a/control-center/connectors/pncp/src/canary.ts
+++ b/control-center/connectors/pncp/src/canary.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+import { evaluatePncpFreshness } from "./evaluate.js";
+import {
+  buildEnvelope,
+  toCanaryReport,
+  type Capability,
+  type CanaryReport,
+} from "./envelope.js";
+import { logEvent } from "./log.js";
+import {
+  PNCP_BINDING_SECRETS,
+  argvLooksForbidden,
+  isFixtureLocator,
+  loadPncpProductionConfig,
+  resolvePncpProductionBinding,
+} from "./production-config.js";
+import { CONTRACT_VERSION, type AdapterConfig, type FreshnessStatus, type PncpFreshnessEvaluation } from "./types.js";
+
+export interface PncpCanaryOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly now?: Date;
+  readonly argv?: readonly string[];
+  readonly exists?: (path: string) => boolean;
+  readonly evaluate?: (config: AdapterConfig) => Promise<PncpFreshnessEvaluation>;
+  readonly commandRunner?: AdapterConfig["commandRunner"];
+}
+
+function confidenceFor(status: FreshnessStatus): number {
+  switch (status) {
+    case "FRESH":
+      return 0.9;
+    case "STALE":
+      return 0.5;
+    case "UNKNOWN":
+      return 0;
+    case "ERROR":
+      return 0;
+  }
+}
+
+function capabilityFor(evaluation: PncpFreshnessEvaluation): Capability {
+  if (evaluation.parse_error?.code === "UNKNOWN_CONTRACT_VERSION") {
+    return "CONTRACT_DRIFT";
+  }
+  if (evaluation.freshness_status === "FRESH") {
+    return "AVAILABLE";
+  }
+  if (evaluation.freshness_status === "STALE" || evaluation.freshness_status === "UNKNOWN") {
+    return "BLOCKED_UPSTREAM";
+  }
+  return "ERROR";
+}
+
+export async function runPncpCanary(options: PncpCanaryOptions = {}): Promise<CanaryReport> {
+  const now = options.now ?? new Date();
+  const observedAt = now.toISOString();
+  const env = options.env ?? process.env;
+  const argv = options.argv ?? [];
+  loadPncpProductionConfig();
+
+  if (argvLooksForbidden(argv)) {
+    const envelope = buildEnvelope({
+      collector: "pncp",
+      freshness_status: "ERROR",
+      observed_at: observedAt,
+      source: { system: "extra-cli", kind: "pncp-contract-freshness", locator: "forbidden-argv" },
+      confidence: 0,
+      error: {
+        code: "FORBIDDEN_LIVE_COLLECTION",
+        message: "PNCP --live / ingest / recrawl / backfill is forbidden",
+      },
+      payload: { forbidden: ["--live", "ingest", "recrawl", "backfill"] },
+    });
+    logEvent("error", "pncp_canary_forbidden", { argv: argv.filter((t) => t.startsWith("-")) });
+    return toCanaryReport(envelope, "ERROR");
+  }
+
+  const binding = resolvePncpProductionBinding(env, options.exists);
+  if (!binding.ok) {
+    const blocked = binding.code === "BINDING_MISSING" || binding.code === "FIXTURE_FORBIDDEN";
+    const envelope = buildEnvelope({
+      collector: "pncp",
+      freshness_status: "UNKNOWN",
+      observed_at: observedAt,
+      source: { system: "extra-cli", kind: "pncp-contract-freshness", locator: "PNCP_CONTRACT_PATH" },
+      confidence: 0,
+      error: { code: binding.code, message: binding.message },
+      payload: {
+        required_bindings: [...PNCP_BINDING_SECRETS],
+        contract: CONTRACT_VERSION,
+      },
+    });
+    return toCanaryReport(envelope, blocked ? "BLOCKED_UPSTREAM" : "ERROR");
+  }
+
+  if (binding.kind === "file" && isFixtureLocator(binding.filePath)) {
+    const envelope = buildEnvelope({
+      collector: "pncp",
+      freshness_status: "UNKNOWN",
+      observed_at: observedAt,
+      source: { system: "extra-cli", kind: "pncp-contract-freshness", locator: "PNCP_CONTRACT_PATH" },
+      confidence: 0,
+      error: { code: "FIXTURE_FORBIDDEN", message: "production PNCP binding must not be a repo fixture" },
+      payload: { required_bindings: [...PNCP_BINDING_SECRETS] },
+    });
+    return toCanaryReport(envelope, "BLOCKED_UPSTREAM");
+  }
+
+  const config: AdapterConfig = {
+    kind: binding.kind,
+    now,
+    ...(binding.kind === "file" ? { filePath: binding.filePath } : { httpUrl: binding.httpUrl }),
+  };
+  if (options.commandRunner) {
+    throw new Error("production PNCP canary must not run extra-cli commands");
+  }
+
+  const evaluate = options.evaluate ?? evaluatePncpFreshness;
+  const evaluation = await evaluate(config);
+  const freshness = evaluation.freshness_status;
+  const envelope = buildEnvelope({
+    collector: "pncp",
+    freshness_status: freshness,
+    observed_at: observedAt,
+    source: {
+      system: "extra-cli",
+      kind: "pncp-contract-freshness",
+      locator: evaluation.locator,
+    },
+    confidence: confidenceFor(freshness),
+    error:
+      freshness === "FRESH"
+        ? null
+        : {
+            code: evaluation.parse_error?.code ?? "PNCP_NOT_FRESH",
+            message: evaluation.parse_error?.message ?? `upstream ${evaluation.upstream_status ?? "unknown"}`,
+          },
+    payload: {
+      contract_version: evaluation.contract_version,
+      upstream_status: evaluation.upstream_status,
+      reason_codes: evaluation.reason_codes,
+      adapter_kind: evaluation.adapter_kind,
+      as_of: evaluation.as_of,
+    },
+  });
+  return toCanaryReport(envelope, capabilityFor(evaluation));
+}
+
+export function parseCanaryArgs(argv: readonly string[]): { collector: "pncp"; now?: Date; argv: readonly string[] } {
+  let now: Date | undefined;
+  const rest: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--help" || token === "-h") {
+      throw new Error("usage: cc-connector-canary pncp [--now UTC-Z]");
+    }
+    if (token === "--now") {
+      const raw = argv[i + 1];
+      i += 1;
+      if (!raw) {
+        throw new Error("--now requires a UTC timestamp");
+      }
+      const parsed = new Date(raw);
+      if (Number.isNaN(parsed.getTime())) {
+        throw new Error(`invalid --now: ${raw}`);
+      }
+      now = parsed;
+      continue;
+    }
+    if (token === "pncp") {
+      continue;
+    }
+    if (token === "warmbly" || token === "asaas" || token === "infra") {
+      throw new Error(`this package canary only accepts pncp, got ${token}`);
+    }
+    if (token) {
+      rest.push(token);
+    }
+  }
+  return now ? { collector: "pncp", now, argv: rest } : { collector: "pncp", argv: rest };
+}
+
+export async function runCli(
+  argv: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  io: { stdout: (line: string) => void; stderr: (line: string) => void } = {
+    stdout: (line) => process.stdout.write(`${line}\n`),
+    stderr: (line) => process.stderr.write(`${line}\n`),
+  },
+): Promise<{ code: number; report?: CanaryReport }> {
+  try {
+    const args = parseCanaryArgs(argv);
+    const report = await runPncpCanary({
+      env,
+      argv: [...argv, ...args.argv],
+      ...(args.now ? { now: args.now } : {}),
+
+    });
+    io.stdout(JSON.stringify(report, null, 2));
+    return { code: 0, report };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "canary failed";
+    io.stderr(JSON.stringify({ event: "pncp.canary.error", error: message }));
+    return { code: 2 };
+  }
+}
+
+const isDirect =
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith("/canary.ts") || process.argv[1].endsWith("/canary.js"));
+
+if (isDirect) {
+  void runCli().then((outcome) => {
+    process.exitCode = outcome.code;
+  });
+}

--- a/control-center/connectors/pncp/src/config.ts
+++ b/control-center/connectors/pncp/src/config.ts
@@ -4,7 +4,16 @@ import { ADAPTER_KINDS } from "./types.js";
 export const EXTRA_CLI_FRESHNESS_SCRIPT =
   "scripts/ops/pncp_contract_freshness.py" as const;
 
-const FORBIDDEN_COMMAND_TOKENS = new Set(["--live", "--ingest", "ingest"]);
+const FORBIDDEN_COMMAND_TOKENS = new Set([
+  "--live",
+  "live",
+  "--ingest",
+  "ingest",
+  "--recrawl",
+  "recrawl",
+  "--backfill",
+  "backfill",
+]);
 
 export const ENV_VAR_DOCS = [
   "PNCP_ADAPTER_KIND=file|http|command",

--- a/control-center/connectors/pncp/src/envelope.ts
+++ b/control-center/connectors/pncp/src/envelope.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import type { FreshnessStatus } from "./types.js";
+
+export const CANARY_COLLECTORS = ["warmbly", "asaas", "pncp", "infra"] as const;
+export type CanaryCollector = (typeof CANARY_COLLECTORS)[number];
+
+export const CAPABILITIES = [
+  "AVAILABLE",
+  "PARTIAL",
+  "BLOCKED_BY_SECRET",
+  "BLOCKED_UPSTREAM",
+  "CONTRACT_DRIFT",
+  "ERROR",
+] as const;
+export type Capability = (typeof CAPABILITIES)[number];
+
+export interface CanaryError {
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface CanaryEnvelope {
+  readonly collector: CanaryCollector;
+  readonly freshness_status: FreshnessStatus;
+  readonly observed_at: string;
+  readonly source: {
+    readonly system: string;
+    readonly kind: string;
+    readonly locator: string;
+  };
+  readonly confidence: number;
+  readonly error: CanaryError | null;
+  readonly payload: Record<string, unknown>;
+  readonly idempotency_key: string;
+}
+
+export interface CanaryReport extends CanaryEnvelope {
+  readonly capability: Capability;
+}
+
+export function stableIdempotencyKey(parts: {
+  readonly collector: CanaryCollector;
+  readonly kind: string;
+  readonly locator: string;
+  readonly observedAt: string;
+}): string {
+  const digest = createHash("sha256")
+    .update(`${parts.collector}|${parts.kind}|${parts.locator}|${parts.observedAt}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `${parts.collector}:${parts.kind}:${digest}:${parts.observedAt}`;
+}
+
+export function buildEnvelope(input: {
+  readonly collector: CanaryCollector;
+  readonly freshness_status: FreshnessStatus;
+  readonly observed_at: string;
+  readonly source: CanaryEnvelope["source"];
+  readonly confidence: number;
+  readonly error: CanaryError | null;
+  readonly payload: Record<string, unknown>;
+}): CanaryEnvelope {
+  return {
+    collector: input.collector,
+    freshness_status: input.freshness_status,
+    observed_at: input.observed_at,
+    source: input.source,
+    confidence: input.confidence,
+    error: input.error,
+    payload: input.payload,
+    idempotency_key: stableIdempotencyKey({
+      collector: input.collector,
+      kind: input.source.kind,
+      locator: input.source.locator,
+      observedAt: input.observed_at,
+    }),
+  };
+}
+
+export function toCanaryReport(envelope: CanaryEnvelope, capability: Capability): CanaryReport {
+  return { ...envelope, capability };
+}

--- a/control-center/connectors/pncp/src/index.ts
+++ b/control-center/connectors/pncp/src/index.ts
@@ -57,3 +57,13 @@ export type {
   StatusMapping,
   UpstreamStatus,
 } from "./types.js";
+export { parseCanaryArgs, runCli as runCanaryCli, runPncpCanary } from "./canary.js";
+export { CAPABILITIES, CANARY_COLLECTORS, buildEnvelope } from "./envelope.js";
+export type { Capability, CanaryReport } from "./envelope.js";
+export {
+  PNCP_BINDING_SECRETS,
+  argvLooksForbidden,
+  isFixtureLocator,
+  loadPncpProductionConfig,
+  resolvePncpProductionBinding,
+} from "./production-config.js";

--- a/control-center/connectors/pncp/src/production-config.ts
+++ b/control-center/connectors/pncp/src/production-config.ts
@@ -1,0 +1,98 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { commandArgvIsForbidden } from "./config.js";
+import { CONTRACT_VERSION } from "./types.js";
+
+export const PNCP_BINDING_SECRETS = ["PNCP_CONTRACT_PATH", "PNCP_CONTRACT_HTTP_URL"] as const;
+
+export const DEFAULT_NETCUP_CANDIDATES = [
+  "/var/lib/extra-cli/pncp/PNCP_CONTRACT_FRESHNESS.json",
+  "/var/lib/extra-cli/pncp-contract-freshness.json",
+  "/opt/extra-cli/var/PNCP_CONTRACT_FRESHNESS.json",
+] as const;
+
+export interface PncpProductionConfig {
+  readonly collector: "pncp";
+  readonly mode: "read-only";
+  readonly contract: typeof CONTRACT_VERSION;
+  readonly netcup_candidates: readonly string[];
+}
+
+export type PncpBinding =
+  | { ok: true; kind: "file"; filePath: string }
+  | { ok: true; kind: "http"; httpUrl: string }
+  | { ok: false; code: "BINDING_MISSING" | "FIXTURE_FORBIDDEN" | "FORBIDDEN_LIVE_COLLECTION"; message: string };
+
+export function productionConfigPath(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "..", "config", "production.json");
+}
+
+export function loadPncpProductionConfig(): PncpProductionConfig {
+  const raw = JSON.parse(readFileSync(productionConfigPath(), "utf8")) as PncpProductionConfig;
+  if (raw.collector !== "pncp" || raw.mode !== "read-only") {
+    throw new Error("pncp production config must be read-only");
+  }
+  if (raw.contract !== CONTRACT_VERSION) {
+    throw new Error(`pncp production contract must be ${CONTRACT_VERSION}`);
+  }
+  return raw;
+}
+
+export function isFixtureLocator(locator: string): boolean {
+  const normalized = locator.replace(/\\/g, "/");
+  return (
+    /(^|\/)fixtures\//.test(normalized) ||
+    normalized.includes("connectors/pncp/fixtures") ||
+    /\/pncp\/fixtures\//.test(normalized)
+  );
+}
+
+export function argvLooksForbidden(argv: readonly string[]): boolean {
+  if (commandArgvIsForbidden(argv)) {
+    return true;
+  }
+  return argv.some((token) => /^(--)?(live|ingest|recrawl|backfill)$/i.test(token));
+}
+
+export function resolvePncpProductionBinding(
+  env: NodeJS.ProcessEnv,
+  exists: (path: string) => boolean = existsSync,
+  candidates: readonly string[] = DEFAULT_NETCUP_CANDIDATES,
+): PncpBinding {
+  const httpUrl = (env.PNCP_CONTRACT_HTTP_URL ?? "").trim();
+  if (httpUrl !== "") {
+    if (isFixtureLocator(httpUrl)) {
+      return {
+        ok: false,
+        code: "FIXTURE_FORBIDDEN",
+        message: "production PNCP binding must not be a repo fixture",
+      };
+    }
+    return { ok: true, kind: "http", httpUrl };
+  }
+  const filePath = (env.PNCP_CONTRACT_PATH ?? "").trim();
+  if (filePath !== "") {
+    if (isFixtureLocator(filePath)) {
+      return {
+        ok: false,
+        code: "FIXTURE_FORBIDDEN",
+        message: "production PNCP binding must not be a repo fixture",
+      };
+    }
+    return { ok: true, kind: "file", filePath };
+  }
+  for (const candidate of candidates) {
+    if (isFixtureLocator(candidate)) {
+      continue;
+    }
+    if (exists(candidate)) {
+      return { ok: true, kind: "file", filePath: candidate };
+    }
+  }
+  return {
+    ok: false,
+    code: "BINDING_MISSING",
+    message: `No extra-cli ${CONTRACT_VERSION} binding (set PNCP_CONTRACT_PATH or PNCP_CONTRACT_HTTP_URL)`,
+  };
+}

--- a/control-center/connectors/pncp/tests/canary.test.ts
+++ b/control-center/connectors/pncp/tests/canary.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "node:test";
+import {
+  argvLooksForbidden,
+  commandArgvIsForbidden,
+  defaultReadOnlyCommandArgv,
+  evaluatePncpFreshness,
+  isFixtureLocator,
+  mapUpstreamStatus,
+  runCanaryCli,
+  runPncpCanary,
+} from "../src/index.js";
+import { CAPABILITIES, CANARY_COLLECTORS } from "../src/envelope.js";
+import { fixturePath } from "./helpers.js";
+
+const NOW = new Date("2026-08-21T12:00:00.000Z");
+const PACKAGE_FIXTURES = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures");
+
+function assertEnvelope(report: Awaited<ReturnType<typeof runPncpCanary>>): void {
+  assert.equal(report.collector, "pncp");
+  assert.ok((CANARY_COLLECTORS as readonly string[]).includes(report.collector));
+  assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(report.freshness_status));
+  assert.ok(report.observed_at.endsWith("Z"));
+  assert.equal(typeof report.source.system, "string");
+  assert.equal(typeof report.source.kind, "string");
+  assert.equal(typeof report.source.locator, "string");
+  assert.equal(typeof report.confidence, "number");
+  assert.ok(
+    report.error === null ||
+      (typeof report.error.code === "string" && typeof report.error.message === "string"),
+  );
+  assert.equal(typeof report.payload, "object");
+  assert.equal(typeof report.idempotency_key, "string");
+  assert.ok((CAPABILITIES as readonly string[]).includes(report.capability));
+}
+
+describe("pncp production canary", () => {
+  test("missing real binding is BLOCKED_UPSTREAM, never fixture FRESH", async () => {
+    const report = await runPncpCanary({
+      env: {},
+      now: NOW,
+      exists: () => false,
+    });
+    assertEnvelope(report);
+    assert.equal(report.capability, "BLOCKED_UPSTREAM");
+    assert.notEqual(report.freshness_status, "FRESH");
+    assert.equal(isFixtureLocator(report.source.locator), false);
+    assert.equal(JSON.stringify(report).includes(PACKAGE_FIXTURES), false);
+    assert.ok((report.payload.required_bindings as string[]).includes("PNCP_CONTRACT_PATH"));
+  });
+
+  test("two pinned-clock blocked runs share idempotency_key", async () => {
+    const first = await runPncpCanary({ env: {}, now: NOW, exists: () => false });
+    const second = await runPncpCanary({ env: {}, now: NOW, exists: () => false });
+    assert.equal(first.idempotency_key, second.idempotency_key);
+    assert.equal(first.capability, second.capability);
+  });
+
+  test("repo fixture path is refused as a production source", async () => {
+    let spawned = 0;
+    const report = await runPncpCanary({
+      env: { PNCP_CONTRACT_PATH: fixturePath("contract-fresh.json") },
+      now: NOW,
+      commandRunner: async () => {
+        spawned += 1;
+        throw new Error("must not spawn");
+      },
+    });
+    assertEnvelope(report);
+    assert.equal(report.capability, "BLOCKED_UPSTREAM");
+    assert.equal(report.error?.code, "FIXTURE_FORBIDDEN");
+    assert.notEqual(report.freshness_status, "FRESH");
+    assert.equal(spawned, 0);
+    assert.equal(isFixtureLocator(fixturePath("contract-fresh.json")), true);
+  });
+
+  test("--live ingest recrawl backfill never spawn", async () => {
+    let spawned = 0;
+    const runner = async () => {
+      spawned += 1;
+      throw new Error("must not spawn live collection");
+    };
+    for (const argv of [
+      ["python3", "scripts/ops/pncp_contract_freshness.py", "--live", "--json"],
+      ["python3", "x.py", "--ingest"],
+      ["python3", "x.py", "--recrawl"],
+      ["python3", "x.py", "backfill"],
+    ]) {
+      assert.equal(commandArgvIsForbidden(argv), true);
+      assert.equal(argvLooksForbidden(argv), true);
+      const evaluation = await evaluatePncpFreshness({
+        kind: "command",
+        commandArgv: argv,
+        now: NOW,
+        commandRunner: runner,
+      });
+      assert.equal(evaluation.freshness_status, "ERROR");
+      assert.equal(evaluation.parse_error?.code, "FORBIDDEN_LIVE_COLLECTION");
+      const canary = await runPncpCanary({ env: {}, now: NOW, argv, commandRunner: runner });
+      assert.equal(canary.error?.code, "FORBIDDEN_LIVE_COLLECTION");
+      assert.notEqual(canary.freshness_status, "FRESH");
+    }
+    assert.equal(spawned, 0);
+    assert.equal(commandArgvIsForbidden(defaultReadOnlyCommandArgv("/var/lib/extra-cli/snapshot.json")), false);
+  });
+
+  test("DEGRADED maps to STALE and is not promoted", async () => {
+    assert.equal(mapUpstreamStatus("DEGRADED").freshness_status, "STALE");
+    const evaluation = await evaluatePncpFreshness({
+      kind: "file",
+      filePath: fixturePath("contract-degraded.json"),
+      now: NOW,
+    });
+    assert.equal(evaluation.freshness_status, "STALE");
+    assert.equal(evaluation.upstream_status, "DEGRADED");
+    const report = await runPncpCanary({
+      env: { PNCP_CONTRACT_PATH: "/var/lib/extra-cli/pncp/PNCP_CONTRACT_FRESHNESS.json" },
+      now: NOW,
+      exists: () => true,
+      evaluate: async () => evaluation,
+    });
+    assertEnvelope(report);
+    assert.equal(report.freshness_status, "STALE");
+    assert.notEqual(report.freshness_status, "FRESH");
+    assert.equal(report.capability, "BLOCKED_UPSTREAM");
+    assert.equal(report.payload.upstream_status, "DEGRADED");
+  });
+
+  test("unknown contract version is CONTRACT_DRIFT", async () => {
+    const evaluation = await evaluatePncpFreshness({
+      kind: "file",
+      filePath: fixturePath("contract-unknown-version.json"),
+      now: NOW,
+    });
+    const report = await runPncpCanary({
+      env: { PNCP_CONTRACT_HTTP_URL: "https://metrics.example.invalid/pncp" },
+      now: NOW,
+      evaluate: async () => evaluation,
+    });
+    assertEnvelope(report);
+    assert.equal(report.capability, "CONTRACT_DRIFT");
+    assert.notEqual(report.freshness_status, "FRESH");
+  });
+
+  test("CLI without binding emits BLOCKED_UPSTREAM JSON", async () => {
+    const lines: string[] = [];
+    const outcome = await runCanaryCli(["pncp", "--now", NOW.toISOString()], {}, {
+      stdout: (line) => lines.push(line),
+      stderr: () => undefined,
+    });
+    assert.equal(outcome.code, 0);
+    const parsed = JSON.parse(lines.join("\n")) as Awaited<ReturnType<typeof runPncpCanary>>;
+    assertEnvelope(parsed);
+    assert.equal(parsed.capability, "BLOCKED_UPSTREAM");
+  });
+});

--- a/control-center/connectors/warmbly/config/production.json
+++ b/control-center/connectors/warmbly/config/production.json
@@ -1,0 +1,25 @@
+{
+  "collector": "warmbly",
+  "mode": "read-only",
+  "network": {
+    "external": "warmbly-confenge_default",
+    "join": "optional-read-only-member",
+    "discovery": "docker inspect (read-only)",
+    "forbidden": ["compose_edit", "volume_mount", "postgres", "redis", "nats"]
+  },
+  "required_secrets": ["WARMBLY_BASE_URL", "WARMBLY_API_TOKEN"],
+  "secret_aliases": {
+    "WARMBLY_API_TOKEN": ["WARMBLY_TOKEN", "WARMBLY_API_KEY"]
+  },
+  "http": {
+    "allowed_methods": ["GET", "HEAD", "POST"],
+    "post_read_paths": [
+      "/v1/contacts/search",
+      "/v1/crm/deals/search",
+      "/v1/crm/deals/summary",
+      "/v1/crm/tasks/search",
+      "/v1/crm/tasks/summary"
+    ],
+    "forbidden_methods": ["PATCH", "PUT", "DELETE"]
+  }
+}

--- a/control-center/connectors/warmbly/package.json
+++ b/control-center/connectors/warmbly/package.json
@@ -12,11 +12,14 @@
     ".": "./src/index.ts"
   },
   "bin": {
-    "warmbly-collect": "./src/cli.ts"
+    "warmbly-collect": "./src/cli.ts",
+    "cc-connector-canary": "./src/canary.ts"
   },
   "scripts": {
     "test": "tsx --test tests/*.test.ts",
     "collect": "tsx src/cli.ts",
+    "canary": "tsx src/canary.ts",
+    "cc-connector-canary": "tsx src/canary.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/control-center/connectors/warmbly/src/canary.ts
+++ b/control-center/connectors/warmbly/src/canary.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+import { collect } from "./collect.ts";
+import { buildEnvelope, toCanaryReport, type CanaryReport, type FreshnessStatus } from "./envelope.ts";
+import { classifyRequest } from "./http/allowlist.ts";
+import { WarmblyClient, type WarmblyClientOptions } from "./http/client.ts";
+import { createStderrLogger, redactUnknown } from "./http/redaction.ts";
+import {
+  REQUIRED_SECRET_NAMES,
+  loadWarmblyProductionConfig,
+  resolveWarmblySecrets,
+  sanitizeLocator,
+} from "./production-config.ts";
+
+export interface WarmblyCanaryOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly now?: Date;
+  readonly clientOptions?: Partial<WarmblyClientOptions>;
+  readonly fetchImpl?: typeof fetch;
+  readonly log?: (line: string) => void;
+}
+
+function confidenceFor(status: FreshnessStatus): number {
+  switch (status) {
+    case "FRESH":
+      return 0.9;
+    case "STALE":
+      return 0.5;
+    case "UNKNOWN":
+      return 0;
+    case "ERROR":
+      return 0;
+  }
+}
+
+function mapHttpStatusFreshness(status: number): FreshnessStatus {
+  if (status === 401 || status === 403) {
+    return "ERROR";
+  }
+  if (status === 429 || status >= 500) {
+    return "ERROR";
+  }
+  return "ERROR";
+}
+
+export async function runWarmblyCanary(options: WarmblyCanaryOptions = {}): Promise<CanaryReport> {
+  const now = options.now ?? new Date();
+  const observedAt = now.toISOString();
+  const env = options.env ?? process.env;
+  const log = options.log ?? ((line: string) => process.stderr.write(`${line}\n`));
+  const production = loadWarmblyProductionConfig();
+  const secrets = resolveWarmblySecrets(env);
+
+  if (!secrets.ok) {
+    const envelope = buildEnvelope({
+      collector: "warmbly",
+      freshness_status: "UNKNOWN",
+      observed_at: observedAt,
+      source: {
+        system: "warmbly",
+        kind: "commercial-api",
+        locator: "WARMBLY_BASE_URL",
+      },
+      confidence: 0,
+      error: {
+        code: "CREDENTIAL_MISSING",
+        message: `Missing ${secrets.missing.join(", ")} (aliases: WARMBLY_TOKEN, WARMBLY_API_KEY)`,
+      },
+      payload: {
+        required_secrets: [...REQUIRED_SECRET_NAMES],
+        secret_aliases: production.secret_aliases,
+        missing: secrets.missing,
+      },
+    });
+    const report = toCanaryReport(envelope, "BLOCKED_BY_SECRET");
+    log(JSON.stringify(redactUnknown({ event: "warmbly.canary.blocked_by_secret", missing: secrets.missing })));
+    return report;
+  }
+
+  const locator = sanitizeLocator(secrets.baseUrl);
+  try {
+    const snapshot = await collect({
+      now,
+      client: new WarmblyClient({
+        baseUrl: secrets.baseUrl,
+        token: secrets.token,
+        timeoutMs: options.clientOptions?.timeoutMs ?? 8_000,
+        maxRetries: options.clientOptions?.maxRetries ?? 0,
+        logger: options.clientOptions?.logger ?? createStderrLogger(),
+        fetchImpl: options.fetchImpl ?? options.clientOptions?.fetchImpl ?? fetch,
+        sleep: options.clientOptions?.sleep,
+        now: options.clientOptions?.now,
+        failureThreshold: options.clientOptions?.failureThreshold,
+        resetMs: options.clientOptions?.resetMs,
+        backoffMs: options.clientOptions?.backoffMs,
+      }),
+    });
+    const freshness = snapshot.freshness_status;
+    const envelope = buildEnvelope({
+      collector: "warmbly",
+      freshness_status: freshness,
+      observed_at: observedAt,
+      source: { system: "warmbly", kind: "commercial-api", locator },
+      confidence: confidenceFor(freshness),
+      error:
+        freshness === "FRESH"
+          ? null
+          : {
+              code: "WARMBLY_NOT_FRESH",
+              message: `Warmbly snapshot freshness=${freshness}`,
+            },
+      payload: {
+        schema: snapshot.schema,
+        health: snapshot.health,
+        attention_count: snapshot.attention.length,
+        observation_count: snapshot.observations.length,
+        observations: snapshot.observations.map((row) => ({
+          surface: row.surface,
+          http_method: row.http_method,
+          http_path: row.http_path,
+          http_status: row.http_status,
+          freshness_status: row.provenance.freshness_status,
+        })),
+      },
+    });
+    const capability =
+      freshness === "FRESH" ? "AVAILABLE" : freshness === "STALE" ? "PARTIAL" : "ERROR";
+    return toCanaryReport(envelope, capability);
+  } catch (err) {
+    const status = typeof err === "object" && err && "status" in err ? Number((err as { status: number }).status) : 0;
+    const freshness = status > 0 ? mapHttpStatusFreshness(status) : "ERROR";
+    const message = err instanceof Error ? err.message : "warmbly canary failed";
+    const envelope = buildEnvelope({
+      collector: "warmbly",
+      freshness_status: freshness,
+      observed_at: observedAt,
+      source: { system: "warmbly", kind: "commercial-api", locator },
+      confidence: 0,
+      error: { code: status === 401 || status === 403 ? "UPSTREAM_AUTH" : "ERROR", message },
+      payload: { required_secrets: [...REQUIRED_SECRET_NAMES] },
+    });
+    return toCanaryReport(envelope, "ERROR");
+  }
+}
+
+export function parseCanaryArgs(argv: readonly string[]): { collector: "warmbly"; now?: Date } {
+  let now: Date | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--help" || token === "-h") {
+      throw new Error("usage: cc-connector-canary warmbly [--now UTC-Z]");
+    }
+    if (token === "--now") {
+      const raw = argv[i + 1];
+      i += 1;
+      if (!raw) {
+        throw new Error("--now requires a UTC timestamp");
+      }
+      const parsed = new Date(raw);
+      if (Number.isNaN(parsed.getTime())) {
+        throw new Error(`invalid --now: ${raw}`);
+      }
+      now = parsed;
+      continue;
+    }
+    if (token === "warmbly") {
+      continue;
+    }
+    if (token === "asaas" || token === "pncp" || token === "infra") {
+      throw new Error(`this package canary only accepts warmbly, got ${token}`);
+    }
+  }
+  return now ? { collector: "warmbly", now } : { collector: "warmbly" };
+}
+
+export async function runCli(
+  argv: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  io: { stdout: (line: string) => void; stderr: (line: string) => void } = {
+    stdout: (line) => process.stdout.write(`${line}\n`),
+    stderr: (line) => process.stderr.write(`${line}\n`),
+  },
+): Promise<{ code: number; report?: CanaryReport }> {
+  try {
+    const args = parseCanaryArgs(argv);
+    const report = await runWarmblyCanary({
+      env,
+      now: args.now,
+      log: io.stderr,
+    });
+    io.stdout(JSON.stringify(redactUnknown(report), null, 2));
+    return { code: 0, report };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "canary failed";
+    io.stderr(JSON.stringify({ event: "warmbly.canary.error", error: message }));
+    return { code: 2 };
+  }
+}
+
+export function assertWarmblyMutationDenied(method: string, path: string): void {
+  const classified = classifyRequest(method, path);
+  if (classified.allowed) {
+    throw new Error(`expected denial for ${method} ${path}`);
+  }
+}
+
+const isDirect =
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith("/canary.ts") || process.argv[1].endsWith("/canary.js"));
+
+if (isDirect) {
+  runCli().then((outcome) => {
+    process.exitCode = outcome.code;
+  });
+}

--- a/control-center/connectors/warmbly/src/envelope.ts
+++ b/control-center/connectors/warmbly/src/envelope.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+
+export const CANARY_COLLECTORS = ["warmbly", "asaas", "pncp", "infra"] as const;
+export type CanaryCollector = (typeof CANARY_COLLECTORS)[number];
+
+export const FRESHNESS_STATUSES = ["FRESH", "STALE", "UNKNOWN", "ERROR"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const CAPABILITIES = [
+  "AVAILABLE",
+  "PARTIAL",
+  "BLOCKED_BY_SECRET",
+  "BLOCKED_UPSTREAM",
+  "CONTRACT_DRIFT",
+  "ERROR",
+] as const;
+export type Capability = (typeof CAPABILITIES)[number];
+
+export interface CanaryError {
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface CanaryEnvelope {
+  readonly collector: CanaryCollector;
+  readonly freshness_status: FreshnessStatus;
+  readonly observed_at: string;
+  readonly source: {
+    readonly system: string;
+    readonly kind: string;
+    readonly locator: string;
+  };
+  readonly confidence: number;
+  readonly error: CanaryError | null;
+  readonly payload: Record<string, unknown>;
+  readonly idempotency_key: string;
+}
+
+export interface CanaryReport extends CanaryEnvelope {
+  readonly capability: Capability;
+}
+
+export function stableIdempotencyKey(parts: {
+  readonly collector: CanaryCollector;
+  readonly kind: string;
+  readonly locator: string;
+  readonly observedAt: string;
+}): string {
+  const digest = createHash("sha256")
+    .update(`${parts.collector}|${parts.kind}|${parts.locator}|${parts.observedAt}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `${parts.collector}:${parts.kind}:${digest}:${parts.observedAt}`;
+}
+
+export function buildEnvelope(input: {
+  readonly collector: CanaryCollector;
+  readonly freshness_status: FreshnessStatus;
+  readonly observed_at: string;
+  readonly source: CanaryEnvelope["source"];
+  readonly confidence: number;
+  readonly error: CanaryError | null;
+  readonly payload: Record<string, unknown>;
+}): CanaryEnvelope {
+  return {
+    collector: input.collector,
+    freshness_status: input.freshness_status,
+    observed_at: input.observed_at,
+    source: input.source,
+    confidence: input.confidence,
+    error: input.error,
+    payload: input.payload,
+    idempotency_key: stableIdempotencyKey({
+      collector: input.collector,
+      kind: input.source.kind,
+      locator: input.source.locator,
+      observedAt: input.observed_at,
+    }),
+  };
+}
+
+export function toCanaryReport(envelope: CanaryEnvelope, capability: Capability): CanaryReport {
+  return { ...envelope, capability };
+}

--- a/control-center/connectors/warmbly/src/index.ts
+++ b/control-center/connectors/warmbly/src/index.ts
@@ -27,3 +27,15 @@ export {
   TimeoutError,
 } from "./http/client.ts";
 export { COLLECT_ROUTES, MAPPED_READ_ROUTES } from "./collector/routes.ts";
+export {
+  parseCanaryArgs,
+  runCli as runCanaryCli,
+  runWarmblyCanary,
+} from "./canary.ts";
+export { CAPABILITIES, CANARY_COLLECTORS, buildEnvelope } from "./envelope.ts";
+export type { Capability, CanaryReport } from "./envelope.ts";
+export {
+  REQUIRED_SECRET_NAMES,
+  loadWarmblyProductionConfig,
+  resolveWarmblySecrets,
+} from "./production-config.ts";

--- a/control-center/connectors/warmbly/src/production-config.ts
+++ b/control-center/connectors/warmbly/src/production-config.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const WARMBLY_BASE_URL_SECRET = "WARMBLY_BASE_URL";
+export const WARMBLY_TOKEN_SECRET = "WARMBLY_API_TOKEN";
+export const WARMBLY_TOKEN_ALIASES = ["WARMBLY_API_TOKEN", "WARMBLY_TOKEN", "WARMBLY_API_KEY"] as const;
+
+export const REQUIRED_SECRET_NAMES = [WARMBLY_BASE_URL_SECRET, WARMBLY_TOKEN_SECRET] as const;
+
+export interface WarmblySecretsOk {
+  readonly ok: true;
+  readonly baseUrl: string;
+  readonly token: string;
+}
+
+export interface WarmblySecretsMissing {
+  readonly ok: false;
+  readonly missing: string[];
+}
+
+export type WarmblySecrets = WarmblySecretsOk | WarmblySecretsMissing;
+
+export interface WarmblyProductionConfig {
+  readonly collector: "warmbly";
+  readonly mode: "read-only";
+  readonly required_secrets: readonly string[];
+  readonly secret_aliases: Record<string, readonly string[]>;
+}
+
+export function productionConfigPath(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "..", "config", "production.json");
+}
+
+export function loadWarmblyProductionConfig(): WarmblyProductionConfig {
+  const raw = JSON.parse(readFileSync(productionConfigPath(), "utf8")) as WarmblyProductionConfig;
+  if (raw.collector !== "warmbly" || raw.mode !== "read-only") {
+    throw new Error("warmbly production config must be read-only collector=warmbly");
+  }
+  return raw;
+}
+
+export function resolveWarmblySecrets(env: NodeJS.ProcessEnv): WarmblySecrets {
+  const baseUrl = env.WARMBLY_BASE_URL?.trim() ?? "";
+  const token =
+    env.WARMBLY_API_TOKEN?.trim() ||
+    env.WARMBLY_TOKEN?.trim() ||
+    env.WARMBLY_API_KEY?.trim() ||
+    "";
+  const missing: string[] = [];
+  if (baseUrl === "") {
+    missing.push(WARMBLY_BASE_URL_SECRET);
+  }
+  if (token === "") {
+    missing.push(WARMBLY_TOKEN_SECRET);
+  }
+  if (missing.length > 0) {
+    return { ok: false, missing };
+  }
+  return { ok: true, baseUrl, token };
+}
+
+export function sanitizeLocator(baseUrl: string): string {
+  try {
+    const parsed = new URL(baseUrl);
+    return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, "");
+  } catch {
+    return "WARMBLY_BASE_URL";
+  }
+}

--- a/control-center/connectors/warmbly/tests/canary.test.ts
+++ b/control-center/connectors/warmbly/tests/canary.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseCanaryArgs, runCli, runWarmblyCanary } from "../src/canary.ts";
+import { collect } from "../src/collect.ts";
+import { CAPABILITIES, CANARY_COLLECTORS } from "../src/envelope.ts";
+import { classifyRequest } from "../src/http/allowlist.ts";
+import {
+  MethodNotAllowedError,
+  TimeoutError,
+  WarmblyClient,
+} from "../src/http/client.ts";
+import { serializeLog } from "../src/http/redaction.ts";
+import {
+  REQUIRED_SECRET_NAMES,
+  loadWarmblyProductionConfig,
+  resolveWarmblySecrets,
+} from "../src/production-config.ts";
+import { startFixtureStub } from "../src/stub-server.ts";
+import { capturingLogger, loadFixture, NOW } from "./helpers.ts";
+
+const TOKEN = "wmbly_canary_secret_token_do_not_log";
+
+function assertEnvelope(report: Awaited<ReturnType<typeof runWarmblyCanary>>): void {
+  assert.equal(report.collector, "warmbly");
+  assert.ok((CANARY_COLLECTORS as readonly string[]).includes(report.collector));
+  assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(report.freshness_status));
+  assert.ok(report.observed_at.endsWith("Z"));
+  assert.equal(typeof report.source.system, "string");
+  assert.equal(typeof report.source.kind, "string");
+  assert.equal(typeof report.source.locator, "string");
+  assert.equal(typeof report.confidence, "number");
+  assert.ok(
+    report.error === null ||
+      (typeof report.error.code === "string" && typeof report.error.message === "string"),
+  );
+  assert.equal(typeof report.payload, "object");
+  assert.equal(typeof report.idempotency_key, "string");
+  assert.ok((CAPABILITIES as readonly string[]).includes(report.capability));
+}
+
+describe("warmbly production canary", () => {
+  it("missing secrets yield CREDENTIAL_MISSING / BLOCKED_BY_SECRET and never open a socket", async () => {
+    let fetches = 0;
+    const report = await runWarmblyCanary({
+      env: {},
+      now: NOW,
+      fetchImpl: async () => {
+        fetches += 1;
+        throw new Error("transport must not run without secrets");
+      },
+    });
+    assertEnvelope(report);
+    assert.equal(report.freshness_status, "UNKNOWN");
+    assert.equal(report.capability, "BLOCKED_BY_SECRET");
+    assert.equal(report.error?.code, "CREDENTIAL_MISSING");
+    assert.equal(report.confidence, 0);
+    assert.notEqual(report.freshness_status, "FRESH");
+    assert.ok(Array.isArray(report.payload.required_secrets));
+    assert.ok((report.payload.required_secrets as string[]).includes("WARMBLY_BASE_URL"));
+    assert.ok((report.payload.required_secrets as string[]).includes("WARMBLY_API_TOKEN"));
+    assert.deepEqual([...REQUIRED_SECRET_NAMES], ["WARMBLY_BASE_URL", "WARMBLY_API_TOKEN"]);
+    const secrets = resolveWarmblySecrets({});
+    assert.equal(secrets.ok, false);
+    assert.equal(fetches, 0);
+  });
+
+  it("two pinned-clock blocked runs share idempotency_key", async () => {
+    const first = await runWarmblyCanary({ env: {}, now: NOW });
+    const second = await runWarmblyCanary({ env: {}, now: NOW });
+    assert.equal(first.idempotency_key, second.idempotency_key);
+    assert.equal(first.capability, second.capability);
+  });
+
+  it("empty 200 commercial payload is not an error, while 401/403/429/5xx stay ERROR", async () => {
+    const emptyPayload = {
+      health: { status: "ok" },
+      pipelines: [],
+      deals: [],
+      tasks: [],
+      contacts: [],
+      campaigns: [],
+      api_version: "v1",
+    };
+    const stub = await startFixtureStub({
+      payload: emptyPayload,
+      token: TOKEN,
+    });
+    try {
+      const fresh = await runWarmblyCanary({
+        env: { WARMBLY_BASE_URL: stub.url, WARMBLY_API_TOKEN: TOKEN },
+        now: NOW,
+      });
+      assertEnvelope(fresh);
+      assert.notEqual(fresh.capability, "BLOCKED_BY_SECRET");
+      assert.notEqual(`${fresh.freshness_status}`, "ERROR");
+    } finally {
+      await stub.close();
+    }
+
+    for (const status of [401, 403, 429, 500, 503]) {
+      const failing = await startFixtureStub({
+        payload: loadFixture("commercial-runtime.json"),
+        token: TOKEN,
+        failStatus: status,
+      });
+      try {
+        const report = await runWarmblyCanary({
+          env: { WARMBLY_BASE_URL: failing.url, WARMBLY_API_TOKEN: TOKEN },
+          now: NOW,
+          clientOptions: { maxRetries: 0, timeoutMs: 500, failureThreshold: 99 },
+        });
+        assertEnvelope(report);
+        assert.notEqual(report.freshness_status, "FRESH");
+        assert.ok(report.freshness_status === "ERROR" || report.freshness_status === "UNKNOWN");
+      } finally {
+        await failing.close();
+      }
+    }
+  });
+
+  it("timeout is ERROR/UNKNOWN, not empty FRESH", async () => {
+    const stub = await startFixtureStub({
+      payload: loadFixture("commercial-runtime.json"),
+      token: TOKEN,
+      delayMs: 250,
+    });
+    try {
+      const client = new WarmblyClient({
+        baseUrl: stub.url,
+        token: TOKEN,
+        timeoutMs: 40,
+        maxRetries: 0,
+        logger: () => undefined,
+      });
+      await assert.rejects(() => client.request({ method: "GET", path: "/health" }), TimeoutError);
+      const report = await runWarmblyCanary({
+        env: { WARMBLY_BASE_URL: stub.url, WARMBLY_API_TOKEN: TOKEN },
+        now: NOW,
+        clientOptions: { timeoutMs: 40, maxRetries: 0, logger: () => undefined, failureThreshold: 99 },
+      });
+      assertEnvelope(report);
+      assert.notEqual(report.freshness_status, "FRESH");
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("mutating POST/PATCH/PUT/DELETE never hit the injected transport; POST /search and /summary may", async () => {
+    const hits: string[] = [];
+    const client = new WarmblyClient({
+      baseUrl: "https://warmbly.example.invalid",
+      token: TOKEN,
+      maxRetries: 0,
+      logger: () => undefined,
+      fetchImpl: async (input, init) => {
+        hits.push(`${init?.method ?? "GET"} ${String(input)}`);
+        throw new Error("transport must not run for denied methods");
+      },
+    });
+    for (const req of [
+      { method: "POST" as const, path: "/v1/crm/deals" },
+      { method: "PATCH" as const, path: "/v1/crm/deals/x" },
+      { method: "PUT" as const, path: "/v1/crm/deals/x" },
+      { method: "DELETE" as const, path: "/v1/crm/tasks/x" },
+    ]) {
+      assert.equal(classifyRequest(req.method, req.path).allowed, false);
+      await assert.rejects(() => client.request(req), MethodNotAllowedError);
+    }
+    assert.equal(hits.length, 0);
+    assert.equal(classifyRequest("POST", "/v1/contacts/search").allowed, true);
+    assert.equal(classifyRequest("POST", "/v1/crm/deals/summary").allowed, true);
+  });
+
+  it("canary collect with recording transport never issues mutating methods", async () => {
+    const payload = loadFixture("commercial-runtime.json");
+    const stub = await startFixtureStub({ payload, token: TOKEN });
+    const hits: string[] = [];
+    try {
+      const snapshot = await collect({
+        now: NOW,
+        client: new WarmblyClient({
+          baseUrl: stub.url,
+          token: TOKEN,
+          maxRetries: 0,
+          logger: () => undefined,
+          fetchImpl: async (input, init) => {
+            hits.push(`${init?.method ?? "GET"} ${String(input)}`);
+            return fetch(input, init);
+          },
+        }),
+      });
+      assert.ok(snapshot);
+      assert.equal(hits.some((h) => /^(PATCH|PUT|DELETE) /.test(h)), false);
+      assert.equal(
+        hits.some((h) => h.startsWith("POST ") && !/\/search|\/summary/.test(h)),
+        false,
+      );
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("redacts secrets from canary JSON and logs", async () => {
+    const logger = capturingLogger();
+    const report = await runWarmblyCanary({
+      env: { WARMBLY_BASE_URL: "https://warmbly.example.invalid", WARMBLY_API_TOKEN: TOKEN },
+      now: NOW,
+      clientOptions: {
+        maxRetries: 0,
+        timeoutMs: 20,
+        logger: logger.logger,
+        fetchImpl: async () => {
+          throw new Error(`failed with Bearer ${TOKEN}`);
+        },
+      },
+    });
+    const serialized = serializeLog({
+      level: "error",
+      msg: "canary",
+      authorization: `Bearer ${TOKEN}`,
+      token: TOKEN,
+    });
+    const blob = `${JSON.stringify(report)}\n${logger.blob()}\n${serialized}`;
+    assert.equal(blob.includes(TOKEN), false);
+    assert.equal(/wmbly_canary_secret/.test(blob), false);
+  });
+
+  it("CLI entry emits the frozen envelope for missing secrets", async () => {
+    const lines: string[] = [];
+    const outcome = await runCli(["warmbly", "--now", NOW.toISOString()], {}, {
+      stdout: (line) => lines.push(line),
+      stderr: () => undefined,
+    });
+    assert.equal(outcome.code, 0);
+    const parsed = JSON.parse(lines.join("\n")) as Awaited<ReturnType<typeof runWarmblyCanary>>;
+    assertEnvelope(parsed);
+    assert.equal(parsed.capability, "BLOCKED_BY_SECRET");
+    assert.equal(parseCanaryArgs(["warmbly"]).collector, "warmbly");
+    const cfg = loadWarmblyProductionConfig();
+    assert.equal(cfg.collector, "warmbly");
+    assert.equal(cfg.mode, "read-only");
+  });
+});


### PR DESCRIPTION
## Campaign
CONFENGE-CC-PRODUCTION-CONNECTOR-ACTIVATION-01

READ-ONLY. No merge. No provider mutation. No production apply.

## What this does
Leaves Warmbly, Asaas, PNCP, and Infra connectors fail-closed and canary-ready for Netcup without touching origin systems.

- `cc-connector-canary warmbly|asaas|pncp|infra` emits the frozen envelope plus capability (`AVAILABLE|PARTIAL|BLOCKED_BY_SECRET|BLOCKED_UPSTREAM|CONTRACT_DRIFT|ERROR`).
- Missing Warmbly/Asaas secrets: `CREDENTIAL_MISSING`, `confidence=0`, never empty-payload `FRESH`.
- PNCP consumes only extra-cli `PNCP_CONTRACT_FRESHNESS/1.0`; missing binding is `BLOCKED_UPSTREAM`; fixtures are refused as production source; `--live`/`ingest`/`recrawl`/`backfill` never spawn.
- Infra splits TCP connect identity (`159.195.18.88`) from TLS SNI / HTTP Host (`api.confenge.com.br`) and health-checks `https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health`.
- Mutating Warmbly/Asaas methods and paths are refused before transport. Asaas `CONFIRMED` stays paid-not-received.

## Ownership
Edits are restricted to:
- `control-center/connectors/warmbly/**`
- `control-center/connectors/asaas/**`
- `control-center/connectors/pncp/**`
- `control-center/connectors/infrastructure/**`

## Evidence
Live infra HTTP canary observed HTTP 200 FRESH with Host/SNI `api.confenge.com.br` while connecting to `159.195.18.88`. Warmbly and Asaas remain `BLOCKED_BY_SECRET` without invented credentials. PNCP remains `BLOCKED_UPSTREAM` off-Netcup.

Do not merge.