### PR TITLE
fix(control-center): keep mapper intel_exceptions_total on commercial snapshot

### DIFF
--- a/control-center/connectors/runner/src/projectors/commercial.ts
+++ b/control-center/connectors/runner/src/projectors/commercial.ts
@@ -159,8 +159,9 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
   const intelExceptions = asArray(
     nested.intel_exceptions ?? payload.intel_exceptions ?? payload.confenge_intel_exceptions,
   );
+  const intelExceptionsTotal = declaredIntelExceptionsTotal(nested, payload, intelExceptions.length);
   const mergedExceptions = mergeExceptions(intelExceptions, attention, observedAt);
-  const exceptionsTotal = mergedExceptions.length;
+  const exceptionsTotal = Math.max(intelExceptionsTotal, mergedExceptions.length);
   const exceptions = capList(mergedExceptions);
 
   const status = asRecord(payload.confenge_status) ?? asRecord(asRecord(payload.health)?.confenge_status) ?? {};
@@ -208,12 +209,25 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
       scoreboard: scoreboardPresent(scoreboard) ? scoreboard : null,
       executive: asRecord(executive) ? stripIdentity(asRecord(executive) as Record<string, unknown>) : null,
       exceptions: intelExceptionsPresent ? capList(intelExceptions) : null,
-      exceptions_total: intelExceptionsPresent ? intelExceptions.length : 0,
-      exceptions_capped: intelExceptionsPresent && intelExceptions.length > LIST_CAP,
+      exceptions_total: intelExceptionsPresent ? intelExceptionsTotal : 0,
+      exceptions_capped: intelExceptionsPresent && intelExceptionsTotal > LIST_CAP,
       organic_scoreboard: organicPresent(organic) ? organic : null,
     },
     growth: growthFromIntel(scoreboard, executive, organic, observedAt),
   };
+}
+
+function declaredIntelExceptionsTotal(
+  nested: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  listed: number,
+): number {
+  const declared =
+    integerOrUndefined(nested.intel_exceptions_total) ?? integerOrUndefined(payload.intel_exceptions_total);
+  if (declared !== undefined && declared >= 0) {
+    return Math.max(declared, listed);
+  }
+  return listed;
 }
 
 function intelExceptionsSourcePresent(nested: Record<string, unknown>, payload: Record<string, unknown>): boolean {

--- a/control-center/connectors/runner/tests/persist-project.test.ts
+++ b/control-center/connectors/runner/tests/persist-project.test.ts
@@ -88,3 +88,40 @@ test("oversized Warmbly observation still persists a commercial snapshot", async
   assert.equal(observation.rowCount, 1);
   assert.equal(observation.rows[0]?.payload._persist_truncation?.reason, "payload_exceeds_persist_limit");
 });
+
+test("persisted commercial snapshot keeps mapper intel_exceptions_total", async () => {
+  const observedAt = "2026-08-21T17:00:00.000Z";
+  const listed = Array.from({ length: 50 }, (_, i) => ({
+    id: `ex-${i}`,
+    code: "orphan_chain",
+    reason: "lead without deal",
+    next_action: "review",
+    status: "open",
+  }));
+  const result = await persistSourceResult(ctx.persistence, {
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: observedAt,
+    source: { system: "warmbly", kind: "collector-runner", locator: "warmbly-capped-total" },
+    confidence: 0.8,
+    payload: {
+      counts: { deals_open: 0, inbound_now: 0 },
+      operations: {
+        cap: 50,
+        intel_exceptions: listed,
+        intel_exceptions_total: 362,
+      },
+    },
+  });
+  assert.equal(result.status, "DONE");
+  const latest = await ctx.pool.query<{ snapshot_json: { operations?: { overview?: { exceptions?: number }; intel?: { exceptions_total?: number; exceptions_capped?: boolean; exceptions?: unknown[] } } } }>(
+    `SELECT snapshot_json FROM control_center.v_latest_operational_snapshots
+     WHERE snapshot_type = 'commercial' AND source_locator = 'warmbly-capped-total'`,
+  );
+  assert.equal(latest.rowCount, 1);
+  const intel = latest.rows[0]?.snapshot_json.operations?.intel;
+  assert.equal(intel?.exceptions_total, 362);
+  assert.equal(intel?.exceptions_capped, true);
+  assert.equal(intel?.exceptions?.length, 50);
+  assert.equal(latest.rows[0]?.snapshot_json.operations?.overview?.exceptions, 362);
+});

--- a/control-center/connectors/runner/tests/projectors.test.ts
+++ b/control-center/connectors/runner/tests/projectors.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { collectFromWarmblyPayload } from "../../warmbly/src/mapper/normalize.ts";
 import { availabilityFromEnvelope } from "../src/projectors/availability.ts";
 import { projectCollector } from "../src/projectors/project.ts";
 import { CONFENGE_OPERATIONAL_REPOS } from "../src/projectors/types.ts";
