### PR TITLE
fix(control-center): persist Warmbly snapshots under the 512KiB cap

### DIFF
--- a/control-center/connectors/runner/src/persist-payload.ts
+++ b/control-center/connectors/runner/src/persist-payload.ts
@@ -1,0 +1,99 @@
+import {
+  MAX_JSON_BYTES,
+  stripSecretOrPiiKeys,
+} from "@confenge/control-center-persistence";
+
+export const PERSIST_ARRAY_CAP = 50;
+
+function asObject(value: unknown): Record<string, unknown> {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return { value: value ?? null };
+}
+
+function byteSize(value: unknown): number {
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function capArrays(value: unknown, cap: number): unknown {
+  if (Array.isArray(value)) {
+    return value.slice(0, cap).map((item) => capArrays(item, cap));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = capArrays(child, cap);
+    }
+    return out;
+  }
+  return value;
+}
+
+function largestDroppableKey(obj: Record<string, unknown>): string | undefined {
+  let best: { key: string; size: number } | undefined;
+  for (const [key, child] of Object.entries(obj)) {
+    if (key === "_persist_truncation") continue;
+    const size = byteSize(child);
+    if (!best || size > best.size) {
+      best = { key, size };
+    }
+  }
+  return best?.key;
+}
+
+/**
+ * Persistence rejects JSON payloads over 512KiB and any leftover PII keys.
+ * Strip secrets, cap large arrays, then drop the largest remaining keys
+ * until the object fits. Record the truncation so the gap is honest.
+ */
+export function fitPersistPayload(
+  payload: unknown,
+  maxBytes = MAX_JSON_BYTES,
+): Record<string, unknown> {
+  const stripped = stripSecretOrPiiKeys(payload);
+  let current = asObject(stripped);
+  const originalBytes = byteSize(current);
+  if (originalBytes <= maxBytes) {
+    return current;
+  }
+
+  const droppedKeys: string[] = [];
+  let arraysCapped = false;
+  const capped = capArrays(current, PERSIST_ARRAY_CAP);
+  if (byteSize(capped) < originalBytes) {
+    arraysCapped = true;
+    current = asObject(capped);
+  }
+
+  const meta = (): Record<string, unknown> => ({
+    reason: "payload_exceeds_persist_limit",
+    original_bytes: originalBytes,
+    limit_bytes: maxBytes,
+    arrays_capped: arraysCapped,
+    array_cap: PERSIST_ARRAY_CAP,
+    dropped_keys: droppedKeys,
+  });
+
+  const withMeta = (): Record<string, unknown> => ({
+    ...current,
+    _persist_truncation: meta(),
+  });
+
+  while (byteSize(withMeta()) > maxBytes) {
+    const dropKey = largestDroppableKey(current);
+    if (!dropKey) {
+      break;
+    }
+    droppedKeys.push(dropKey);
+    const next = { ...current };
+    delete next[dropKey];
+    current = next;
+  }
+
+  return withMeta();
+}

--- a/control-center/connectors/runner/src/persist.ts
+++ b/control-center/connectors/runner/src/persist.ts
@@ -1,9 +1,9 @@
 import {
   canonicalObservationIdempotencyKey,
   canonicalSnapshotIdempotencyKey,
-  stripSecretOrPiiKeys,
   type Persistence,
 } from "@confenge/control-center-persistence";
+import { fitPersistPayload } from "./persist-payload.ts";
 import { projectCollector } from "./projectors/project.ts";
 import type { CollectorEnvelope, CollectorName } from "./run.ts";
 
@@ -35,11 +35,20 @@ function scopeFor(collector: CollectorName): string {
 }
 
 function payloadObject(payload: unknown): Record<string, unknown> {
-  const stripped = stripSecretOrPiiKeys(payload);
-  if (stripped !== null && typeof stripped === "object" && !Array.isArray(stripped)) {
-    return stripped as Record<string, unknown>;
-  }
-  return { value: stripped ?? null };
+  return fitPersistPayload(payload);
+}
+
+function logPersistFailure(stage: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(
+    `${JSON.stringify({
+      ts: new Date().toISOString(),
+      component: "control-center-collector",
+      event: "persist_failed",
+      stage,
+      error: message.slice(0, 512),
+    })}\n`,
+  );
 }
 
 export async function persistSourceResult(
@@ -82,8 +91,9 @@ export async function persistSourceResult(
       freshnessStatus: envelope.freshness_status,
       confidence: envelope.confidence,
     });
