### PR TITLE
feat(web-shell): live founder cockpit on frozen operational HTTP

### DIFF
--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -1,6 +1,8 @@
 import type { DestinationId } from "../destinations";
+import type { HojeViewModel } from "../hoje-compose";
 import type {
   ActorRef,
+  AgentActivity,
   AgentSession,
   AttentionItem,
   ClientStatus,
@@ -12,6 +14,7 @@ import type {
   ServiceHealth,
   UtcDateTime,
 } from "../types";
+import type { WriteShortcutKind } from "./paths";
 
 /** The mock/HTTP adapter is read-only. Mutation verbs are not part of the contract. */
 export const ADAPTER_ACTIONS = ["read"] as const;
@@ -49,6 +52,8 @@ export interface DestinationPage {
   health?: ServiceHealth[];
   directives?: Directive[];
   sessions?: AgentSession[];
+  activities?: AgentActivity[];
+  hoje?: HojeViewModel;
 }
 
 export interface AdapterError {
@@ -61,10 +66,17 @@ export type AdapterReadResult =
   | { ok: false; loading: false; error: AdapterError }
   | { ok: true; loading: true; page: null };
 
+export interface AdapterWriteResult {
+  ok: boolean;
+  path: string;
+  kind: WriteShortcutKind;
+  message: string;
+}
+
 /**
- * Read-only Control Center port. Default implementation is in-repo fixtures.
- * A later convergence campaign may swap this for HTTP; MCP stays the agent
- * interface and is not consumed here.
+ * Production default is HTTP. Mock exists only by explicit test injection.
+ * MCP is the agent interface and is not consumed here. Provider mutations
+ * stay forbidden; the only writes are authorized Context Service shortcuts.
  */
 export interface ControlCenterReadAdapter {
   readonly mode: "mock" | "http";
@@ -73,6 +85,10 @@ export interface ControlCenterReadAdapter {
   readDestination(id: DestinationId): AdapterReadResult | Promise<AdapterReadResult>;
   readAttention(): AttentionItem[] | Promise<AttentionItem[]>;
   readPriorities(): PriorityRecommendation[] | Promise<PriorityRecommendation[]>;
+  writeShortcut?(
+    kind: WriteShortcutKind,
+    draft: { title: string; body: string },
+  ): AdapterWriteResult | Promise<AdapterWriteResult>;
 }
 
 export function adapterAllows(action: string): action is AdapterAction {

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -1,105 +1,37 @@
 import type { DestinationId } from "../destinations";
 import { getDestination } from "../destinations";
-import type {
-  ActorRef,
-  AttentionItem,
-  Directive,
-  PriorityRecommendation,
-  Provenance,
-} from "../types";
+import type { ActorRef, AttentionItem, PriorityRecommendation, Provenance } from "../types";
 import {
   ADAPTER_ACTIONS,
   type AdapterAction,
   type AdapterReadResult,
+  type AdapterWriteResult,
   type ControlCenterReadAdapter,
   type DestinationPage,
 } from "./contract";
-import { createMockAdapter } from "./mock";
-
-function scopeFor(id: DestinationId): string {
-  return getDestination(id).scope;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  return null;
-}
-
-function provenanceOf(row: Record<string, unknown>, fallback: Provenance): Provenance {
-  const source = asRecord(row.source);
-  const freshness = row.freshness_status;
-  return {
-    source: source
-      ? {
-          system: String(source.system ?? "control-center"),
-          kind: String(source.kind ?? "context"),
-          locator: String(source.locator ?? "http"),
-        }
-      : fallback.source,
-    observed_at: String(row.observed_at ?? fallback.observed_at),
-    freshness_status:
-      freshness === "FRESH" || freshness === "STALE" || freshness === "UNKNOWN" || freshness === "ERROR"
-        ? freshness
-        : fallback.freshness_status,
-    confidence: typeof row.confidence === "number" ? row.confidence : fallback.confidence,
-  };
-}
-
-function attentionFrom(row: Record<string, unknown>, fallback: Provenance): AttentionItem {
-  const prov = provenanceOf(row, fallback);
-  return {
-    schema_version: "control-center.attention-item.v1",
-    id: String(row.id ?? "cc:attention-item:unknown"),
-    scope: String(row.scope ?? "company"),
-    severity: (row.severity as AttentionItem["severity"]) ?? "medium",
-    status: (row.status as AttentionItem["status"]) ?? "open",
-    title: String(row.title ?? "Sem título"),
-    summary: String(row.summary ?? row.body ?? ""),
-    provenance: prov,
-    detected_at: String(row.detected_at ?? prov.observed_at),
-    homepage_eligible: row.homepage_eligible !== false,
-  };
-}
-
-function priorityFrom(row: Record<string, unknown>, index: number, fallback: Provenance): PriorityRecommendation {
-  const prov = provenanceOf(row, fallback);
-  return {
-    schema_version: "control-center.priority-recommendation.v1",
-    id: String(row.id ?? `cc:priority-recommendation:${index}`),
-    scope: String(row.scope ?? "company"),
-    rank: typeof row.rank === "number" ? row.rank : index + 1,
-    title: String(row.title ?? "Prioridade"),
-    rationale: String(row.rationale ?? row.body ?? ""),
-    provenance: prov,
-    generated_at: String(row.generated_at ?? prov.observed_at),
-    horizon: (row.horizon as PriorityRecommendation["horizon"]) ?? "today",
-  };
-}
-
-function directiveFrom(row: Record<string, unknown>): Directive {
-  const created = asRecord(row.created_by);
-  return {
-    schema_version: "control-center.directive.v1",
-    id: String(row.id ?? "cc:directive:unknown"),
-    kind: (row.kind as Directive["kind"]) ?? "fact",
-    scope: String(row.scope ?? "company"),
-    status: (row.status as Directive["status"]) ?? "active",
-    title: String(row.title ?? ""),
-    body: String(row.body ?? ""),
-    effective_from: String(row.effective_from ?? new Date().toISOString()),
-    expires_at: row.expires_at === null || row.expires_at === undefined ? null : String(row.expires_at),
-    supersedes: Array.isArray(row.supersedes) ? (row.supersedes as string[]) : null,
-    created_by: {
-      kind: (created?.kind as ActorRef["kind"]) ?? "human",
-      id: String(created?.id ?? "unknown"),
-    },
-    created_at: String(row.created_at ?? new Date().toISOString()),
-    updated_at: String(row.updated_at ?? new Date().toISOString()),
-    audit: [],
-  };
-}
+import {
+  activityFrom,
+  asRecord,
+  clientFrom,
+  commercialFrom,
+  composePageFromHojeInput,
+  engineeringFrom,
+  fallbackProvenance,
+  financeFrom,
+  healthFrom,
+  itemsOf,
+  mapContextDirectives,
+  mapHojePayloads,
+} from "./map";
+import {
+  AUTHORIZED_WRITE_PATH,
+  WRITE_SHORTCUT_DIRECTIVE_KIND,
+  WRITE_SHORTCUT_KINDS,
+  destinationUsesContext,
+  isAuthorizedWritePath,
+  readPathsFor,
+  type WriteShortcutKind,
+} from "./paths";
 
 export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
   readonly mode = "http" as const;
@@ -128,7 +60,10 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
         loading: false,
         error: {
           code: "CONTEXT_UNAVAILABLE",
-          message: err instanceof Error ? err.message : "context http failed",
+          message:
+            err instanceof Error
+              ? err.message
+              : "Backend operacional indisponível. Nenhuma origem mock foi usada.",
         },
       };
     }
@@ -146,46 +81,179 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     return result.page.priorities;
   }
 
-  private async loadPage(id: DestinationId): Promise<DestinationPage> {
-    const scope = scopeFor(id);
-    const ctx = asRecord(await this.getJson(`/v1/context?scope=${encodeURIComponent(scope)}`));
-    if (!ctx) {
-      throw new Error("context payload is not an object");
+  async writeShortcut(kind: WriteShortcutKind, draft: { title: string; body: string }): Promise<AdapterWriteResult> {
+    if (!(WRITE_SHORTCUT_KINDS as readonly string[]).includes(kind)) {
+      return { ok: false, path: AUTHORIZED_WRITE_PATH, kind, message: "atalho não autorizado" };
     }
-    const fallback: Provenance = provenanceOf(ctx, {
-      source: { system: "control-center", kind: "context", locator: this.baseUrl },
-      observed_at: new Date().toISOString(),
-      freshness_status: "UNKNOWN",
-      confidence: 0,
+    const title = draft.title.trim();
+    const body = draft.body.trim();
+    if (!title || !body) {
+      return { ok: false, path: AUTHORIZED_WRITE_PATH, kind, message: "título e corpo são obrigatórios" };
+    }
+    const observed_at = new Date().toISOString();
+    const payload = {
+      kind: WRITE_SHORTCUT_DIRECTIVE_KIND[kind],
+      title,
+      body,
+      scope: "company",
+      source: {
+        system: "control-center",
+        kind: "founder-shortcut",
+        locator: "hoje",
+      },
+      observed_at,
+      freshness_status: "FRESH",
+      confidence: 1,
+    };
+    if (!isAuthorizedWritePath(AUTHORIZED_WRITE_PATH)) {
+      return { ok: false, path: AUTHORIZED_WRITE_PATH, kind, message: "write path not authorized" };
+    }
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${AUTHORIZED_WRITE_PATH}`, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "x-actor-id": this.operator.id,
+          "x-actor-kind": this.operator.kind,
+        },
+        body: JSON.stringify(payload),
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        return {
+          ok: false,
+          path: AUTHORIZED_WRITE_PATH,
+          kind,
+          message: `gravação recusada (${response.status})`,
+        };
+      }
+      void text;
+      return {
+        ok: true,
+        path: AUTHORIZED_WRITE_PATH,
+        kind,
+        message: "gravado no Context Service",
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        path: AUTHORIZED_WRITE_PATH,
+        kind,
+        message: err instanceof Error ? err.message : "gravação indisponível",
+      };
+    }
+  }
+
+  private async loadPage(id: DestinationId): Promise<DestinationPage> {
+    const fallback = fallbackProvenance(this.baseUrl || "relative", new Date().toISOString());
+    if (id === "hoje") {
+      return this.loadHoje(fallback);
+    }
+    if (id === "memoria") {
+      return this.loadMemoria(fallback);
+    }
+    if (id === "agentes") {
+      return this.loadAgentes(fallback);
+    }
+    return this.loadDomain(id, fallback);
+  }
+
+  private async loadHoje(fallback: Provenance): Promise<DestinationPage> {
+    const paths = readPathsFor("hoje");
+    const [today, attentionNow, attentionToday, snapshot, activities] = await Promise.all(
+      paths.map((path) => this.getJson(path)),
+    );
+    const composeInput = mapHojePayloads({
+      today,
+      attentionNow,
+      attentionToday,
+      snapshot,
+      activities,
+      fallback,
     });
-    const directives = Array.isArray(ctx.active_directives)
-      ? ctx.active_directives.map((row) => directiveFrom(asRecord(row) ?? {}))
-      : [];
-    const riskRows =
-      Array.isArray(ctx.risks) && ctx.risks.length > 0
-        ? ctx.risks
-        : Array.isArray(ctx.active_directives)
-          ? ctx.active_directives.filter((row) => asRecord(row)?.kind === "risk")
-          : directives.filter((row) => row.kind === "risk");
-    const attention = riskRows.map((row) => attentionFrom(asRecord(row) ?? {}, fallback));
-    const priorities = (Array.isArray(ctx.priorities) ? ctx.priorities : [])
-      .slice(0, 3)
-      .map((row, index) => priorityFrom(asRecord(row) ?? {}, index, fallback));
+    return composePageFromHojeInput("hoje", this.readOperator(), composeInput);
+  }
+
+  private async loadMemoria(fallback: Provenance): Promise<DestinationPage> {
+    if (!destinationUsesContext("memoria")) {
+      throw new Error("memoria must use /v1/context");
+    }
+    const [path] = readPathsFor("memoria");
+    const ctx = asRecord(await this.getJson(path!));
+    if (!ctx) throw new Error("context payload is not an object");
+    const dest = getDestination("memoria");
+    const directives = mapContextDirectives(ctx, fallback);
     return {
-      id,
-      label: getDestination(id).label,
-      scope,
-      generated_at: fallback.observed_at,
+      id: "memoria",
+      label: dest.label,
+      scope: dest.scope,
+      generated_at: String(ctx.observed_at ?? fallback.observed_at),
       operator: this.readOperator(),
-      headline: getDestination(id).description,
-      attention,
-      priorities,
+      headline: dest.description,
+      attention: [],
+      priorities: [],
       directives,
     };
   }
 
+  private async loadAgentes(fallback: Provenance): Promise<DestinationPage> {
+    const [path] = readPathsFor("agentes");
+    const payload = await this.getJson(path!);
+    const dest = getDestination("agentes");
+    const activities = itemsOf(payload).map((row) => activityFrom(asRecord(row) ?? {}, fallback));
+    return {
+      id: "agentes",
+      label: dest.label,
+      scope: dest.scope,
+      generated_at: fallback.observed_at,
+      operator: this.readOperator(),
+      headline: dest.description,
+      attention: [],
+      priorities: [],
+      activities,
+    };
+  }
+
+  private async loadDomain(id: DestinationId, fallback: Provenance): Promise<DestinationPage> {
+    const [path] = readPathsFor(id);
+    const payload = await this.getJson(path!);
+    const dest = getDestination(id);
+    const rec = asRecord(payload) ?? {};
+    const inner = asRecord(rec.snapshot) ?? rec;
+    const page: DestinationPage = {
+      id,
+      label: dest.label,
+      scope: dest.scope,
+      generated_at: String(inner.generated_at ?? rec.generated_at ?? fallback.observed_at),
+      operator: this.readOperator(),
+      headline: dest.description,
+      attention: [],
+      priorities: [],
+    };
+    if (id === "comercial") {
+      page.commercial = commercialFrom(inner, fallback);
+    } else if (id === "financeiro") {
+      page.finance = financeFrom(inner, fallback);
+    } else if (id === "engenharia") {
+      page.engineering = engineeringFrom(inner, fallback);
+    } else if (id === "clientes") {
+      const rows = itemsOf(payload).length > 0 ? itemsOf(payload) : itemsOf(rec.clients);
+      page.clients = (rows.length > 0 ? rows : inner.schema_version ? [inner] : []).map((row) =>
+        clientFrom(asRecord(row) ?? {}, fallback),
+      );
+    } else if (id === "infra") {
+      const rows = itemsOf(payload).length > 0 ? itemsOf(payload) : itemsOf(rec.health);
+      page.health = (rows.length > 0 ? rows : inner.schema_version ? [inner] : []).map((row) =>
+        healthFrom(asRecord(row) ?? {}, fallback),
+      );
+    }
+    return page;
+  }
+
   private async getJson(path: string): Promise<unknown> {
-    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+    const url = `${this.baseUrl}${path}`;
+    const response = await this.fetchImpl(url, {
       headers: {
         accept: "application/json",
         "x-actor-id": this.operator.id,
@@ -194,9 +262,13 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     });
     const text = await response.text();
     if (!response.ok) {
-      throw new Error(`context ${response.status}`);
+      throw new Error(`Backend operacional indisponível (${response.status} ${path}).`);
     }
-    return JSON.parse(text) as unknown;
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      throw new Error(`Backend operacional devolveu JSON inválido em ${path}.`);
+    }
   }
 }
 
@@ -241,13 +313,11 @@ export function productionContextUrl(): string {
   return "";
 }
 
+/**
+ * Production boot always constructs the HTTP adapter.
+ * Mock is never selected here — only via explicit test injection in boot/mount.
+ */
 export function createProductionAdapter(): ControlCenterReadAdapter {
-  const mock =
-    typeof document !== "undefined" &&
-    document.querySelector('meta[name="cc-use-mock"]')?.getAttribute("content") === "1";
-  if (mock) {
-    return createMockAdapter();
-  }
   const base = productionContextUrl() || "";
   return createHttpAdapter(base, undefined, productionActorFromDocument());
 }

--- a/control-center/apps/web-shell/src/adapters/index.ts
+++ b/control-center/apps/web-shell/src/adapters/index.ts
@@ -6,6 +6,7 @@ export {
   isForbiddenAdapterAction,
   type AdapterAction,
   type AdapterReadResult,
+  type AdapterWriteResult,
   type ControlCenterReadAdapter,
   type DestinationPage,
   type ForbiddenAdapterAction,
@@ -16,4 +17,16 @@ export {
   createHttpAdapter,
   createProductionAdapter,
   productionActorFromDocument,
+  productionContextUrl,
 } from "./http";
+export {
+  AUTHORIZED_WRITE_PATH,
+  WRITE_SHORTCUT_DIRECTIVE_KIND,
+  WRITE_SHORTCUT_KINDS,
+  WRITE_SHORTCUT_LABELS,
+  destinationUsesContext,
+  isAuthorizedWritePath,
+  isContextPath,
+  readPathsFor,
+  type WriteShortcutKind,
+} from "./paths";

--- a/control-center/apps/web-shell/src/adapters/map.ts
+++ b/control-center/apps/web-shell/src/adapters/map.ts
@@ -1,0 +1,651 @@
+import { composeHoje, type HojeComposeInput, type HojeViewModel } from "../hoje-compose";
+import { getDestination, type DestinationId } from "../destinations";
+import type {
+  ActorRef,
+  AgentActivity,
+  AgentActivityPresentationStatus,
+  AttentionItem,
+  ClientStatus,
+  CommercialSnapshot,
+  Directive,
+  EngineeringSnapshot,
+  FinanceSnapshot,
+  FreshnessStatus,
+  Money,
+  PriorityRecommendation,
+  Provenance,
+  ServiceHealth,
+  SourceRef,
+} from "../types";
+import { AGENT_ACTIVITY_STATUSES } from "../types";
+import type { DestinationPage } from "./contract";
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+export function asArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  const rec = asRecord(value);
+  if (rec && Array.isArray(rec.items)) return rec.items;
+  return [];
+}
+
+export function itemsOf(value: unknown): unknown[] {
+  return asArray(value);
+}
+
+function str(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function num(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export function fallbackProvenance(locator: string, now: string): Provenance {
+  return {
+    source: { system: "control-center", kind: "http", locator },
+    observed_at: now,
+    freshness_status: "UNKNOWN",
+    confidence: 0,
+  };
+}
+
+export function provenanceOf(row: Record<string, unknown>, fallback: Provenance): Provenance {
+  const nested = asRecord(row.provenance);
+  const sourceRaw = asRecord(nested?.source) ?? asRecord(row.source);
+  const freshness = nested?.freshness_status ?? row.freshness_status;
+  const observed = nested?.observed_at ?? row.observed_at;
+  const confidence = nested?.confidence ?? row.confidence;
+  const window = nested?.freshness_window_seconds ?? row.freshness_window_seconds;
+  const source: SourceRef = sourceRaw
+    ? {
+        system: str(sourceRaw.system, fallback.source.system),
+        kind: str(sourceRaw.kind, fallback.source.kind),
+        locator: str(sourceRaw.locator, fallback.source.locator),
+        ...(typeof sourceRaw.label === "string" ? { label: sourceRaw.label } : {}),
+      }
+    : fallback.source;
+  const result: Provenance = {
+    source,
+    observed_at: str(observed, fallback.observed_at),
+    freshness_status: isFreshness(freshness) ? freshness : fallback.freshness_status,
+    confidence: typeof confidence === "number" ? confidence : fallback.confidence,
+  };
+  if (typeof window === "number") result.freshness_window_seconds = window;
+  return result;
+}
+
+function isFreshness(value: unknown): value is FreshnessStatus {
+  return value === "FRESH" || value === "STALE" || value === "UNKNOWN" || value === "ERROR";
+}
+
+export function moneyOf(value: unknown): Money | undefined {
+  const rec = asRecord(value);
+  if (!rec) return undefined;
+  if (!Number.isInteger(rec.amount_cents) || typeof rec.currency !== "string") return undefined;
+  return { amount_cents: rec.amount_cents as number, currency: rec.currency };
+}
+
+export function attentionFrom(row: Record<string, unknown>, fallback: Provenance): AttentionItem {
+  const prov = provenanceOf(row, fallback);
+  const item: AttentionItem = {
+    schema_version: "control-center.attention-item.v1",
+    id: str(row.id, "cc:attention-item:unknown"),
+    scope: str(row.scope, "company"),
+    severity: (row.severity as AttentionItem["severity"]) ?? "medium",
+    status: (row.status as AttentionItem["status"]) ?? "open",
+    title: str(row.title, "Sem título"),
+    summary: str(row.summary, str(row.body)),
+    provenance: prov,
+    detected_at: str(row.detected_at, prov.observed_at),
+    homepage_eligible: row.homepage_eligible !== false,
+  };
+  if (typeof row.recommended_action === "string") item.recommended_action = row.recommended_action;
+  if (Array.isArray(row.related_ids)) item.related_ids = row.related_ids.map(String);
+  return item;
+}
+
+export function priorityFrom(
+  row: Record<string, unknown>,
+  index: number,
+  fallback: Provenance,
+): PriorityRecommendation {
+  const prov = provenanceOf(row, fallback);
+  const item: PriorityRecommendation = {
+    schema_version: "control-center.priority-recommendation.v1",
+    id: str(row.id, `cc:priority-recommendation:${index}`),
+    scope: str(row.scope, "company"),
+    rank: typeof row.rank === "number" ? row.rank : index + 1,
+    title: str(row.title, "Prioridade"),
+    rationale: str(row.rationale, str(row.body)),
+    provenance: prov,
+    generated_at: str(row.generated_at, prov.observed_at),
+    horizon: (row.horizon as PriorityRecommendation["horizon"]) ?? "today",
+  };
+  if (Array.isArray(row.attention_item_ids)) item.attention_item_ids = row.attention_item_ids.map(String);
+  if (Array.isArray(row.directive_ids)) item.directive_ids = row.directive_ids.map(String);
+  return item;
+}
+
+export function directiveFrom(row: Record<string, unknown>): Directive {
+  const created = asRecord(row.created_by);
+  const supersedes = row.supersedes;
+  return {
+    schema_version: "control-center.directive.v1",
+    id: str(row.id, "cc:directive:unknown"),
+    kind: (row.kind as Directive["kind"]) ?? "fact",
+    scope: str(row.scope, "company"),
+    status: (row.status as Directive["status"]) ?? "active",
+    title: str(row.title),
+    body: str(row.body),
+    effective_from: str(row.effective_from, str(row.observed_at, new Date().toISOString())),
+    expires_at: row.expires_at === null || row.expires_at === undefined ? null : String(row.expires_at),
+    supersedes: Array.isArray(supersedes) ? supersedes.map(String) : null,
+    created_by: {
+      kind: (created?.kind as ActorRef["kind"]) ?? "human",
+      id: str(created?.id, "unknown"),
+      ...(typeof created?.display_name === "string" ? { display_name: created.display_name } : {}),
+    },
+    created_at: str(row.created_at, new Date().toISOString()),
+    updated_at: str(row.updated_at, new Date().toISOString()),
+    audit: Array.isArray(row.audit)
+      ? row.audit
+          .map((entry) => asRecord(entry))
+          .filter((entry): entry is Record<string, unknown> => entry != null)
+          .map((entry) => ({
+            at: str(entry.at),
+            actor: {
+              kind: ((asRecord(entry.actor)?.kind as ActorRef["kind"]) ?? "human") as ActorRef["kind"],
+              id: str(asRecord(entry.actor)?.id, "unknown"),
+            },
+            action: (entry.action as Directive["audit"][number]["action"]) ?? "created",
+          }))
+      : [],
+  };
+}
+
+function stringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.map(String);
+}
+
+export function clientFrom(row: Record<string, unknown>, fallback: Provenance): ClientStatus {
+  const item: ClientStatus = {
+    schema_version: "control-center.client-status.v1",
+    id: str(row.id, "cc:client-status:unknown"),
+    scope: str(row.scope, `client:${str(row.client_slug, "unknown")}`),
+    client_slug: str(row.client_slug, "unknown"),
+    display_name: str(row.display_name, str(row.title, "Cliente")),
+    lifecycle: (row.lifecycle as ClientStatus["lifecycle"]) ?? "unknown",
+    provenance: provenanceOf(row, fallback),
+  };
+  if (Array.isArray(row.attention_item_ids)) item.attention_item_ids = row.attention_item_ids.map(String);
+  const money = moneyOf(row.open_receivables);
+  if (money) item.open_receivables = money;
+  if (typeof row.notes === "string") item.notes = row.notes;
+  if (typeof row.health === "string") item.health = row.health;
+  const commitments = stringList(row.commitments);
+  if (commitments) item.commitments = commitments;
+  if (typeof row.owner === "string") item.owner = row.owner;
+  if (typeof row.due_date === "string") item.due_date = row.due_date;
+  const deliverables = stringList(row.deliverables);
+  if (deliverables) item.deliverables = deliverables;
+  const blockers = stringList(row.blockers);
+  if (blockers) item.blockers = blockers;
+  if (typeof row.next_action === "string") item.next_action = row.next_action;
+  if (typeof row.evidence === "string") item.evidence = row.evidence;
+  return item;
+}
+
+export function commercialFrom(row: Record<string, unknown>, fallback: Provenance): CommercialSnapshot {
+  const authority = asRecord(row.authority);
+  const funnel = asRecord(row.funnel);
+  const offerPin = asRecord(row.offer_pin);
+  const extra = asRecord(row.extra_historical);
+  const drift = asRecord(row.offer_version_drift);
+  const weighted = asRecord(row.pipeline_weighted);
+  const snap: CommercialSnapshot = {
+    schema_version: "control-center.commercial-snapshot.v1",
+    id: str(row.id, "cc:commercial-snapshot:unknown"),
+    scope: str(row.scope, "commercial"),
+    generated_at: str(row.generated_at, fallback.observed_at),
+    provenance: provenanceOf(row, fallback),
+    authority: {
+      catalog_authority: "governance",
+      commercial_runtime: "warmbly",
+      this_document: "read_model",
+    },
+    pipeline_open_count: num(row.pipeline_open_count),
+    inbound_unread_count: num(row.inbound_unread_count),
+    at_risk_client_count: num(row.at_risk_client_count),
+  };
+  if (authority) {
+    snap.authority = {
+      catalog_authority: "governance",
+      commercial_runtime: "warmbly",
+      this_document: "read_model",
+    };
+  }
+  if (offerPin && typeof offerPin.catalog_id === "string") {
+    snap.offer_pin = {
+      catalog_authority: "governance",
+      catalog_id: offerPin.catalog_id,
+      ...(Array.isArray(offerPin.known_offer_ids)
+        ? { known_offer_ids: offerPin.known_offer_ids.map(String) }
+        : {}),
+    };
+  }
+  if (funnel) {
+    snap.funnel = {
+      new_leads: num(funnel.new_leads),
+      qualified: num(funnel.qualified),
+      opportunities: num(funnel.opportunities),
+      proposals: num(funnel.proposals),
+      clients: num(funnel.clients),
+    };
+  }
+  const nominal = moneyOf(row.pipeline_nominal);
+  if (nominal) snap.pipeline_nominal = nominal;
+  if (weighted && weighted.probability_reliable === true) {
+    const money = moneyOf(weighted);
+    if (money) snap.pipeline_weighted = { ...money, probability_reliable: true };
+  }
+  if (typeof row.aging_count === "number") snap.aging_count = row.aging_count;
+  if (typeof row.stalled_count === "number") snap.stalled_count = row.stalled_count;
+  if (typeof row.missing_next_action_count === "number") {
+    snap.missing_next_action_count = row.missing_next_action_count;
+  }
+  if (Array.isArray(row.attention_item_ids)) snap.attention_item_ids = row.attention_item_ids.map(String);
+  if (extra && extra.treated_as_public_offer === false) {
+    snap.extra_historical = {
+      treated_as_public_offer: false,
+      ...(typeof extra.label === "string" ? { label: extra.label } : {}),
+      ...(typeof extra.note === "string" ? { note: extra.note } : {}),
+    };
+  }
+  if (drift && typeof drift.count === "number") {
+    snap.offer_version_drift = {
+      count: drift.count,
+      ...(typeof drift.detail === "string" ? { detail: drift.detail } : {}),
+    };
+  }
+  return snap;
+}
+
+export function financeFrom(row: Record<string, unknown>, fallback: Provenance): FinanceSnapshot {
+  const overdue = moneyOf(row.overdue) ?? moneyOf(row.receivables_overdue) ?? {
+    amount_cents: 0,
+    currency: "BRL",
+  };
+  const receivable = moneyOf(row.receivable) ?? moneyOf(row.receivables_open) ?? {
+    amount_cents: 0,
+    currency: "BRL",
+  };
+  const snap: FinanceSnapshot = {
+    schema_version: "control-center.finance-snapshot.v1",
+    id: str(row.id, "cc:finance-snapshot:unknown"),
+    scope: str(row.scope, "finance"),
+    generated_at: str(row.generated_at, fallback.observed_at),
+    provenance: provenanceOf(row, fallback),
+    read_model_only: true,
+    provider_mutations: "forbidden",
+    receivables_open: receivable,
+    receivables_overdue: overdue,
+  };
+  const contracted = moneyOf(row.contracted);
+  if (contracted) snap.contracted = contracted;
+  const billed = moneyOf(row.billed);
+  if (billed) snap.billed = billed;
+  const paid = moneyOf(row.paid);
+  if (paid) snap.paid = paid;
+  const received = moneyOf(row.effectively_received);
+  if (received) snap.effectively_received = received;
+  snap.overdue = overdue;
+  snap.receivable = receivable;
+  const refunds = moneyOf(row.refunds);
+  if (refunds) snap.refunds = refunds;
+  const chargebacks = moneyOf(row.chargebacks);
+  if (chargebacks) snap.chargebacks = chargebacks;
+  const cash = asRecord(row.cash_in);
+  if (cash && cash.evidenced === true) {
+    const money = moneyOf(cash);
+    const source = asRecord(cash.source);
+    if (money && source) {
+      snap.cash_in = {
+        ...money,
+        evidenced: true,
+        source: {
+          system: str(source.system, "asaas"),
+          kind: str(source.kind, "settlement-read"),
+          locator: str(source.locator, "finance/settlements"),
+        },
+      };
+    }
+  }
+  const mrr = asRecord(row.mrr);
+  if (mrr && mrr.applicable === true) {
+    const money = moneyOf(mrr);
+    if (money) snap.mrr = { ...money, applicable: true, basis: "recurring_monthly" };
+  }
+  const runway = asRecord(row.runway);
+  if (runway && runway.cash_reliable === true && runway.expense_reliable === true) {
+    const cashBalance = moneyOf(runway.cash_balance);
+    const expense = moneyOf(runway.monthly_expense);
+    if (cashBalance && expense && typeof runway.months === "number") {
+      snap.runway = {
+        months: runway.months,
+        cash_balance: cashBalance,
+        monthly_expense: expense,
+        cash_reliable: true,
+        expense_reliable: true,
+      };
+    }
+  }
+  if (Array.isArray(row.attention_item_ids)) snap.attention_item_ids = row.attention_item_ids.map(String);
+  return snap;
+}
+
+export function engineeringFrom(row: Record<string, unknown>, fallback: Provenance): EngineeringSnapshot {
+  const snap: EngineeringSnapshot = {
+    schema_version: "control-center.engineering-snapshot.v1",
+    id: str(row.id, "cc:engineering-snapshot:unknown"),
+    scope: str(row.scope, "company"),
+    generated_at: str(row.generated_at, fallback.observed_at),
+    provenance: provenanceOf(row, fallback),
+    open_pr_count: num(row.open_pr_count),
+    failing_check_count: num(row.failing_check_count),
+    open_incident_count: num(row.open_incident_count),
+  };
+  if (Array.isArray(row.repo_scopes)) snap.repo_scopes = row.repo_scopes.map(String);
+  if (Array.isArray(row.attention_item_ids)) snap.attention_item_ids = row.attention_item_ids.map(String);
+  if (typeof row.repository === "string") snap.repository = row.repository;
+  if (typeof row.default_branch === "string") snap.default_branch = row.default_branch;
+  if (Array.isArray(row.prs)) {
+    snap.prs = row.prs.map((pr) => {
+      const rec = asRecord(pr) ?? {};
+      return {
+        ...(typeof rec.id === "string" ? { id: rec.id } : {}),
+        ...(typeof rec.title === "string" ? { title: rec.title } : {}),
+        ...(typeof rec.status === "string" ? { status: rec.status } : {}),
+      };
+    });
+  }
+  const ci = asRecord(row.ci);
+  if (ci) {
+    snap.ci = {
+      ...(typeof ci.status === "string" ? { status: ci.status } : {}),
+      ...(typeof ci.detail === "string" ? { detail: ci.detail } : {}),
+    };
+  }
+  if (typeof row.p0_count === "number") snap.p0_count = row.p0_count;
+  if (typeof row.p1_count === "number") snap.p1_count = row.p1_count;
+  const aging = asRecord(row.aging);
+  if (aging) {
+    snap.aging = {
+      ...(typeof aging.count === "number" ? { count: aging.count } : {}),
+      ...(typeof aging.oldest_days === "number" ? { oldest_days: aging.oldest_days } : {}),
+    };
+  }
+  const blockers = stringList(row.blockers);
+  if (blockers) snap.blockers = blockers;
+  if (typeof row.last_evidence === "string") snap.last_evidence = row.last_evidence;
+  const hypo = asRecord(row.active_work_without_evidence);
+  if (hypo && hypo.remains === "hypothesis") {
+    snap.active_work_without_evidence = {
+      remains: "hypothesis",
+      ...(typeof hypo.detail === "string" ? { detail: hypo.detail } : {}),
+    };
+  }
+  return snap;
+}
+
+export function healthFrom(row: Record<string, unknown>, fallback: Provenance): ServiceHealth {
+  const prov = provenanceOf(row, fallback);
+  const item: ServiceHealth = {
+    schema_version: "control-center.service-health.v1",
+    id: str(row.id, "cc:service-health:unknown"),
+    scope: str(row.scope, "infrastructure"),
+    service_name: str(row.service_name, "service"),
+    status: (row.status as ServiceHealth["status"]) ?? "unknown",
+    provenance: prov,
+    checked_at: str(row.checked_at, prov.observed_at),
+  };
+  if (typeof row.latency_ms === "number") item.latency_ms = row.latency_ms;
+  if (typeof row.message === "string") item.message = row.message;
+  if (Array.isArray(row.checks)) {
+    item.checks = row.checks.map((check) => {
+      const rec = asRecord(check) ?? {};
+      return {
+        name: str(rec.name, "check"),
+        status: (rec.status as ServiceHealth["status"]) ?? "unknown",
+        ...(typeof rec.detail === "string" ? { detail: rec.detail } : {}),
+      };
+    });
+  }
+  const http = asRecord(row.http);
+  if (http) {
+    item.http = {
+      ...(typeof http.status === "string" ? { status: http.status } : {}),
+      ...(typeof http.detail === "string" ? { detail: http.detail } : {}),
+    };
+  }
+  const tls = asRecord(row.tls);
+  if (tls) {
+    item.tls = {
+      ...(typeof tls.status === "string" ? { status: tls.status } : {}),
+      ...(typeof tls.detail === "string" ? { detail: tls.detail } : {}),
+    };
+  }
+  const docker = asRecord(row.docker);
+  if (docker) {
+    item.docker = {
+      ...(typeof docker.status === "string" ? { status: docker.status } : {}),
+      ...(typeof docker.detail === "string" ? { detail: docker.detail } : {}),
+    };
+  }
+  const backup = asRecord(row.backup);
+  if (backup) {
+    item.backup = {
+      ...(typeof backup.status === "string" ? { status: backup.status } : {}),
+      ...(typeof backup.detail === "string" ? { detail: backup.detail } : {}),
+    };
+  }
+  const disk = asRecord(row.disk);
+  if (disk) {
+    item.disk = {
+      ...(typeof disk.used_pct === "number" ? { used_pct: disk.used_pct } : {}),
+      ...(typeof disk.detail === "string" ? { detail: disk.detail } : {}),
+    };
+  }
+  const memory = asRecord(row.memory);
+  if (memory) {
+    item.memory = {
+      ...(typeof memory.used_pct === "number" ? { used_pct: memory.used_pct } : {}),
+      ...(typeof memory.detail === "string" ? { detail: memory.detail } : {}),
+    };
+  }
+  const pncp = asRecord(row.pncp_freshness);
+  if (pncp && isFreshness(pncp.freshness_status)) {
+    item.pncp_freshness = {
+      freshness_status: pncp.freshness_status,
+      ...(typeof pncp.observed_at === "string" ? { observed_at: pncp.observed_at } : {}),
+      ...(typeof pncp.detail === "string" ? { detail: pncp.detail } : {}),
+    };
+  }
+  if (typeof row.partial_outage === "boolean") item.partial_outage = row.partial_outage;
+  return item;
+}
+
+export function presentAgentStatus(raw: unknown, freshness: FreshnessStatus): AgentActivityPresentationStatus {
+  const value = typeof raw === "string" ? raw.toLowerCase() : "";
+  if ((AGENT_ACTIVITY_STATUSES as readonly string[]).includes(value)) {
+    const mapped = value.toUpperCase() as AgentActivityPresentationStatus;
+    if (mapped === "RUNNING" && freshness === "STALE") return "RUNNING";
+    if (mapped === "DONE") return "DONE";
+    return mapped;
+  }
+  return "UNKNOWN";
+}
+
+export function activityFrom(row: Record<string, unknown>, fallback: Provenance): AgentActivity {
+  const prov = provenanceOf(row, fallback);
+  const presentation = presentAgentStatus(row.status, prov.freshness_status);
+  const finishedRaw = row.finished_at;
+  const finished_at =
+    presentation === "RUNNING" ? null : finishedRaw === null || finishedRaw === undefined ? null : String(finishedRaw);
+  const activity: AgentActivity = {
+    schema_version: "control-center.agent-activity.v1",
+    id: str(row.id, "cc:agent-activity:unknown"),
+    agent_id: str(row.agent_id, str(asRecord(row.agent)?.id, "agent:unknown")),
+    scope: str(row.scope, "company"),
+    status: str(row.status, "unknown"),
+    presentation_status: presentation,
+    started_at: str(row.started_at, prov.observed_at),
+    finished_at,
+    goal: str(row.goal, str(row.purpose, "sem goal")),
+    summary: str(row.summary),
+    provenance: prov,
+  };
+  if (typeof row.provider === "string") activity.provider = row.provider;
+  const agent = asRecord(row.agent);
+  if (!activity.provider && typeof agent?.provider === "string") activity.provider = agent.provider;
+  if (typeof row.session_id === "string") activity.session_id = row.session_id;
+  if (typeof row.repo === "string") activity.repo = row.repo;
+  if (typeof row.campaign === "string") activity.campaign = row.campaign;
+  else if (row.campaign === null) activity.campaign = null;
+  const actor = asRecord(row.actor);
+  if (actor) {
+    activity.actor = {
+      kind: (actor.kind as ActorRef["kind"]) ?? "agent",
+      id: str(actor.id, activity.agent_id),
+    };
+  }
+  const evidence = stringList(row.evidence_refs);
+  if (evidence) activity.evidence_refs = evidence;
+  const residual = stringList(row.residual_work);
+  if (residual) activity.residual_work = residual;
+  const blockers = stringList(row.blockers);
+  if (blockers) activity.blockers = blockers;
+  if (Array.isArray(row.related_ids)) activity.related_ids = row.related_ids.map(String);
+  return activity;
+}
+
+function dedupeById<T extends { id: string }>(rows: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const row of rows) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    out.push(row);
+  }
+  return out;
+}
+
+export function mapContextDirectives(ctx: Record<string, unknown>, fallback: Provenance): Directive[] {
+  const buckets = [
+    ctx.active_directives,
+    ctx.decisions,
+    ctx.directives,
+    ctx.facts,
+    ctx.constraints,
+    ctx.priorities,
+    ctx.risks,
+    ctx.hypotheses,
+  ];
+  const rows: Directive[] = [];
+  for (const bucket of buckets) {
+    for (const item of asArray(bucket)) {
+      rows.push(directiveFrom(asRecord(item) ?? {}));
+    }
+  }
+  void fallback;
+  return dedupeById(rows);
+}
+
+export function mapHojePayloads(input: {
+  today: unknown;
+  attentionNow: unknown;
+  attentionToday: unknown;
+  snapshot: unknown;
+  activities: unknown;
+  fallback: Provenance;
+}): HojeComposeInput {
+  const today = asRecord(input.today) ?? {};
+  const snapshot = asRecord(input.snapshot) ?? {};
+  const incidents = dedupeById(
+    [
+      ...asArray(today.incidents),
+      ...itemsOf(input.attentionNow),
+      ...itemsOf(input.attentionToday),
+      ...asArray(snapshot.attention_items),
+    ].map((row) => attentionFrom(asRecord(row) ?? {}, input.fallback)),
+  );
+  const priorities = [
+    ...asArray(today.recommended_actions),
+    ...asArray(today.priorities),
+    ...asArray(snapshot.top_priorities),
+  ].map((row, index) => priorityFrom(asRecord(row) ?? {}, index, input.fallback));
+  const clients = [
+    ...asArray(today.clients),
+    ...asArray(snapshot.clients),
+    ...itemsOf(snapshot.client_statuses),
+  ].map((row) => clientFrom(asRecord(row) ?? {}, input.fallback));
+  const commercialRaw = asRecord(today.commercial) ?? asRecord(snapshot.commercial);
+  const financeRaw = asRecord(today.finance) ?? asRecord(snapshot.finance);
+  const engineeringRaw = asRecord(today.engineering) ?? asRecord(snapshot.engineering);
+  const infra = [...asArray(today.infra), ...asArray(snapshot.health), ...itemsOf(snapshot.infra)].map((row) =>
+    healthFrom(asRecord(row) ?? {}, input.fallback),
+  );
+  const activityRows = itemsOf(input.activities);
+  const fromToday = asArray(today.agent_activity);
+  const activities = (activityRows.length > 0 ? activityRows : fromToday).map((row) =>
+    activityFrom(asRecord(row) ?? {}, input.fallback),
+  );
+  return {
+    generated_at: str(today.generated_at, input.fallback.observed_at),
+    headline: str(today.headline, "O que exige atenção agora."),
+    priorities,
+    incidents,
+    clients,
+    commercial: commercialRaw ? commercialFrom(commercialRaw, input.fallback) : null,
+    finance: financeRaw ? financeFrom(financeRaw, input.fallback) : null,
+    engineering: engineeringRaw ? engineeringFrom(engineeringRaw, input.fallback) : null,
+    infra,
+    activities,
+  };
+}
+
+export function pageFromHoje(
+  id: DestinationId,
+  operator: ActorRef,
+  composeInput: HojeComposeInput,
+  hoje: HojeViewModel,
+): DestinationPage {
+  const dest = getDestination(id);
+  return {
+    id,
+    label: dest.label,
+    scope: dest.scope,
+    generated_at: composeInput.generated_at,
+    operator,
+    headline: composeInput.headline,
+    attention: [...composeInput.incidents],
+    priorities: [...composeInput.priorities].slice(0, 3),
+    ...(composeInput.commercial ? { commercial: composeInput.commercial } : {}),
+    ...(composeInput.finance ? { finance: composeInput.finance } : {}),
+    ...(composeInput.engineering ? { engineering: composeInput.engineering } : {}),
+    clients: [...composeInput.clients],
+    health: [...composeInput.infra],
+    activities: [...composeInput.activities],
+    hoje,
+  };
+}
+
+export function composePageFromHojeInput(id: DestinationId, operator: ActorRef, input: HojeComposeInput): DestinationPage {
+  return pageFromHoje(id, operator, input, composeHoje(input));
+}

--- a/control-center/apps/web-shell/src/adapters/mock.ts
+++ b/control-center/apps/web-shell/src/adapters/mock.ts
@@ -10,9 +10,11 @@ import {
   ADAPTER_ACTIONS,
   type AdapterAction,
   type AdapterReadResult,
+  type AdapterWriteResult,
   type ControlCenterReadAdapter,
   type DestinationPage,
 } from "./contract";
+import { AUTHORIZED_WRITE_PATH, type WriteShortcutKind } from "./paths";
 
 export type MockScenario = "default" | "loading" | "error" | "stale" | "empty";
 
@@ -69,6 +71,16 @@ export class MockControlCenterAdapter implements ControlCenterReadAdapter {
 
   readPriorities() {
     return clonePage(defaultPages().hoje).priorities;
+  }
+
+  writeShortcut(kind: WriteShortcutKind, draft: { title: string; body: string }): AdapterWriteResult {
+    void draft;
+    return {
+      ok: false,
+      path: AUTHORIZED_WRITE_PATH,
+      kind,
+      message: "mock adapter does not POST; inject HttpControlCenterAdapter for writes",
+    };
   }
 
   private catalog(): Record<DestinationId, DestinationPage> {

--- a/control-center/apps/web-shell/src/adapters/paths.ts
+++ b/control-center/apps/web-shell/src/adapters/paths.ts
@@ -1,0 +1,72 @@
+import type { DestinationId } from "../destinations";
+import { getDestination } from "../destinations";
+
+export const AUTHORIZED_WRITE_PATH = "/v1/directives";
+
+export const WRITE_SHORTCUT_KINDS = ["decision", "nota", "risco", "hipotese"] as const;
+export type WriteShortcutKind = (typeof WRITE_SHORTCUT_KINDS)[number];
+
+export const WRITE_SHORTCUT_DIRECTIVE_KIND = {
+  decision: "decision",
+  nota: "fact",
+  risco: "risk",
+  hipotese: "hypothesis",
+} as const;
+
+export const WRITE_SHORTCUT_LABELS: Record<WriteShortcutKind, string> = {
+  decision: "Registrar decisão",
+  nota: "Registrar nota",
+  risco: "Registrar risco",
+  hipotese: "Registrar hipótese",
+};
+
+const DOMAIN_BY_DESTINATION: Record<Exclude<DestinationId, "hoje" | "memoria" | "agentes">, string> = {
+  comercial: "commercial",
+  clientes: "clients",
+  financeiro: "finance",
+  engenharia: "engineering",
+  infra: "infrastructure",
+};
+
+function q(path: string, params: Record<string, string>): string {
+  const search = new URLSearchParams(params);
+  return `${path}?${search.toString()}`;
+}
+
+export function readPathsFor(id: DestinationId): readonly string[] {
+  const scope = getDestination(id).scope;
+  switch (id) {
+    case "hoje":
+      return [
+        q("/v1/today", { scope: "company" }),
+        q("/v1/attention", { scope: "company", horizon: "now" }),
+        q("/v1/attention", { scope: "company", horizon: "today" }),
+        q("/v1/operational-snapshots", { scope: "company" }),
+        q("/v1/agent-activities", { scope: "company" }),
+      ];
+    case "memoria":
+      return [q("/v1/context", { scope })];
+    case "agentes":
+      return [q("/v1/agent-activities", { scope })];
+    default:
+      return [q(`/v1/domains/${DOMAIN_BY_DESTINATION[id]}`, { scope })];
+  }
+}
+
+export function isContextPath(url: string): boolean {
+  try {
+    const parsed = new URL(url, "https://ops.confenge.com.br/");
+    return parsed.pathname === "/v1/context";
+  } catch {
+    return url.includes("/v1/context");
+  }
+}
+
+export function destinationUsesContext(id: DestinationId): boolean {
+  return id === "memoria";
+}
+
+export function isAuthorizedWritePath(path: string): boolean {
+  const pathname = path.split("?")[0] ?? path;
+  return pathname === AUTHORIZED_WRITE_PATH;
+}

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -1,5 +1,6 @@
-import { createMockAdapter, type MockScenario } from "./adapters/mock";
+import type { MockScenario } from "./adapters/mock";
 import type { ControlCenterReadAdapter, DestinationPage } from "./adapters/contract";
+import type { WriteShortcutKind } from "./adapters/paths";
 import { parseHash } from "./destinations";
 import { pageIsEmpty, pageIsStale } from "./page";
 import { renderShell } from "./ui/render";
@@ -63,6 +64,11 @@ export function createMemoryRuntime(initialHash = "#/hoje"): ShellRuntime {
 
 export interface MountableRoot {
   innerHTML: string;
+  querySelectorAll?(selector: string): ArrayLike<{
+    addEventListener(type: string, listener: (event: Event) => void): void;
+    getAttribute(name: string): string | null;
+    querySelector(selector: string): { value: string } | null;
+  }>;
 }
 
 function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
@@ -97,6 +103,30 @@ function applyPaint(
     mockScenario: adapter.getScenario?.() ?? adapter.mode,
     adapterMode: adapter.mode,
   });
+  bindWriteShortcuts(root, adapter, () => {
+    paintShell(root, adapter, `#/${parsed.destination}`);
+  });
+}
+
+function bindWriteShortcuts(
+  root: MountableRoot,
+  adapter: ControlCenterReadAdapter,
+  onDone: () => void,
+): void {
+  if (!adapter.writeShortcut || typeof root.querySelectorAll !== "function") return;
+  const forms = root.querySelectorAll("[data-shortcut-form]");
+  for (let i = 0; i < forms.length; i += 1) {
+    const form = forms[i];
+    if (!form) continue;
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const kind = form.getAttribute("data-shortcut-form") as WriteShortcutKind | null;
+      if (!kind) return;
+      const title = form.querySelector('[name="title"]')?.value ?? "";
+      const body = form.querySelector('[name="body"]')?.value ?? "";
+      void Promise.resolve(adapter.writeShortcut?.(kind, { title, body })).then(onDone);
+    });
+  }
 }
 
 export function paintShell(
@@ -129,7 +159,7 @@ export function mount(
   adapter: ControlCenterReadAdapter & {
     setScenario?(s: MockScenario): void;
     getScenario?(): MockScenario;
-  } = createMockAdapter(),
+  },
   runtime: ShellRuntime = browserRuntime(),
 ): { unmount: () => void } {
   let generation = 0;

--- a/control-center/apps/web-shell/src/boot.ts
+++ b/control-center/apps/web-shell/src/boot.ts
@@ -1,5 +1,6 @@
-import { createMockAdapter } from "./adapters/mock";
+import type { ControlCenterReadAdapter } from "./adapters/contract";
 import { createProductionAdapter } from "./adapters/http";
+import { createMockAdapter } from "./adapters/mock";
 import { mount, type MountableRoot } from "./app";
 import { DESTINATION_IDS, PRIMARY_SURFACE } from "./destinations";
 
@@ -20,6 +21,7 @@ export interface ShellGlobals {
 export interface ShellWindow {
   location: { protocol: string };
   __CONFENGE_CONTROL_CENTER__?: ShellGlobals;
+  __CC_TEST_ADAPTER__?: ControlCenterReadAdapter;
 }
 
 export function installShellGlobals(win: ShellWindow): ShellGlobals {
@@ -59,7 +61,12 @@ export function applyFileProtocolGuard(
 
 export function startBrowser(
   win: ShellWindow | undefined = globalThis.window as unknown as ShellWindow | undefined,
-  doc: { getElementById(id: string): MountableRoot | null } | undefined = globalThis.document,
+  doc:
+    | ({
+        getElementById(id: string): MountableRoot | null;
+        querySelector?(selector: string): { getAttribute(name: string): string | null } | null;
+      } & AdapterDocument)
+    | undefined = globalThis.document,
 ): void {
   if (win == null || doc == null) {
     return;
@@ -72,10 +79,31 @@ export function startBrowser(
   if (applyFileProtocolGuard(win.location, root)) {
     return;
   }
-  const adapter =
-    typeof document !== "undefined" &&
-    document.querySelector('meta[name="cc-use-mock"]')?.getAttribute("content") === "1"
-      ? createMockAdapter()
-      : createProductionAdapter();
-  mount(root, adapter);
+  mount(root, resolveBrowserAdapter(win, doc));
+}
+
+export interface AdapterDocument {
+  querySelector?(selector: string): { getAttribute(name: string): string | null } | null;
+}
+
+export interface AdapterWindow {
+  __CC_TEST_ADAPTER__?: ControlCenterReadAdapter;
+}
+
+/**
+ * Mock is selected only by explicit injection (window.__CC_TEST_ADAPTER__ or
+ * meta cc-use-mock=1). Production boot constructs HttpControlCenterAdapter.
+ */
+export function resolveBrowserAdapter(
+  win: AdapterWindow | undefined,
+  doc: AdapterDocument | undefined,
+): ControlCenterReadAdapter {
+  if (win?.__CC_TEST_ADAPTER__) {
+    return win.__CC_TEST_ADAPTER__;
+  }
+  const mockMeta = doc?.querySelector?.('meta[name="cc-use-mock"]')?.getAttribute("content") === "1";
+  if (mockMeta) {
+    return createMockAdapter();
+  }
+  return createProductionAdapter();
 }

--- a/control-center/apps/web-shell/src/fixtures/catalog.ts
+++ b/control-center/apps/web-shell/src/fixtures/catalog.ts
@@ -2,8 +2,10 @@ import type { DestinationId } from "../destinations";
 import { DESTINATIONS, getDestination } from "../destinations";
 import { selectHomepageAttention, selectHomepagePriorities } from "../homepage";
 import type { DestinationPage } from "../adapters/contract";
+import { composeHoje } from "../hoje-compose";
 import type {
   ActorRef,
+  AgentActivity,
   AgentSession,
   AttentionItem,
   ClientStatus,
@@ -267,9 +269,36 @@ export const COMMERCIAL_SNAPSHOT: CommercialSnapshot = {
     commercial_runtime: "warmbly",
     this_document: "read_model",
   },
+  offer_pin: {
+    catalog_authority: "governance",
+    catalog_id: "CFG-OFFER-CATALOG-v1",
+    known_offer_ids: ["CFG-DIAG-EXP-v1", "CFG-DIRB2G-FLEX-v1"],
+  },
+  funnel: {
+    new_leads: 6,
+    qualified: 4,
+    opportunities: 3,
+    proposals: 2,
+    clients: 1,
+  },
+  pipeline_nominal: { amount_cents: 4800000, currency: "BRL" },
+  pipeline_weighted: {
+    amount_cents: 2100000,
+    currency: "BRL",
+    probability_reliable: true,
+  },
+  aging_count: 1,
+  stalled_count: 1,
+  missing_next_action_count: 2,
   pipeline_open_count: 4,
   inbound_unread_count: 3,
   at_risk_client_count: 1,
+  extra_historical: {
+    treated_as_public_offer: false,
+    label: "Extra histórica",
+    note: "Nunca tratada como oferta pública.",
+  },
+  offer_version_drift: { count: 1, detail: "proposta com versão de catálogo defasada" },
   attention_item_ids: ["cc:attention-item:01K3CC-INBOUND-UNREAD"],
 };
 
@@ -288,6 +317,14 @@ export const FINANCE_SNAPSHOT: FinanceSnapshot = {
   ),
   read_model_only: true,
   provider_mutations: "forbidden",
+  contracted: { amount_cents: 5000000, currency: "BRL" },
+  billed: { amount_cents: 4000000, currency: "BRL" },
+  paid: { amount_cents: 2500000, currency: "BRL" },
+  effectively_received: { amount_cents: 2300000, currency: "BRL" },
+  overdue: { amount_cents: 1500000, currency: "BRL" },
+  receivable: { amount_cents: 2500000, currency: "BRL" },
+  refunds: { amount_cents: 100000, currency: "BRL" },
+  chargebacks: { amount_cents: 100000, currency: "BRL" },
   receivables_open: { amount_cents: 2500000, currency: "BRL" },
   receivables_overdue: { amount_cents: 1500000, currency: "BRL" },
   attention_item_ids: ["cc:attention-item:01K3CC-OVERDUE-INVOICE"],
@@ -310,6 +347,17 @@ export const ENGINEERING_SNAPSHOT: EngineeringSnapshot = {
   failing_check_count: 1,
   open_incident_count: 0,
   repo_scopes: ["repo:tjsasakifln/Governance"],
+  repository: "tjsasakifln/Governance",
+  default_branch: "main",
+  p0_count: 0,
+  p1_count: 1,
+  aging: { count: 1, oldest_days: 4 },
+  blockers: ["CI vermelho no default"],
+  last_evidence: "check suite 2026-08-20T17:54:00Z",
+  active_work_without_evidence: {
+    remains: "hypothesis",
+    detail: "Trabalho ativo sem evidência permanece hipótese.",
+  },
   attention_item_ids: ["cc:attention-item:01K3CC-FAILING-CHECK"],
 };
 
@@ -332,6 +380,14 @@ export const CLIENT_FIXTURES: ClientStatus[] = [
     open_receivables: { amount_cents: 1500000, currency: "BRL" },
     attention_item_ids: ["cc:attention-item:01K3CC-OVERDUE-INVOICE"],
     notes: "Recebível em atraso. Origem Warmbly/Asaas; sem cobrança daqui.",
+    health: "churn_risk",
+    commitments: ["Diagnóstico v1.1"],
+    owner: "founder",
+    due_date: "2026-08-22T15:00:00Z",
+    deliverables: ["relatório Diagnóstico"],
+    blockers: ["fatura vencida"],
+    next_action: "Revisar no Warmbly; não cobrar daqui",
+    evidence: "asaas/receivables/open",
   },
   {
     schema_version: "control-center.client-status.v1",
@@ -388,6 +444,14 @@ export const HEALTH_FIXTURES: ServiceHealth[] = [
     checked_at: "2026-08-20T17:12:00Z",
     message: "Última sonda falhou. Sem chute de saúde.",
     checks: [{ name: "ready", status: "unknown", detail: "probe error" }],
+    http: { status: "unknown", detail: "probe error" },
+    tls: { status: "unknown" },
+    docker: { status: "unknown" },
+    backup: { status: "unknown" },
+    disk: { used_pct: 91, detail: "91%" },
+    memory: { used_pct: 82, detail: "82%" },
+    pncp_freshness: { freshness_status: "ERROR", observed_at: "2026-08-20T17:12:00Z" },
+    partial_outage: true,
   },
   {
     schema_version: "control-center.service-health.v1",
@@ -594,6 +658,78 @@ export const DIRECTIVE_FIXTURES: Directive[] = [
   },
 ];
 
+export const AGENT_ACTIVITY_FIXTURES: AgentActivity[] = [
+  {
+    schema_version: "control-center.agent-activity.v1",
+    id: "cc:agent-activity:01K3CC-LEDGER-RUNNING",
+    agent_id: "agent:cc-context",
+    provider: "grok",
+    scope: "finance",
+    repo: "tjsasakifln/Governance",
+    status: "running",
+    presentation_status: "RUNNING",
+    started_at: "2026-08-20T17:50:00Z",
+    finished_at: null,
+    goal: "Preparar briefing de recebíveis",
+    campaign: "CONFENGE-CC-LIVE-FOUNDER-COCKPIT-01",
+    summary: "RUNNING defasado: ainda em execução. Não promover a DONE.",
+    provenance: provenance(
+      "collector",
+      "report",
+      "agent-activity/running",
+      "2026-08-20T16:00:00Z",
+      "STALE",
+      0.5,
+    ),
+    evidence_refs: [],
+    residual_work: ["confirmar evidência de settlement"],
+    blockers: ["snapshot financeiro STALE"],
+  },
+  {
+    schema_version: "control-center.agent-activity.v1",
+    id: "cc:agent-activity:01K3CC-LEDGER-PARTIAL",
+    agent_id: "agent:cc-context",
+    provider: "grok",
+    scope: "finance",
+    status: "partial",
+    presentation_status: "PARTIAL",
+    started_at: "2026-08-20T17:50:00Z",
+    finished_at: "2026-08-20T18:10:00Z",
+    goal: "Prepare a scoped finance briefing for overdue receivables.",
+    summary: "Read finance snapshot; leftover: confirm settlement evidence.",
+    provenance: provenance(
+      "collector",
+      "report",
+      "agent-activity/01K3CC-LEDGER-PARTIAL",
+      "2026-08-20T18:10:00Z",
+      "FRESH",
+      0.9,
+    ),
+    evidence_refs: ["cc:finance-snapshot:01K3CC-RO-RECEIVABLES"],
+    residual_work: ["Confirm settlement evidence for invoice overdue more than 30 days"],
+  },
+  {
+    schema_version: "control-center.agent-activity.v1",
+    id: "cc:agent-activity:01K3CC-LEDGER-UNKNOWN",
+    agent_id: "agent:cc-context",
+    scope: "company",
+    status: "not-a-status",
+    presentation_status: "UNKNOWN",
+    started_at: "2026-08-20T17:00:00Z",
+    finished_at: null,
+    goal: "status não reconhecido",
+    summary: "Status ausente no enum v1; apresentado como UNKNOWN.",
+    provenance: provenance(
+      "collector",
+      "report",
+      "agent-activity/unknown",
+      "2026-08-20T17:00:00Z",
+      "UNKNOWN",
+      0.2,
+    ),
+  },
+];
+
 export const AGENT_SESSION_FIXTURES: AgentSession[] = [
   {
     schema_version: "control-center.agent-session.v1",
@@ -662,6 +798,24 @@ export function defaultPages(): Record<DestinationId, DestinationPage> {
       headline: "O que exige atenção agora. Não é chat e não é parede de KPIs.",
       attention: hojeAttention,
       priorities: hojePriorities,
+      commercial: COMMERCIAL_SNAPSHOT,
+      finance: FINANCE_SNAPSHOT,
+      engineering: ENGINEERING_SNAPSHOT,
+      clients: CLIENT_FIXTURES,
+      health: HEALTH_FIXTURES,
+      activities: AGENT_ACTIVITY_FIXTURES,
+      hoje: composeHoje({
+        generated_at: GENERATED_AT,
+        headline: "O que exige atenção agora. Não é chat e não é parede de KPIs.",
+        priorities: hojePriorities,
+        incidents: hojeAttention,
+        clients: CLIENT_FIXTURES,
+        commercial: COMMERCIAL_SNAPSHOT,
+        finance: FINANCE_SNAPSHOT,
+        engineering: ENGINEERING_SNAPSHOT,
+        infra: HEALTH_FIXTURES,
+        activities: AGENT_ACTIVITY_FIXTURES,
+      }),
     }),
     comercial: pageFor("comercial", {
       headline: "Recorte comercial somente leitura. Origem Warmbly; catálogo canônico em Governance.",
@@ -707,6 +861,7 @@ export function defaultPages(): Record<DestinationId, DestinationPage> {
       attention: [],
       priorities: [],
       sessions: AGENT_SESSION_FIXTURES,
+      activities: AGENT_ACTIVITY_FIXTURES,
     }),
   };
 }
@@ -752,6 +907,26 @@ export function stalePages(): Record<DestinationId, DestinationPage> {
     if (page.clients) {
       page.clients = page.clients.map((item) => ({ ...item, provenance: stamp(item.provenance) }));
     }
+    if (page.activities) {
+      page.activities = page.activities.map((item) => ({
+        ...item,
+        provenance: stamp(item.provenance),
+        presentation_status:
+          item.presentation_status === "RUNNING" ? "RUNNING" : item.presentation_status,
+      }));
+    }
+    page.hoje = composeHoje({
+      generated_at: page.generated_at,
+      headline: page.headline,
+      priorities: page.priorities,
+      incidents: page.attention,
+      clients: page.clients ?? [],
+      commercial: page.commercial ?? null,
+      finance: page.finance ?? null,
+      engineering: page.engineering ?? null,
+      infra: page.health ?? [],
+      activities: page.activities ?? [],
+    });
   }
   return pages;
 }

--- a/control-center/apps/web-shell/src/freshness-tone.ts
+++ b/control-center/apps/web-shell/src/freshness-tone.ts
@@ -1,0 +1,49 @@
+import type { FreshnessStatus, HealthStatus } from "./types";
+
+export type FreshnessTone = "green" | "amber" | "slate" | "red";
+
+/**
+ * STALE / UNKNOWN / ERROR are never the healthy green tone.
+ * Color is paired with a text label elsewhere; this only maps recency.
+ */
+export function freshnessTone(status: FreshnessStatus): FreshnessTone {
+  switch (status) {
+    case "FRESH":
+      return "green";
+    case "STALE":
+      return "amber";
+    case "UNKNOWN":
+      return "slate";
+    case "ERROR":
+      return "red";
+  }
+}
+
+export function healthTone(status: HealthStatus): FreshnessTone {
+  switch (status) {
+    case "healthy":
+      return "green";
+    case "degraded":
+      return "amber";
+    case "unknown":
+      return "slate";
+    case "down":
+      return "red";
+  }
+}
+
+export function combinedTone(freshness: FreshnessStatus, health?: HealthStatus): FreshnessTone {
+  const fresh = freshnessTone(freshness);
+  if (!health) return fresh;
+  const rank: Record<FreshnessTone, number> = { green: 0, amber: 1, slate: 2, red: 3 };
+  const other = healthTone(health);
+  return rank[other] > rank[fresh] ? other : fresh;
+}
+
+export function isHealthyGreen(status: FreshnessStatus): boolean {
+  return status === "FRESH";
+}
+
+export function neverGreenStatuses(): readonly FreshnessStatus[] {
+  return ["STALE", "UNKNOWN", "ERROR"];
+}

--- a/control-center/apps/web-shell/src/hoje-compose.ts
+++ b/control-center/apps/web-shell/src/hoje-compose.ts
@@ -1,0 +1,616 @@
+import { formatLocal } from "./datetime";
+import { combinedTone, freshnessTone, type FreshnessTone } from "./freshness-tone";
+import { selectHomepageAttention, selectHomepagePriorities } from "./homepage";
+import type {
+  AgentActivity,
+  AttentionItem,
+  ClientStatus,
+  CommercialSnapshot,
+  EngineeringSnapshot,
+  FinanceSnapshot,
+  FreshnessStatus,
+  HealthStatus,
+  PriorityRecommendation,
+  Provenance,
+  ServiceHealth,
+  SourceRef,
+} from "./types";
+import {
+  WRITE_SHORTCUT_KINDS,
+  WRITE_SHORTCUT_LABELS,
+  type WriteShortcutKind,
+} from "./adapters/paths";
+
+export const HOJE_SECTION_IDS = [
+  "top3",
+  "incidents",
+  "clients",
+  "commercial",
+  "finance",
+  "engineering",
+  "agents",
+  "shortcuts",
+] as const;
+export type HojeSectionId = (typeof HOJE_SECTION_IDS)[number];
+
+export const HOJE_SECTION_TITLES = [
+  "Se eu só puder fazer 3 coisas hoje.",
+  "Incidentes, blockers e riscos.",
+  "Clientes que exigem atenção.",
+  "Comercial em exceção.",
+  "Financeiro em exceção.",
+  "Engenharia e infraestrutura em exceção.",
+  "Atividade recente dos agentes.",
+  "Atalhos para decisão, nota, risco e hipótese.",
+] as const;
+export type HojeSectionTitle = (typeof HOJE_SECTION_TITLES)[number];
+
+export interface HojeRow {
+  id: string;
+  title: string;
+  summary: string;
+  source: SourceRef;
+  observed_at: string;
+  observed_at_local: string;
+  freshness_status: FreshnessStatus;
+  freshness_tone: FreshnessTone;
+  confidence?: number;
+  kind?: string;
+  severity?: string;
+  money?: { amount_cents: number; currency: string };
+  health?: string;
+}
+
+export interface HojeShortcut {
+  kind: WriteShortcutKind;
+  label: string;
+  hint: string;
+}
+
+export interface HojeSection {
+  id: HojeSectionId;
+  title: HojeSectionTitle;
+  compressed: boolean;
+  compressed_summary: string | null;
+  rows: HojeRow[];
+  shortcuts: HojeShortcut[];
+}
+
+export interface HojeViewModel {
+  schema_version: "control-center.hoje-view.v1";
+  generated_at: string;
+  headline: string;
+  sections: HojeSection[];
+  charts_emitted: false;
+}
+
+export interface HojeComposeInput {
+  generated_at: string;
+  headline: string;
+  priorities: readonly PriorityRecommendation[];
+  incidents: readonly AttentionItem[];
+  clients: readonly ClientStatus[];
+  commercial: CommercialSnapshot | null;
+  finance: FinanceSnapshot | null;
+  engineering: EngineeringSnapshot | null;
+  infra: readonly ServiceHealth[];
+  activities: readonly AgentActivity[];
+}
+
+const CLIENT_NEEDS = new Set(["churn_risk", "paused", "churned"]);
+const AGENT_NEEDS = new Set(["RUNNING", "PARTIAL", "BLOCKED", "FAILED", "UNKNOWN"]);
+
+function isUntrusted(status: FreshnessStatus): boolean {
+  return status !== "FRESH";
+}
+
+function isHealth(value: string | undefined): value is HealthStatus {
+  return value === "healthy" || value === "degraded" || value === "down" || value === "unknown";
+}
+
+function rowFrom(
+  base: {
+    id: string;
+    title: string;
+    summary: string;
+    kind?: string;
+    severity?: string;
+    money?: HojeRow["money"];
+    health?: string;
+  },
+  provenance: Provenance,
+): HojeRow {
+  const row: HojeRow = {
+    id: base.id,
+    title: base.title,
+    summary: base.summary,
+    source: provenance.source,
+    observed_at: provenance.observed_at,
+    observed_at_local: formatLocal(provenance.observed_at),
+    freshness_status: provenance.freshness_status,
+    freshness_tone: combinedTone(
+      provenance.freshness_status,
+      isHealth(base.health) ? base.health : undefined,
+    ),
+    confidence: provenance.confidence,
+  };
+  if (base.kind) row.kind = base.kind;
+  if (base.severity) row.severity = base.severity;
+  if (base.money) row.money = base.money;
+  if (base.health) row.health = base.health;
+  return row;
+}
+
+function section(
+  index: number,
+  rows: HojeRow[],
+  compressed: boolean,
+  compressed_summary: string | null,
+  shortcuts: HojeShortcut[] = [],
+): HojeSection {
+  return {
+    id: HOJE_SECTION_IDS[index]!,
+    title: HOJE_SECTION_TITLES[index]!,
+    compressed,
+    compressed_summary,
+    rows,
+    shortcuts,
+  };
+}
+
+function composeTop3(input: HojeComposeInput): HojeSection {
+  const priorities = selectHomepagePriorities(input.priorities);
+  const rows = priorities.map((item) =>
+    rowFrom(
+      {
+        id: item.id,
+        title: item.title,
+        summary: item.rationale,
+        kind: `rank-${item.rank}`,
+      },
+      item.provenance,
+    ),
+  );
+  const compressed = rows.length === 0;
+  return section(
+    0,
+    rows,
+    compressed,
+    compressed ? "Nenhuma ação recomendada — não inventar trabalho" : null,
+  );
+}
+
+function composeIncidents(input: HojeComposeInput): HojeSection {
+  const items = selectHomepageAttention(input.incidents);
+  const rows = items.map((item) =>
+    rowFrom(
+      {
+        id: item.id,
+        title: item.title,
+        summary: item.summary,
+        kind: "incident",
+        severity: item.severity,
+      },
+      item.provenance,
+    ),
+  );
+  const compressed = rows.length === 0;
+  return section(
+    1,
+    rows,
+    compressed,
+    compressed ? "Nenhum incidente, blocker ou risco aberto — ignorar" : null,
+  );
+}
+
+function clientNeedsAttention(client: ClientStatus): boolean {
+  if (CLIENT_NEEDS.has(client.lifecycle)) return true;
+  if (client.attention_item_ids && client.attention_item_ids.length > 0) return true;
+  if (client.blockers && client.blockers.length > 0) return true;
+  return isUntrusted(client.provenance.freshness_status);
+}
+
+function composeClients(input: HojeComposeInput): HojeSection {
+  const rows = input.clients.filter(clientNeedsAttention).map((client) =>
+    rowFrom(
+      {
+        id: client.id,
+        title: client.display_name,
+        summary: client.next_action ?? client.notes ?? client.lifecycle,
+        kind: client.lifecycle,
+        money: client.open_receivables,
+      },
+      client.provenance,
+    ),
+  );
+  const compressed = rows.length === 0;
+  return section(2, rows, compressed, compressed ? "Nenhum cliente exige atenção — ignorar" : null);
+}
+
+function commercialInException(snap: CommercialSnapshot): boolean {
+  return (
+    snap.at_risk_client_count > 0 ||
+    snap.inbound_unread_count > 0 ||
+    (snap.missing_next_action_count ?? 0) > 0 ||
+    (snap.stalled_count ?? 0) > 0 ||
+    (snap.aging_count ?? 0) > 0 ||
+    (snap.offer_version_drift?.count ?? 0) > 0 ||
+    isUntrusted(snap.provenance.freshness_status)
+  );
+}
+
+function composeCommercial(input: HojeComposeInput): HojeSection {
+  const snap = input.commercial;
+  if (!snap) {
+    return section(3, [], true, "Sem recorte comercial — ignorar");
+  }
+  const funnel = snap.funnel
+    ? `leads ${snap.funnel.new_leads} · qualificados ${snap.funnel.qualified} · oportunidades ${snap.funnel.opportunities}`
+    : `pipeline ${snap.pipeline_open_count} aberto`;
+  if (!commercialInException(snap)) {
+    return section(3, [], true, `${funnel} — ignorar`);
+  }
+  const rows: HojeRow[] = [];
+  if (snap.inbound_unread_count > 0 || isUntrusted(snap.provenance.freshness_status)) {
+    rows.push(
+      rowFrom(
+        {
+          id: `${snap.id}:inbound`,
+          title: "Inbound sem leitura",
+          summary: `${snap.inbound_unread_count} item(ns) no inbound Warmbly (somente leitura)`,
+          kind: "inbound",
+        },
+        snap.provenance,
+      ),
+    );
+  }
+  if (snap.at_risk_client_count > 0) {
+    rows.push(
+      rowFrom(
+        {
+          id: `${snap.id}:at-risk`,
+          title: "Clientes em risco no recorte comercial",
+          summary: `${snap.at_risk_client_count} cliente(s) at-risk`,
+          kind: "at-risk",
+        },
+        snap.provenance,
+      ),
+    );
+  }
+  if ((snap.missing_next_action_count ?? 0) > 0) {
+    rows.push(
+      rowFrom(
+        {
+          id: `${snap.id}:missing-next`,
+          title: "Missing next action",
+          summary: `${snap.missing_next_action_count} oportunidade(s) sem próxima ação`,
+          kind: "missing-next-action",
+        },
+        snap.provenance,
+      ),
+    );
+  }
+  if ((snap.stalled_count ?? 0) > 0) {
+    rows.push(
+      rowFrom(
+        {
+          id: `${snap.id}:stalled`,
+          title: "Stalled stage",
+          summary: `${snap.stalled_count} estágio(s) parado(s)`,
+          kind: "stalled-stage",
+        },
+        snap.provenance,
+      ),
+    );
+  }
+  if ((snap.offer_version_drift?.count ?? 0) > 0) {
+    rows.push(
+      rowFrom(
+        {
+          id: `${snap.id}:drift`,
+          title: "Offer/version drift",
+          summary: snap.offer_version_drift?.detail ?? `${snap.offer_version_drift?.count} desvio(s)`,
+          kind: "offer-version-drift",
+        },
+        snap.provenance,
+      ),
+    );
+  }
+  if (rows.length === 0) {
+    rows.push(
+      rowFrom(
+        {
+          id: snap.id,
+          title: "Recorte comercial em exceção",
+          summary: funnel,
+          kind: "snapshot",
+        },
+        snap.provenance,
+      ),
+    );
+  }
+  return section(3, rows, false, null);
+}
+
+function financeInException(snap: FinanceSnapshot): boolean {
+  const overdue = snap.overdue ?? snap.receivables_overdue;
+  return (
+    overdue.amount_cents > 0 ||
+    (snap.chargebacks?.amount_cents ?? 0) > 0 ||
+    isUntrusted(snap.provenance.freshness_status)
+  );
+}
+
+function composeFinance(input: HojeComposeInput): HojeSection {
+  const snap = input.finance;
+  if (!snap) {
+    return section(4, [], true, "Sem recorte financeiro — ignorar");
+  }
+  const overdue = snap.overdue ?? snap.receivables_overdue;
+  const receivable = snap.receivable ?? snap.receivables_open;
+  const kpi = `a receber ${receivable.currency} ${receivable.amount_cents}¢ · vencido ${overdue.amount_cents}¢`;
+  if (!financeInException(snap)) {
+    return section(4, [], true, `${kpi} — ignorar (somente leitura; sem cobrança neste cockpit)`);
+  }
+  const rows: HojeRow[] = [];
+  if (overdue.amount_cents > 0) {
+    rows.push(
+      rowFrom(
+        {
+          id: `${snap.id}:overdue`,
+          title: "Financeiro em exceção — vencido",
+          summary: "Somente leitura. Cobrança, checkout, refund e mutação Asaas são proibidos neste cockpit.",
+          kind: "overdue",
+          money: overdue,
+        },
+        snap.provenance,
+      ),
+    );
+  }
+  if ((snap.chargebacks?.amount_cents ?? 0) > 0 && snap.chargebacks) {
+    rows.push(
+      rowFrom(
+        {
+          id: `${snap.id}:chargebacks`,
+          title: "Chargebacks",
+          summary: "Chargebacks observados no recorte somente leitura.",
+          kind: "chargebacks",
+          money: snap.chargebacks,
+        },
+        snap.provenance,
+      ),
+    );
+  }
+  if (rows.length === 0) {
+    rows.push(
+      rowFrom(
+        {
+          id: snap.id,
+          title: "Recorte financeiro defasado",
+          summary: kpi,
+          kind: "snapshot",
+          money: receivable,
+        },
+        snap.provenance,
+      ),
+    );
+  }
+  return section(4, rows, false, null);
+}
+
+function engineeringInException(snap: EngineeringSnapshot): boolean {
+  return (
+    snap.failing_check_count > 0 ||
+    snap.open_incident_count > 0 ||
+    (snap.p0_count ?? 0) > 0 ||
+    (snap.p1_count ?? 0) > 0 ||
+    (snap.blockers?.length ?? 0) > 0 ||
+    isUntrusted(snap.provenance.freshness_status)
+  );
+}
+
+function infraInException(svc: ServiceHealth): boolean {
+  return svc.status !== "healthy" || svc.partial_outage === true || isUntrusted(svc.provenance.freshness_status);
+}
+
+function composeEngineering(input: HojeComposeInput): HojeSection {
+  const snap = input.engineering;
+  const infra = input.infra;
+  const rows: HojeRow[] = [];
+  if (snap && engineeringInException(snap)) {
+    if (snap.failing_check_count > 0) {
+      rows.push(
+        rowFrom(
+          {
+            id: `${snap.id}:checks`,
+            title: "CI falhando",
+            summary: `${snap.failing_check_count} check(s) falhando`,
+            kind: "failing-check",
+            severity: "high",
+          },
+          snap.provenance,
+        ),
+      );
+    }
+    if ((snap.p0_count ?? 0) > 0 || (snap.p1_count ?? 0) > 0) {
+      rows.push(
+        rowFrom(
+          {
+            id: `${snap.id}:p0p1`,
+            title: "P0/P1 abertos",
+            summary: `P0 ${snap.p0_count ?? 0} · P1 ${snap.p1_count ?? 0}`,
+            kind: "p0-p1",
+            severity: (snap.p0_count ?? 0) > 0 ? "critical" : "high",
+          },
+          snap.provenance,
+        ),
+      );
+    }
+    if (snap.open_incident_count > 0) {
+      rows.push(
+        rowFrom(
+          {
+            id: `${snap.id}:incidents`,
+            title: "Incidentes de engenharia abertos",
+            summary: `${snap.open_incident_count} incidente(s) aberto(s)`,
+            kind: "eng-incident",
+            severity: "critical",
+          },
+          snap.provenance,
+        ),
+      );
+    }
+    if (snap.active_work_without_evidence) {
+      rows.push(
+        rowFrom(
+          {
+            id: `${snap.id}:hypothesis`,
+            title: "Trabalho ativo sem evidência",
+            summary: snap.active_work_without_evidence.detail ?? "Permanece hipótese até haver evidência.",
+            kind: "hypothesis",
+          },
+          snap.provenance,
+        ),
+      );
+    }
+    if (rows.length === 0) {
+      rows.push(
+        rowFrom(
+          {
+            id: snap.id,
+            title: "Recorte de engenharia em exceção",
+            summary: `PRs ${snap.open_pr_count} · CI falhando ${snap.failing_check_count} · incidentes ${snap.open_incident_count}`,
+            kind: "snapshot",
+          },
+          snap.provenance,
+        ),
+      );
+    }
+  }
+  for (const svc of infra) {
+    if (!infraInException(svc)) continue;
+    rows.push(
+      rowFrom(
+        {
+          id: svc.id,
+          title: svc.service_name,
+          summary: svc.message ?? `status ${svc.status}${svc.partial_outage ? " · partial outage" : ""}`,
+          kind: "infra",
+          health: svc.status,
+        },
+        svc.provenance,
+      ),
+    );
+  }
+  const compressed = rows.length === 0;
+  if (!compressed) return section(5, rows, false, null);
+  const parts: string[] = [];
+  if (snap && !engineeringInException(snap)) {
+    parts.push(`PRs ${snap.open_pr_count} · CI ok · incidentes 0`);
+  }
+  if (infra.length > 0 && infra.every((s) => !infraInException(s))) {
+    parts.push("infra saudável");
+  }
+  if (!snap && infra.length === 0) parts.push("Sem recorte de engenharia/infra");
+  return section(5, [], true, `${parts.join(" · ") || "Sem recorte de engenharia/infra"} — ignorar`);
+}
+
+function agentNeedsAttention(item: AgentActivity): boolean {
+  if (AGENT_NEEDS.has(item.presentation_status)) return true;
+  if (item.blockers && item.blockers.length > 0) return true;
+  if (item.residual_work && item.residual_work.length > 0) return true;
+  if (isUntrusted(item.provenance.freshness_status)) return true;
+  return false;
+}
+
+function composeAgents(input: HojeComposeInput): HojeSection {
+  const items = input.activities.slice();
+  if (items.length === 0) {
+    return section(6, [], true, "Zero atividade de agentes — não inventar trabalho");
+  }
+  const actionable = items.filter(agentNeedsAttention);
+  if (actionable.length === 0) {
+    return section(6, [], true, `${items.length} sessão(ões) concluída(s) sem leftover — ignorar`);
+  }
+  const rows = actionable.map((item) =>
+    rowFrom(
+      {
+        id: item.id,
+        title: `${item.agent_id}${item.provider ? ` · ${item.provider}` : ""} · ${item.presentation_status}`,
+        summary: item.summary,
+        kind: item.presentation_status,
+      },
+      item.provenance,
+    ),
+  );
+  return section(6, rows, false, null);
+}
+
+function composeShortcuts(): HojeSection {
+  const shortcuts: HojeShortcut[] = WRITE_SHORTCUT_KINDS.map((kind) => ({
+    kind,
+    label: WRITE_SHORTCUT_LABELS[kind],
+    hint: "Grava no Context Service (POST /v1/directives). Não muta Warmbly, Asaas ou GitHub.",
+  }));
+  return {
+    id: "shortcuts",
+    title: HOJE_SECTION_TITLES[7]!,
+    compressed: false,
+    compressed_summary: null,
+    rows: [],
+    shortcuts,
+  };
+}
+
+export function composeHoje(input: HojeComposeInput): HojeViewModel {
+  const sections = [
+    composeTop3(input),
+    composeIncidents(input),
+    composeClients(input),
+    composeCommercial(input),
+    composeFinance(input),
+    composeEngineering(input),
+    composeAgents(input),
+    composeShortcuts(),
+  ];
+  if (sections.length !== HOJE_SECTION_TITLES.length) {
+    throw new Error("compose produced the wrong number of sections");
+  }
+  for (let i = 0; i < HOJE_SECTION_TITLES.length; i += 1) {
+    if (sections[i]?.title !== HOJE_SECTION_TITLES[i] || sections[i]?.id !== HOJE_SECTION_IDS[i]) {
+      throw new Error("compose produced sections out of order");
+    }
+  }
+  const top3 = sections[0];
+  if (top3 && top3.rows.length > 3) {
+    throw new Error("Top 3 exceeded homepage cap");
+  }
+  return {
+    schema_version: "control-center.hoje-view.v1",
+    generated_at: input.generated_at,
+    headline: input.headline,
+    sections,
+    charts_emitted: false,
+  };
+}
+
+export function hojeHasUntrustedGreen(view: HojeViewModel): boolean {
+  return view.sections.some((section) =>
+    section.rows.some(
+      (row) => row.freshness_status !== "FRESH" && row.freshness_tone === "green",
+    ),
+  );
+}
+
+export function assertNoGreenForUntrusted(view: HojeViewModel): void {
+  for (const section of view.sections) {
+    for (const row of section.rows) {
+      if (row.freshness_status !== "FRESH" && row.freshness_tone === "green") {
+        throw new Error(`untrusted ${row.freshness_status} rendered green on ${row.id}`);
+      }
+      if (freshnessTone(row.freshness_status) === "green" && row.freshness_status !== "FRESH") {
+        throw new Error(`tone map leaked green for ${row.freshness_status}`);
+      }
+    }
+  }
+}

--- a/control-center/apps/web-shell/src/page.ts
+++ b/control-center/apps/web-shell/src/page.ts
@@ -33,7 +33,8 @@ export function collectProvenance(page: DestinationPage): Provenance[] {
 }
 
 export function pageIsEmpty(page: DestinationPage): boolean {
-  const hojeRows = page.hoje?.sections.reduce((sum, section) => sum + section.rows.length, 0) ?? 0;
+  if (page.hoje != null && page.hoje.sections.length > 0) return false;
+  if ((page.activities?.length ?? 0) > 0) return false;
   return (
     page.attention.length === 0 &&
     page.priorities.length === 0 &&
@@ -43,9 +44,7 @@ export function pageIsEmpty(page: DestinationPage): boolean {
     (page.clients?.length ?? 0) === 0 &&
     (page.health?.length ?? 0) === 0 &&
     (page.directives?.length ?? 0) === 0 &&
-    (page.sessions?.length ?? 0) === 0 &&
-    (page.activities?.length ?? 0) === 0 &&
-    hojeRows === 0
+    (page.sessions?.length ?? 0) === 0
   );
 }
 

--- a/control-center/apps/web-shell/src/page.ts
+++ b/control-center/apps/web-shell/src/page.ts
@@ -14,10 +14,26 @@ export function collectProvenance(page: DestinationPage): Provenance[] {
   if (page.health) {
     for (const row of page.health) items.push(row.provenance);
   }
+  if (page.activities) {
+    for (const row of page.activities) items.push(row.provenance);
+  }
+  if (page.hoje) {
+    for (const section of page.hoje.sections) {
+      for (const row of section.rows) {
+        items.push({
+          source: row.source,
+          observed_at: row.observed_at,
+          freshness_status: row.freshness_status,
+          confidence: row.confidence ?? 0,
+        });
+      }
+    }
+  }
   return items;
 }
 
 export function pageIsEmpty(page: DestinationPage): boolean {
+  const hojeRows = page.hoje?.sections.reduce((sum, section) => sum + section.rows.length, 0) ?? 0;
   return (
     page.attention.length === 0 &&
     page.priorities.length === 0 &&
@@ -27,7 +43,9 @@ export function pageIsEmpty(page: DestinationPage): boolean {
     (page.clients?.length ?? 0) === 0 &&
     (page.health?.length ?? 0) === 0 &&
     (page.directives?.length ?? 0) === 0 &&
-    (page.sessions?.length ?? 0) === 0
+    (page.sessions?.length ?? 0) === 0 &&
+    (page.activities?.length ?? 0) === 0 &&
+    hojeRows === 0
   );
 }
 

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -356,6 +356,113 @@ h2 {
   margin-top: 1rem;
 }
 
+.band {
+  margin: 0.85rem 0 1.1rem;
+}
+
+.band[data-compressed="true"] {
+  padding: 0.45rem 0.55rem;
+  border: 1px dashed var(--line);
+  background: var(--bg-elev);
+}
+
+.band[data-compressed="false"] {
+  padding: 0;
+}
+
+.band[data-compressed="true"] h2 {
+  margin-top: 0.2rem;
+}
+
+.kpi-summary {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+
+.prov-inline {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 0.8rem;
+}
+
+.shortcut-grid {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.shortcut-form {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.75rem;
+  border: 1px solid var(--line);
+  background: var(--bg-card);
+}
+
+.shortcut-form label {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+}
+
+.shortcut-form input,
+.shortcut-form textarea,
+.shortcut-form button {
+  font: inherit;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--line);
+  padding: 0.45rem 0.55rem;
+  min-height: 44px;
+}
+
+.shortcut-form button {
+  cursor: pointer;
+}
+
+.shortcut-form .hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+}
+
+[data-tone="green"] .pill-fresh {
+  border-color: var(--ok);
+}
+
+[data-tone="amber"] .pill,
+[data-freshness="STALE"] .pill-stale {
+  border-color: var(--high);
+}
+
+[data-tone="slate"] .pill,
+[data-freshness="UNKNOWN"] .pill-unknown {
+  border-color: var(--low);
+}
+
+[data-tone="red"] .pill,
+[data-freshness="ERROR"] .pill-error {
+  border-color: var(--crit);
+}
+
+[data-freshness="STALE"],
+[data-freshness="UNKNOWN"],
+[data-freshness="ERROR"] {
+  --ok: var(--high);
+}
+
+.health[data-status="unknown"],
+.health[data-status="down"],
+.health[data-status="degraded"],
+.activity[data-status="UNKNOWN"],
+.activity[data-status="FAILED"],
+.activity[data-status="BLOCKED"] {
+  border-left: 3px solid var(--crit);
+}
+
+
+
 .authority,
 .constraint,
 .action,

--- a/control-center/apps/web-shell/src/topology.ts
+++ b/control-center/apps/web-shell/src/topology.ts
@@ -1,0 +1,6 @@
+/** Productive Control Center topology. Not an /intranet alternative. */
+export const PRODUCTIVE_URL = "https://ops.confenge.com.br/";
+export const AUTH_URL = "https://auth.ops.confenge.com.br/";
+
+export const PRODUCTIVE_HOST = "ops.confenge.com.br";
+export const AUTH_HOST = "auth.ops.confenge.com.br";

--- a/control-center/apps/web-shell/src/types.ts
+++ b/control-center/apps/web-shell/src/types.ts
@@ -48,6 +48,25 @@ export type PriorityHorizon = (typeof PRIORITY_HORIZONS)[number];
 export const AGENT_SESSION_STATUSES = ["open", "closed", "denied"] as const;
 export type AgentSessionStatus = (typeof AGENT_SESSION_STATUSES)[number];
 
+export const AGENT_ACTIVITY_STATUSES = [
+  "running",
+  "done",
+  "partial",
+  "blocked",
+  "failed",
+] as const;
+export type AgentActivityStatus = (typeof AGENT_ACTIVITY_STATUSES)[number];
+
+export const AGENT_ACTIVITY_PRESENTATION_STATUSES = [
+  "RUNNING",
+  "DONE",
+  "PARTIAL",
+  "BLOCKED",
+  "FAILED",
+  "UNKNOWN",
+] as const;
+export type AgentActivityPresentationStatus = (typeof AGENT_ACTIVITY_PRESENTATION_STATUSES)[number];
+
 export const CLIENT_LIFECYCLES = [
   "lead",
   "active",
@@ -158,12 +177,43 @@ export interface ClientStatus {
   attention_item_ids?: ResourceId[];
   open_receivables?: Money;
   notes?: string;
+  health?: string;
+  commitments?: string[];
+  owner?: string;
+  due_date?: UtcDateTime;
+  deliverables?: string[];
+  blockers?: string[];
+  next_action?: string;
+  evidence?: string;
 }
 
 export interface CommercialAuthorityStamp {
   catalog_authority: "governance";
   commercial_runtime: "warmbly";
   this_document: "read_model";
+}
+
+export interface CommercialFunnel {
+  new_leads: number;
+  qualified: number;
+  opportunities: number;
+  proposals: number;
+  clients: number;
+}
+
+export interface WeightedPipeline extends Money {
+  probability_reliable: true;
+}
+
+export interface ExtraHistorical {
+  treated_as_public_offer: false;
+  label?: string;
+  note?: string;
+}
+
+export interface OfferVersionDrift {
+  count: number;
+  detail?: string;
 }
 
 export interface CommercialSnapshot {
@@ -177,6 +227,38 @@ export interface CommercialSnapshot {
   inbound_unread_count: number;
   at_risk_client_count: number;
   attention_item_ids?: ResourceId[];
+  offer_pin?: {
+    catalog_authority: "governance";
+    catalog_id: string;
+    known_offer_ids?: string[];
+  };
+  funnel?: CommercialFunnel;
+  pipeline_nominal?: Money;
+  pipeline_weighted?: WeightedPipeline;
+  aging_count?: number;
+  stalled_count?: number;
+  missing_next_action_count?: number;
+  extra_historical?: ExtraHistorical;
+  offer_version_drift?: OfferVersionDrift;
+}
+
+export interface EvidencedCashIn extends Money {
+  evidenced: true;
+  source: SourceRef;
+  window?: { from: UtcDateTime; to: UtcDateTime };
+}
+
+export interface ApplicableMrr extends Money {
+  applicable: true;
+  basis: "recurring_monthly";
+}
+
+export interface ReliableRunway {
+  months: number;
+  cash_balance: Money;
+  monthly_expense: Money;
+  cash_reliable: true;
+  expense_reliable: true;
 }
 
 export interface FinanceSnapshot {
@@ -187,8 +269,19 @@ export interface FinanceSnapshot {
   provenance: Provenance;
   read_model_only: true;
   provider_mutations: "forbidden";
+  contracted?: Money;
+  billed?: Money;
+  paid?: Money;
+  effectively_received?: Money;
+  overdue?: Money;
+  receivable?: Money;
+  refunds?: Money;
+  chargebacks?: Money;
   receivables_open: Money;
   receivables_overdue: Money;
+  cash_in?: EvidencedCashIn;
+  mrr?: ApplicableMrr;
+  runway?: ReliableRunway;
   attention_item_ids?: ResourceId[];
 }
 
@@ -203,6 +296,16 @@ export interface EngineeringSnapshot {
   open_incident_count: number;
   repo_scopes?: Scope[];
   attention_item_ids?: ResourceId[];
+  repository?: string;
+  default_branch?: string;
+  prs?: Array<{ id?: string; title?: string; status?: string }>;
+  ci?: { status?: string; detail?: string };
+  p0_count?: number;
+  p1_count?: number;
+  aging?: { count?: number; oldest_days?: number };
+  blockers?: string[];
+  last_evidence?: string;
+  active_work_without_evidence?: { remains: "hypothesis"; detail?: string };
 }
 
 export interface ServiceHealthCheck {
@@ -222,4 +325,35 @@ export interface ServiceHealth {
   latency_ms?: number;
   message?: string;
   checks?: ServiceHealthCheck[];
+  http?: { status?: string; detail?: string };
+  tls?: { status?: string; detail?: string };
+  docker?: { status?: string; detail?: string };
+  backup?: { status?: string; detail?: string };
+  disk?: { used_pct?: number; detail?: string };
+  memory?: { used_pct?: number; detail?: string };
+  pncp_freshness?: { freshness_status: FreshnessStatus; observed_at?: UtcDateTime; detail?: string };
+  partial_outage?: boolean;
+}
+
+export interface AgentActivity {
+  schema_version: "control-center.agent-activity.v1";
+  id: ResourceId;
+  agent_id: string;
+  provider?: string;
+  session_id?: ResourceId;
+  scope: Scope;
+  repo?: string;
+  status: string;
+  presentation_status: AgentActivityPresentationStatus;
+  started_at: UtcDateTime;
+  finished_at: UtcDateTime | null;
+  goal: string;
+  campaign?: string | null;
+  summary: string;
+  provenance: Provenance;
+  actor?: ActorRef;
+  evidence_refs?: string[];
+  residual_work?: string[];
+  blockers?: string[];
+  related_ids?: ResourceId[];
 }

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -1,0 +1,287 @@
+import { escapeHtml } from "../escape";
+import { formatLocal } from "../datetime";
+import { formatMoney } from "../money";
+import type {
+  AgentActivity,
+  ClientStatus,
+  CommercialSnapshot,
+  Directive,
+  EngineeringSnapshot,
+  FinanceSnapshot,
+  ServiceHealth,
+} from "../types";
+import { provenanceBlock } from "./provenance";
+
+function fact(label: string, value: string, extra = ""): string {
+  return `<div${extra}><dt>${escapeHtml(label)}</dt><dd>${value}</dd></div>`;
+}
+
+function moneyFact(label: string, money: { amount_cents: number; currency: string }): string {
+  return `
+    <div class="money" data-amount-cents="${money.amount_cents}" data-currency="${escapeHtml(money.currency)}">
+      <dt>${escapeHtml(label)}</dt>
+      <dd>${escapeHtml(formatMoney(money))}</dd>
+    </div>
+  `;
+}
+
+function listFact(label: string, items: string[] | undefined): string {
+  if (!items || items.length === 0) return "";
+  return fact(label, escapeHtml(items.join(", ")));
+}
+
+export function commercialBlock(snapshot: CommercialSnapshot): string {
+  const funnel = snapshot.funnel;
+  const weighted =
+    snapshot.pipeline_weighted && snapshot.pipeline_weighted.probability_reliable
+      ? moneyFact("Pipeline ponderado (probabilidade confiável)", snapshot.pipeline_weighted)
+      : fact("Pipeline ponderado", "omitido — probabilidade não confiável");
+  const extra = snapshot.extra_historical
+    ? fact(
+        snapshot.extra_historical.label ?? "Extra histórica",
+        escapeHtml(
+          snapshot.extra_historical.note ??
+            "Nunca tratada como oferta pública. Catálogo canônico permanece em Governance.",
+        ),
+        ` data-extra-historical="true" data-public-offer="false"`,
+      )
+    : fact("Extra histórica", "não é oferta pública", ` data-extra-historical="true" data-public-offer="false"`);
+  const drift = snapshot.offer_version_drift
+    ? fact(
+        "Offer/version drift",
+        escapeHtml(snapshot.offer_version_drift.detail ?? String(snapshot.offer_version_drift.count)),
+      )
+    : "";
+  return `
+    <section class="compact domain-comercial" aria-labelledby="comercial-recorte" data-domain="commercial">
+      <h2 id="comercial-recorte">Recorte comercial (somente leitura)</h2>
+      <p class="authority">Autoridade do catálogo: ${escapeHtml(snapshot.authority.catalog_authority)}. Runtime comercial: ${escapeHtml(snapshot.authority.commercial_runtime)}. Este documento: ${escapeHtml(snapshot.authority.this_document)}.</p>
+      <dl class="facts">
+        ${funnel ? fact("Novos leads", String(funnel.new_leads)) : ""}
+        ${funnel ? fact("Qualificados", String(funnel.qualified)) : ""}
+        ${funnel ? fact("Oportunidades", String(funnel.opportunities)) : ""}
+        ${funnel ? fact("Propostas", String(funnel.proposals)) : ""}
+        ${funnel ? fact("Clientes", String(funnel.clients)) : ""}
+        ${snapshot.pipeline_nominal ? moneyFact("Pipeline nominal", snapshot.pipeline_nominal) : ""}
+        ${weighted}
+        ${typeof snapshot.aging_count === "number" ? fact("Aging", String(snapshot.aging_count)) : ""}
+        ${typeof snapshot.missing_next_action_count === "number" ? fact("Missing next action", String(snapshot.missing_next_action_count)) : ""}
+        ${typeof snapshot.stalled_count === "number" ? fact("Stalled stage", String(snapshot.stalled_count)) : ""}
+        ${drift}
+        ${extra}
+        <div><dt>Pipeline aberto</dt><dd>${snapshot.pipeline_open_count}</dd></div>
+        <div><dt>Inbound sem leitura</dt><dd>${snapshot.inbound_unread_count}</dd></div>
+        <div><dt>Clientes em risco</dt><dd>${snapshot.at_risk_client_count}</dd></div>
+      </dl>
+      ${provenanceBlock(snapshot.provenance)}
+    </section>
+  `;
+}
+
+export function financeBlock(snapshot: FinanceSnapshot): string {
+  const mrr =
+    snapshot.mrr && snapshot.mrr.applicable
+      ? moneyFact("MRR (aplicável)", snapshot.mrr)
+      : fact("MRR", "omitido — não aplicável");
+  const runway =
+    snapshot.runway && snapshot.runway.cash_reliable && snapshot.runway.expense_reliable
+      ? fact("Runway", `${snapshot.runway.months} mês(es)`)
+      : fact("Runway", "omitido — caixa e despesas não confiáveis");
+  return `
+    <section class="compact domain-financeiro" aria-labelledby="financeiro-recorte" data-domain="finance">
+      <h2 id="financeiro-recorte">Recorte financeiro (somente leitura)</h2>
+      <p class="constraint" role="note">Mutações de provedor: ${escapeHtml(snapshot.provider_mutations)}. read_model_only=${String(snapshot.read_model_only)}. Sem cobrança, checkout, refund, cancelamento ou escrita Asaas neste cockpit.</p>
+      <dl class="facts">
+        ${snapshot.contracted ? moneyFact("Contratado", snapshot.contracted) : ""}
+        ${snapshot.billed ? moneyFact("Faturado", snapshot.billed) : ""}
+        ${snapshot.paid ? moneyFact("Pago", snapshot.paid) : ""}
+        ${snapshot.effectively_received ? moneyFact("Efetivamente recebido", snapshot.effectively_received) : ""}
+        ${moneyFact("Vencido", snapshot.overdue ?? snapshot.receivables_overdue)}
+        ${moneyFact("A receber", snapshot.receivable ?? snapshot.receivables_open)}
+        ${snapshot.refunds ? moneyFact("Refunds", snapshot.refunds) : ""}
+        ${snapshot.chargebacks ? moneyFact("Chargebacks", snapshot.chargebacks) : ""}
+        ${mrr}
+        ${runway}
+        ${moneyFact("Recebíveis abertos", snapshot.receivables_open)}
+        ${moneyFact("Recebíveis em atraso", snapshot.receivables_overdue)}
+      </dl>
+      ${provenanceBlock(snapshot.provenance)}
+    </section>
+  `;
+}
+
+export function engineeringBlock(snapshot: EngineeringSnapshot): string {
+  const hypo = snapshot.active_work_without_evidence
+    ? fact(
+        "Trabalho ativo sem evidência",
+        escapeHtml(snapshot.active_work_without_evidence.detail ?? "permanece hipótese"),
+        ` data-hypothesis="true"`,
+      )
+    : "";
+  return `
+    <section class="compact domain-engenharia" aria-labelledby="engenharia-recorte" data-domain="engineering">
+      <h2 id="engenharia-recorte">Recorte de engenharia</h2>
+      <dl class="facts">
+        ${snapshot.repository ? fact("Repositório", escapeHtml(snapshot.repository)) : ""}
+        ${snapshot.default_branch ? fact("Branch/default", escapeHtml(snapshot.default_branch)) : ""}
+        <div><dt>PRs</dt><dd>${snapshot.open_pr_count}</dd></div>
+        <div><dt>CI</dt><dd>${snapshot.failing_check_count} falhando${snapshot.ci?.status ? ` · ${escapeHtml(snapshot.ci.status)}` : ""}</dd></div>
+        ${typeof snapshot.p0_count === "number" || typeof snapshot.p1_count === "number" ? fact("P0/P1", `P0 ${snapshot.p0_count ?? 0} · P1 ${snapshot.p1_count ?? 0}`) : ""}
+        ${snapshot.aging ? fact("Aging", `${snapshot.aging.count ?? 0}${typeof snapshot.aging.oldest_days === "number" ? ` · ${snapshot.aging.oldest_days}d` : ""}`) : ""}
+        ${listFact("Blockers", snapshot.blockers)}
+        ${snapshot.last_evidence ? fact("Última evidência", escapeHtml(snapshot.last_evidence)) : ""}
+        ${hypo}
+        <div><dt>Checks falhando</dt><dd>${snapshot.failing_check_count}</dd></div>
+        <div><dt>Incidentes abertos</dt><dd>${snapshot.open_incident_count}</dd></div>
+      </dl>
+      ${provenanceBlock(snapshot.provenance)}
+    </section>
+  `;
+}
+
+export function clientCard(item: ClientStatus): string {
+  const money = item.open_receivables
+    ? `<p class="money" data-amount-cents="${item.open_receivables.amount_cents}" data-currency="${escapeHtml(item.open_receivables.currency)}">${escapeHtml(formatMoney(item.open_receivables))}</p>`
+    : "";
+  const due = item.due_date
+    ? `<time datetime="${escapeHtml(item.due_date)}">${escapeHtml(formatLocal(item.due_date))}</time>`
+    : "";
+  return `
+    <article class="card client" data-lifecycle="${escapeHtml(item.lifecycle)}" data-id="${escapeHtml(item.id)}">
+      <header>
+        <p class="kicker"><span class="pill">${escapeHtml(item.lifecycle)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
+        <h3>${escapeHtml(item.display_name)}</h3>
+      </header>
+      ${item.notes ? `<p>${escapeHtml(item.notes)}</p>` : ""}
+      ${money}
+      <dl class="facts">
+        <div><dt>Cliente</dt><dd>${escapeHtml(item.display_name)}</dd></div>
+        ${item.health ? fact("Saúde", escapeHtml(item.health)) : fact("Saúde", escapeHtml(item.lifecycle))}
+        ${listFact("Compromissos", item.commitments)}
+        ${item.owner ? fact("Owner", escapeHtml(item.owner)) : ""}
+        ${due ? fact("Due date", due) : ""}
+        ${listFact("Entregáveis", item.deliverables)}
+        ${listFact("Blockers", item.blockers)}
+        ${item.next_action ? fact("Próxima ação", escapeHtml(item.next_action)) : ""}
+        ${item.evidence ? fact("Evidência", escapeHtml(item.evidence)) : ""}
+      </dl>
+      ${provenanceBlock(item.provenance)}
+    </article>
+  `;
+}
+
+function checkLine(label: string, value: { status?: string; detail?: string } | undefined): string {
+  if (!value) return "";
+  return fact(label, escapeHtml([value.status, value.detail].filter(Boolean).join(" · ")));
+}
+
+export function healthCard(item: ServiceHealth): string {
+  const tone = item.status === "healthy" && item.provenance.freshness_status === "FRESH" ? "green" : "not-green";
+  return `
+    <article class="card health" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}" data-tone="${tone}" data-partial-outage="${item.partial_outage === true ? "true" : "false"}">
+      <header>
+        <p class="kicker"><span class="pill">${escapeHtml(item.status)}</span> <span class="sr-only">${escapeHtml(item.status)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
+        <h3>${escapeHtml(item.service_name)}</h3>
+      </header>
+      ${item.message ? `<p>${escapeHtml(item.message)}</p>` : ""}
+      ${item.latency_ms !== undefined ? `<p>Latência observada: ${item.latency_ms} ms</p>` : ""}
+      ${item.partial_outage ? `<p class="constraint">Partial outage</p>` : ""}
+      <dl class="facts">
+        ${checkLine("HTTP", item.http)}
+        ${checkLine("TLS", item.tls)}
+        ${checkLine("Docker", item.docker)}
+        ${checkLine("Backup", item.backup)}
+        ${item.disk ? fact("Disco", escapeHtml(item.disk.detail ?? `${item.disk.used_pct ?? "?"}%`)) : ""}
+        ${item.memory ? fact("Memória", escapeHtml(item.memory.detail ?? `${item.memory.used_pct ?? "?"}%`)) : ""}
+        ${
+          item.pncp_freshness
+            ? fact(
+                "PNCP freshness",
+                escapeHtml(
+                  `${item.pncp_freshness.freshness_status}${item.pncp_freshness.detail ? ` · ${item.pncp_freshness.detail}` : ""}`,
+                ),
+              )
+            : ""
+        }
+      </dl>
+      ${provenanceBlock(item.provenance)}
+    </article>
+  `;
+}
+
+export function directiveCard(item: Directive): string {
+  const expires = item.expires_at ?? "sem expiração";
+  const supersedes = item.supersedes?.join(", ") ?? "nenhuma";
+  const actor = item.created_by.display_name ?? item.created_by.id;
+  return `
+    <article class="card directive" data-kind="${escapeHtml(item.kind)}" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}">
+      <header>
+        <p class="kicker"><span class="pill">${escapeHtml(item.kind)}</span> <span class="pill">${escapeHtml(item.status)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
+        <h3>${escapeHtml(item.title)}</h3>
+      </header>
+      <p>${escapeHtml(item.body)}</p>
+      <dl class="facts">
+        <div><dt>Vigente desde</dt><dd><time datetime="${escapeHtml(item.effective_from)}">${escapeHtml(item.effective_from)}</time></dd></div>
+        <div><dt>Expira</dt><dd>${escapeHtml(expires)}</dd></div>
+        <div><dt>Substitui</dt><dd>${escapeHtml(supersedes)}</dd></div>
+        <div><dt>Revisões / supersession</dt><dd>${escapeHtml(supersedes)}</dd></div>
+        <div><dt>Criado por</dt><dd>${escapeHtml(actor)}</dd></div>
+      </dl>
+      <p class="audit">Auditoria: ${item.audit.length} evento(s). Provenance no recorte de memória.</p>
+    </article>
+  `;
+}
+
+export function activityCard(item: AgentActivity): string {
+  const staleRunning =
+    item.presentation_status === "RUNNING" && item.provenance.freshness_status === "STALE"
+      ? `<p class="constraint" data-stale-running="true">RUNNING defasado permanece RUNNING — não vira DONE.</p>`
+      : "";
+  return `
+    <article class="card session activity" data-status="${escapeHtml(item.presentation_status)}" data-raw-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}">
+      <header>
+        <p class="kicker"><span class="pill">${escapeHtml(item.presentation_status)}</span> <span class="sr-only">${escapeHtml(item.presentation_status)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
+        <h3>${escapeHtml(item.agent_id)}${item.provider ? ` · ${escapeHtml(item.provider)}` : ""}</h3>
+      </header>
+      <p>${escapeHtml(item.summary)}</p>
+      ${staleRunning}
+      <dl class="facts">
+        <div><dt>Agent/provider</dt><dd>${escapeHtml(item.agent_id)}${item.provider ? ` / ${escapeHtml(item.provider)}` : ""}</dd></div>
+        <div><dt>Repo/scope</dt><dd>${escapeHtml(item.repo ?? item.scope)}</dd></div>
+        <div><dt>Goal/campaign</dt><dd>${escapeHtml(item.goal)}${item.campaign ? ` · ${escapeHtml(item.campaign)}` : ""}</dd></div>
+        ${listFact("Evidência", item.evidence_refs)}
+        ${listFact("Blocker", item.blockers)}
+        ${listFact("residual_work", item.residual_work)}
+      </dl>
+      ${provenanceBlock(item.provenance)}
+    </article>
+  `;
+}
+
+export function memoriaGroups(directives: Directive[]): string {
+  const kinds = [
+    "decision",
+    "directive",
+    "fact",
+    "constraint",
+    "priority",
+    "risk",
+    "hypothesis",
+  ] as const;
+  const labels: Record<(typeof kinds)[number], string> = {
+    decision: "Decisions",
+    directive: "Directives",
+    fact: "Facts",
+    constraint: "Constraints",
+    priority: "Priorities",
+    risk: "Risks",
+    hypothesis: "Hypotheses",
+  };
+  return kinds
+    .map((kind) => {
+      const rows = directives.filter((item) => item.kind === kind);
+      if (rows.length === 0) return "";
+      return `<section aria-labelledby="memoria-${kind}" data-memory-kind="${kind}"><h2 id="memoria-${kind}">${labels[kind]}</h2><div class="stack">${rows.map(directiveCard).join("")}</div></section>`;
+    })
+    .join("");
+}

--- a/control-center/apps/web-shell/src/ui/hoje.ts
+++ b/control-center/apps/web-shell/src/ui/hoje.ts
@@ -1,0 +1,85 @@
+import { escapeHtml } from "../escape";
+import { formatMoney } from "../money";
+import type { HojeSection, HojeViewModel } from "../hoje-compose";
+import { WRITE_SHORTCUT_LABELS } from "../adapters/paths";
+import { freshnessTone } from "../freshness-tone";
+
+function rowCard(sectionId: string, row: HojeSection["rows"][number]): string {
+  const tone = row.freshness_tone || freshnessTone(row.freshness_status);
+  const money = row.money
+    ? `<p class="money" data-amount-cents="${row.money.amount_cents}" data-currency="${escapeHtml(row.money.currency)}">${escapeHtml(formatMoney(row.money))}</p>`
+    : "";
+  const severity = row.severity ? `<span class="pill">${escapeHtml(row.severity)}</span>` : "";
+  return `
+    <article class="card ${sectionId === "incidents" ? "attention" : "hoje-row"}" data-id="${escapeHtml(row.id)}" data-freshness="${escapeHtml(row.freshness_status)}" data-tone="${escapeHtml(tone)}"${row.severity ? ` data-severity="${escapeHtml(row.severity)}"` : ""}>
+      <header>
+        <p class="kicker">${severity}<span class="pill pill-${escapeHtml(row.freshness_status.toLowerCase())}">${escapeHtml(row.freshness_status)}</span> <span class="sr-only">${escapeHtml(row.freshness_status)}</span></p>
+        <h3>${escapeHtml(row.title)}</h3>
+      </header>
+      <p>${escapeHtml(row.summary)}</p>
+      ${money}
+      <p class="prov-inline">
+        <span>${escapeHtml(row.source.system)} · ${escapeHtml(row.source.kind)}</span>
+        · <time datetime="${escapeHtml(row.observed_at)}">${escapeHtml(row.observed_at_local)}</time>
+        <span class="sr-only">UTC ${escapeHtml(row.observed_at)}</span>
+        · confiança ${row.confidence !== undefined ? String(row.confidence).replace(".", ",") : "—"}
+      </p>
+    </article>
+  `;
+}
+
+function shortcutForm(section: HojeSection): string {
+  return section.shortcuts
+    .map((shortcut) => {
+      const label = WRITE_SHORTCUT_LABELS[shortcut.kind];
+      return `
+        <form class="shortcut-form" data-shortcut-form="${escapeHtml(shortcut.kind)}" data-write-path="/v1/directives">
+          <h3>${escapeHtml(label)}</h3>
+          <p class="hint">${escapeHtml(shortcut.hint)}</p>
+          <label>
+            Título
+            <input name="title" type="text" required maxlength="200" autocomplete="off" />
+          </label>
+          <label>
+            Corpo
+            <textarea name="body" required maxlength="8000" rows="3"></textarea>
+          </label>
+          <button type="submit">${escapeHtml(label)}</button>
+        </form>
+      `;
+    })
+    .join("");
+}
+
+function renderSection(section: HojeSection): string {
+  let body: string;
+  if (section.id === "shortcuts") {
+    body = `<div class="shortcut-grid">${shortcutForm(section)}</div>`;
+  } else if (section.compressed) {
+    body = `<p class="kpi-summary">${escapeHtml(section.compressed_summary ?? "")}</p>`;
+  } else if (section.id === "top3") {
+    body = `<ol class="priorities">${section.rows
+      .map(
+        (row) =>
+          `<li class="card priority" data-rank="${escapeHtml(row.kind?.replace("rank-", "") ?? "")}" data-id="${escapeHtml(row.id)}">${rowCard(section.id, row)}</li>`,
+      )
+      .join("")}</ol>`;
+  } else {
+    body = `<div class="stack">${section.rows.map((row) => rowCard(section.id, row)).join("")}</div>`;
+  }
+  return `
+    <section class="band" data-band="${escapeHtml(section.id)}" data-compressed="${section.compressed ? "true" : "false"}" aria-labelledby="hoje-${escapeHtml(section.id)}">
+      <h2 id="hoje-${escapeHtml(section.id)}">${escapeHtml(section.title)}</h2>
+      ${body}
+    </section>
+  `;
+}
+
+export function renderHoje(view: HojeViewModel): string {
+  return view.sections.map(renderSection).join("");
+}
+
+export function hojeSectionTitlesInOrder(html: string): string[] {
+  const matches = [...html.matchAll(/data-band="[^"]+"[^>]*>\s*<h2[^>]*>([^<]+)<\/h2>/g)];
+  return matches.map((m) => m[1] ?? "");
+}

--- a/control-center/apps/web-shell/src/ui/provenance.ts
+++ b/control-center/apps/web-shell/src/ui/provenance.ts
@@ -1,0 +1,35 @@
+import { escapeHtml } from "../escape";
+import { mapProvenance, type ProvenancePresentation } from "../provenance";
+import type { Provenance } from "../types";
+import { freshnessTone } from "../freshness-tone";
+
+export function provenanceBlock(provenance: Provenance): string {
+  const p: ProvenancePresentation = mapProvenance(provenance);
+  const tone = freshnessTone(p.freshnessStatus);
+  return `
+    <dl class="prov" data-freshness="${escapeHtml(p.freshnessStatus)}" data-tone="${tone}" data-source="${escapeHtml(p.sourceSystem)}">
+      <div>
+        <dt>Origem</dt>
+        <dd>${escapeHtml(p.sourceLabel)}</dd>
+      </div>
+      <div>
+        <dt>Observado</dt>
+        <dd>
+          <time datetime="${escapeHtml(p.observedAtUtc)}">${escapeHtml(p.observedAtLocal)}</time>
+          <span class="sr-only">UTC ${escapeHtml(p.observedAtUtc)}</span>
+        </dd>
+      </div>
+      <div>
+        <dt>Freshness</dt>
+        <dd>
+          <span class="pill pill-${escapeHtml(p.freshnessStatus.toLowerCase())}">${escapeHtml(p.freshnessStatus)} · ${escapeHtml(p.freshnessLabel)}</span>
+          <span class="sr-only">${escapeHtml(p.freshnessStatus)}</span>
+        </dd>
+      </div>
+      <div>
+        <dt>Confiança</dt>
+        <dd>${escapeHtml(p.confidenceLabel)}</dd>
+      </div>
+    </dl>
+  `;
+}

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -1,26 +1,26 @@
 import type { DestinationPage } from "../adapters/contract";
 import { DESTINATIONS, hashFor, type DestinationId } from "../destinations";
 import { escapeHtml } from "../escape";
-import { formatMoney } from "../money";
-import { mapProvenance, type ProvenancePresentation } from "../provenance";
+import { AUTH_URL, PRODUCTIVE_URL } from "../topology";
 import {
   DEFAULT_LOADING_LABEL,
   VIEW_KINDS,
   type ViewKind,
   type ViewState,
 } from "../view-state";
-import type {
-  AgentSession,
-  AttentionItem,
-  ClientStatus,
-  CommercialSnapshot,
-  Directive,
-  EngineeringSnapshot,
-  FinanceSnapshot,
-  PriorityRecommendation,
-  Provenance,
-  ServiceHealth,
-} from "../types";
+import type { AgentSession, AttentionItem, PriorityRecommendation } from "../types";
+import { composeHoje } from "../hoje-compose";
+import { renderHoje } from "./hoje";
+import {
+  activityCard,
+  clientCard,
+  commercialBlock,
+  engineeringBlock,
+  financeBlock,
+  healthCard,
+  memoriaGroups,
+} from "./domains";
+import { provenanceBlock } from "./provenance";
 
 export interface ShellModel {
   destination: DestinationId;
@@ -30,36 +30,9 @@ export interface ShellModel {
   adapterMode?: "mock" | "http";
 }
 
-function provenanceBlock(provenance: Provenance): string {
-  const p: ProvenancePresentation = mapProvenance(provenance);
-  return `
-    <dl class="prov" data-freshness="${escapeHtml(p.freshnessStatus)}" data-source="${escapeHtml(p.sourceSystem)}">
-      <div>
-        <dt>Origem</dt>
-        <dd>${escapeHtml(p.sourceLabel)}</dd>
-      </div>
-      <div>
-        <dt>Observado</dt>
-        <dd>
-          <time datetime="${escapeHtml(p.observedAtUtc)}">${escapeHtml(p.observedAtLocal)}</time>
-          <span class="sr-only">UTC ${escapeHtml(p.observedAtUtc)}</span>
-        </dd>
-      </div>
-      <div>
-        <dt>Freshness</dt>
-        <dd><span class="pill pill-${escapeHtml(p.freshnessStatus.toLowerCase())}">${escapeHtml(p.freshnessStatus)} · ${escapeHtml(p.freshnessLabel)}</span></dd>
-      </div>
-      <div>
-        <dt>Confiança</dt>
-        <dd>${escapeHtml(p.confidenceLabel)}</dd>
-      </div>
-    </dl>
-  `;
-}
-
 function attentionCard(item: AttentionItem): string {
   return `
-    <article class="card attention" data-severity="${escapeHtml(item.severity)}" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}">
+    <article class="card attention" data-severity="${escapeHtml(item.severity)}" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}" data-freshness="${escapeHtml(item.provenance.freshness_status)}">
       <header>
         <p class="kicker"><span class="pill">${escapeHtml(item.severity)}</span> <span class="pill">${escapeHtml(item.status)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
         <h3>${escapeHtml(item.title)}</h3>
@@ -79,111 +52,6 @@ function priorityCard(item: PriorityRecommendation): string {
       <p>${escapeHtml(item.rationale)}</p>
       ${provenanceBlock(item.provenance)}
     </li>
-  `;
-}
-
-function moneyDl(label: string, money: { amount_cents: number; currency: string }): string {
-  return `
-    <div class="money" data-amount-cents="${money.amount_cents}" data-currency="${escapeHtml(money.currency)}">
-      <dt>${escapeHtml(label)}</dt>
-      <dd>${escapeHtml(formatMoney(money))}</dd>
-    </div>
-  `;
-}
-
-function commercialBlock(snapshot: CommercialSnapshot): string {
-  return `
-    <section class="compact" aria-labelledby="comercial-recorte">
-      <h2 id="comercial-recorte">Recorte comercial (somente leitura)</h2>
-      <p class="authority">Autoridade do catálogo: ${escapeHtml(snapshot.authority.catalog_authority)}. Runtime comercial: ${escapeHtml(snapshot.authority.commercial_runtime)}. Este documento: ${escapeHtml(snapshot.authority.this_document)}.</p>
-      <dl class="facts">
-        <div><dt>Pipeline aberto</dt><dd>${snapshot.pipeline_open_count}</dd></div>
-        <div><dt>Inbound sem leitura</dt><dd>${snapshot.inbound_unread_count}</dd></div>
-        <div><dt>Clientes em risco</dt><dd>${snapshot.at_risk_client_count}</dd></div>
-      </dl>
-      ${provenanceBlock(snapshot.provenance)}
-    </section>
-  `;
-}
-
-function financeBlock(snapshot: FinanceSnapshot): string {
-  return `
-    <section class="compact" aria-labelledby="financeiro-recorte">
-      <h2 id="financeiro-recorte">Recorte financeiro (somente leitura)</h2>
-      <p class="constraint" role="note">Mutações de provedor: ${escapeHtml(snapshot.provider_mutations)}. read_model_only=${String(snapshot.read_model_only)}. Sem cobrança, checkout, refund, cancelamento ou escrita Asaas neste cockpit.</p>
-      <dl class="facts">
-        ${moneyDl("Recebíveis abertos", snapshot.receivables_open)}
-        ${moneyDl("Recebíveis em atraso", snapshot.receivables_overdue)}
-      </dl>
-      ${provenanceBlock(snapshot.provenance)}
-    </section>
-  `;
-}
-
-function engineeringBlock(snapshot: EngineeringSnapshot): string {
-  return `
-    <section class="compact" aria-labelledby="engenharia-recorte">
-      <h2 id="engenharia-recorte">Recorte de engenharia</h2>
-      <dl class="facts">
-        <div><dt>PRs abertos</dt><dd>${snapshot.open_pr_count}</dd></div>
-        <div><dt>Checks falhando</dt><dd>${snapshot.failing_check_count}</dd></div>
-        <div><dt>Incidentes abertos</dt><dd>${snapshot.open_incident_count}</dd></div>
-      </dl>
-      ${provenanceBlock(snapshot.provenance)}
-    </section>
-  `;
-}
-
-function clientCard(item: ClientStatus): string {
-  const money = item.open_receivables
-    ? `<p class="money" data-amount-cents="${item.open_receivables.amount_cents}" data-currency="${escapeHtml(item.open_receivables.currency)}">${escapeHtml(formatMoney(item.open_receivables))}</p>`
-    : "";
-  return `
-    <article class="card client" data-lifecycle="${escapeHtml(item.lifecycle)}" data-id="${escapeHtml(item.id)}">
-      <header>
-        <p class="kicker"><span class="pill">${escapeHtml(item.lifecycle)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
-        <h3>${escapeHtml(item.display_name)}</h3>
-      </header>
-      ${item.notes ? `<p>${escapeHtml(item.notes)}</p>` : ""}
-      ${money}
-      ${provenanceBlock(item.provenance)}
-    </article>
-  `;
-}
-
-function healthCard(item: ServiceHealth): string {
-  return `
-    <article class="card health" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}">
-      <header>
-        <p class="kicker"><span class="pill">${escapeHtml(item.status)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
-        <h3>${escapeHtml(item.service_name)}</h3>
-      </header>
-      ${item.message ? `<p>${escapeHtml(item.message)}</p>` : ""}
-      ${item.latency_ms !== undefined ? `<p>Latência observada: ${item.latency_ms} ms</p>` : ""}
-      ${provenanceBlock(item.provenance)}
-    </article>
-  `;
-}
-
-function directiveCard(item: Directive): string {
-  const expires = item.expires_at ?? "sem expiração";
-  const supersedes = item.supersedes?.join(", ") ?? "nenhuma";
-  const actor = item.created_by.display_name ?? item.created_by.id;
-  return `
-    <article class="card directive" data-kind="${escapeHtml(item.kind)}" data-status="${escapeHtml(item.status)}" data-id="${escapeHtml(item.id)}">
-      <header>
-        <p class="kicker"><span class="pill">${escapeHtml(item.kind)}</span> <span class="pill">${escapeHtml(item.status)}</span> <span class="scope">${escapeHtml(item.scope)}</span></p>
-        <h3>${escapeHtml(item.title)}</h3>
-      </header>
-      <p>${escapeHtml(item.body)}</p>
-      <dl class="facts">
-        <div><dt>Vigente desde</dt><dd><time datetime="${escapeHtml(item.effective_from)}">${escapeHtml(item.effective_from)}</time></dd></div>
-        <div><dt>Expira</dt><dd>${escapeHtml(expires)}</dd></div>
-        <div><dt>Substitui</dt><dd>${escapeHtml(supersedes)}</dd></div>
-        <div><dt>Criado por</dt><dd>${escapeHtml(actor)}</dd></div>
-      </dl>
-      <p class="audit">Auditoria: ${item.audit.length} evento(s).</p>
-    </article>
   `;
 }
 
@@ -219,26 +87,41 @@ function viewBanner(view: ViewState<DestinationPage>): string {
   return "";
 }
 
+function hojeBody(page: DestinationPage): string {
+  const view =
+    page.hoje ??
+    composeHoje({
+      generated_at: page.generated_at,
+      headline: page.headline,
+      priorities: page.priorities,
+      incidents: page.attention,
+      clients: page.clients ?? [],
+      commercial: page.commercial ?? null,
+      finance: page.finance ?? null,
+      engineering: page.engineering ?? null,
+      infra: page.health ?? [],
+      activities: page.activities ?? [],
+    });
+  return renderHoje(view);
+}
+
 function pageBody(page: DestinationPage, destination: DestinationId): string {
-  const priorities =
-    page.priorities.length > 0
-      ? `
-        <section class="priorities" aria-labelledby="prioridades-title">
-          <h2 id="prioridades-title">${destination === "hoje" ? "As 3 coisas mais importantes agora" : "Prioridades deste recorte"}</h2>
-          <ol>${page.priorities.map(priorityCard).join("")}</ol>
-        </section>
-      `
-      : "";
-  const attention =
-    page.attention.length > 0
-      ? `
-        <section class="exceptions" aria-labelledby="excecoes-title">
-          <h2 id="excecoes-title">Exceções</h2>
-          <div class="stack">${page.attention.map(attentionCard).join("")}</div>
-        </section>
-      `
-      : "";
-  const extra = [
+  if (destination === "hoje") {
+    return hojeBody(page);
+  }
+  if (destination === "memoria") {
+    return page.directives && page.directives.length > 0 ? memoriaGroups(page.directives) : "";
+  }
+  if (destination === "agentes") {
+    if (page.activities && page.activities.length > 0) {
+      return `<section aria-labelledby="agentes-title"><h2 id="agentes-title">Atividade recente dos agentes</h2><div class="stack">${page.activities.map(activityCard).join("")}</div></section>`;
+    }
+    if (page.sessions && page.sessions.length > 0) {
+      return `<section aria-labelledby="agentes-title"><h2 id="agentes-title">Sessões</h2><div class="stack">${page.sessions.map(sessionCard).join("")}</div></section>`;
+    }
+    return "";
+  }
+  const extras = [
     page.commercial ? commercialBlock(page.commercial) : "",
     page.finance ? financeBlock(page.finance) : "",
     page.engineering ? engineeringBlock(page.engineering) : "",
@@ -248,14 +131,16 @@ function pageBody(page: DestinationPage, destination: DestinationId): string {
     page.health && page.health.length > 0
       ? `<section aria-labelledby="infra-title"><h2 id="infra-title">Serviços</h2><div class="stack">${page.health.map(healthCard).join("")}</div></section>`
       : "",
-    page.directives && page.directives.length > 0
-      ? `<section aria-labelledby="memoria-title"><h2 id="memoria-title">Diretivas</h2><div class="stack">${page.directives.map(directiveCard).join("")}</div></section>`
-      : "",
-    page.sessions && page.sessions.length > 0
-      ? `<section aria-labelledby="agentes-title"><h2 id="agentes-title">Sessões</h2><div class="stack">${page.sessions.map(sessionCard).join("")}</div></section>`
-      : "",
   ].join("");
-  return `${priorities}${attention}${extra}`;
+  const attention =
+    page.attention.length > 0
+      ? `<section class="exceptions" aria-labelledby="excecoes-title"><h2 id="excecoes-title">Exceções</h2><div class="stack">${page.attention.map(attentionCard).join("")}</div></section>`
+      : "";
+  const priorities =
+    page.priorities.length > 0
+      ? `<section class="priorities" aria-labelledby="prioridades-title"><h2 id="prioridades-title">Prioridades deste recorte</h2><ol>${page.priorities.map(priorityCard).join("")}</ol></section>`
+      : "";
+  return `${attention}${priorities}${extras}`;
 }
 
 function mockLab(destination: DestinationId, current: ViewKind): string {
@@ -299,7 +184,7 @@ export function renderShell(model: ShellModel): string {
 
   return `
     <a class="skip-link" href="#conteudo">Saltar para o conteúdo</a>
-    <div class="shell" data-destination="${escapeHtml(model.destination)}" data-view-state="${escapeHtml(model.viewKind)}">
+    <div class="shell" data-destination="${escapeHtml(model.destination)}" data-view-state="${escapeHtml(model.viewKind)}" data-productive-origin="${escapeHtml(PRODUCTIVE_URL)}" data-auth-origin="${escapeHtml(AUTH_URL)}">
       <header class="topbar">
         <p class="brand">Control Center</p>
         <p class="operator" title="${escapeHtml(operatorId)}">${escapeHtml(operator)}${model.adapterMode === "http" ? "" : " · modo mock"}</p>
@@ -328,4 +213,12 @@ export function hasMutationControls(html: string): boolean {
   return /data-mutate=|data-action="(cobranca|checkout|refund|cancelamento|asaas_write|commercial_send)"/i.test(
     html,
   );
+}
+
+export function hasMcpNav(html: string): boolean {
+  return /data-nav="mcp"|aria-label="[^"]*MCP/i.test(html);
+}
+
+export function hasIntranetPath(html: string): boolean {
+  return /\/intranet/i.test(html);
 }

--- a/control-center/apps/web-shell/tests/adapters.test.ts
+++ b/control-center/apps/web-shell/tests/adapters.test.ts
@@ -93,50 +93,73 @@ test("fixture catalog covers every freshness status", () => {
   }
 });
 
-test("production HTTP adapter is not mock and maps context provenance", async () => {
+test("production HTTP adapter is not mock and maps frozen-path provenance", async () => {
   const seenHeaders: string[] = [];
+  const seenUrls: string[] = [];
   const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
-    assert.match(url, /\/v1\/context/);
+    seenUrls.push(url);
     const headers = new Headers(init?.headers);
     seenHeaders.push(`${headers.get("x-actor-id")}:${headers.get("x-actor-kind")}`);
-    return new Response(
-      JSON.stringify({
-        scope: "company",
-        active_directives: [
-          {
-            id: "cc:directive:01",
-            kind: "risk",
-            title: "Collector credentials missing",
-            body: "GitHub token absent",
-            scope: "company",
-            status: "active",
-            source: { system: "control-center", kind: "context", locator: "company" },
-            observed_at: "2026-08-20T12:00:00.000Z",
-            freshness_status: "ERROR",
-            confidence: 0,
-          },
-        ],
-        priorities: [
-          {
-            id: "cc:directive:02",
-            kind: "priority",
-            title: "Wire production adapters",
-            body: "HTTP not mock",
-            scope: "company",
-            observed_at: "2026-08-20T12:00:00.000Z",
-            freshness_status: "FRESH",
-            confidence: 1,
-            source: { system: "control-center", kind: "context", locator: "company" },
-          },
-        ],
-        source: { system: "control-center", kind: "context", locator: "company" },
-        observed_at: "2026-08-20T12:00:00.000Z",
-        freshness_status: "ERROR",
-        confidence: 0,
-      }),
-      { status: 200, headers: { "content-type": "application/json" } },
-    );
+    const path = url.replace(/^https?:\/\/[^/]+/, "").split("?")[0];
+    if (path === "/v1/today") {
+      return new Response(
+        JSON.stringify({
+          generated_at: "2026-08-20T12:00:00.000Z",
+          headline: "HTTP not mock",
+          recommended_actions: [
+            {
+              id: "cc:priority-recommendation:01",
+              rank: 1,
+              title: "Wire production adapters",
+              rationale: "HTTP not mock",
+              scope: "company",
+              observed_at: "2026-08-20T12:00:00.000Z",
+              freshness_status: "FRESH",
+              confidence: 1,
+              source: { system: "control-center", kind: "today", locator: "company" },
+            },
+          ],
+          incidents: [
+            {
+              id: "cc:attention-item:01",
+              kind: "risk",
+              title: "Collector credentials missing",
+              summary: "GitHub token absent",
+              scope: "company",
+              status: "open",
+              severity: "high",
+              homepage_eligible: true,
+              detected_at: "2026-08-20T12:00:00.000Z",
+              source: { system: "control-center", kind: "attention", locator: "company" },
+              observed_at: "2026-08-20T12:00:00.000Z",
+              freshness_status: "ERROR",
+              confidence: 0,
+            },
+          ],
+          clients: [],
+          commercial: null,
+          finance: null,
+          engineering: null,
+          infra: [],
+          agent_activity: [],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (path === "/v1/attention" || path === "/v1/agent-activities") {
+      return new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (path === "/v1/operational-snapshots") {
+      return new Response(JSON.stringify({ attention_items: [], top_priorities: [], health: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
   }) as typeof fetch;
   const adapter = createHttpAdapter("http://127.0.0.1:8787", fetchImpl, {
     kind: "human",
@@ -149,6 +172,8 @@ test("production HTTP adapter is not mock and maps context provenance", async ()
   assert.equal(page.page.attention.length > 0, true);
   assert.ok(["FRESH", "STALE", "UNKNOWN", "ERROR"].includes(page.page.attention[0]?.provenance.freshness_status ?? ""));
   assert.equal(seenHeaders.includes("founder-local:human"), true);
+  assert.equal(seenUrls.some((url) => url.includes("/v1/today")), true);
+  assert.equal(seenUrls.some((url) => url.includes("/v1/context")), false);
 });
 
 test("async HTTP destination read paints loading before the promise settles", () => {

--- a/control-center/apps/web-shell/tests/contract.test.ts
+++ b/control-center/apps/web-shell/tests/contract.test.ts
@@ -33,8 +33,8 @@ test("mounted Hoje HTML is an attention cockpit without chat or mutation control
   const handle = mount(root, createMockAdapter(), runtime);
   try {
     assert.match(root.innerHTML, /data-destination="hoje"/);
-    assert.match(root.innerHTML, /As 3 coisas mais importantes agora/);
-    assert.match(root.innerHTML, />Exceções</);
+    assert.match(root.innerHTML, /Se eu só puder fazer 3 coisas hoje\./);
+    assert.match(root.innerHTML, /Incidentes, blockers e riscos\./);
     assert.match(root.innerHTML, /aria-label="Áreas do Control Center"/);
     for (const label of [
       "Hoje",
@@ -54,7 +54,7 @@ test("mounted Hoje HTML is an attention cockpit without chat or mutation control
     assert.ok(root.innerHTML.includes("data-severity="));
     assert.equal(hasChatComposer(root.innerHTML), false);
     assert.equal(hasMutationControls(root.innerHTML), false);
-    assert.doesNotMatch(root.innerHTML, /<textarea/i);
+    assert.match(root.innerHTML, /data-shortcut-form="decision"/);
     assert.doesNotMatch(root.innerHTML, /type="password"/i);
   } finally {
     handle.unmount();

--- a/control-center/apps/web-shell/tests/domain-fields.test.ts
+++ b/control-center/apps/web-shell/tests/domain-fields.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createMemoryRuntime, mount } from "../src/app";
+import { createMockAdapter } from "../src/adapters/index";
+import { httpAdapterFor } from "./helpers";
+import { renderShell } from "../src/ui/render";
+import { presentAgentStatus } from "../src/adapters/map";
+
+test("Comercial page surfaces funnel, pipelines, aging, next action, stalled, drift and Extra histórica", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/comercial"));
+  try {
+    assert.match(root.innerHTML, /Novos leads/);
+    assert.match(root.innerHTML, /Qualificados/);
+    assert.match(root.innerHTML, /Oportunidades/);
+    assert.match(root.innerHTML, /Propostas/);
+    assert.match(root.innerHTML, /Clientes/);
+    assert.match(root.innerHTML, /Pipeline nominal/);
+    assert.match(root.innerHTML, /Pipeline ponderado \(probabilidade confiável\)/);
+    assert.match(root.innerHTML, /Aging/);
+    assert.match(root.innerHTML, /Missing next action/);
+    assert.match(root.innerHTML, /Stalled stage/);
+    assert.match(root.innerHTML, /Offer\/version drift/);
+    assert.match(root.innerHTML, /Extra histórica/);
+    assert.match(root.innerHTML, /data-public-offer="false"/);
+    assert.doesNotMatch(root.innerHTML, /oferta pública da Extra/i);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("Clientes page surfaces saúde, compromissos, owner, due date, entregáveis, blockers, próxima ação, evidência", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/clientes"));
+  try {
+    assert.match(root.innerHTML, /Acme Indústria/);
+    assert.match(root.innerHTML, /Saúde/);
+    assert.match(root.innerHTML, /Compromissos/);
+    assert.match(root.innerHTML, /Owner/);
+    assert.match(root.innerHTML, /Due date/);
+    assert.match(root.innerHTML, /Entregáveis/);
+    assert.match(root.innerHTML, /Blockers/);
+    assert.match(root.innerHTML, /Próxima ação/);
+    assert.match(root.innerHTML, /Evidência/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("Financeiro page surfaces contracted/billed/paid/received/overdue/receivable/refunds/chargebacks and gates MRR/runway", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/financeiro"));
+  try {
+    assert.match(root.innerHTML, /Contratado/);
+    assert.match(root.innerHTML, /Faturado/);
+    assert.match(root.innerHTML, /Pago/);
+    assert.match(root.innerHTML, /Efetivamente recebido/);
+    assert.match(root.innerHTML, /Vencido/);
+    assert.match(root.innerHTML, /A receber/);
+    assert.match(root.innerHTML, /Refunds/);
+    assert.match(root.innerHTML, /Chargebacks/);
+    assert.match(root.innerHTML, /MRR/);
+    assert.match(root.innerHTML, /Runway/);
+    assert.match(root.innerHTML, /omitido — caixa e despesas não confiáveis/);
+    assert.match(root.innerHTML, /data-amount-cents="1500000"/);
+    assert.match(root.innerHTML, /Mutações de provedor: forbidden/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("Engenharia page surfaces repo, branch, PRs, CI, P0/P1, aging, blockers, evidência and hipótese", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/engenharia"));
+  try {
+    assert.match(root.innerHTML, /Repositório/);
+    assert.match(root.innerHTML, /Branch\/default/);
+    assert.match(root.innerHTML, />PRs</);
+    assert.match(root.innerHTML, />CI</);
+    assert.match(root.innerHTML, /P0\/P1/);
+    assert.match(root.innerHTML, /Aging/);
+    assert.match(root.innerHTML, /Blockers/);
+    assert.match(root.innerHTML, /Última evidência/);
+    assert.match(root.innerHTML, /Trabalho ativo sem evidência/);
+    assert.match(root.innerHTML, /data-hypothesis="true"/);
+    assert.match(root.innerHTML, /permanece hipótese/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("Infra page surfaces HTTP, TLS, Docker, backup, disk/memory, PNCP freshness and partial outage", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/infra"));
+  try {
+    assert.match(root.innerHTML, />HTTP</);
+    assert.match(root.innerHTML, />TLS</);
+    assert.match(root.innerHTML, />Docker</);
+    assert.match(root.innerHTML, />Backup</);
+    assert.match(root.innerHTML, /Disco/);
+    assert.match(root.innerHTML, /Memória/);
+    assert.match(root.innerHTML, /PNCP freshness/);
+    assert.match(root.innerHTML, /Partial outage/);
+    assert.match(root.innerHTML, /data-partial-outage="true"/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("Memória groups decisions, directives, facts, constraints, priorities, risks, hypotheses", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/memoria"));
+  try {
+    for (const kind of [
+      "decision",
+      "directive",
+      "fact",
+      "constraint",
+      "priority",
+      "risk",
+      "hypothesis",
+    ]) {
+      assert.match(root.innerHTML, new RegExp(`data-memory-kind="${kind}"`));
+    }
+    assert.match(root.innerHTML, /Decisions/);
+    assert.match(root.innerHTML, /Revisões \/ supersession/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("Agentes page presents RUNNING/DONE/PARTIAL/BLOCKED/FAILED/UNKNOWN and never coerces stale RUNNING to DONE", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/agentes"));
+  try {
+    assert.match(root.innerHTML, /RUNNING/);
+    assert.match(root.innerHTML, /PARTIAL/);
+    assert.match(root.innerHTML, /UNKNOWN/);
+    assert.match(root.innerHTML, /Agent\/provider/);
+    assert.match(root.innerHTML, /Repo\/scope/);
+    assert.match(root.innerHTML, /Goal\/campaign/);
+    assert.match(root.innerHTML, /residual_work/);
+    assert.match(root.innerHTML, /data-stale-running="true"/);
+    assert.match(root.innerHTML, /não vira DONE/);
+    const running = root.innerHTML.match(/data-status="RUNNING"[\s\S]*?data-freshness="STALE"/);
+    assert.ok(running);
+  } finally {
+    handle.unmount();
+  }
+  assert.equal(presentAgentStatus("running", "STALE"), "RUNNING");
+  assert.equal(presentAgentStatus("done", "FRESH"), "DONE");
+  assert.equal(presentAgentStatus("wat", "FRESH"), "UNKNOWN");
+});
+
+test("HTTP domain pages populate from Goal 04 fixtures via frozen domain paths", async () => {
+  const { adapter, calls } = httpAdapterFor();
+  const root = { innerHTML: "" };
+  const runtime = createMemoryRuntime("#/financeiro");
+  const handle = mount(root, adapter, runtime);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  try {
+    assert.match(root.innerHTML, /Contratado/);
+    assert.match(root.innerHTML, /Efetivamente recebido/);
+    assert.match(calls.join("\n"), /\/v1\/domains\/finance/);
+    runtime.setHash("#/comercial");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.match(root.innerHTML, /Novos leads/);
+    assert.match(calls.join("\n"), /\/v1\/domains\/commercial/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("weighted pipeline without reliable probability is omitted", () => {
+  const html = renderShell({
+    destination: "comercial",
+    viewKind: "ready",
+    mockScenario: "http",
+    adapterMode: "http",
+    view: {
+      kind: "ready",
+      data: {
+        id: "comercial",
+        label: "Comercial",
+        scope: "commercial",
+        generated_at: "2026-08-20T18:00:00Z",
+        operator: { kind: "human", id: "human:operator" },
+        headline: "x",
+        attention: [],
+        priorities: [],
+        commercial: {
+          schema_version: "control-center.commercial-snapshot.v1",
+          id: "cc:commercial-snapshot:x",
+          scope: "commercial",
+          generated_at: "2026-08-20T18:00:00Z",
+          provenance: {
+            source: { system: "warmbly", kind: "crm-read-model", locator: "x" },
+            observed_at: "2026-08-20T18:00:00Z",
+            freshness_status: "FRESH",
+            confidence: 1,
+          },
+          authority: {
+            catalog_authority: "governance",
+            commercial_runtime: "warmbly",
+            this_document: "read_model",
+          },
+          pipeline_open_count: 0,
+          inbound_unread_count: 0,
+          at_risk_client_count: 0,
+          pipeline_nominal: { amount_cents: 1, currency: "BRL" },
+        },
+      },
+    },
+  });
+  assert.match(html, /omitido — probabilidade não confiável/);
+});

--- a/control-center/apps/web-shell/tests/empty-hoje-agentes.test.ts
+++ b/control-center/apps/web-shell/tests/empty-hoje-agentes.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createMemoryRuntime, mount } from "../src/app";
+import { pageIsEmpty } from "../src/page";
+import { HOJE_SECTION_TITLES } from "../src/hoje-compose";
+import { httpAdapterFor, readContractFixture } from "./helpers";
+
+async function waitSettled(root: { innerHTML: string }): Promise<void> {
+  for (let i = 0; i < 80; i += 1) {
+    if (
+      root.innerHTML.includes("data-view-state=") &&
+      !root.innerHTML.includes('data-view-state="loading"')
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`view never settled: ${root.innerHTML.slice(0, 200)}`);
+}
+
+function emptyDayRouter(): (url: string) => unknown {
+  const emptyToday = {
+    generated_at: "2026-08-20T18:00:00Z",
+    headline: "Nada exige atenção.",
+    recommended_actions: [],
+    incidents: [],
+    clients: [],
+    commercial: null,
+    finance: null,
+    engineering: null,
+    infra: [],
+    agent_activity: [],
+  };
+  return (url: string) => {
+    const path = url.split("?")[0] ?? url;
+    if (path.endsWith("/v1/today")) return emptyToday;
+    if (path.endsWith("/v1/attention") || path.endsWith("/v1/agent-activities")) {
+      return { items: [] };
+    }
+    if (path.endsWith("/v1/operational-snapshots")) {
+      return { attention_items: [], top_priorities: [], health: [] };
+    }
+    return undefined;
+  };
+}
+
+function agentesRouter(): (url: string) => unknown {
+  const partial = readContractFixture("agent-activity") as Record<string, unknown>;
+  const observed = {
+    source: { system: "collector", kind: "report", locator: "agent-activity/ledger" },
+    observed_at: "2026-08-20T18:10:00Z",
+    freshness_status: "FRESH",
+    confidence: 0.9,
+  };
+  const items = [
+    { ...partial, id: "cc:agent-activity:running", status: "running", finished_at: null, provenance: { ...observed, freshness_status: "STALE" } },
+    { ...partial, id: "cc:agent-activity:done", status: "done" },
+    { ...partial, id: "cc:agent-activity:partial", status: "partial" },
+    { ...partial, id: "cc:agent-activity:blocked", status: "blocked" },
+    { ...partial, id: "cc:agent-activity:failed", status: "failed" },
+    { ...partial, id: "cc:agent-activity:unknown", status: "not-a-status" },
+  ];
+  return (url: string) => {
+    const path = url.split("?")[0] ?? url;
+    if (path.endsWith("/v1/agent-activities")) return { items };
+    return undefined;
+  };
+}
+
+test("pageIsEmpty is false when activities are present even without attention or snapshots", () => {
+  assert.equal(
+    pageIsEmpty({
+      id: "agentes",
+      label: "Agentes",
+      scope: "company",
+      generated_at: "2026-08-20T18:00:00Z",
+      operator: { kind: "human", id: "founder-local" },
+      headline: "ledger",
+      attention: [],
+      priorities: [],
+      activities: [
+        {
+          schema_version: "control-center.agent-activity.v1",
+          id: "cc:agent-activity:partial",
+          agent_id: "agent:cc-context",
+          scope: "finance",
+          status: "partial",
+          presentation_status: "PARTIAL",
+          started_at: "2026-08-20T17:50:00Z",
+          finished_at: "2026-08-20T18:10:00Z",
+          goal: "briefing",
+          summary: "leftover work",
+          provenance: {
+            source: { system: "collector", kind: "report", locator: "x" },
+            observed_at: "2026-08-20T18:10:00Z",
+            freshness_status: "FRESH",
+            confidence: 0.9,
+          },
+        },
+      ],
+    }),
+    false,
+  );
+});
+
+test("pageIsEmpty is false when a composed Hoje view exists with no exception rows", () => {
+  assert.equal(
+    pageIsEmpty({
+      id: "hoje",
+      label: "Hoje",
+      scope: "company",
+      generated_at: "2026-08-20T18:00:00Z",
+      operator: { kind: "human", id: "founder-local" },
+      headline: "quiet day",
+      attention: [],
+      priorities: [],
+      hoje: {
+        schema_version: "control-center.hoje-view.v1",
+        generated_at: "2026-08-20T18:00:00Z",
+        headline: "quiet day",
+        charts_emitted: false,
+        sections: HOJE_SECTION_TITLES.map((title, index) => ({
+          id: (
+            [
+              "top3",
+              "incidents",
+              "clients",
+              "commercial",
+              "finance",
+              "engineering",
+              "agents",
+              "shortcuts",
+            ] as const
+          )[index]!,
+          title,
+          compressed: index !== 7,
+          compressed_summary: index === 7 ? null : "ignorar",
+          rows: [],
+          shortcuts:
+            index === 7
+              ? [
+                  {
+                    kind: "decision" as const,
+                    label: "Registrar decisão",
+                    hint: "POST /v1/directives",
+                  },
+                ]
+              : [],
+        })),
+      },
+    }),
+    false,
+  );
+});
+
+test("HTTP #/agentes with Goal 04 activities paints ready ledger, not empty", async () => {
+  const { adapter, calls } = httpAdapterFor(agentesRouter());
+  const root = { innerHTML: "" };
+  const handle = mount(root, adapter, createMemoryRuntime("#/agentes"));
+  try {
+    await waitSettled(root);
+    assert.match(root.innerHTML, /data-destination="agentes"/);
+    assert.match(root.innerHTML, /data-view-state="ready"/);
+    assert.doesNotMatch(root.innerHTML, /data-view-state="empty"/);
+    assert.match(root.innerHTML, /RUNNING/);
+    assert.match(root.innerHTML, /DONE/);
+    assert.match(root.innerHTML, /PARTIAL/);
+    assert.match(root.innerHTML, /BLOCKED/);
+    assert.match(root.innerHTML, /FAILED/);
+    assert.match(root.innerHTML, /UNKNOWN/);
+    assert.match(root.innerHTML, /data-stale-running="true"/);
+    assert.match(calls.join("\n"), /\/v1\/agent-activities/);
+    assert.doesNotMatch(calls.join("\n"), /\/v1\/context/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("HTTP empty-day Hoje still shows the eight section titles and write shortcuts", async () => {
+  const { adapter, calls } = httpAdapterFor(emptyDayRouter());
+  const root = { innerHTML: "" };
+  const handle = mount(root, adapter, createMemoryRuntime("#/hoje"));
+  try {
+    await waitSettled(root);
+    assert.match(root.innerHTML, /data-destination="hoje"/);
+    assert.doesNotMatch(root.innerHTML, /data-view-state="empty"/);
+    assert.doesNotMatch(root.innerHTML, /data-view-state="error"/);
+    const titles = HOJE_SECTION_TITLES.map((title) => root.innerHTML.indexOf(title));
+    for (let i = 0; i < titles.length; i += 1) {
+      assert.ok(titles[i]! >= 0, `missing ${HOJE_SECTION_TITLES[i]}`);
+      if (i > 0) assert.ok(titles[i]! > titles[i - 1]!, "section order");
+    }
+    assert.match(root.innerHTML, /data-shortcut-form="decision"/);
+    assert.match(root.innerHTML, /data-shortcut-form="nota"/);
+    assert.match(root.innerHTML, /data-shortcut-form="risco"/);
+    assert.match(root.innerHTML, /data-shortcut-form="hipotese"/);
+    assert.match(root.innerHTML, /data-write-path="\/v1\/directives"/);
+    assert.doesNotMatch(calls.join("\n"), /\/v1\/context/);
+    assert.match(calls.join("\n"), /\/v1\/today/);
+  } finally {
+    handle.unmount();
+  }
+});

--- a/control-center/apps/web-shell/tests/helpers.ts
+++ b/control-center/apps/web-shell/tests/helpers.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHttpAdapter } from "../src/adapters/index";
+import { DESTINATION_IDS, type DestinationId } from "../src/destinations";
+import { readPathsFor } from "../src/adapters/paths";
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const CONTRACT_FIXTURES = join(here, "../../../contracts/fixtures/valid");
+
+export function readContractFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(CONTRACT_FIXTURES, `${name}.json`), "utf8")) as unknown;
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export function recordingFetch(
+  router: (url: string) => unknown,
+  calls: string[] = [],
+): { fetchImpl: typeof fetch; calls: string[] } {
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push(`${init?.method ?? "GET"} ${url}`);
+    const path = url.replace(/^https?:\/\/[^/]+/, "");
+    if ((init?.method ?? "GET") !== "GET") {
+      const body = router(path);
+      return jsonResponse(body ?? { ok: true }, 201);
+    }
+    const payload = router(path);
+    if (payload instanceof Response) return payload;
+    if (payload === undefined) {
+      return jsonResponse({ error: "not_found" }, 404);
+    }
+    return jsonResponse(payload);
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+export function operationalRouter(): (url: string) => unknown {
+  const commercial = readContractFixture("commercial-snapshot");
+  const finance = readContractFixture("finance-snapshot");
+  const engineering = readContractFixture("engineering-snapshot");
+  const client = readContractFixture("client-status");
+  const health = readContractFixture("service-health");
+  const attention = readContractFixture("attention-item");
+  const priority = readContractFixture("priority-recommendation");
+  const activity = readContractFixture("agent-activity");
+  const snapshot = readContractFixture("operational-snapshot");
+  const directive = readContractFixture("directive");
+  const today = {
+    schema_version: "control-center.hoje-payload.v1",
+    generated_at: "2026-08-20T18:00:00Z",
+    headline: "Exceções operacionais reais.",
+    recommended_actions: [priority],
+    incidents: [attention],
+    clients: [client],
+    commercial,
+    finance,
+    engineering,
+    infra: [health],
+    agent_activity: [activity],
+  };
+  const context = {
+    scope: "company",
+    active_directives: [directive],
+    decisions: [directive],
+    facts: [],
+    constraints: [directive],
+    priorities: [],
+    risks: [],
+    directives: [],
+    hypotheses: [],
+    source: { system: "control-center", kind: "context", locator: "company" },
+    observed_at: "2026-08-20T12:00:00Z",
+    freshness_status: "FRESH",
+    confidence: 1,
+  };
+  return (url: string) => {
+    const path = url.split("?")[0] ?? url;
+    if (path.endsWith("/v1/today")) return today;
+    if (path.endsWith("/v1/attention")) return { items: [attention] };
+    if (path.endsWith("/v1/operational-snapshots")) return snapshot;
+    if (path.endsWith("/v1/agent-activities")) return { items: [activity] };
+    if (path.endsWith("/v1/domains/commercial")) return commercial;
+    if (path.endsWith("/v1/domains/clients")) return { items: [client] };
+    if (path.endsWith("/v1/domains/finance")) return finance;
+    if (path.endsWith("/v1/domains/engineering")) return engineering;
+    if (path.endsWith("/v1/domains/infrastructure")) return { items: [health] };
+    if (path.endsWith("/v1/context")) return context;
+    if (path.endsWith("/v1/directives")) return { ok: true };
+    return undefined;
+  };
+}
+
+export function httpAdapterFor(router = operationalRouter(), calls: string[] = []) {
+  const { fetchImpl } = recordingFetch(router, calls);
+  return {
+    adapter: createHttpAdapter("http://127.0.0.1:8787", fetchImpl, {
+      kind: "human",
+      id: "founder-local",
+    }),
+    calls,
+  };
+}
+
+export function pathOf(url: string): string {
+  return url.replace(/^GET |^POST /, "").replace(/^https?:\/\/[^/]+/, "");
+}
+
+export { DESTINATION_IDS, readPathsFor };
+export type { DestinationId };

--- a/control-center/apps/web-shell/tests/hoje-compose.test.ts
+++ b/control-center/apps/web-shell/tests/hoje-compose.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createMockAdapter } from "../src/adapters/index";
+import { mount, createMemoryRuntime, paintShell } from "../src/app";
+import {
+  HOJE_SECTION_IDS,
+  HOJE_SECTION_TITLES,
+  assertNoGreenForUntrusted,
+  composeHoje,
+  hojeHasUntrustedGreen,
+} from "../src/hoje-compose";
+import {
+  ATTENTION_FIXTURES,
+  CLIENT_FIXTURES,
+  COMMERCIAL_SNAPSHOT,
+  ENGINEERING_SNAPSHOT,
+  FINANCE_SNAPSHOT,
+  HEALTH_FIXTURES,
+  AGENT_ACTIVITY_FIXTURES,
+  PRIORITY_FIXTURES,
+} from "../src/fixtures/catalog";
+import { httpAdapterFor } from "./helpers";
+import { hasChatComposer, hasMutationControls, hasMcpNav, hasIntranetPath } from "../src/ui/render";
+
+function sampleInput() {
+  return {
+    generated_at: "2026-08-20T18:00:00Z",
+    headline: "cockpit",
+    priorities: PRIORITY_FIXTURES,
+    incidents: ATTENTION_FIXTURES,
+    clients: CLIENT_FIXTURES,
+    commercial: COMMERCIAL_SNAPSHOT,
+    finance: FINANCE_SNAPSHOT,
+    engineering: ENGINEERING_SNAPSHOT,
+    infra: HEALTH_FIXTURES,
+    activities: AGENT_ACTIVITY_FIXTURES,
+  };
+}
+
+test("Hoje compose emits the eight section titles in criterion-2 order with ≤3 priorities", () => {
+  const view = composeHoje(sampleInput());
+  assert.equal(view.sections.length, 8);
+  assert.deepEqual(
+    view.sections.map((s) => s.title),
+    [...HOJE_SECTION_TITLES],
+  );
+  assert.deepEqual(
+    view.sections.map((s) => s.id),
+    [...HOJE_SECTION_IDS],
+  );
+  assert.ok(view.sections[0]!.rows.length <= 3);
+  assert.equal(view.charts_emitted, false);
+  assert.equal(hojeHasUntrustedGreen(view), false);
+  assertNoGreenForUntrusted(view);
+});
+
+test("exceptions are expanded and healthy KPIs are compressed", () => {
+  const view = composeHoje(sampleInput());
+  const byId = Object.fromEntries(view.sections.map((s) => [s.id, s]));
+  assert.equal(byId.commercial?.compressed, false);
+  assert.equal(byId.finance?.compressed, false);
+  assert.equal(byId.engineering?.compressed, false);
+  assert.equal(byId.incidents?.compressed, false);
+  assert.equal(byId.clients?.compressed, false);
+  const healthy = composeHoje({
+    ...sampleInput(),
+    incidents: [],
+    clients: CLIENT_FIXTURES.filter((c) => c.lifecycle === "active"),
+    commercial: {
+      ...COMMERCIAL_SNAPSHOT,
+      inbound_unread_count: 0,
+      at_risk_client_count: 0,
+      aging_count: 0,
+      stalled_count: 0,
+      missing_next_action_count: 0,
+      offer_version_drift: { count: 0 },
+    },
+    finance: {
+      ...FINANCE_SNAPSHOT,
+      overdue: { amount_cents: 0, currency: "BRL" },
+      receivables_overdue: { amount_cents: 0, currency: "BRL" },
+      chargebacks: { amount_cents: 0, currency: "BRL" },
+      provenance: { ...FINANCE_SNAPSHOT.provenance, freshness_status: "FRESH" },
+    },
+    engineering: {
+      ...ENGINEERING_SNAPSHOT,
+      failing_check_count: 0,
+      open_incident_count: 0,
+      p0_count: 0,
+      p1_count: 0,
+      blockers: [],
+    },
+    infra: HEALTH_FIXTURES.filter((s) => s.status === "healthy" && s.provenance.freshness_status === "FRESH"),
+    activities: [],
+    priorities: [],
+  });
+  assert.equal(healthy.sections.find((s) => s.id === "commercial")?.compressed, true);
+  assert.equal(healthy.sections.find((s) => s.id === "finance")?.compressed, true);
+  assert.equal(healthy.sections.find((s) => s.id === "engineering")?.compressed, true);
+  assert.match(healthy.sections.find((s) => s.id === "commercial")?.compressed_summary ?? "", /ignorar/);
+});
+
+test("mounted Hoje HTML has the eight titles in order, no chart/KPI wall/MCP/intranet", () => {
+  const root = { innerHTML: "" };
+  const runtime = createMemoryRuntime("#/hoje");
+  const handle = mount(root, createMockAdapter(), runtime);
+  try {
+    const titles = HOJE_SECTION_TITLES.map((title) => root.innerHTML.indexOf(title));
+    for (let i = 0; i < titles.length; i += 1) {
+      assert.ok(titles[i]! >= 0, `missing ${HOJE_SECTION_TITLES[i]}`);
+      if (i > 0) assert.ok(titles[i]! > titles[i - 1]!, "section order");
+    }
+    assert.match(root.innerHTML, /data-compressed="false"/);
+    assert.match(root.innerHTML, /data-compressed="true"|data-compressed="false"/);
+    assert.doesNotMatch(root.innerHTML, /<canvas/i);
+    assert.doesNotMatch(root.innerHTML, /data-chart|kpi-wall|chart\.js/i);
+    assert.equal(hasChatComposer(root.innerHTML), false);
+    assert.equal(hasMutationControls(root.innerHTML), false);
+    assert.equal(hasMcpNav(root.innerHTML), false);
+    assert.equal(hasIntranetPath(root.innerHTML), false);
+    const ranks = [...root.innerHTML.matchAll(/data-rank="(\d+)"/g)].map((m) => Number(m[1]));
+    assert.ok(ranks.length <= 3);
+    assert.match(root.innerHTML, /data-shortcut-form="decision"/);
+    assert.match(root.innerHTML, /data-shortcut-form="nota"/);
+    assert.match(root.innerHTML, /data-shortcut-form="risco"/);
+    assert.match(root.innerHTML, /data-shortcut-form="hipotese"/);
+    assert.match(root.innerHTML, /data-write-path="\/v1\/directives"/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("partial-outage payload keeps ERROR out of the green tone", () => {
+  const view = composeHoje({
+    ...sampleInput(),
+    infra: [
+      {
+        ...HEALTH_FIXTURES[2]!,
+        status: "healthy",
+        provenance: { ...HEALTH_FIXTURES[2]!.provenance, freshness_status: "FRESH" },
+      },
+      {
+        ...HEALTH_FIXTURES[0]!,
+        status: "unknown",
+        provenance: { ...HEALTH_FIXTURES[0]!.provenance, freshness_status: "ERROR" },
+        partial_outage: true,
+      },
+    ],
+  });
+  const errorRows = view.sections.flatMap((s) => s.rows).filter((r) => r.freshness_status === "ERROR");
+  assert.ok(errorRows.length > 0);
+  for (const row of errorRows) {
+    assert.notEqual(row.freshness_tone, "green");
+  }
+  const fresh = view.sections.flatMap((s) => s.rows).filter((r) => r.freshness_status === "FRESH");
+  assert.ok(fresh.length > 0);
+  assertNoGreenForUntrusted(view);
+});
+
+test("HTTP Hoje compose uses injected frozen-path payloads, not /v1/context", async () => {
+  const calls: string[] = [];
+  const { adapter } = httpAdapterFor(undefined, calls);
+  const root = { innerHTML: "" };
+  paintShell(root, adapter, "#/hoje");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.match(root.innerHTML, /Se eu só puder fazer 3 coisas hoje\./);
+  assert.match(root.innerHTML, /Incidentes, blockers e riscos\./);
+  assert.doesNotMatch(calls.join("\n"), /\/v1\/context/);
+  assert.match(calls.join("\n"), /\/v1\/today/);
+  assert.match(calls.join("\n"), /\/v1\/attention/);
+  assert.match(calls.join("\n"), /\/v1\/operational-snapshots/);
+  assert.match(calls.join("\n"), /\/v1\/agent-activities/);
+});

--- a/control-center/apps/web-shell/tests/http-paths.test.ts
+++ b/control-center/apps/web-shell/tests/http-paths.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import {
+  createHttpAdapter,
+  createProductionAdapter,
+  destinationUsesContext,
+  isContextPath,
+  readPathsFor,
+} from "../src/adapters/index";
+import { createProductionAdapter as createProductionAdapterFromHttp } from "../src/adapters/http";
+import { DESTINATION_IDS } from "../src/destinations";
+import { paintShell } from "../src/app";
+import { httpAdapterFor, jsonResponse, operationalRouter, pathOf } from "./helpers";
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "../src");
+
+test("each destination requests the frozen GETs and only Memória hits /v1/context", async () => {
+  const router = operationalRouter();
+  for (const id of DESTINATION_IDS) {
+    const calls: string[] = [];
+    const { adapter } = httpAdapterFor(router, calls);
+    const result = await adapter.readDestination(id);
+    assert.equal(result.ok, true, `${id} should succeed`);
+    const requested = calls.map(pathOf);
+    const expected = [...readPathsFor(id)];
+    for (const path of expected) {
+      assert.equal(
+        requested.includes(path),
+        true,
+        `${id} missing ${path}; got ${requested.join(",")}`,
+      );
+    }
+    const contextGets = requested.filter((url) => isContextPath(url));
+    if (destinationUsesContext(id)) {
+      assert.ok(contextGets.length > 0, "memoria must request /v1/context");
+    } else {
+      assert.equal(contextGets.length, 0, `${id} must not request /v1/context`);
+    }
+  }
+});
+
+test("Hoje/Comercial/Clientes/Financeiro/Engenharia/Infra/Agentes never request /v1/context", async () => {
+  const calls: string[] = [];
+  const { adapter } = httpAdapterFor(operationalRouter(), calls);
+  for (const id of ["hoje", "comercial", "clientes", "financeiro", "engenharia", "infra", "agentes"] as const) {
+    calls.length = 0;
+    await adapter.readDestination(id);
+    assert.equal(
+      calls.some((url) => url.includes("/v1/context")),
+      false,
+      `${id} leaked /v1/context`,
+    );
+  }
+});
+
+test("5xx and network failure paint unavailable/error rather than mock", async () => {
+  const fetchImpl = (async () => jsonResponse({ error: "boom" }, 503)) as typeof fetch;
+  const adapter = createHttpAdapter("http://127.0.0.1:8787", fetchImpl);
+  const result = await adapter.readDestination("hoje");
+  assert.equal(result.ok, false);
+  if (result.ok || result.loading) throw new Error("expected error");
+  assert.equal(result.error.code, "CONTEXT_UNAVAILABLE");
+  assert.match(result.error.message, /indisponível|503/);
+  const root = { innerHTML: "" };
+  paintShell(root, adapter, "#/hoje");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.match(root.innerHTML, /data-view-state="error"/);
+  assert.doesNotMatch(root.innerHTML, /modo mock/);
+  assert.doesNotMatch(root.innerHTML, /Destravar os três inbound/);
+
+  const net = createHttpAdapter("http://127.0.0.1:8787", (async () => {
+    throw new Error("network down");
+  }) as typeof fetch);
+  const failed = await net.readDestination("comercial");
+  assert.equal(failed.ok, false);
+});
+
+test("createProductionAdapter is HTTP and its source does not select mock", () => {
+  assert.equal(createProductionAdapterFromHttp, createProductionAdapter);
+  const httpSrc = readFileSync(join(srcDir, "adapters/http.ts"), "utf8");
+  assert.match(httpSrc, /createHttpAdapter/);
+  assert.doesNotMatch(httpSrc, /createMockAdapter/);
+  assert.doesNotMatch(httpSrc, /from "\.\/mock"/);
+  const bootSrc = readFileSync(join(srcDir, "boot.ts"), "utf8");
+  assert.match(bootSrc, /createProductionAdapter/);
+  assert.match(bootSrc, /__CC_TEST_ADAPTER__/);
+  assert.match(bootSrc, /cc-use-mock/);
+});
+
+test("production HTTP adapter maps Goal 04 commercial/finance/engineering fixtures onto domain fields", async () => {
+  const { adapter } = httpAdapterFor();
+  const comercial = await adapter.readDestination("comercial");
+  assert.equal(comercial.ok, true);
+  if (!comercial.ok || comercial.loading) throw new Error("comercial");
+  const snap = comercial.page.commercial;
+  assert.ok(snap);
+  assert.equal(snap.funnel?.new_leads, 6);
+  assert.equal(snap.funnel?.qualified, 4);
+  assert.equal(snap.funnel?.opportunities, 3);
+  assert.equal(snap.funnel?.proposals, 2);
+  assert.equal(snap.funnel?.clients, 1);
+  assert.equal(snap.pipeline_nominal?.amount_cents, 4800000);
+  assert.equal(snap.pipeline_weighted?.probability_reliable, true);
+  assert.equal(snap.aging_count, 1);
+  assert.equal(snap.missing_next_action_count, 2);
+  assert.equal(snap.stalled_count, 1);
+
+  const financeiro = await adapter.readDestination("financeiro");
+  if (!financeiro.ok || financeiro.loading) throw new Error("financeiro");
+  const finance = financeiro.page.finance;
+  assert.ok(finance);
+  assert.equal(finance.contracted?.amount_cents, 5000000);
+  assert.equal(finance.billed?.amount_cents, 4000000);
+  assert.equal(finance.paid?.amount_cents, 2500000);
+  assert.equal(finance.effectively_received?.amount_cents, 2300000);
+  assert.equal(finance.overdue?.amount_cents, 1500000);
+  assert.equal(finance.receivable?.amount_cents, 2500000);
+  assert.equal(finance.refunds?.amount_cents, 100000);
+  assert.equal(finance.chargebacks?.amount_cents, 100000);
+  assert.equal(finance.mrr?.applicable, true);
+  assert.equal(finance.runway?.cash_reliable, true);
+
+  const engenharia = await adapter.readDestination("engenharia");
+  if (!engenharia.ok || engenharia.loading) throw new Error("engenharia");
+  assert.equal(engenharia.page.engineering?.open_pr_count, 1);
+  assert.equal(engenharia.page.engineering?.failing_check_count, 0);
+});

--- a/control-center/apps/web-shell/tests/ux.test.ts
+++ b/control-center/apps/web-shell/tests/ux.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { createMemoryRuntime, mount } from "../src/app";
+import { createMockAdapter } from "../src/adapters/index";
+import { PRESENTATION_TIME_ZONE } from "../src/datetime";
+import { formatMoney } from "../src/money";
+import { escapeHtml } from "../src/escape";
+import { freshnessTone, neverGreenStatuses } from "../src/freshness-tone";
+import { renderShell } from "../src/ui/render";
+import { AUTH_URL, PRODUCTIVE_URL } from "../src/topology";
+import { ATTENTION_FIXTURES } from "../src/fixtures/catalog";
+import { loadingState, errorState, emptyState, staleState, readyState } from "../src/view-state";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("money is integer cents plus ISO currency", () => {
+  assert.equal(formatMoney({ amount_cents: 1500000, currency: "BRL" }), "BRL 15.000,00");
+  assert.throws(() => formatMoney({ amount_cents: 1.5, currency: "BRL" }));
+  assert.throws(() => formatMoney({ amount_cents: 1, currency: "brl" }));
+});
+
+test("observed_at stays UTC Z in data and America/Sao_Paulo in the visible string", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/hoje"));
+  try {
+    assert.match(root.innerHTML, /datetime="2026-08-20T17:/);
+    assert.match(root.innerHTML, new RegExp(PRESENTATION_TIME_ZONE.replace("/", "\\/")));
+    assert.match(root.innerHTML, /sr-only">UTC /);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("XSS payloads in titles/bodies are escaped in HTML", () => {
+  const payload = `<img src=x onerror="alert(1)">`;
+  const escaped = escapeHtml(payload);
+  assert.equal(escaped.includes("<img"), false);
+  const html = renderShell({
+    destination: "hoje",
+    viewKind: "ready",
+    mockScenario: "http",
+    adapterMode: "http",
+    view: {
+      kind: "ready",
+      data: {
+        id: "hoje",
+        label: "Hoje",
+        scope: "company",
+        generated_at: "2026-08-20T18:00:00Z",
+        operator: { kind: "human", id: "human:operator" },
+        headline: payload,
+        attention: [
+          {
+            ...ATTENTION_FIXTURES[0]!,
+            title: payload,
+            summary: `<script>alert("xss")</script>`,
+          },
+        ],
+        priorities: [],
+      },
+    },
+  });
+  assert.doesNotMatch(html, /<img src=x/);
+  assert.doesNotMatch(html, /<script>alert/);
+  assert.match(html, /&lt;img/);
+});
+
+test("STALE/UNKNOWN/ERROR have non-color text labels and are never green", () => {
+  for (const status of neverGreenStatuses()) {
+    assert.notEqual(freshnessTone(status), "green");
+  }
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/hoje"));
+  try {
+    assert.match(root.innerHTML, /STALE/);
+    assert.match(root.innerHTML, /ERROR/);
+    assert.match(root.innerHTML, /UNKNOWN|desconhecido|erro de coleta|defasado/);
+    assert.match(root.innerHTML, /sr-only/);
+    const errorBlocks = [...root.innerHTML.matchAll(/data-freshness="ERROR"[\s\S]{0,400}data-tone="([^"]+)"/g)];
+    for (const match of errorBlocks) {
+      assert.notEqual(match[1], "green");
+    }
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("loading, empty, stale and error remain distinct view states", () => {
+  assert.equal(loadingState().kind, "loading");
+  assert.equal(errorState().kind, "error");
+  assert.equal(emptyState().kind, "empty");
+  assert.equal(staleState({}).kind, "stale");
+  assert.equal(readyState({}).kind, "ready");
+  const root = { innerHTML: "" };
+  const runtime = createMemoryRuntime("#/hoje?view=loading");
+  const handle = mount(root, createMockAdapter(), runtime);
+  try {
+    assert.match(root.innerHTML, /data-view-state="loading"/);
+    runtime.setHash("#/hoje?view=error");
+    assert.match(root.innerHTML, /data-view-state="error"/);
+    runtime.setHash("#/hoje?view=empty");
+    assert.match(root.innerHTML, /data-view-state="empty"/);
+    runtime.setHash("#/hoje?view=stale");
+    assert.match(root.innerHTML, /data-view-state="stale"/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("keyboard-focusable nav exists and skip link is present", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/hoje"));
+  try {
+    assert.match(root.innerHTML, /class="skip-link"/);
+    assert.match(root.innerHTML, /href="#conteudo"/);
+    assert.match(root.innerHTML, /nav class="nav"/);
+    assert.match(root.innerHTML, /data-nav="hoje"/);
+    assert.match(root.innerHTML, /tabindex="-1"/);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("productive topology is ops.confenge.com.br with auth.ops; no secrets/PII in sources", () => {
+  const root = { innerHTML: "" };
+  const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/hoje"));
+  try {
+    assert.match(root.innerHTML, new RegExp(PRODUCTIVE_URL.replaceAll("/", "\\/")));
+    assert.match(root.innerHTML, new RegExp(AUTH_URL.replaceAll("/", "\\/")));
+    assert.doesNotMatch(root.innerHTML, /\/intranet/);
+  } finally {
+    handle.unmount();
+  }
+  const scanDirs = [join(rootDir, "src")];
+  const secret = /(sk_live|sk_test|ghp_[A-Za-z0-9]{20,}|BEGIN PRIVATE KEY|password\s*=\s*['"][^'"]+['"])/i;
+  const pii = /\b[A-Z][a-z]+ [A-Z][a-z]+ \d{3}\.\d{3}\.\d{3}-\d{2}\b/;
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!/\.(ts|css|svg|webmanifest)$/.test(entry.name)) continue;
+      const text = readFileSync(full, "utf8");
+      assert.equal(secret.test(text), false, `secret-like token in ${full}`);
+      assert.equal(pii.test(text), false, `PII dump in ${full}`);
+    }
+  }
+  for (const dir of scanDirs) walk(dir);
+});

--- a/control-center/apps/web-shell/tests/writes.test.ts
+++ b/control-center/apps/web-shell/tests/writes.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  AUTHORIZED_WRITE_PATH,
+  WRITE_SHORTCUT_DIRECTIVE_KIND,
+  WRITE_SHORTCUT_KINDS,
+  createHttpAdapter,
+  isAuthorizedWritePath,
+} from "../src/adapters/index";
+import { jsonResponse } from "./helpers";
+
+test("write shortcuts POST only authorized Context Service paths and never provider verbs", async () => {
+  const calls: Array<{ url: string; method: string; body: unknown }> = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+    calls.push({ url, method, body });
+    return jsonResponse({ id: "cc:directive:written" }, 201);
+  }) as typeof fetch;
+  const adapter = createHttpAdapter("http://127.0.0.1:8787", fetchImpl, {
+    kind: "human",
+    id: "founder-local",
+  });
+  for (const kind of WRITE_SHORTCUT_KINDS) {
+    const result = await adapter.writeShortcut(kind, { title: `t ${kind}`, body: "corpo do atalho" });
+    assert.equal(result.ok, true, kind);
+    assert.equal(result.path, AUTHORIZED_WRITE_PATH);
+  }
+  assert.equal(calls.length, 4);
+  for (const call of calls) {
+    assert.equal(call.method, "POST");
+    assert.equal(isAuthorizedWritePath(new URL(call.url).pathname), true);
+    assert.equal(call.url.endsWith("/v1/directives"), true);
+    assert.doesNotMatch(call.url, /asaas|checkout|refund|cobranca|cancelamento/i);
+    const body = call.body as { kind: string; source: { kind: string } };
+    assert.ok(Object.values(WRITE_SHORTCUT_DIRECTIVE_KIND).includes(body.kind as never));
+    assert.equal(body.source.kind, "founder-shortcut");
+  }
+  assert.equal(WRITE_SHORTCUT_DIRECTIVE_KIND.decision, "decision");
+  assert.equal(WRITE_SHORTCUT_DIRECTIVE_KIND.nota, "fact");
+  assert.equal(WRITE_SHORTCUT_DIRECTIVE_KIND.risco, "risk");
+  assert.equal(WRITE_SHORTCUT_DIRECTIVE_KIND.hipotese, "hypothesis");
+});


### PR DESCRIPTION
CAMPANHA: CONFENGE-CC-LIVE-FOUNDER-COCKPIT-01

Production default is `HttpControlCenterAdapter`. Operational pages consume the frozen GETs (`/v1/today`, `/v1/operational-snapshots`, `/v1/domains/:domain`, `/v1/attention`, `/v1/agent-activities`). `/v1/context` is used only for Memória/Decisões. Missing/5xx backends paint unavailable/error — never mock and never a silent `/v1/context` stand-in.

Hoje renders the eight required sections in order, with ≤3 priorities, expanded exceptions, compressed healthy KPIs, and write shortcuts that POST only `/v1/directives`.

Each domain page surfaces its operational fields from Goal 04 payloads (funnel/pipeline gating, finance stages, engineering evidência/hipótese, agent RUNNING never coerced to DONE).

Do not merge this PR.

Topology: `https://ops.confenge.com.br/` behind Authelia at `https://auth.ops.confenge.com.br/`. No `/intranet` alternative. No MCP in public nav. No credentials in the bundle.
