### PR TITLE
fix(control-center): inject founder actor into production web

### DIFF
--- a/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
+++ b/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
@@ -272,6 +272,8 @@ services:
       HOST: 0.0.0.0
       PORT: "8080"
       CC_TRUSTED_PROXY_CIDRS: "${CC_TRUSTED_PROXY_CIDRS:?CC_TRUSTED_PROXY_CIDRS must be set}"
+      CC_ACTOR_KIND: human
+      CC_ACTOR_ID: "${CONTROL_CENTER_FOUNDER_ACTOR_ID:?CONTROL_CENTER_FOUNDER_ACTOR_ID must be set}"
     networks:
       cc_edge:
         ipv4_address: 10.89.0.5

--- a/control-center/deploy/tests/production-edge.test.ts
+++ b/control-center/deploy/tests/production-edge.test.ts
@@ -140,6 +140,12 @@ test("production-edge compose publishes loopback Caddy only, unpublished datasto
     assert.match(probe, /node-http-probe\.mjs/, `${name} healthcheck`);
     assert.doesNotMatch(probe, /wget|curl|npx/, `${name} healthcheck`);
   }
+  const web = doc.services.web;
+  assert.ok(isRecord(web));
+  const webEnv = isRecord(web.environment) ? web.environment : {};
+  assert.equal(String(webEnv.CC_ACTOR_KIND ?? ""), "human");
+  assert.match(String(webEnv.CC_ACTOR_ID ?? ""), /CONTROL_CENTER_FOUNDER_ACTOR_ID/);
+  assert.doesNotMatch(String(webEnv.CC_ACTOR_ID ?? ""), /human:operator/);
 });
 
 test("Warmbly collector override adds only an external network and no datastore volumes", () => {
@@ -294,4 +300,7 @@ test("docker compose config of the production-edge overlay interpolates loopback
   assert.match(result.stdout, /redis:7-alpine/);
   assert.match(result.stdout, /authelia/);
   assert.match(result.stdout, /internal: true/);
+  assert.match(result.stdout, /CC_ACTOR_KIND: human/);
+  assert.match(result.stdout, /interpolation-only-founder/);
+  assert.doesNotMatch(result.stdout, /human:operator/);
 });


### PR DESCRIPTION
## Summary

After Authelia TOTP, the cockpit HTML loaded but `/v1/*` returned 401 because the web fallback actor is `human:operator`, which is not `CONTROL_CENTER_FOUNDER_ACTOR_ID`.

Wire `CC_ACTOR_ID`/`CC_ACTOR_KIND` from the founder secret in the production-edge compose. Tests freeze that interpolation.

Does not change Authelia/MFA policy. PR #8 untouched.

## Test plan

- [x] `npx tsx --test deploy/tests/production-edge.test.ts`
- Live: HTML meta matches founder secret; `GET /v1/today?scope=company` 200 as founder