@@ -210,6 +211,87 @@ test("intel exceptions above LIST_CAP stay capped and keep an honest total", () 
   assert.equal(ops.intel.exceptions_capped, true);
   const serialized = JSON.stringify(commercial.payload);
   assert.ok(serialized.length < 512 * 1024, `commercial snapshot is ${serialized.length} bytes`);
+});
+
+test("mapper-capped intel_exceptions keep the declared upstream total", () => {
+  const intelExceptions = Array.from({ length: 50 }, (_, i) => ({
+    id: `ex-intel-${i}`,
+    code: "orphan_chain",
+    reason: `lead without deal ${i}`,
+    next_action: "review",
+    status: "open",
+  }));
+  const projected = projectCollector({
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: now,
+    source: { system: "warmbly", kind: "collector-runner", locator: "warmbly" },
+    confidence: 0.8,
+    payload: {
+      counts: { deals_open: 1, inbound_now: 0 },
+      operations: {
+        cap: 50,
+        intel_exceptions: intelExceptions,
+        intel_exceptions_total: 362,
+      },
+    },
+  });
+  const commercial = projected.find((row) => row.snapshot_kind === "commercial");
+  assert.ok(commercial);
+  const ops = commercial.payload.operations as {
+    overview: { exceptions: number; exceptions_shown: number };
+    exceptions: unknown[];
+    intel: { exceptions: unknown[]; exceptions_total: number; exceptions_capped: boolean };
+  };
+  assert.equal(ops.intel.exceptions.length, 50);
+  assert.equal(ops.intel.exceptions_total, 362);
+  assert.equal(ops.intel.exceptions_capped, true);
+  assert.equal(ops.overview.exceptions, 362);
+  assert.equal(ops.overview.exceptions_shown, 50);
+  assert.equal(ops.exceptions.length, 50);
+});
+
+test("shipped mapper cap then projector preserves intel_exceptions_total", () => {
+  const exceptions = Array.from({ length: 62 }, (_, i) => ({
+    id: `ex-${i}`,
+    organization_id: "org",
+    code: "orphan_chain",
+    reason: "lead without deal",
+    next_action: "review",
+    status: "open",
+  }));
+  const snapshot = collectFromWarmblyPayload(
+    {
+      health: { status: "ok" },
+      pipelines: [],
+      deals: { data: [] },
+      tasks: { data: [] },
+      contacts: { data: [] },
+      confenge_intel_exceptions: exceptions,
+    },
+    { now: new Date(now) },
+  );
+  assert.equal(snapshot.operations?.intel_exceptions_total, 62);
+  assert.equal(Array.isArray(snapshot.operations?.intel_exceptions) && snapshot.operations.intel_exceptions.length, 50);
+  const projected = projectCollector({
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: now,
+    source: { system: "warmbly", kind: "collector-runner", locator: "warmbly" },
+    confidence: 0.8,
+    payload: snapshot,
+  });
+  const commercial = projected.find((row) => row.snapshot_kind === "commercial");
+  assert.ok(commercial);
+  const ops = commercial.payload.operations as {
+    overview: { exceptions: number; exceptions_shown: number };
+    intel: { exceptions: unknown[]; exceptions_total: number; exceptions_capped: boolean };
+  };
+  assert.equal(ops.intel.exceptions.length, 50);
+  assert.equal(ops.intel.exceptions_total, 62);
+  assert.equal(ops.intel.exceptions_capped, true);
+  assert.equal(ops.overview.exceptions, 62);
+  assert.equal(ops.overview.exceptions_shown, 50);
 });
 
 test("intel exceptions feed Commercial Exceptions and organic scoreboard feeds Crescimento", () => {


### PR DESCRIPTION
Follow-up to PR #45. Production mapper already writes `operations.intel_exceptions_total=362` and a 50-row cap. The projector counted only the capped array, so the FRESH commercial snapshot showed `exceptions_total=50` and `exceptions_capped=false`.

## Fix
Prefer `operations.intel_exceptions_total` when present (never below listed length). `exceptions_capped` is true when that total exceeds `LIST_CAP`. Overview exception count uses the same total.

## Tests (shipped projector + persist)
- Uncapped 60-row array still caps at 50 and keeps total 60.
- Mapper-shaped persist payload `{intel_exceptions: 50, intel_exceptions_total: 362}` keeps 362 / capped=true on `v_latest_operational_snapshots`.
- Shipped `collectFromWarmblyPayload` then `projectCollector` preserves mapper total.

Does not touch PR #8. Auto-send stays false. No email send.