-  } catch {
+  } catch (error) {
     observationFailed = true;
+    logPersistFailure("observation", error);
   }
 
   const projections = projectCollector(envelope);
@@ -105,8 +115,9 @@ export async function persistSourceResult(
         confidence: projectedSnapshot.confidence,
       });
       projected += 1;
-    } catch {
+    } catch (error) {
       snapshotFailed = true;
+      logPersistFailure(`snapshot:${projectedSnapshot.snapshot_kind}`, error);
     }
   }
 

--- a/control-center/connectors/runner/src/projectors/commercial.ts
+++ b/control-center/connectors/runner/src/projectors/commercial.ts
@@ -159,7 +159,9 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
   const intelExceptions = asArray(
     nested.intel_exceptions ?? payload.intel_exceptions ?? payload.confenge_intel_exceptions,
   );
-  const exceptions = capList(mergeExceptions(intelExceptions, attention, observedAt));
+  const mergedExceptions = mergeExceptions(intelExceptions, attention, observedAt);
+  const exceptionsTotal = mergedExceptions.length;
+  const exceptions = capList(mergedExceptions);
 
   const status = asRecord(payload.confenge_status) ?? asRecord(asRecord(payload.health)?.confenge_status) ?? {};
   const autoSend =
@@ -192,7 +194,8 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
     },
     auto_send: autoSend,
     overview: {
-      exceptions: exceptions.length,
+      exceptions: exceptionsTotal,
+      exceptions_shown: exceptions.length,
       overdue_work: integerOrUndefined(asRecord(payload.counts)?.tasks_overdue),
       inbound_requiring_attention: integerOrUndefined(asRecord(payload.counts)?.inbound_now),
       opportunities_requiring_action: pipeline.filter((row) => row.status === "open").length,
@@ -204,7 +207,9 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
     intel: {
       scoreboard: scoreboardPresent(scoreboard) ? scoreboard : null,
       executive: asRecord(executive) ? stripIdentity(asRecord(executive) as Record<string, unknown>) : null,
-      exceptions: intelExceptionsPresent ? intelExceptions : null,
+      exceptions: intelExceptionsPresent ? capList(intelExceptions) : null,
+      exceptions_total: intelExceptionsPresent ? intelExceptions.length : 0,
+      exceptions_capped: intelExceptionsPresent && intelExceptions.length > LIST_CAP,
       organic_scoreboard: organicPresent(organic) ? organic : null,
     },
     growth: growthFromIntel(scoreboard, executive, organic, observedAt),

--- a/control-center/connectors/runner/tests/persist-payload.test.ts
+++ b/control-center/connectors/runner/tests/persist-payload.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  assertSanitizedJson,
+  MAX_JSON_BYTES,
+} from "@confenge/control-center-persistence";
+import { fitPersistPayload, PERSIST_ARRAY_CAP } from "../src/persist-payload.ts";
+
+test("small payloads pass through without truncation metadata", () => {
+  const fitted = fitPersistPayload({
+    counts: { deals_open: 1 },
+    email: "founder@example.com",
+    nested: { phone: "+5511999999999", company: "Acme" },
+  });
+  assert.equal("email" in fitted, false);
+  assert.equal("phone" in (fitted.nested as Record<string, unknown>), false);
+  assert.equal((fitted.nested as { company: string }).company, "Acme");
+  assert.equal("_persist_truncation" in fitted, false);
+  assertSanitizedJson(fitted, "small");
+});
+
+test("oversized intel exception lists are capped under the persist byte limit", () => {
+  const exceptions = Array.from({ length: 500 }, (_, i) => ({
+    id: `ex-${i}`,
+    code: "orphan_chain",
+    reason: "lead without deal ".repeat(40),
+    next_action: "review pipeline and owner",
+    status: "open",
+    identity: { kind: "lead", id: `lead-${i}` },
+    allowed_actions: ["ack", "snooze", "assign"],
+  }));
+  const today = {
+    summary: { inferred_emails: ["a@example.com"], note: "x".repeat(40_000) },
+    actions: Array.from({ length: 300 }, (_, i) => ({
+      id: `act-${i}`,
+      title: "follow up ".repeat(50),
+    })),
+    lanes: { a: "y".repeat(80_000) },
+  };
+  const raw = {
+    operations: { intel_exceptions: exceptions, intel_organic_scoreboard: { windows: ["z".repeat(1_000)] } },
+    confenge_today: today,
+    email: "leak@example.com",
+  };
+  const original = JSON.stringify(raw).length;
+  assert.ok(original > MAX_JSON_BYTES, `fixture must exceed persist limit, got ${original}`);
+
+  const fitted = fitPersistPayload(raw);
+  const bytes = JSON.stringify(fitted).length;
+  assert.ok(bytes <= MAX_JSON_BYTES, `fitted payload is ${bytes} bytes`);
+  assert.equal("email" in fitted, false);
+  const truncation = fitted._persist_truncation as {
+    reason: string;
+    original_bytes: number;
+    arrays_capped: boolean;
+    array_cap: number;
+  };
+  assert.ok(truncation);
+  assert.equal(truncation.reason, "payload_exceeds_persist_limit");
+  assert.equal(truncation.array_cap, PERSIST_ARRAY_CAP);
+  assert.equal(truncation.arrays_capped, true);
+  const ops = fitted.operations as { intel_exceptions: unknown[] };
+  assert.ok(Array.isArray(ops.intel_exceptions));
+  assert.ok(ops.intel_exceptions.length <= PERSIST_ARRAY_CAP);
+  assertSanitizedJson(fitted, "fitted");
+});

