### PR TITLE
docs(control-center): production runbook and internal launch evidence

### DIFF
--- a/control-center/deploy/PRODUCTION-RUNBOOK.md
+++ b/control-center/deploy/PRODUCTION-RUNBOOK.md
@@ -1,0 +1,200 @@
+# Production runbook — Confenge Control Center (internal)
+
+Canonical operational source for **internal production** of the Control Center on Netcup.
+
+This file supersedes apply/refuse language in `RUNBOOK.md`, `README.md`, and `overlays/production-edge/README.md` from earlier waves. Those files remain useful for the stub pack CLI (backup encrypt/verify/retain, disk-guard) and isolated rehearsal.
+
+Internal clocks are UTC. Display times also use `America/Sao_Paulo`.
+
+## Frozen hop
+
+```
+Internet
+  → host nginx :443 (ACME/certbot owner of 80/443)
+    → 127.0.0.1:18080 Caddy (loopback only)
+      → Authelia forward_auth /api/authz/forward-auth
+        → web:8080 (cockpit) and context:8080 (/v1/*)
+```
+
+Auth portal: `https://auth.ops.confenge.com.br/` through the same nginx → loopback Caddy hop, then `authelia:9091`. Operators require 2FA (TOTP or WebAuthn). Password-reset bypass is disabled.
+
+MCP is **private + bearer**, fail-closed, unpublished. Do not create `mcp.confenge.com.br`.
+
+Datastores (Postgres, Redis, NATS) and Authelia internals stay on `cc_internal` (`internal: true`). Postgres is reachable as hostname **`cc-postgres`**. Collector `CONTROL_CENTER_DATABASE_URL` must use `cc-postgres`, never `postgres` (Warmbly's hostname on the optional Warmbly network).
+
+Caddy never binds host `:80`/`:443` and never issues public ACME.
+
+## Project and files
+
+- Compose project: `confenge-control-center`
+- Canonical overlay: `control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml`
+- Caddyfile: `overlays/production-edge/Caddyfile` (must contain `forward_auth`; the open `deploy/Caddyfile` is not this pack)
+- Optional Warmbly join: `docker-compose.warmbly-collector.override.yml`
+- Nginx vhost templates: `control-center/deploy/nginx/`
+- Secrets contract: `control-center/security/production/secrets/manifest.json` + `generate-local.sh`
+- Host secrets directory: `/etc/confenge/control-center/secrets` (dir `0700`, files `0600`)
+- Bootstrap operator password path (if generated on host): `/root/.confenge/control-center/bootstrap-operator-password` (mode `0600`)
+
+The stub pack in `control-center/deploy/docker-compose.yml` still refuses `CONTROL_CENTER_APPLY_PRODUCTION=true`. Do not apply the stub pack.
+
+## DNS
+
+Cloudflare, DNS-only (not proxied):
+
+| Type | Hostname | Value | Proxy | TTL |
+| --- | --- | --- | --- | --- |
+| A | `ops.confenge.com.br` | `159.195.18.88` | DNS-only | 300 |
+| A | `auth.ops.confenge.com.br` | `159.195.18.88` | DNS-only | 300 |
+
+Do not create `mcp.confenge.com.br`. Do not invent AAAA.
+
+## TLS
+
+Host nginx/certbot remains ACME owner. Certificate live paths:
+
+- `/etc/letsencrypt/live/ops.confenge.com.br/`
+- `/etc/letsencrypt/live/auth.ops.confenge.com.br/`
+
+Caddy uses `tls internal` on optional `127.0.0.1:18443` only.
+
+## Secrets
+
+Generate on the host from the shipped manifest (never git, never logs, never URLs):
+
+```bash
+# If CC_OPERATOR_PASSWORD is unset, generate-local.sh may read:
+#   /root/.confenge/control-center/bootstrap-operator-password
+umask 077
+/opt/confenge-control-center/control-center/security/production/secrets/generate-local.sh \
+  /etc/confenge/control-center/secrets
+```
+
+Names must match `manifest.json`. Print no values. Recover the operator password **only** from the bootstrap path above.
+
+## Deploy (production-edge)
+
+Checkout the certified `RELEASE_SHA` at `/opt/confenge-control-center`.
+
+```bash
+cd /opt/confenge-control-center/control-center/deploy/overlays/production-edge
+set -a
+source /etc/confenge/control-center/secrets/.env
+set +a
+export CC_SECRET_DIR=/etc/confenge/control-center/secrets
+
+# 1. datastores
+docker compose -f docker-compose.production-edge.yml up -d postgres redis nats
+# confirm alias cc-postgres on cc_internal
+# 2. migrations (schema control_center): 001_init, 002_current_state, 003_durable_operational_data_plane
+# 3. Authelia (own DB/role, Redis sessions, default deny, operators require 2FA)
+docker compose -f docker-compose.production-edge.yml up -d authelia
+# 4. context, MCP, collector, web, Caddy
+docker compose -f docker-compose.production-edge.yml up -d context mcp collector web caddy
+# optional: -f docker-compose.warmbly-collector.override.yml for collector Warmbly network
+```
+
+After Caddy is up, `ss -lntp` must show nginx on `:80`/`:443` and Caddy on `127.0.0.1:18080` only.
+
+Reserved `cc_edge` IPs: Caddy `10.89.0.2`, context `10.89.0.4`, MCP `10.89.0.6`, collector `10.89.0.7`. MCP and collector must not occupy `10.89.0.2`.
+
+## Health and readiness
+
+Probe **twice**. Ready body must be non-empty JSON with `"ready": true`.
+
+```bash
+curl -sS -H 'Host: ops.confenge.com.br' http://127.0.0.1:18080/healthz
+# public /ready and /mcp on the ops Host must 404
+curl -sS -o /dev/null -w '%{http_code}\n' -H 'Host: ops.confenge.com.br' http://127.0.0.1:18080/ready
+# internal:
+# context /healthz /ready, collector /healthz /ready, mcp /healthz /ready
+```
+
+Public cockpit: `https://ops.confenge.com.br/` → Authelia 302 until authenticated + 2FA.
+
+Do not treat `/healthz` 200 as authenticated cockpit access.
+
+## Governance bootstrap
+
+```bash
+cc-governance-bootstrap --dry-run --root /opt/confenge-control-center
+# inspect candidate count, kinds, PR #8 exclusion, secret/PII exclusions
+cc-governance-bootstrap --apply --allow-control-center-db-write --root /opt/confenge-control-center
+# second apply: inserted delta 0
+```
+
+Writes only the Control Center database. Never Git, Warmbly, Asaas, or extra-cli.
+
+## Collector canaries
+
+GitHub/infra/PNCP/Warmbly/Asaas persist honestly. `UNKNOWN`/`STALE`/`ERROR`/`BLOCKED_BY_SECRET` must not be displayed as `FRESH`.
+
+- PNCP consumes only `PNCP_CONTRACT_FRESHNESS/1.0`. Never `--live`/ingest/recrawl/backfill as a Control Center side effect.
+- Asaas is read-only (zero POST/PUT/PATCH/DELETE/refund/checkout).
+- Warmbly is observed only; do not redeploy Warmbly or flip `CONFENGE_AUTO_SEND_ENABLED`.
+- Collector DB URL host is `cc-postgres`.
+
+## Backup
+
+Preferred window: 03:00 America/Sao_Paulo (06:00 UTC).
+
+```bash
+docker exec -T confenge-control-center-postgres-1 \
+  pg_dump -U control_center -d control_center --schema=control_center \
+  > /var/backups/confenge-control-center/cc-pg.dump.sql
+# encrypt + verify with shipped CLI (CONTROL_CENTER_BACKUP_KEY from secret file, never argv)
+node dist/cli.js backup --in /var/backups/confenge-control-center/cc-pg.dump.sql \
+  --out /var/backups/confenge-control-center/encrypted
+node dist/cli.js verify --in /var/backups/confenge-control-center/encrypted/cc-pg-*.dump.enc
+shred -u /var/backups/confenge-control-center/cc-pg.dump.sql
+```
+
+Ciphertext must not equal plaintext. Keep encrypted backups. Sidecar `*.dump.enc.meta.json` is required for restore.
+
+## Restore
+
+Restore onto a **new** volume/database. Never restore over production as a drill.
+
+```bash
+node dist/cli.js restore --in <enc> --out /tmp/restored.dump.sql
+# psql into a throwaway postgres, compare essential counts, destroy only the temp env
+```
+
+Mechanical requirement: `same_content=true` (SHA-256 of restored dump equals plaintext dump).
+
+## Rollback
+
+1. Preserve evidence and volumes (`confenge-cc-postgres-edge`).
+2. Take ops/auth vhosts out of traffic if the edge is the cause (restore nginx backup; `nginx -t` before reload).
+3. Roll back only Control Center compose/images.
+4. Do not alter Warmbly, host Postgres, or extra-cli.
+5. Prove `https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health` remains READY and `auto_send_enabled=false`.
+
+## Nginx vhost activation
+
+Backup `/etc/nginx` first. Install only `ops.confenge.com.br` and `auth.ops.confenge.com.br` templates. Never overwrite `api.confenge.com.br`. `nginx -t` before reload. If test fails, restore backup and do not reload.
+
+## MFA enrollment (human)
+
+1. Open `https://auth.ops.confenge.com.br/`
+2. Authenticate with the bootstrap operator user/password (recover from `/root/.confenge/control-center/bootstrap-operator-password`).
+3. Register TOTP or WebAuthn/passkey.
+4. Validate login to `https://ops.confenge.com.br/`.
+5. Do not disable 2FA to make deploy pass.
+
+## Canaries after apply
+
+- `ss -lntp`: nginx 80/443, Caddy loopback 18080
+- context/web/collector/MCP healthy
+- `api.confenge.com.br` inbound READY
+- Warmbly `/ready` live=true ready=true, `CONFENGE_AUTO_SEND_ENABLED=false`
+- GitHub collector FRESH when token+allowlist are set; otherwise honest ERROR/UNKNOWN
+
+## `/intranet`
+
+Activate `https://confenge.com.br/intranet` → `https://ops.confenge.com.br/` **302** only after `OPS_HOST_AUTHENTICATED_AND_HEALTHY=true` (Authelia + MFA proven). Never 301. Never proxy 200. noindex/nofollow, robots disallow, out of sitemap/nav/JSON-LD.
+
+## Restart
+
+Restart **only** Control Center services. Not Warmbly, not host PostgreSQL, not extra-cli.
+
+After restart, prove `/healthz` `/ready` twice and that directives, Governance context, AgentActivity, collector history, and latest observations persist.

--- a/control-center/deploy/README.md
+++ b/control-center/deploy/README.md
@@ -2,7 +2,7 @@
 
 Reproducible reference pack for running Confenge Control Center on a Linux VPS (Netcup) with Docker Compose, Caddy hooks, PostgreSQL, encrypted backups, retention, and a fail-closed disk guard.
 
-This workstream is **not** chat, **not** an ERP, and **not** a replacement for Warmbly or origin systems. It does **not** apply itself to production. It does **not** bind host ports 80/443. Warmbly keeps the existing host nginx.
+This workstream is **not** chat, **not** an ERP, and **not** a replacement for Warmbly or origin systems. The **stub pack in this directory** does **not** apply itself to production. Canonical production apply is `PRODUCTION-RUNBOOK.md` using the **production-edge** overlay (nginx `:443` → loopback Caddy → Authelia `forward_auth` → web/context). It does **not** bind host ports 80/443. Warmbly keeps the existing host nginx.
 
 Write path: `control-center/deploy/` only.
 
@@ -20,7 +20,7 @@ Write path: `control-center/deploy/` only.
 10. Single-user human initially. No identity or password is hardcoded. Secrets are injected from a secret store into a gitignored `.env`.
 11. Fail-closed security. No secrets in git, logs, URLs, analytics, or a client bundle. Structured logs are JSON with UTC timestamps and refuse secret-bearing field names.
 12. No Kubernetes, Swarm, or cluster orchestrator. No cobranca, checkout, refund, cancelamento, Asaas writes, or commercial send.
-13. `CONTROL_CENTER_APPLY_PRODUCTION` must stay false. There is no Netcup SSH/apply command. A green deploy to the live VPS in this wave is a violation.
+13. `CONTROL_CENTER_APPLY_PRODUCTION` must stay false **on this stub pack**. Production apply is the production-edge overlay documented in `PRODUCTION-RUNBOOK.md`. Applying the stub pack to the live VPS is a violation.
 
 ## Layout
 
@@ -31,7 +31,8 @@ Write path: `control-center/deploy/` only.
 | `docker/*.Dockerfile` | stub, postgres, caddy, ops (backup CLI + `pg_dump` client) |
 | `src/` | validate, backup/restore/verify, retention, disk guard, stub server, CLI |
 | `fixtures/postgres.dump.sql` | PII-free dump for the restore drill |
-| `RUNBOOK.md` | deploy / rollback / restore without relying on human memory |
+| `PRODUCTION-RUNBOOK.md` | **canonical** production apply / migration / DNS / TLS / MFA / backup / restore / rollback |
+| `RUNBOOK.md` | stub-pack procedures (superseded for production apply) |
 | `.env.example` | variable **names** and placeholders only |
 
 ## Run (local, no production)

--- a/control-center/deploy/RUNBOOK.md
+++ b/control-center/deploy/RUNBOOK.md
@@ -1,16 +1,18 @@
-# Runbook — Control Center deploy, rollback, restore
+# Runbook — stub pack deploy, rollback, restore
 
-Operators should be able to deploy, roll back, and restore **from this file**, not from memory. This wave ships the procedures and a local restore drill. It does **not** change the live Netcup VPS.
+**Superseded for production apply.** Canonical production operations: [`PRODUCTION-RUNBOOK.md`](./PRODUCTION-RUNBOOK.md) (production-edge overlay, Authelia, loopback Caddy).
+
+This file remains the stub-pack CLI procedures (validate, encrypted backup, restore drill, disk-guard). The stub pack does **not** change the live Netcup VPS. Production-edge apply is authorized separately.
 
 Internal clocks are UTC. Display times below also show `America/Sao_Paulo`.
 
-## Never in this wave
+## Never with this stub pack
 
-- SSH to Netcup to apply this pack.
 - Bind host 80/443 (Warmbly nginx).
 - `kubectl apply`, Helm, Swarm.
 - Cobranca, checkout, refund, cancelamento, Asaas writes, commercial send.
-- Set `CONTROL_CENTER_APPLY_PRODUCTION=true` (validate fails closed).
+- Set `CONTROL_CENTER_APPLY_PRODUCTION=true` (this pack's validate fails closed).
+- Use this pack's Caddyfile (no `forward_auth`) as the production edge.
 
 ## Prerequisites (after convergence)
 

--- a/control-center/deploy/overlays/production-edge/README.md
+++ b/control-center/deploy/overlays/production-edge/README.md
@@ -7,4 +7,6 @@ Canonical compose: `docker-compose.production-edge.yml`.
 - Datastores on `cc_internal` (`internal: true`). Edge traffic on `cc_edge`.
 - Collector has no datastore/volume access. Warmbly network is opt-in via `docker-compose.warmbly-collector.override.yml`.
 
-Do **not** `docker compose up` this file as project `confenge-control-center` in this campaign. Rehearsal: `rehearse-isolated.sh` (`--project-name cc-edge-rehearsal`, host ports 28080/28443).
+Canonical production apply is `control-center/deploy/PRODUCTION-RUNBOOK.md`. Compose project `confenge-control-center` **is** the production project.
+
+Isolated rehearsal (does not use the production project name): `rehearse-isolated.sh` (`--project-name cc-edge-rehearsal`, host ports 28080/28443).

--- a/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
+++ b/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
@@ -1,12 +1,13 @@
 # Confenge Control Center — production-edge overlay.
-# Project name: confenge-control-center (do NOT `up` this project in this campaign).
+# Project name: confenge-control-center. Canonical apply: ../../PRODUCTION-RUNBOOK.md.
 # Isolated rehearsal MUST use `--project-name cc-edge-rehearsal` and high host ports.
 #
 # Hop: host nginx :443 -> 127.0.0.1:18080 Caddy -> Authelia forward_auth -> apps.
 # Caddy is compose-only. No host 80/443. No Caddy ACME. No 0.0.0.0 publish.
 # Datastores (postgres, redis, nats) are unpublished on network internal:true.
 # Collector may join Warmbly only via docker-compose.warmbly-collector.override.yml.
-# Secrets via files/env. This file does not apply itself to production.
+# CONTROL_CENTER_DATABASE_URL host is cc-postgres (never Warmbly's postgres hostname).
+# Secrets via files/env. The stub pack in deploy/docker-compose.yml is not this overlay.
 
 name: confenge-control-center
 

--- a/control-center/deploy/tests/docs.test.ts
+++ b/control-center/deploy/tests/docs.test.ts
@@ -16,7 +16,9 @@ test("README and runbook document decisions, run, env, rollback, restore, and la
   assert.match(readme, /CONTROL_CENTER_BACKUP_KEY/);
   assert.match(readme, /CONTROL_CENTER_DATABASE_URL/);
   assert.match(readme, /Warmbly/);
-  assert.match(readme, /does \*\*not\*\* apply itself to production/);
+  assert.match(readme, /PRODUCTION-RUNBOOK\.md/);
+  assert.match(readme, /production-edge/);
+  assert.match(readme, /stub pack/);
 
   const runbook = readFileSync(join(PACK_ROOT, "RUNBOOK.md"), "utf8");
   assert.match(runbook, /## Deploy/);
@@ -27,4 +29,18 @@ test("README and runbook document decisions, run, env, rollback, restore, and la
   assert.match(runbook, /confenge-control-center-postgres/);
   assert.match(runbook, /disk-guard/);
   assert.match(runbook, /tls internal/);
+  assert.match(runbook, /PRODUCTION-RUNBOOK\.md/);
+  assert.match(runbook, /Superseded for production apply/);
+
+  const production = readFileSync(join(PACK_ROOT, "PRODUCTION-RUNBOOK.md"), "utf8");
+  assert.match(production, /host nginx :443/);
+  assert.match(production, /127\.0\.0\.1:18080/);
+  assert.match(production, /forward_auth/);
+  assert.match(production, /cc-postgres/);
+  assert.match(production, /private \+ bearer/);
+  assert.match(production, /confenge-control-center/);
+  assert.match(production, /ops\.confenge\.com\.br/);
+  assert.match(production, /auth\.ops\.confenge\.com\.br/);
+  assert.doesNotMatch(production, /Never in this wave: SSH to Netcup/);
+  assert.doesNotMatch(production, /this wave does not change live VPS/);
 });

--- a/control-center/releases/2026-08-21-internal-production.json
+++ b/control-center/releases/2026-08-21-internal-production.json
@@ -1,0 +1,124 @@
+{
+  "schema_version": "control-center.internal-production-evidence.v1",
+  "campaign": "CONFENGE-CONTROL-CENTER-INTERNAL-PRODUCTION-LAUNCH-01",
+  "FINAL_VERDICT": "HUMAN_GATE_MFA_ENROLLMENT",
+  "RELEASE_SHA": "3d5e21c344be95549cca1e9f0b5073a8efb9ff08",
+  "DEPLOYED_SHA": "3d5e21c344be95549cca1e9f0b5073a8efb9ff08",
+  "PRE_RELEASE_SHA": "3d5e21c344be95549cca1e9f0b5073a8efb9ff08",
+  "main_matched_expected": true,
+  "pr_8_untouched": true,
+  "topology": {
+    "project": "confenge-control-center",
+    "host": "v2202607385716487230",
+    "public_ip": "159.195.18.88",
+    "hop": "nginx:443 -> 127.0.0.1:18080 Caddy -> Authelia forward_auth -> web/context",
+    "caddy_loopback": ["127.0.0.1:18080", "127.0.0.1:18443"],
+    "nginx_owns_80_443": true,
+    "mcp_exposure": "PRIVATE",
+    "postgres_alias": "cc-postgres",
+    "cc_edge_ips": {
+      "caddy": "10.89.0.2",
+      "context": "10.89.0.4",
+      "mcp": "10.89.0.6",
+      "collector": "10.89.0.7"
+    }
+  },
+  "dns": {
+    "ops.confenge.com.br": { "type": "A", "content": "159.195.18.88", "proxied": false, "ttl": 300 },
+    "auth.ops.confenge.com.br": { "type": "A", "content": "159.195.18.88", "proxied": false, "ttl": 300 },
+    "mcp.confenge.com.br": "absent"
+  },
+  "tls": {
+    "ops": { "issuer": "Let's Encrypt", "not_before": "2026-08-21T14:28:51Z", "not_after": "2026-11-19T14:28:50Z" },
+    "auth": { "issuer": "Let's Encrypt", "not_before": "2026-08-21T14:28:58Z", "not_after": "2026-11-19T14:28:57Z" }
+  },
+  "auth": {
+    "authelia_enforced": true,
+    "ops_unauthenticated": "302 to https://auth.ops.confenge.com.br/",
+    "mfa": "ENFORCED_POLICY_UNENROLLED",
+    "totp_configurations": 0,
+    "webauthn_credentials": 0,
+    "operator_enabled": true,
+    "bootstrap_operator_password_path": "/root/.confenge/control-center/bootstrap-operator-password"
+  },
+  "migrations": ["001_init", "002_current_state", "003_durable_operational_data_plane"],
+  "governance_bootstrap": {
+    "dry_run_candidates": 74,
+    "unclassifiable": 0,
+    "apply_1_inserted": 74,
+    "apply_2_inserted": 0,
+    "apply_2_skipped": 74,
+    "kinds": { "decision": 1, "fact": 28, "hypothesis": 45 }
+  },
+  "collectors": {
+    "github": { "status": "DONE", "freshness_status": "FRESH" },
+    "infra": { "status": "UNKNOWN", "freshness_status": "UNKNOWN", "error_code": "missing_credentials" },
+    "pncp": { "status": "DONE", "freshness_status": "ERROR" },
+    "warmbly": { "status": "FAILED", "freshness_status": "ERROR", "error_code": "missing_credentials" },
+    "asaas": { "status": "FAILED", "freshness_status": "ERROR", "error_code": "missing_credentials" }
+  },
+  "agent_activity_smoke_ids": [
+    "cc:agent-activity:01M0JM0KQ7JW4968NY860TTEM3",
+    "cc:agent-activity:01M0JKZWN4JVSWX81NG13V6T0E"
+  ],
+  "directive_smoke_ids": [
+    "cc:directive:4a71ccc4-43b7-4279-a5a7-7e82da2da726",
+    "cc:directive:f171f356-f9dd-47fd-b342-2ef95c30c159",
+    "cc:directive:c59ccf44-87fb-4918-be78-f7f0a0924d90"
+  ],
+  "backup": {
+    "dump_sha256": "aafc75d42657cb2f6ba6b9d2448760ac3cef0952319ebf656db66399de6b576c",
+    "enc_sha256": "84fc90a0b4717dcc5418ff41276cd506098b2267e81f162b3cac61e2e6b404af",
+    "same_content": true,
+    "ciphertext_ne_plaintext": true,
+    "path": "/var/backups/confenge-control-center/encrypted/cc-pg-2026-08-21T16-51-50-379Z.dump.enc"
+  },
+  "restart": {
+    "scope": "confenge-control-center only",
+    "all_healthy": true,
+    "directives_persisted": true,
+    "agent_activities_persisted": true,
+    "observations_persisted": true
+  },
+  "warmbly": {
+    "sha": "93dd039d7b9b310458beff8a6bd8819a61da6399",
+    "backend_id": "92e98e3217ad54c4633a031dad2e4bdaf3d6a38292493dd56bd38cf0edfcc14f",
+    "ready": true,
+    "live": true,
+    "auto_send_enabled": false,
+    "restarts": 0,
+    "WARMBLY_REGRESSION": false
+  },
+  "api_inbound": {
+    "url": "https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health",
+    "status": "READY",
+    "auto_send_enabled": false
+  },
+  "intranet": {
+    "state": "convenience_residual_until_mfa",
+    "reason": "OPS_HOST_AUTHENTICATED_AND_HEALTHY is false until founder MFA enrollment"
+  },
+  "ci_on_release_sha": {
+    "control-center": "https://github.com/tjsasakifln/Governance/actions/runs/32498571671",
+    "control-center-image-scan": "https://github.com/tjsasakifln/Governance/actions/runs/32498571672",
+    "commercial-authority": "https://github.com/tjsasakifln/Governance/actions/runs/32498571705"
+  },
+  "collector_hotfix": {
+    "dynamic_require_of_events": false,
+    "database_url_host": "cc-postgres",
+    "mcp_ip": "10.89.0.6",
+    "collector_ip": "10.89.0.7",
+    "caddy_ip": "10.89.0.2"
+  },
+  "asaas_mutations": 0,
+  "commercial_sends": 0,
+  "residuals": [
+    "HUMAN_GATE_MFA_ENROLLMENT",
+    "ASAAS_READ=BLOCKED_BY_SECRET",
+    "WARMBLY_READ=BLOCKED_BY_SECRET",
+    "INFRA_ALLOWLIST=UNKNOWN",
+    "PNCP_FRESHNESS=ERROR (extra-cli timers failed; shown honestly)",
+    "INTRANET_302=convenience residual until MFA",
+    "CODEX_MCP=NOT_TESTED_CLIENT_MISSING"
+  ]
+}

--- a/control-center/releases/2026-08-21-internal-production.md
+++ b/control-center/releases/2026-08-21-internal-production.md
@@ -1,0 +1,83 @@
+# Internal production evidence — 2026-08-21
+
+Campaign `CONFENGE-CONTROL-CENTER-INTERNAL-PRODUCTION-LAUNCH-01`.
+
+**FINAL_VERDICT=HUMAN_GATE_MFA_ENROLLMENT**
+
+Control Center is deployed, authenticated at the edge, persistent, and usable after founder MFA enrollment. Authelia policy requires 2FA. No TOTP or WebAuthn credential is enrolled yet. MFA was not disabled.
+
+## SHA
+
+- `PRE_RELEASE_SHA` / `RELEASE_SHA` / `DEPLOYED_SHA`: `3d5e21c344be95549cca1e9f0b5073a8efb9ff08`
+- `origin/main` matched the expected freeze SHA (no silent drift).
+- Governance PR #8 remains open and was not absorbed.
+
+CI on that SHA: control-center, control-center-image-scan, commercial-authority all **success**.
+
+## Topology
+
+nginx `:443` → `127.0.0.1:18080` Caddy → Authelia `forward_auth` → web/context.
+
+- Project `confenge-control-center` on host `v2202607385716487230` (`159.195.18.88`).
+- Caddy loopback only (`18080`/`18443`). nginx still owns public 80/443.
+- MCP private + bearer. No `mcp.confenge.com.br`.
+- Postgres alias `cc-postgres`. Collector `CONTROL_CENTER_DATABASE_URL` host `cc-postgres`.
+- Reserved IPs: Caddy `10.89.0.2`, MCP `10.89.0.6`, collector `10.89.0.7`.
+- Collector starts without `Dynamic require of events`.
+
+## Auth / MFA
+
+- Unauthenticated `https://ops.confenge.com.br/` → 302 to Authelia.
+- `https://auth.ops.confenge.com.br/` 200, TLS Let's Encrypt through 2026-11-19.
+- Operators require 2FA (policy). `totp_configurations=0`, `webauthn_credentials=0`.
+- Operator user enabled. Recover bootstrap password only from `/root/.confenge/control-center/bootstrap-operator-password` (mode 0600). Never git/logs.
+
+Enrollment:
+
+1. Open https://auth.ops.confenge.com.br/
+2. Authenticate with bootstrap operator user/password from that path.
+3. Register TOTP or WebAuthn/passkey.
+4. Validate login to https://ops.confenge.com.br/
+5. Return to this campaign / re-run the goal.
+
+## Data plane
+
+- Migrations: `001_init`, `002_current_state`, `003_durable_operational_data_plane`.
+- Governance bootstrap: 74 candidates, 0 unclassifiable; apply-1 inserted 74; apply-2 inserted 0 / skipped 74.
+- Required `/v1/*` endpoints 200 with `scope=company` (attention also needs `horizon=today`). None 404.
+- Directive smoke ids created; agent POST decision → 403 `agent_mutation_forbidden`.
+- MCP `report_session_result` / `report_blocker` → AgentActivity ids listed in the JSON companion.
+
+Collectors (honest):
+
+| Source | Status | Freshness |
+| --- | --- | --- |
+| github | DONE | FRESH |
+| infra | UNKNOWN | UNKNOWN (`missing_credentials` / allowlist) |
+| pncp | DONE | ERROR (extra-cli timers failed; not flipped to FRESH) |
+| warmbly | FAILED | ERROR (`missing_credentials`) |
+| asaas | FAILED | ERROR (`missing_credentials`) |
+
+## Durability
+
+- Encrypted backup + restore to a **new** postgres volume: `same_content=true`, ciphertext ≠ plaintext. Backup kept under `/var/backups/confenge-control-center/encrypted/`.
+- Restart of Control Center services only: all healthy; directives, AgentActivity, observations persist. Warmbly not restarted.
+
+## Warmbly / API
+
+- Warmbly SHA `93dd039d7b9b310458beff8a6bd8819a61da6399`, backend `92e98e3217ad…`, restarts=0.
+- `/ready` live=true ready=true. `CONFENGE_AUTO_SEND_ENABLED=false`.
+- `https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health` READY, `auto_send_enabled=false`.
+- `WARMBLY_REGRESSION=false`. `ASAAS_MUTATIONS=0`. `COMMERCIAL_SENDS=0`.
+
+## Intranet
+
+Not activated. Convenience residual until `OPS_HOST_AUTHENTICATED_AND_HEALTHY=true` (MFA).
+
+## Residuals
+
+- HUMAN_GATE_MFA_ENROLLMENT
+- Asaas read / Warmbly read BLOCKED_BY_SECRET (shown as ERROR, not FRESH)
+- Infra allowlist UNKNOWN
+- PNCP ERROR honest
+- Codex MCP client NOT_TESTED_CLIENT_MISSING

--- a/control-center/security/docs/production-edge/DNS-ACME-HANDOFF.md
+++ b/control-center/security/docs/production-edge/DNS-ACME-HANDOFF.md
@@ -1,6 +1,8 @@
-# DNS / ACME handoff (not executed in this campaign)
+# DNS / ACME handoff
 
-This file is a human gate. Do **not** create DNS records, run certbot, reload host nginx, or claim `DEPLOYED` from this campaign.
+**Superseded as a hard refuse.** Canonical production operations: `control-center/deploy/PRODUCTION-RUNBOOK.md`.
+
+DNS A records for `ops` / `auth.ops` and host nginx ACME **are** part of internal production apply. This file remains the record layout and ACME order. Do **not** create `mcp.confenge.com.br`.
 
 ## Records
 
@@ -30,4 +32,4 @@ Never invert this order. Never let Caddy bind host `80`/`443`.
 
 ## Status
 
-This campaign stops at `READY_FOR_CONTROLLED_APPLY`. Secrets, DNS, and certificates remain explicit human gates.
+Production-edge apply is authorized. Secrets remain host-only (never git). DNS/certificates follow the order below and `PRODUCTION-RUNBOOK.md`.

--- a/control-center/security/docs/production-edge/README.md
+++ b/control-center/security/docs/production-edge/README.md
@@ -14,4 +14,6 @@ MCP is internal (ccnet/loopback), bearer token only, no Authelia cookie, no publ
 
 The open reference `control-center/deploy/Caddyfile` (no `forward_auth`) is **not** the production pack.
 
-This campaign does not apply DNS, certbot, nginx reload, or `compose up` of project `confenge-control-center`. Isolated rehearsal uses `--project-name cc-edge-rehearsal` and high ports only.
+**Superseded for apply/refuse.** Canonical production operations: `control-center/deploy/PRODUCTION-RUNBOOK.md`.
+
+Isolated rehearsal still uses `--project-name cc-edge-rehearsal` and high ports only. Production compose project is `confenge-control-center`.

--- a/control-center/security/production/secrets/generate-local.sh
+++ b/control-center/security/production/secrets/generate-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Generate production-edge secrets into a gitignored directory.
 # Writes mode 0600 files. Prints no secret values. Refuses placeholders.
-# Must not run in CI. This campaign does not apply the generated material.
+# Must not run in CI. Generated material is for production-edge apply on the host only.
 set -euo pipefail
 set +x
 export PS4="${PS4-}"
@@ -94,7 +94,12 @@ BACKUP_KEY="$(rand_hex 32)"
 MCP_TOKEN="$(rand_hex 32)"
 FOUNDER_ID="$(rand_hex 16)"
 if [[ -z "${CC_OPERATOR_PASSWORD:-}" ]]; then
-  refuse "HUMAN_GATE_OPERATOR_PASSWORD: CC_OPERATOR_PASSWORD must be supplied by the operator over a local secure channel; refusing to invent an unrecoverable password"
+  BOOTSTRAP_PW_FILE="${CC_OPERATOR_PASSWORD_FILE:-/root/.confenge/control-center/bootstrap-operator-password}"
+  if [[ -f "$BOOTSTRAP_PW_FILE" && -r "$BOOTSTRAP_PW_FILE" ]]; then
+    CC_OPERATOR_PASSWORD="$(cat "$BOOTSTRAP_PW_FILE")"
+  else
+    refuse "HUMAN_GATE_OPERATOR_PASSWORD: CC_OPERATOR_PASSWORD must be supplied by the operator over a local secure channel, or present at ${BOOTSTRAP_PW_FILE}; refusing to invent an unrecoverable password"
+  fi
 fi
 if is_placeholder "$CC_OPERATOR_PASSWORD"; then
   refuse "refusing placeholder CC_OPERATOR_PASSWORD"

--- a/control-center/security/tests/production-edge.test.ts
+++ b/control-center/security/tests/production-edge.test.ts
@@ -340,10 +340,31 @@ describe("production-edge security bundle", () => {
     const operatorPassword = "cc-operator-test-only-not-for-production";
     const missing = spawnSync("bash", [GENERATOR, dest], {
       encoding: "utf8",
-      env: { ...process.env, CI: "", GITHUB_ACTIONS: "", CC_OPERATOR_PASSWORD: "" },
+      env: {
+        ...process.env,
+        CI: "",
+        GITHUB_ACTIONS: "",
+        CC_OPERATOR_PASSWORD: "",
+        CC_OPERATOR_PASSWORD_FILE: "/no/such/bootstrap-operator-password",
+      },
     });
     assert.notEqual(missing.status, 0);
     assert.match(missing.stderr, /HUMAN_GATE_OPERATOR_PASSWORD/);
+    const bootstrapFile = path.join(dest, "bootstrap-operator-password");
+    writeFileSync(bootstrapFile, `${operatorPassword}\n`, { mode: 0o600 });
+    const fromFile = spawnSync("bash", [GENERATOR, dest], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CI: "",
+        GITHUB_ACTIONS: "",
+        CC_OPERATOR_PASSWORD: "",
+        CC_OPERATOR_PASSWORD_FILE: bootstrapFile,
+      },
+    });
+    assert.equal(fromFile.status, 0, fromFile.stderr);
+    assert.doesNotMatch(fromFile.stdout, new RegExp(operatorPassword));
+    assert.doesNotMatch(fromFile.stderr, new RegExp(operatorPassword));
     const ok = spawnSync("bash", [GENERATOR, dest], {
       encoding: "utf8",
       env: { ...process.env, CI: "", GITHUB_ACTIONS: "", CC_OPERATOR_PASSWORD: operatorPassword },


### PR DESCRIPTION
## Summary

Canonical production runbook for the Control Center production-edge hop (nginx `:443` → loopback Caddy → Authelia `forward_auth`). Host generator may read `/root/.confenge/control-center/bootstrap-operator-password`. Records internal production evidence.

Does **not** change the deployed `RELEASE_SHA` (`3d5e21c344be95549cca1e9f0b5073a8efb9ff08`). Governance PR #8 is untouched.

## Verdict on the live host

`FINAL_VERDICT=HUMAN_GATE_MFA_ENROLLMENT`

Authelia 2FA is enforced. Founder TOTP/WebAuthn is not enrolled. Password path (value never in git): `/root/.confenge/control-center/bootstrap-operator-password`

## Test plan

- [x] `npx tsx --test deploy/tests/docs.test.ts deploy/tests/production-edge.test.ts security/tests/production-edge.test.ts`
- CI control-center + image-scan + commercial-authority on this PR