--- a/control-center/connectors/runner/tests/persist-project.test.ts
+++ b/control-center/connectors/runner/tests/persist-project.test.ts
@@ -51,3 +51,40 @@ test("collector envelope projects to commercial snapshot_kind consumed by latest
   });
   assert.equal(replay.status, "DONE");
 });
+
+test("oversized Warmbly observation still persists a commercial snapshot", async () => {
+  const observedAt = "2026-08-21T16:00:00.000Z";
+  const intelExceptions = Array.from({ length: 400 }, (_, i) => ({
+    id: `ex-${i}`,
+    code: "orphan_chain",
+    reason: "lead without deal ".repeat(40),
+    next_action: "review",
+    status: "open",
+  }));
+  const result = await persistSourceResult(ctx.persistence, {
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: observedAt,
+    source: { system: "warmbly", kind: "collector-runner", locator: "warmbly-large" },
+    confidence: 0.8,
+    payload: {
+      counts: { deals_open: 1, inbound_now: 0 },
+      operations: { intel_exceptions: intelExceptions, deals: [{ id: "d-large", name: "Acme", status: "open" }] },
+      confenge_today: { lanes: { blob: "n".repeat(200_000) }, actions: intelExceptions },
+    },
+  });
+  assert.equal(result.status, "DONE");
+  assert.equal(result.errorCode, null);
+  const latest = await ctx.pool.query<{ snapshot_type: string }>(
+    `SELECT snapshot_type FROM control_center.v_latest_operational_snapshots
+     WHERE snapshot_type = 'commercial' AND source_locator = 'warmbly-large'`,
+  );
+  assert.equal(latest.rowCount, 1);
+  const observation = await ctx.pool.query<{ payload: { _persist_truncation?: { reason?: string } } }>(
+    `SELECT payload FROM control_center.source_observations
+     WHERE observation_kind = 'warmbly-collect' AND source_locator = 'warmbly-large'
+     ORDER BY observed_at DESC LIMIT 1`,
+  );
+  assert.equal(observation.rowCount, 1);
+  assert.equal(observation.rows[0]?.payload._persist_truncation?.reason, "payload_exceeds_persist_limit");
+});

--- a/control-center/connectors/runner/tests/projectors.test.ts
+++ b/control-center/connectors/runner/tests/projectors.test.ts
@@ -176,6 +176,42 @@ test("reply_rate denominator is contacted count and is never substituted with po
   assert.notEqual(open.reply_rate.denominator, open.population);
 });
 
+test("intel exceptions above LIST_CAP stay capped and keep an honest total", () => {
+  const intelExceptions = Array.from({ length: 60 }, (_, i) => ({
+    id: `ex-intel-${i}`,
+    code: "orphan_chain",
+    reason: `lead without deal ${i}`,
+    next_action: "review",
+    status: "open",
+  }));
+  const projected = projectCollector({
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: now,
+    source: { system: "warmbly", kind: "collector-runner", locator: "warmbly" },
+    confidence: 0.8,
+    payload: {
+      counts: { deals_open: 1, inbound_now: 0 },
+      operations: { intel_exceptions: intelExceptions },
+    },
+  });
+  const commercial = projected.find((row) => row.snapshot_kind === "commercial");
+  assert.ok(commercial);
+  const ops = commercial.payload.operations as {
+    overview: { exceptions: number; exceptions_shown: number };
+    exceptions: unknown[];
+    intel: { exceptions: unknown[]; exceptions_total: number; exceptions_capped: boolean };
+  };
+  assert.equal(ops.overview.exceptions, 60);
+  assert.equal(ops.overview.exceptions_shown, 50);
+  assert.equal(ops.exceptions.length, 50);
+  assert.equal(ops.intel.exceptions.length, 50);
+  assert.equal(ops.intel.exceptions_total, 60);
+  assert.equal(ops.intel.exceptions_capped, true);
+  const serialized = JSON.stringify(commercial.payload);
+  assert.ok(serialized.length < 512 * 1024, `commercial snapshot is ${serialized.length} bytes`);
+});
+
 test("intel exceptions feed Commercial Exceptions and organic scoreboard feeds Crescimento", () => {
   const projected = projectCollector({
     collector: "warmbly",

--- a/control-center/connectors/warmbly/src/collector/routes.ts
+++ b/control-center/connectors/warmbly/src/collector/routes.ts
@@ -33,7 +33,8 @@ export const COLLECT_ROUTES: CollectRoute[] = [
     required: false,
   },
   { key: "contacts", method: "POST", path: "/v1/contacts/search", body: {}, required: true },
-  { key: "campaigns", method: "GET", path: "/v1/campaigns?limit=100", required: true },
+  // List is currently 500 on production Warmbly; campaigns-overview is the working read.
+  { key: "campaigns", method: "GET", path: "/v1/campaigns?limit=100", required: false },
   { key: "campaigns_overview", method: "GET", path: "/v1/campaigns-overview", required: false },
   { key: "unibox_overview", method: "GET", path: "/v1/unibox/overview", required: false },
   { key: "confenge_status", method: "GET", path: "/v1/confenge/status", required: false },

--- a/control-center/connectors/warmbly/src/mapper/normalize.ts
+++ b/control-center/connectors/warmbly/src/mapper/normalize.ts
@@ -17,6 +17,7 @@ import {
   type WarmblyPayload,
   type WarmblyTask,
 } from "../contracts/warmbly-payload.ts";
+import { COLLECT_ROUTES } from "../collector/routes.ts";
 import {
   attentionFromCampaigns,
   attentionFromConfenge,
@@ -31,6 +32,26 @@ import {
 } from "./attention.ts";
 import { provenance, rollupFreshness } from "./freshness.ts";
 import { majorUnitsToCents, sumOpenDealValue } from "./money.ts";
+
+const OPERATIONS_CAP = 50;
+
+function isRequiredPath(method: string, path: string): boolean {
+  const clean = path.split("?")[0] ?? path;
+  return COLLECT_ROUTES.some(
+    (route) =>
+      route.required &&
+      route.method === method &&
+      (route.path.split("?")[0] ?? route.path) === clean,
+  );
+}
+
+function unknownList(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (value !== null && typeof value === "object" && Array.isArray((value as { data?: unknown }).data)) {
+    return (value as { data: unknown[] }).data;
+  }
+  return [];
+}
 
 export type NormalizeOptions = {
   now?: Date;
@@ -82,8 +103,9 @@ export function collectFromWarmblyPayload(
     httpMethod: string,
   ): FreshnessStatus => {
     if (failure) {
+      const required = isRequiredPath(httpMethod, httpPath);
       const status: FreshnessStatus =
-        failure.status >= 500 ? "ERROR" : failure.status === 404 ? "UNKNOWN" : "ERROR";
+        failure.status === 404 || !required ? "UNKNOWN" : "ERROR";
       freshnessBySurface.push(status);
       observations.push(
         observation(surface, now, status, {
@@ -298,6 +320,8 @@ export function collectFromWarmblyPayload(
     uniqueContracts.set(c.id, c);
   }
 
+  const intelExceptions = unknownList(payload.confenge_intel_exceptions);
+
   const snapshot: CommercialSnapshot = {
     schema: COMMERCIAL_SNAPSHOT_SCHEMA,
     source: SNAPSHOT_SOURCE,
@@ -338,8 +362,8 @@ export function collectFromWarmblyPayload(
   snapshot.operations = {
     authority: "warmbly",
     this_document: "read_model",
-    cap: 50,
-    deals: deals.slice(0, 50).map((d) => ({
+    cap: OPERATIONS_CAP,
+    deals: deals.slice(0, OPERATIONS_CAP).map((d) => ({
       id: d.id,
       name: d.name,
       status: d.status,
@@ -357,7 +381,7 @@ export function collectFromWarmblyPayload(
       expected_close_date: d.expected_close_date,
       campaign_id: d.campaign_id,
     })),
-    tasks: tasks.slice(0, 50).map((t) => ({
+    tasks: tasks.slice(0, OPERATIONS_CAP).map((t) => ({
       id: t.id,
       title: t.title,
       status: t.status,
@@ -367,7 +391,7 @@ export function collectFromWarmblyPayload(
       created_at: t.created_at,
       updated_at: t.updated_at,
     })),
-    contacts: contacts.slice(0, 50).map((c) => ({
+    contacts: contacts.slice(0, OPERATIONS_CAP).map((c) => ({
       id: c.id,
       company: c.company,
       first_name: c.first_name,
@@ -379,7 +403,7 @@ export function collectFromWarmblyPayload(
       account_id: c.account_id ?? null,
       lead_id: c.lead_id ?? null,
     })),
-    inbound: inbound.slice(0, 50).map((row) => ({
+    inbound: inbound.slice(0, OPERATIONS_CAP).map((row) => ({
       lead_id: row.lead_id,
       company: row.company,
       person: row.person,
@@ -389,7 +413,8 @@ export function collectFromWarmblyPayload(
     })),
     intel_scoreboard: payload.confenge_intel_scoreboard ?? null,
     intel_executive: payload.confenge_intel_executive ?? null,
-    intel_exceptions: payload.confenge_intel_exceptions ?? null,
+    intel_exceptions: intelExceptions.slice(0, OPERATIONS_CAP),
+    intel_exceptions_total: intelExceptions.length,
     intel_organic_scoreboard: payload.confenge_intel_organic_scoreboard ?? null,
     confenge_status: payload.confenge_status ?? null,
   };

--- a/control-center/connectors/warmbly/tests/collect.test.ts
+++ b/control-center/connectors/warmbly/tests/collect.test.ts
@@ -105,6 +105,36 @@ describe("collectFromWarmblyPayload (shipped normalize)", () => {
     assert.ok(snapshot.attention.some((a) => a.id.includes("task-overdue-1")));
     assert.equal(snapshot.attention.some((a) => a.kind === "confenge_attention"), false);
   });
+
+  it("campaigns list 500 is a gap and does not ERROR required CRM freshness", () => {
+    const payload = loadFixture("commercial-runtime.json");
+    payload.campaigns = undefined;
+    payload.unavailable = [
+      ...(payload.unavailable ?? []),
+      {
+        method: "GET",
+        path: "/v1/campaigns",
+        status: 500,
+        reason: "Warmbly returned 500 for GET /v1/campaigns",
+      },
+    ];
+    const snapshot = collectFromWarmblyPayload(payload, { now: NOW });
+    assert.equal(snapshot.freshness_status, "FRESH");
+    const camp = snapshot.observations.find((o) => o.http_path === "/v1/campaigns");
+    assert.ok(camp);
+    assert.equal(camp.provenance.freshness_status, "UNKNOWN");
+    const exceptions = Array.from({ length: 60 }, (_, i) => ({
+      id: `ex-${i}`,
+      code: "orphan_chain",
+      reason: "lead without deal",
+    }));
+    payload.confenge_intel_exceptions = exceptions;
+    const capped = collectFromWarmblyPayload(payload, { now: NOW });
+    const stored = capped.operations?.intel_exceptions;
+    assert.ok(Array.isArray(stored));
+    assert.equal(stored.length, 50);
+    assert.equal(capped.operations?.intel_exceptions_total, 60);
+  });
 });
 
 describe("collect() against a local Warmbly-shaped stub", () => {

--- a/control-center/persistence/src/index.ts
+++ b/control-center/persistence/src/index.ts
@@ -24,6 +24,7 @@ export { expectedMigrationsPresent, pingStore, EXPECTED_MIGRATION_IDS } from './
 export {
   assertSanitizedJson,
   isSecretOrPiiKey,
+  MAX_JSON_BYTES,
   sanitizeErrorCode,
   sanitizeErrorMessage,
   stripSecretOrPiiKeys,

--- a/control-center/persistence/src/sanitize.ts
+++ b/control-center/persistence/src/sanitize.ts
@@ -3,7 +3,7 @@ import { ValidationError } from './errors.js';
 const SECRET_OR_PII_KEY =
   /(^|[_-])(password|passwd|secret|token|authorization|auth|api[_-]?key|private[_-]?key|cookie|session[_-]?id|ssn|cpf|cnpj|email|phone|telefone|credit[_-]?card|card[_-]?number|access[_-]?token|refresh[_-]?token)s?$/i;
 
-const MAX_JSON_BYTES = 512 * 1024;
+export const MAX_JSON_BYTES = 512 * 1024;
 
 export function isSecretOrPiiKey(key: string): boolean {
   const normalized = key.trim();


### PR DESCRIPTION
Post-merge production defect on Operational V1 (after PR #44).

## Production evidence
Collector run `cc:collector-run:01M0KB5V9DM4WKMXJ2GS8EN9KD` finished `PARTIAL` / `persist_partial` with `observationFailed=true`, `snapshotFailed=true`, `projected=1`.

- Live Warmbly intel reads succeeded (`/v1/confenge/intel/{scoreboard,executive,exceptions,organic-scoreboard}` all HTTP 200).
- Persistence rejects JSON over 512KiB. Combined Warmbly payload was ~757KiB; `GET /v1/confenge/intel/exceptions` alone is 362 rows / ~466KiB.
- Clients snapshot persisted (small). Commercial snapshot did not, because `operations.intel.exceptions` copied the uncapped array.
- `GET /v1/campaigns` returns 500 (`internal_error`). That optional list was `required: true`, so rollup freshness became `ERROR` / UI `UPSTREAM_ERROR` even though CRM + intel were live. `GET /v1/campaigns-overview` is 200. Warmbly is not redeployed.

## Fix
- Mapper already caps deals/tasks/contacts/inbound at 50; cap `intel_exceptions` the same way and keep `intel_exceptions_total`.
- Projector caps Commercial Exceptions / `intel.exceptions` at `LIST_CAP` and reports the real total.
- Persist fits observation/snapshot JSON under 512KiB (strip PII, cap arrays, drop largest keys) and records `_persist_truncation` instead of swallowing `ValidationError`.
- Optional upstream 5xx (including campaigns list) is a gap (`UNKNOWN`), not a snapshot-wide `ERROR`.

## Tests
- `persist-payload.test.ts` and postgres `persist-project.test.ts`: oversized Warmbly observation still writes `snapshot_kind=commercial`.
- Projector: 60 intel exceptions → 50 shown, total 60.
- Collect: campaigns 500 does not ERROR required CRM freshness.

Does not touch PR #8. Auto-send stays false. No email send.