### PR TITLE
feat(cc-warmbly): narrow operator action channel, hardened after adversarial review

### DIFF
--- a/control-center/connectors/warmbly/README.md
+++ b/control-center/connectors/warmbly/README.md
@@ -20,7 +20,13 @@ Canonical CRM remains Warmbly. This workstream does not persist leads/deals/stag
   Terms of the amendment:
   - There is **no generic proxy**. A caller names an action; the action owns its method, its path template and its body. No caller-supplied method or path is ever forwarded (`src/operator/actions.ts`, `src/operator/allowlist.ts`).
   - Every action requires an authenticated founder from Authelia's `Remote-User` / `Remote-Groups` / `Remote-Name` / `Remote-Email`, resolved through the existing `control-center/security` ForwardAuth contract (`parseForwardAuthIdentity` + trusted-hop check). The `ops.confenge.com.br` nginx vhost blanks any client-supplied `Remote-*`, so Authelia is the only writer. A caller cannot hand in a pre-built actor.
-  - Every path is fail-closed: unknown action, missing/spoofed/ungrouped actor, unsafe target id, missing audit reason, missing or invalid confirmation, open circuit breaker, non-2xx upstream, and transport failure all produce a **recorded refusal**. There is no branch that returns without writing a ledger entry.
+  - Every path is fail-closed: unknown action, missing/spoofed/ungrouped actor, unsafe target id, missing audit reason, missing or invalid confirmation, open circuit breaker, non-2xx upstream, and a transport failure that never left this process all produce a **recorded refusal**. There is no branch that returns without writing a ledger entry.
+  - **A written-but-unanswered call is `unknown`, never `refused`.** When the POST was already on the wire (timeout, or any failure not provably pre-flight) Warmbly may have applied it, so the outcome is recorded as `unknown` with `upstream.status: null` and `upstream.path` set, and the returned reason tells the operator to read `GET /v1/confenge/dispatch/status` before retrying. Calling that a refusal is how an operator ends up believing dispatch is paused while Warmbly is sending.
+  - **A confirmation token spent on an `unknown` stays spent.** Re-arming it would turn one observed token into a replayable resume; the operator reads dispatch status and, if still paused, mints a fresh confirmation. The `unknown` reason says so.
+  - **Redirects are never followed** (`redirect: "manual"`). A 3xx would re-issue the POST — Bearer token and body included — at a `Location` that `classifyOperatorRequest` never saw (e.g. `dispatch-now`), while the ledger recorded the allowlisted path. Any 3xx is an `upstream_error` refusal.
+  - **The ledger key is minted here.** `correlation_id` (and therefore the entry `id` and the agent-activity session) is always server-minted; a caller's own string is carried as `client_reference` and keys nothing, so replaying it can never rewrite an executed entry. While `paused_by` is missing upstream (`gaps` in `required_upstream_contract.json`) this ledger is the sole non-repudiation record.
+  - **A ledger failure is never silent.** `ledger.record` is wrapped: on failure the entry goes to a durable stderr WAL line (`cc.warmbly.operator-action.wal`) before the error is rethrown, and `createFanOutOperatorActionLedger` requires an `onSinkError` handler — `defaultOperatorSinkErrorHandler()` logs at error level with the full entry serialized.
+  - **Duplicated identity headers fail closed.** `control-center/security` returns no value for a `Remote-*` header that arrives more than once, so a client-supplied copy can never beat the proxy's.
   - `resume_dispatch` is two step because it is the action that can let traffic flow: `requestResumeConfirmation` mints a single-use, 2-minute, actor-bound and target-bound token, and `execute` refuses without it. `pause_dispatch` is one step and is never confirmation-gated.
   - Operator writes are **never retried** (a retried acknowledge would double-acknowledge). 4xx from Warmbly does not trip the circuit breaker; 5xx/429/timeout does.
   - The channel may share the read client's `CircuitBreaker`, so a degraded Warmbly blocks operator writes too. When the breaker is open, the refusal names the out-of-band fallback: `deploy/confenge-vps/pause.sh` on the VPS.
@@ -67,13 +73,20 @@ import {
   createFanOutOperatorActionLedger,
   createMemoryOperatorActionLedger,
   createOperatorHttpHandler,
+  defaultOperatorSinkErrorHandler,
 } from "@confenge/control-center-warmbly-connector";
 
 const client = new WarmblyOperatorClient({ baseUrl, token, breaker: readClient.breaker });
 const memory = createMemoryOperatorActionLedger();
 const channel = createWarmblyOperatorChannel({
   client,
-  ledger: createFanOutOperatorActionLedger(memory, [createAgentActivityLedgerSink(agentLedger)]),
+  // onSinkError is required: a mirror that fails silently is an executed
+  // action with no visible timeline row and no error.
+  ledger: createFanOutOperatorActionLedger(
+    memory,
+    [createAgentActivityLedgerSink(agentLedger)],
+    defaultOperatorSinkErrorHandler(),
+  ),
 });
 
 await channel.pauseDispatch({ request, reason: "spike de bounce" });        // one step
@@ -91,11 +104,12 @@ One `control-center.warmbly-operator-action.v1` entry per call, on success and o
 ```json
 {
   "schema_version": "control-center.warmbly-operator-action.v1",
-  "id": "cc:warmbly-operator-action:<correlation_id>",
+  "id": "cc:warmbly-operator-action:<minted correlation_id>",
   "correlation_id": "cc:warmbly-op:<uuid>",
+  "client_reference": "<the caller's own string, or null — keys nothing>",
   "requested_action": "pause_dispatch",
   "action": "pause_dispatch",
-  "outcome": "executed | refused | challenged",
+  "outcome": "executed | refused | challenged | unknown",
   "refusal_code": null,
   "refusal_reason": null,
   "actor": { "kind": "founder", "id": "<Remote-User>", "display_name": "<Remote-Name>" },
@@ -112,7 +126,11 @@ One `control-center.warmbly-operator-action.v1` entry per call, on success and o
 }
 ```
 
-`Remote-Email` never enters the record; the actor id is the `Remote-User` handle. `createAgentActivityLedgerSink` mirrors each entry into `control-center/domains/agent-activity` as a start + report pair (`executed → DONE`, `challenged → PARTIAL`, `refused → BLOCKED`; identity kind `human` → ledger kind `founder`), so operator actions appear on the same timeline as agent runs.
+`confirmation.token_id` is `cnf:<action>:<target_id>:<uuid>` — unique per challenge, so the ledger shows which challenge was spent and how many were minted and abandoned. The audit reason is bound to the challenge by hash: a token confirmed under one reason cannot be executed under another.
+
+`Remote-Email` never enters the record; the actor id is the `Remote-User` handle. `createAgentActivityLedgerSink` mirrors each entry into `control-center/domains/agent-activity` as a start + report pair (`executed → DONE`, `challenged → PARTIAL`, `refused → BLOCKED`, `unknown → UNKNOWN`; identity kind `human` → ledger kind `founder`), so operator actions appear on the same timeline as agent runs. The session is keyed by the minted `correlation_id`, so a replayed `client_reference` cannot revise an existing row.
+
+An `unknown` outcome is answered over HTTP as `503 {"outcome":"unknown","code":"transport_unknown"}`; the reason names `GET /v1/confenge/dispatch/status` as the only thing that settles it.
 
 ## Env vars (names only)
 

--- a/control-center/connectors/warmbly/README.md
+++ b/control-center/connectors/warmbly/README.md
@@ -1,6 +1,6 @@
 # Warmbly connector (Control Center)
 
-Read-only adapter that turns Warmbly's commercial runtime into a `CommercialSnapshot` plus `observations` so the cockpit can answer **o que exige atenção comercial** without owning the CRM pipeline.
+Read-only adapter that turns Warmbly's commercial runtime into a `CommercialSnapshot` plus `observations` so the cockpit can answer **o que exige atenção comercial** without owning the CRM pipeline — plus one narrow, named **operator action channel** (`src/operator/`) for three operational controls.
 
 Canonical CRM remains Warmbly. This workstream does not persist leads/deals/stages as Control Center source of truth.
 
@@ -8,8 +8,23 @@ Canonical CRM remains Warmbly. This workstream does not persist leads/deals/stag
 
 - Governance is strategic/canonical; Warmbly is operational commercial/CRM authority.
 - HTTP is fail-closed: timeouts, exponential backoff, circuit breaker, method allowlist.
-- Allowed methods: `GET`/`HEAD` of discovered commercial reads; `POST` only for Warmbly's existing `/search` and `/summary` on contacts, deals, and tasks (read queries that must not change stub/upstream state).
-- Forbidden: `PATCH`/`PUT`/`DELETE`, creating contacts/deals/tasks, campaign start/stop/send, Confenge import/enroll/bootstrap/dispatch, unibox reply/compose, any Asaas/financial mutation.
+- **Collect path (`src/http/`) stays read-only.** Allowed methods: `GET`/`HEAD` of discovered commercial reads; `POST` only for Warmbly's existing `/search` and `/summary` on contacts, deals, and tasks (read queries that must not change stub/upstream state). `classifyRequest` still denies every operator write path listed below, so the read client can never reach one.
+- **Amended boundary (operator action channel).** The earlier blanket "no writes" decision is deliberately amended for exactly three named, individually typed operational controls, and for nothing else:
+
+  | Action | Method + path | Confirmation | Effect |
+  | --- | --- | --- | --- |
+  | `pause_dispatch` | `POST /v1/confenge/dispatch/pause` | one step | engage the CONFENGE outbound kill switch |
+  | `resume_dispatch` | `POST /v1/confenge/dispatch/resume` | **two step** | release the kill switch |
+  | `acknowledge_inbound_alert` | `POST /v1/confenge/inbound/{lead_id}/acknowledge` | one step | mark one inbound alert as seen by a human |
+
+  Terms of the amendment:
+  - There is **no generic proxy**. A caller names an action; the action owns its method, its path template and its body. No caller-supplied method or path is ever forwarded (`src/operator/actions.ts`, `src/operator/allowlist.ts`).
+  - Every action requires an authenticated founder from Authelia's `Remote-User` / `Remote-Groups` / `Remote-Name` / `Remote-Email`, resolved through the existing `control-center/security` ForwardAuth contract (`parseForwardAuthIdentity` + trusted-hop check). The `ops.confenge.com.br` nginx vhost blanks any client-supplied `Remote-*`, so Authelia is the only writer. A caller cannot hand in a pre-built actor.
+  - Every path is fail-closed: unknown action, missing/spoofed/ungrouped actor, unsafe target id, missing audit reason, missing or invalid confirmation, open circuit breaker, non-2xx upstream, and transport failure all produce a **recorded refusal**. There is no branch that returns without writing a ledger entry.
+  - `resume_dispatch` is two step because it is the action that can let traffic flow: `requestResumeConfirmation` mints a single-use, 2-minute, actor-bound and target-bound token, and `execute` refuses without it. `pause_dispatch` is one step and is never confirmation-gated.
+  - Operator writes are **never retried** (a retried acknowledge would double-acknowledge). 4xx from Warmbly does not trip the circuit breaker; 5xx/429/timeout does.
+  - The channel may share the read client's `CircuitBreaker`, so a degraded Warmbly blocks operator writes too. When the breaker is open, the refusal names the out-of-band fallback: `deploy/confenge-vps/pause.sh` on the VPS.
+- **Still forbidden, through this channel or any other:** `PATCH`/`PUT`/`DELETE` on any path, creating contacts/deals/tasks, campaign start/stop/send, `dispatch-now` / cohort dispatch, enroll, approve-content, draft send, `POST /v1/confenge/inbound/:id/outcome` and `/resolve`, Confenge import/sync/bootstrap, unibox reply/compose/snooze, and **any Asaas / checkout / refund / financial mutation** (`commercial/authority/authority-manifest.v1.json` still carries `real_money_mutation_approved: false`).
 - Every aggregated item carries `source`, `observed_at` (UTC), `freshness_status`, and `confidence` when the upstream payload supplies it.
 - Deal money is integer **cents** + `currency`. Warmbly `value` is treated as major units (1500.50 BRL → 150050 cents).
 - No `GET /leads` exists on Warmbly. Contacts search + Confenge inbound (when enabled) are the lead surface. The gap is documented in `required_upstream_contract.json`.
@@ -39,6 +54,65 @@ See `required_upstream_contract.json` for the full table. Collect calls:
 | GET | `/v1/confenge/inbound` | inbound leads needing a human |
 
 Auth: `Authorization: Bearer <token>` and `API-Version: v1`. Tokens are prefixed `wmbly_`.
+
+## Operator action channel (`src/operator/`)
+
+The only write surface in this connector. Read `required_upstream_contract.json → operator_actions` for the upstream table.
+
+```ts
+import {
+  WarmblyOperatorClient,
+  createWarmblyOperatorChannel,
+  createAgentActivityLedgerSink,
+  createFanOutOperatorActionLedger,
+  createMemoryOperatorActionLedger,
+  createOperatorHttpHandler,
+} from "@confenge/control-center-warmbly-connector";
+
+const client = new WarmblyOperatorClient({ baseUrl, token, breaker: readClient.breaker });
+const memory = createMemoryOperatorActionLedger();
+const channel = createWarmblyOperatorChannel({
+  client,
+  ledger: createFanOutOperatorActionLedger(memory, [createAgentActivityLedgerSink(agentLedger)]),
+});
+
+await channel.pauseDispatch({ request, reason: "spike de bounce" });        // one step
+const step1 = await channel.requestResumeConfirmation({ request, reason: "incidente resolvido" });
+await channel.resumeDispatch({ request, reason: "incidente resolvido", confirmation_token });
+await channel.acknowledgeInboundAlert({ request, target_id: "lead-2f7c" });
+```
+
+`request` is `{ remoteAddress, headers }` from the inbound HTTP request — nothing else. `createOperatorHttpHandler(channel)` mounts four POST-only routes (`/v1/warmbly/operator/dispatch/pause`, `.../resume/confirm`, `.../resume`, `/v1/warmbly/operator/inbound/acknowledge`) and maps refusals to 400/401/403/428/502/503; a refusal is never rendered as a success.
+
+### Ledger record
+
+One `control-center.warmbly-operator-action.v1` entry per call, on success and on refusal alike:
+
+```json
+{
+  "schema_version": "control-center.warmbly-operator-action.v1",
+  "id": "cc:warmbly-operator-action:<correlation_id>",
+  "correlation_id": "cc:warmbly-op:<uuid>",
+  "requested_action": "pause_dispatch",
+  "action": "pause_dispatch",
+  "outcome": "executed | refused | challenged",
+  "refusal_code": null,
+  "refusal_reason": null,
+  "actor": { "kind": "founder", "id": "<Remote-User>", "display_name": "<Remote-Name>" },
+  "target": { "kind": "dispatch", "id": "confenge-dispatch" },
+  "upstream": { "method": "POST", "path": "/v1/confenge/dispatch/pause", "status": 200 },
+  "confirmation": { "required": false, "satisfied": false, "token_id": null },
+  "circuit_state": "closed",
+  "reason": "spike de bounce",
+  "recorded_at": "2026-08-22T12:00:00.000Z",
+  "source": { "system": "control-center", "kind": "warmbly-operator-action", "locator": "cc:warmbly-op:<uuid>" },
+  "observed_at": "2026-08-22T12:00:00.000Z",
+  "freshness_status": "FRESH",
+  "confidence": 1
+}
+```
+
+`Remote-Email` never enters the record; the actor id is the `Remote-User` handle. `createAgentActivityLedgerSink` mirrors each entry into `control-center/domains/agent-activity` as a start + report pair (`executed → DONE`, `challenged → PARTIAL`, `refused → BLOCKED`; identity kind `human` → ledger kind `founder`), so operator actions appear on the same timeline as agent runs.
 
 ## Env vars (names only)
 

--- a/control-center/connectors/warmbly/package.json
+++ b/control-center/connectors/warmbly/package.json
@@ -2,7 +2,7 @@
   "name": "@confenge/control-center-warmbly-connector",
   "version": "0.1.0",
   "private": true,
-  "description": "Read-only Warmbly adapter that yields CommercialSnapshot + observations for the Confenge Control Center cockpit.",
+  "description": "Warmbly adapter for the Confenge Control Center cockpit: read-only collect (CommercialSnapshot + observations) plus a three-action operator channel (pause/resume dispatch, acknowledge inbound alert).",
   "type": "module",
   "engines": {
     "node": ">=20"
@@ -22,7 +22,11 @@
     "cc-connector-canary": "tsx src/canary.ts",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@confenge/control-center-security": "*"
+  },
   "devDependencies": {
+    "@confenge/control-center-agent-activity": "*",
     "@types/node": "^24.3.0",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"

--- a/control-center/connectors/warmbly/required_upstream_contract.json
+++ b/control-center/connectors/warmbly/required_upstream_contract.json
@@ -24,15 +24,116 @@
     { "method": "GET", "path": "/v1/confenge/today", "notes": "feature-flagged executable human work" },
     { "method": "GET", "path": "/v1/confenge/inbound", "notes": "feature-flagged inbound-now queue (lead surface)" }
   ],
+  "operator_actions": {
+    "note": "Amended boundary. Three named, individually typed operational controls are the ONLY writes this connector may issue. Verified against the live Warmbly backend on the VPS (warmbly-confenge-backend-1, 127.0.0.1:8080) on 2026-08-22: each route answers 401 unauthenticated (registered) and 404 on the wrong method (not registered for it). Discovered in Warmbly internal/api/routes.go lines 594-604 under the feature-flagged `confengeWrite` group.",
+    "identity": "Authelia ForwardAuth Remote-User / Remote-Groups / Remote-Name / Remote-Email via control-center/security; the ops.confenge.com.br nginx vhost blanks client-supplied copies",
+    "retries": "none — operator writes are never retried",
+    "mapped_writes": [
+      {
+        "action": "pause_dispatch",
+        "method": "POST",
+        "path": "/v1/confenge/dispatch/pause",
+        "exists_upstream": true,
+        "verified_at": "2026-08-22",
+        "verification": "POST -> 401 (route registered, auth required); GET -> 404",
+        "handler": "internal/api/handler/confenge.go PauseConfengeDispatch",
+        "permission": "PermManageContacts / APIPermWriteContacts",
+        "confirmation": "one_step",
+        "request": { "body": { "reason": "string (1-200 safe chars, required by this connector)" } },
+        "response": { "status": 200, "body": { "data": "dispatch status object" } },
+        "out_of_band_fallback": "warmbly deploy/confenge-vps/pause.sh (file kill switch + governor API)"
+      },
+      {
+        "action": "resume_dispatch",
+        "method": "POST",
+        "path": "/v1/confenge/dispatch/resume",
+        "exists_upstream": true,
+        "verified_at": "2026-08-22",
+        "verification": "POST -> 401 (route registered, auth required); GET -> 404",
+        "handler": "internal/api/handler/confenge.go ResumeConfengeDispatch",
+        "permission": "PermManageContacts / APIPermWriteContacts",
+        "confirmation": "two_step",
+        "request": { "body": {} },
+        "response": { "status": 200, "body": { "data": "dispatch status object" } },
+        "out_of_band_fallback": "warmbly deploy/confenge-vps/resume.sh"
+      },
+      {
+        "action": "acknowledge_inbound_alert",
+        "method": "POST",
+        "path": "/v1/confenge/inbound/{lead_id}/acknowledge",
+        "exists_upstream": true,
+        "verified_at": "2026-08-22",
+        "verification": "POST -> 401 (route registered, auth required); GET -> 404",
+        "handler": "internal/api/handler/confenge_inbound.go AcknowledgeConfengeInboundAlert",
+        "permission": "PermManageContacts / APIPermWriteContacts",
+        "confirmation": "one_step",
+        "request": { "path_params": { "lead_id": "opaque id matching ^[A-Za-z0-9_~-]{1,128}$" }, "body": {} },
+        "response": { "status": 200, "body": { "data": "inbound alert object" } }
+      }
+    ],
+    "supporting_read": {
+      "method": "GET",
+      "path": "/v1/confenge/dispatch/status",
+      "notes": "already on the read allowlist; the operator UI should render kill-switch state from this before offering resume"
+    }
+  },
   "forbidden_in_this_connector": [
     "PATCH/PUT/DELETE any path",
     "POST /v1/campaigns, /start, /stop, /test-email, enroll, import, dispatch",
-    "POST /v1/confenge/import, /sync, /crm/bootstrap, /campaign/bootstrap, /inbound/:id/outcome, send/enroll/approve",
+    "POST /v1/confenge/import, /sync, /crm/bootstrap, /campaign/bootstrap, /inbound/:id/outcome, /inbound/:id/resolve, send/enroll/approve",
+    "POST /v1/confenge/cohorts/:id/dispatch, /accounts/:id/resume, /drafts/:id/send",
     "POST /v1/unibox/reply, /compose, /snooze",
     "POST /v1/crm/deals (create), POST /v1/crm/tasks (create), POST /v1/contacts (create)",
-    "Any Asaas / checkout / refund / financial mutation"
+    "Any Asaas / checkout / refund / financial mutation",
+    "Any POST outside the three operator_actions.mapped_writes rows"
   ],
   "gaps": [
+    {
+      "id": "dispatch status lacks paused_by / paused_at",
+      "method": "GET",
+      "path": "/v1/confenge/dispatch/status",
+      "reason": "Warmbly's dispatch.Status (internal/app/confenge/dispatch/types.go:186) exposes `paused` and `pause_reason` but no `paused_by` and no `paused_at`. The Control Center operator ledger records who paused and when on its side, but it cannot reconcile that against Warmbly truth, and it cannot tell an API pause apart from the file kill switch written by deploy/confenge-vps/pause.sh. Until this lands, the ledger is the only record of the actor. No route is invented here.",
+      "min_request": {
+        "method": "GET",
+        "path": "/v1/confenge/dispatch/status",
+        "headers": ["Authorization", "API-Version"]
+      },
+      "min_response": {
+        "status": 200,
+        "body": {
+          "data": {
+            "paused": true,
+            "pause_reason": "string",
+            "paused_by": "actor handle or null",
+            "paused_at": "RFC3339 UTC or null",
+            "pause_source": "api | file_kill_switch | env_flag"
+          }
+        }
+      }
+    },
+    {
+      "id": "no read-back for inbound alert acknowledgement",
+      "method": "GET",
+      "path": "/v1/confenge/inbound",
+      "reason": "GET /v1/confenge/inbound returns the inbound-now queue but does not carry `acknowledged_by` / `acknowledged_at`, so a Control Center acknowledge cannot be confirmed from a later read. The connector records the upstream 2xx and the actor in its own ledger instead. No route is invented here.",
+      "min_request": {
+        "method": "GET",
+        "path": "/v1/confenge/inbound",
+        "headers": ["Authorization", "API-Version"]
+      },
+      "min_response": {
+        "status": 200,
+        "body": {
+          "data": [
+            {
+              "id": "string",
+              "acknowledged_by": "actor handle or null",
+              "acknowledged_at": "RFC3339 UTC or null"
+            }
+          ]
+        }
+      }
+    },
     {
       "id": "GET /v1/leads",
       "method": "GET",

--- a/control-center/connectors/warmbly/src/index.ts
+++ b/control-center/connectors/warmbly/src/index.ts
@@ -42,3 +42,8 @@ export {
   loadWarmblyProductionConfig,
   resolveWarmblySecrets,
 } from "./production-config.ts";
+/**
+ * Operator action channel — the narrow, named write surface. Everything else
+ * exported from this connector stays read-only.
+ */
+export * from "./operator/index.ts";

--- a/control-center/connectors/warmbly/src/operator/actions.ts
+++ b/control-center/connectors/warmbly/src/operator/actions.ts
@@ -1,0 +1,143 @@
+/**
+ * Named, individually typed operator actions.
+ *
+ * This is the ONLY place a Warmbly write may be described. There is no generic
+ * proxy and no pass-through of a caller-supplied method+path: a caller names an
+ * action, and the action owns its method, its path template and its body.
+ *
+ * Amended boundary (see README "Decisions"): three operational controls are
+ * allowed. Everything else — send, dispatch-now, enroll, approve-content,
+ * campaign start/stop, import/bootstrap, unibox reply/compose and every
+ * Asaas/financial mutation — stays forbidden.
+ */
+
+export const OPERATOR_ACTION_NAMES = [
+  "pause_dispatch",
+  "resume_dispatch",
+  "acknowledge_inbound_alert",
+] as const;
+
+export type OperatorActionName = (typeof OPERATOR_ACTION_NAMES)[number];
+
+export type OperatorTargetKind = "dispatch" | "inbound_alert";
+
+export type OperatorConfirmationMode = "none" | "two_step";
+
+/** Singleton target for the dispatch kill switch. Not a path parameter. */
+export const DISPATCH_TARGET_ID = "confenge-dispatch";
+
+/**
+ * Target ids are opaque, safe handles. No slashes, no dots-dots, no encoded
+ * separators: a target can never widen the path into another Warmbly route.
+ */
+export const TARGET_ID_PATTERN = /^[A-Za-z0-9_~-]{1,128}$/;
+
+/** Free-text audit reason. Control characters and separators are rejected. */
+export const REASON_PATTERN = /^[A-Za-z0-9 _.,:;()À-ſ-]{1,200}$/;
+
+export interface OperatorActionDefinition {
+  readonly name: OperatorActionName;
+  readonly method: "POST";
+  readonly path_template: string;
+  readonly target_kind: OperatorTargetKind;
+  /** true when the target id is interpolated into the path. */
+  readonly target_in_path: boolean;
+  readonly default_target_id: string | null;
+  readonly confirmation: OperatorConfirmationMode;
+  readonly reason_required: boolean;
+  readonly effect: string;
+  buildPath(targetId: string): string;
+  buildBody(input: { reason: string | null }): Record<string, unknown>;
+}
+
+const PAUSE: OperatorActionDefinition = {
+  name: "pause_dispatch",
+  method: "POST",
+  path_template: "/v1/confenge/dispatch/pause",
+  target_kind: "dispatch",
+  target_in_path: false,
+  default_target_id: DISPATCH_TARGET_ID,
+  confirmation: "none",
+  reason_required: true,
+  effect: "engage the CONFENGE outbound kill switch (stops traffic)",
+  buildPath: () => "/v1/confenge/dispatch/pause",
+  buildBody: ({ reason }) => ({ reason: reason ?? "" }),
+};
+
+const RESUME: OperatorActionDefinition = {
+  name: "resume_dispatch",
+  method: "POST",
+  path_template: "/v1/confenge/dispatch/resume",
+  target_kind: "dispatch",
+  target_in_path: false,
+  default_target_id: DISPATCH_TARGET_ID,
+  // Releasing the kill switch is the only action that can let traffic flow.
+  confirmation: "two_step",
+  reason_required: true,
+  effect: "release the CONFENGE outbound kill switch (lets traffic flow)",
+  buildPath: () => "/v1/confenge/dispatch/resume",
+  buildBody: () => ({}),
+};
+
+const ACKNOWLEDGE: OperatorActionDefinition = {
+  name: "acknowledge_inbound_alert",
+  method: "POST",
+  path_template: "/v1/confenge/inbound/{lead_id}/acknowledge",
+  target_kind: "inbound_alert",
+  target_in_path: true,
+  default_target_id: null,
+  confirmation: "none",
+  reason_required: false,
+  effect: "mark one inbound alert as seen by a human (no reply, no send)",
+  buildPath: (targetId) => `/v1/confenge/inbound/${encodeURIComponent(targetId)}/acknowledge`,
+  buildBody: () => ({}),
+};
+
+export const OPERATOR_ACTIONS: Readonly<Record<OperatorActionName, OperatorActionDefinition>> =
+  Object.freeze({
+    pause_dispatch: PAUSE,
+    resume_dispatch: RESUME,
+    acknowledge_inbound_alert: ACKNOWLEDGE,
+  });
+
+/**
+ * Explicitly NOT reachable through this channel. Kept as data so the refusal
+ * boundary is testable and greppable, never as a route table.
+ */
+export const OPERATOR_FORBIDDEN_ACTIONS = [
+  "send",
+  "send_email",
+  "send_whatsapp",
+  "dispatch_now",
+  "dispatch_cohort",
+  "enroll",
+  "approve_content",
+  "campaign_start",
+  "campaign_stop",
+  "import",
+  "bootstrap",
+  "unibox_reply",
+  "unibox_compose",
+  "charge",
+  "refund",
+  "payment",
+] as const;
+
+export function isOperatorActionName(value: unknown): value is OperatorActionName {
+  return typeof value === "string" && (OPERATOR_ACTION_NAMES as readonly string[]).includes(value);
+}
+
+export function resolveOperatorAction(value: unknown): OperatorActionDefinition | undefined {
+  if (!isOperatorActionName(value)) {
+    return undefined;
+  }
+  return OPERATOR_ACTIONS[value];
+}
+
+export function isValidTargetId(value: unknown): value is string {
+  return typeof value === "string" && TARGET_ID_PATTERN.test(value);
+}
+
+export function isValidReason(value: unknown): value is string {
+  return typeof value === "string" && REASON_PATTERN.test(value.trim());
+}

--- a/control-center/connectors/warmbly/src/operator/agent-activity-sink.ts
+++ b/control-center/connectors/warmbly/src/operator/agent-activity-sink.ts
@@ -8,6 +8,7 @@
  * - outcome "executed"   -> ExecutionStatus DONE
  * - outcome "challenged" -> ExecutionStatus PARTIAL (step 1 of 2 completed)
  * - outcome "refused"    -> ExecutionStatus BLOCKED
+ * - outcome "unknown"    -> ExecutionStatus UNKNOWN (written, answer never came)
  *
  * Nothing sensitive crosses: the actor id is the Authelia `Remote-User` handle,
  * never `Remote-Email`, and no token or reason-with-secret shape is carried.
@@ -25,12 +26,17 @@ export interface AgentLedgerLike {
   reportResult(raw: unknown): unknown;
 }
 
-function statusFor(entry: OperatorActionLedgerEntry): "DONE" | "PARTIAL" | "BLOCKED" {
+function statusFor(entry: OperatorActionLedgerEntry): "DONE" | "PARTIAL" | "BLOCKED" | "UNKNOWN" {
   if (entry.outcome === "executed") {
     return "DONE";
   }
   if (entry.outcome === "challenged") {
     return "PARTIAL";
+  }
+  // Never BLOCKED: "unknown" means the request was written and Warmbly may have
+  // applied it. Showing it as blocked would claim nothing happened.
+  if (entry.outcome === "unknown") {
+    return "UNKNOWN";
   }
   return "BLOCKED";
 }
@@ -54,11 +60,15 @@ function evidenceFor(entry: OperatorActionLedgerEntry): string[] {
       entry.upstream.status === null ? "none" : entry.upstream.status
     }`,
     `circuit=${entry.circuit_state}`,
+    `client_reference=${entry.client_reference ?? "none"}`,
     `confirmation=required:${entry.confirmation.required} satisfied:${entry.confirmation.satisfied}`,
     `recorded_at=${entry.recorded_at}`,
   ];
   if (entry.refusal_code) {
     evidence.push(`refusal_code=${entry.refusal_code}`);
+  }
+  if (entry.confirmation.token_id) {
+    evidence.push(`confirmation_token_id=${entry.confirmation.token_id}`);
   }
   return evidence;
 }

--- a/control-center/connectors/warmbly/src/operator/agent-activity-sink.ts
+++ b/control-center/connectors/warmbly/src/operator/agent-activity-sink.ts
@@ -1,0 +1,110 @@
+/**
+ * Sink that lands every operator action in the existing agent execution ledger
+ * (`control-center/domains/agent-activity`), so an operator action shows up on
+ * the same timeline as everything else that acted on the estate.
+ *
+ * Vocabulary map (documented, not silent):
+ * - identity actor kind "human" (security ForwardAuth)  -> "founder" (ledger)
+ * - outcome "executed"   -> ExecutionStatus DONE
+ * - outcome "challenged" -> ExecutionStatus PARTIAL (step 1 of 2 completed)
+ * - outcome "refused"    -> ExecutionStatus BLOCKED
+ *
+ * Nothing sensitive crosses: the actor id is the Authelia `Remote-User` handle,
+ * never `Remote-Email`, and no token or reason-with-secret shape is carried.
+ */
+
+import type { OperatorActionLedger, OperatorActionLedgerEntry } from "./ledger.ts";
+
+export const OPERATOR_LEDGER_AGENT_ID = "cc-warmbly-operator-channel";
+export const OPERATOR_LEDGER_AGENT_PROVIDER = "control-center";
+export const OPERATOR_LEDGER_REPO = "confenge/warmbly";
+
+/** Structural port so the connector does not hard-depend on the domain build. */
+export interface AgentLedgerLike {
+  startSession(raw: unknown): unknown;
+  reportResult(raw: unknown): unknown;
+}
+
+function statusFor(entry: OperatorActionLedgerEntry): "DONE" | "PARTIAL" | "BLOCKED" {
+  if (entry.outcome === "executed") {
+    return "DONE";
+  }
+  if (entry.outcome === "challenged") {
+    return "PARTIAL";
+  }
+  return "BLOCKED";
+}
+
+function goalFor(entry: OperatorActionLedgerEntry): string {
+  return `warmbly operator action ${entry.requested_action} on ${entry.target.kind}:${entry.target.id}`;
+}
+
+function summaryFor(entry: OperatorActionLedgerEntry): string {
+  const status = entry.upstream.status === null ? "no-upstream-call" : `HTTP ${entry.upstream.status}`;
+  const refusal = entry.refusal_code ? ` refusal=${entry.refusal_code}` : "";
+  return `${entry.outcome} ${entry.requested_action} (${status})${refusal}`;
+}
+
+function evidenceFor(entry: OperatorActionLedgerEntry): string[] {
+  const evidence = [
+    `action=${entry.requested_action}`,
+    `outcome=${entry.outcome}`,
+    `target=${entry.target.kind}:${entry.target.id}`,
+    `upstream=${entry.upstream.method ?? "none"} ${entry.upstream.path ?? "none"} ${
+      entry.upstream.status === null ? "none" : entry.upstream.status
+    }`,
+    `circuit=${entry.circuit_state}`,
+    `confirmation=required:${entry.confirmation.required} satisfied:${entry.confirmation.satisfied}`,
+    `recorded_at=${entry.recorded_at}`,
+  ];
+  if (entry.refusal_code) {
+    evidence.push(`refusal_code=${entry.refusal_code}`);
+  }
+  return evidence;
+}
+
+/**
+ * `startSession` then `reportResult` so the ledger keeps a revision trail for
+ * the action rather than a single opaque row.
+ */
+export function createAgentActivityLedgerSink(ledger: AgentLedgerLike): OperatorActionLedger {
+  const mirrored: OperatorActionLedgerEntry[] = [];
+  return {
+    record(entry) {
+      const actor = entry.actor ?? { kind: "system" as const, id: "cc-warmbly-operator-channel" };
+      const provenance = {
+        source: {
+          system: entry.source.system,
+          kind: entry.source.kind,
+          locator: entry.source.locator,
+        },
+        observed_at: entry.observed_at,
+        freshness_status: entry.freshness_status,
+        confidence: entry.confidence,
+      };
+      ledger.startSession({
+        correlation_id: entry.correlation_id,
+        agent: { id: OPERATOR_LEDGER_AGENT_ID, provider: OPERATOR_LEDGER_AGENT_PROVIDER },
+        repo: OPERATOR_LEDGER_REPO,
+        goal: goalFor(entry),
+        started_at: entry.recorded_at,
+        actor,
+        ...provenance,
+      });
+      ledger.reportResult({
+        correlation_id: entry.correlation_id,
+        status: statusFor(entry),
+        finished_at: entry.recorded_at,
+        summary: summaryFor(entry),
+        evidence: evidenceFor(entry),
+        blockers: entry.refusal_reason ? [entry.refusal_reason] : [],
+        actor,
+        ...provenance,
+      });
+      mirrored.push(structuredClone(entry));
+    },
+    list() {
+      return mirrored.map((entry) => structuredClone(entry));
+    },
+  };
+}

--- a/control-center/connectors/warmbly/src/operator/allowlist.ts
+++ b/control-center/connectors/warmbly/src/operator/allowlist.ts
@@ -1,0 +1,83 @@
+/**
+ * Fail-closed write allowlist for the operator action channel.
+ *
+ * Separate from `src/http/allowlist.ts`, which stays read-only. Nothing here
+ * widens the read client: the read client keeps refusing every write, and this
+ * allowlist only ever accepts POST on three exact operational controls.
+ */
+
+import { pathnameOf } from "../http/allowlist.ts";
+import type { DeniedRequest } from "../http/allowlist.ts";
+
+export const OPERATOR_PAUSE_PATH = "/v1/confenge/dispatch/pause";
+export const OPERATOR_RESUME_PATH = "/v1/confenge/dispatch/resume";
+export const OPERATOR_ACK_PREFIX = "/v1/confenge/inbound/";
+export const OPERATOR_ACK_SUFFIX = "/acknowledge";
+
+const OPERATOR_POST_EXACT = new Set<string>([OPERATOR_PAUSE_PATH, OPERATOR_RESUME_PATH]);
+
+const ACK_SEGMENT = /^[A-Za-z0-9_~%-]{1,160}$/;
+
+export type AllowedOperatorRequest = {
+  allowed: true;
+  method: "POST";
+  path: string;
+};
+
+function isAcknowledgePath(pathname: string): boolean {
+  if (!pathname.startsWith(OPERATOR_ACK_PREFIX) || !pathname.endsWith(OPERATOR_ACK_SUFFIX)) {
+    return false;
+  }
+  const parts = pathname.split("/").filter((p) => p.length > 0);
+  // v1 / confenge / inbound / <leadId> / acknowledge
+  if (parts.length !== 5) {
+    return false;
+  }
+  if (parts[0] !== "v1" || parts[1] !== "confenge" || parts[2] !== "inbound") {
+    return false;
+  }
+  if (parts[4] !== "acknowledge") {
+    return false;
+  }
+  const segment = parts[3] ?? "";
+  if (!ACK_SEGMENT.test(segment)) {
+    return false;
+  }
+  // A percent-encoded separator must not smuggle another route in.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    return false;
+  }
+  return !decoded.includes("/") && !decoded.includes("\\") && decoded !== ".." && decoded !== ".";
+}
+
+export function classifyOperatorRequest(
+  method: string,
+  urlOrPath: string,
+): AllowedOperatorRequest | DeniedRequest {
+  const path = pathnameOf(urlOrPath);
+  const m = method.toUpperCase();
+  if (m !== "POST") {
+    return {
+      allowed: false,
+      method: m,
+      path,
+      reason: `${m} is forbidden on the Warmbly operator channel (POST only)`,
+    };
+  }
+  if (OPERATOR_POST_EXACT.has(path) || isAcknowledgePath(path)) {
+    return { allowed: true, method: "POST", path };
+  }
+  return {
+    allowed: false,
+    method: m,
+    path,
+    reason: `path is not one of the three allowed Warmbly operator controls: ${path}`,
+  };
+}
+
+export function isAllowedOperatorWrite(method: string, urlOrPath: string): boolean {
+  return classifyOperatorRequest(method, urlOrPath).allowed;
+}

--- a/control-center/connectors/warmbly/src/operator/channel.ts
+++ b/control-center/connectors/warmbly/src/operator/channel.ts
@@ -1,0 +1,599 @@
+/**
+ * The Warmbly operator action channel.
+ *
+ * Narrow by construction: a caller names one of three actions and supplies the
+ * raw HTTP request whose Authelia `Remote-*` headers carry the founder. There
+ * is no method parameter, no path parameter, and no escape hatch. Every call
+ * — executed, refused or challenged — writes exactly one ledger entry before
+ * it returns.
+ */
+
+import { randomUUID } from "node:crypto";
+import { CircuitOpenError } from "../http/circuit-breaker.ts";
+import type { CircuitState } from "../http/circuit-breaker.ts";
+import { createStderrLogger, type Logger } from "../http/redaction.ts";
+import {
+  DISPATCH_TARGET_ID,
+  OPERATOR_ACTION_NAMES,
+  TARGET_ID_PATTERN,
+  isValidReason,
+  isValidTargetId,
+  resolveOperatorAction,
+  type OperatorActionDefinition,
+  type OperatorActionName,
+} from "./actions.ts";
+import { classifyOperatorRequest } from "./allowlist.ts";
+import {
+  OperatorPathNotAllowedError,
+  OperatorTimeoutError,
+  type WarmblyOperatorClient,
+} from "./client.ts";
+import {
+  createConfirmationStore,
+  type ConfirmationStore,
+  type OperatorConfirmationChallenge,
+} from "./confirmation.ts";
+import {
+  defaultOperatorIdentityPolicy,
+  resolveOperatorActor,
+  type IdentityRequest,
+  type OperatorActor,
+  type TrustedHopPolicy,
+} from "./identity.ts";
+import {
+  OPERATOR_LEDGER_SCHEMA,
+  OPERATOR_LEDGER_SOURCE_KIND,
+  OPERATOR_LEDGER_SOURCE_SYSTEM,
+  createMemoryOperatorActionLedger,
+  operatorLedgerId,
+  type OperatorActionLedger,
+  type OperatorActionLedgerEntry,
+  type OperatorLedgerConfirmation,
+  type OperatorLedgerTarget,
+  type OperatorLedgerUpstream,
+  type OperatorRefusalCode,
+} from "./ledger.ts";
+
+export interface OperatorActionInput {
+  /** Deliberately `string`: an unknown name must be refusable and recordable. */
+  action: string;
+  /** Raw request. Identity is derived from it; it cannot be supplied directly. */
+  request: IdentityRequest | undefined;
+  target_id?: string;
+  reason?: string;
+  confirmation_token?: string;
+  correlation_id?: string;
+}
+
+export type NamedOperatorActionInput = Omit<OperatorActionInput, "action">;
+
+export interface OperatorExecuted {
+  ok: true;
+  outcome: "executed";
+  action: OperatorActionName;
+  target: OperatorLedgerTarget;
+  upstream_status: number;
+  upstream_body: unknown;
+  entry: OperatorActionLedgerEntry;
+}
+
+export interface OperatorChallenged {
+  ok: true;
+  outcome: "challenged";
+  action: OperatorActionName;
+  target: OperatorLedgerTarget;
+  challenge: OperatorConfirmationChallenge;
+  entry: OperatorActionLedgerEntry;
+}
+
+export interface OperatorRefused {
+  ok: false;
+  outcome: "refused";
+  code: OperatorRefusalCode;
+  reason: string;
+  entry: OperatorActionLedgerEntry;
+}
+
+export type OperatorActionResult = OperatorExecuted | OperatorChallenged | OperatorRefused;
+
+export interface WarmblyOperatorChannelOptions {
+  client: WarmblyOperatorClient;
+  ledger?: OperatorActionLedger;
+  identityPolicy?: TrustedHopPolicy;
+  confirmations?: ConfirmationStore;
+  confirmationTtlMs?: number;
+  now?: () => Date;
+  newCorrelationId?: () => string;
+  logger?: Logger;
+}
+
+export interface WarmblyOperatorChannel {
+  readonly actions: readonly OperatorActionName[];
+  readonly ledger: OperatorActionLedger;
+  circuitState(): CircuitState;
+  /** Step 1 of the two-step release. Only `resume_dispatch` accepts it. */
+  requestConfirmation(input: OperatorActionInput): Promise<OperatorActionResult>;
+  requestResumeConfirmation(input: NamedOperatorActionInput): Promise<OperatorActionResult>;
+  execute(input: OperatorActionInput): Promise<OperatorActionResult>;
+  pauseDispatch(input: NamedOperatorActionInput): Promise<OperatorActionResult>;
+  resumeDispatch(input: NamedOperatorActionInput): Promise<OperatorActionResult>;
+  acknowledgeInboundAlert(input: NamedOperatorActionInput): Promise<OperatorActionResult>;
+}
+
+const UNKNOWN_TARGET: OperatorLedgerTarget = { kind: "unknown", id: "unknown" };
+const NO_UPSTREAM: OperatorLedgerUpstream = { method: null, path: null, status: null };
+const NO_CONFIRMATION: OperatorLedgerConfirmation = {
+  required: false,
+  satisfied: false,
+  token_id: null,
+};
+
+export function createWarmblyOperatorChannel(
+  options: WarmblyOperatorChannelOptions,
+): WarmblyOperatorChannel {
+  const client = options.client;
+  const ledger = options.ledger ?? createMemoryOperatorActionLedger();
+  const identityPolicy = options.identityPolicy ?? defaultOperatorIdentityPolicy();
+  const confirmations =
+    options.confirmations ??
+    createConfirmationStore(
+      options.confirmationTtlMs === undefined ? {} : { ttlMs: options.confirmationTtlMs },
+    );
+  const now = options.now ?? (() => new Date());
+  const newCorrelationId = options.newCorrelationId ?? (() => randomUUID());
+  const logger = options.logger ?? createStderrLogger();
+
+  function correlationOf(input: OperatorActionInput): string {
+    const raw = typeof input.correlation_id === "string" ? input.correlation_id.trim() : "";
+    if (raw !== "" && /^[A-Za-z0-9._:~-]{1,96}$/.test(raw)) {
+      return raw;
+    }
+    return `cc:warmbly-op:${newCorrelationId()}`;
+  }
+
+  function record(entry: OperatorActionLedgerEntry): OperatorActionLedgerEntry {
+    ledger.record(entry);
+    logger({
+      level: entry.outcome === "executed" ? "info" : "warn",
+      msg: "warmbly.operator.recorded",
+      correlation_id: entry.correlation_id,
+      requested_action: entry.requested_action,
+      outcome: entry.outcome,
+      refusal_code: entry.refusal_code,
+      actor_id: entry.actor?.id ?? null,
+      target: `${entry.target.kind}:${entry.target.id}`,
+      upstream_status: entry.upstream.status,
+      circuit_state: entry.circuit_state,
+    });
+    return entry;
+  }
+
+  function buildEntry(parts: {
+    correlation_id: string;
+    requested_action: string;
+    action: OperatorActionName | null;
+    outcome: OperatorActionLedgerEntry["outcome"];
+    refusal_code: OperatorRefusalCode | null;
+    refusal_reason: string | null;
+    actor: OperatorActor | null;
+    target: OperatorLedgerTarget;
+    upstream: OperatorLedgerUpstream;
+    confirmation: OperatorLedgerConfirmation;
+    reason: string | null;
+  }): OperatorActionLedgerEntry {
+    const at = now().toISOString();
+    return {
+      schema_version: OPERATOR_LEDGER_SCHEMA,
+      id: operatorLedgerId(parts.correlation_id),
+      correlation_id: parts.correlation_id,
+      requested_action: parts.requested_action,
+      action: parts.action,
+      outcome: parts.outcome,
+      refusal_code: parts.refusal_code,
+      refusal_reason: parts.refusal_reason,
+      actor: parts.actor,
+      target: parts.target,
+      upstream: parts.upstream,
+      confirmation: parts.confirmation,
+      circuit_state: safeCircuitState(),
+      reason: parts.reason,
+      recorded_at: at,
+      source: {
+        system: OPERATOR_LEDGER_SOURCE_SYSTEM,
+        kind: OPERATOR_LEDGER_SOURCE_KIND,
+        locator: parts.correlation_id,
+      },
+      observed_at: at,
+      freshness_status: "FRESH",
+      confidence: 1,
+    };
+  }
+
+  function safeCircuitState(): CircuitState {
+    try {
+      return client.circuitState();
+    } catch {
+      return "open";
+    }
+  }
+
+  function refuse(parts: {
+    correlation_id: string;
+    requested_action: string;
+    action: OperatorActionName | null;
+    code: OperatorRefusalCode;
+    reason: string;
+    actor: OperatorActor | null;
+    target?: OperatorLedgerTarget;
+    upstream?: OperatorLedgerUpstream;
+    confirmation?: OperatorLedgerConfirmation;
+    auditReason?: string | null;
+  }): OperatorRefused {
+    const entry = record(
+      buildEntry({
+        correlation_id: parts.correlation_id,
+        requested_action: parts.requested_action,
+        action: parts.action,
+        outcome: "refused",
+        refusal_code: parts.code,
+        refusal_reason: parts.reason,
+        actor: parts.actor,
+        target: parts.target ?? UNKNOWN_TARGET,
+        upstream: parts.upstream ?? NO_UPSTREAM,
+        confirmation: parts.confirmation ?? NO_CONFIRMATION,
+        reason: parts.auditReason ?? null,
+      }),
+    );
+    return { ok: false, outcome: "refused", code: parts.code, reason: parts.reason, entry };
+  }
+
+  interface Prepared {
+    action: OperatorActionDefinition;
+    actor: OperatorActor;
+    target: OperatorLedgerTarget;
+    path: string;
+    reason: string | null;
+  }
+
+  /**
+   * Shared, ordered gate for both `requestConfirmation` and `execute`.
+   * Identity first: an unauthenticated caller must not learn which action names
+   * exist. Then allowlist, then target, then reason, then path.
+   */
+  function prepare(
+    input: OperatorActionInput,
+    correlationId: string,
+  ): Prepared | OperatorRefused {
+    const requested = typeof input.action === "string" ? input.action : String(input.action);
+
+    const identity = resolveOperatorActor(input.request, identityPolicy);
+    if (!identity.ok) {
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: requested,
+        action: null,
+        code: "missing_actor",
+        reason: `authenticated founder identity is required (${identity.code}: ${identity.reason})`,
+        actor: null,
+      });
+    }
+    const actor = identity.actor;
+
+    const action = resolveOperatorAction(requested);
+    if (!action) {
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: requested,
+        action: null,
+        code: "unknown_action",
+        reason: `"${requested}" is not an allowed Warmbly operator action (allowed: ${OPERATOR_ACTION_NAMES.join(", ")})`,
+        actor,
+      });
+    }
+
+    const rawTarget =
+      typeof input.target_id === "string" && input.target_id.trim() !== ""
+        ? input.target_id.trim()
+        : action.default_target_id;
+    if (rawTarget === null || !isValidTargetId(rawTarget)) {
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: requested,
+        action: action.name,
+        code: "invalid_target",
+        reason: `${action.name} requires a safe target id matching ${TARGET_ID_PATTERN.source}`,
+        actor,
+        target: { kind: action.target_kind, id: "invalid" },
+      });
+    }
+    if (!action.target_in_path && rawTarget !== action.default_target_id) {
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: requested,
+        action: action.name,
+        code: "invalid_target",
+        reason: `${action.name} targets the singleton "${action.default_target_id}" only`,
+        actor,
+        target: { kind: action.target_kind, id: rawTarget },
+      });
+    }
+    const target: OperatorLedgerTarget = { kind: action.target_kind, id: rawTarget };
+
+    const rawReason = typeof input.reason === "string" ? input.reason.trim() : "";
+    if (action.reason_required && !isValidReason(rawReason)) {
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: requested,
+        action: action.name,
+        code: "invalid_reason",
+        reason: `${action.name} requires a 1-200 character audit reason without control characters or separators`,
+        actor,
+        target,
+      });
+    }
+    if (rawReason !== "" && !isValidReason(rawReason)) {
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: requested,
+        action: action.name,
+        code: "invalid_reason",
+        reason: "reason contains characters that are not allowed in an audit reason",
+        actor,
+        target,
+      });
+    }
+    const reason = rawReason === "" ? null : rawReason;
+
+    // Defence in depth: the built path is re-classified against the write
+    // allowlist even though the action owns its own template.
+    const path = action.buildPath(target.id);
+    const classified = classifyOperatorRequest(action.method, path);
+    if (!classified.allowed) {
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: requested,
+        action: action.name,
+        code: "forbidden_path",
+        reason: classified.reason,
+        actor,
+        target,
+        upstream: { method: null, path, status: null },
+        auditReason: reason,
+      });
+    }
+
+    return { action, actor, target, path: classified.path, reason };
+  }
+
+  function isRefusal(value: Prepared | OperatorRefused): value is OperatorRefused {
+    return (value as OperatorRefused).ok === false;
+  }
+
+  async function requestConfirmation(input: OperatorActionInput): Promise<OperatorActionResult> {
+    const correlationId = correlationOf(input);
+    const prepared = prepare(input, correlationId);
+    if (isRefusal(prepared)) {
+      return prepared;
+    }
+    const { action, actor, target, reason } = prepared;
+    if (action.confirmation !== "two_step") {
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: action.name,
+        action: action.name,
+        code: "confirmation_not_applicable",
+        reason: `${action.name} is a one-step action and does not take a confirmation token`,
+        actor,
+        target,
+        auditReason: reason,
+      });
+    }
+    const challenge = confirmations.issue({
+      action: action.name,
+      target_id: target.id,
+      actor_id: actor.id,
+      now: now(),
+    });
+    const entry = record(
+      buildEntry({
+        correlation_id: correlationId,
+        requested_action: action.name,
+        action: action.name,
+        outcome: "challenged",
+        refusal_code: null,
+        refusal_reason: null,
+        actor,
+        target,
+        upstream: NO_UPSTREAM,
+        confirmation: { required: true, satisfied: false, token_id: challenge.token_id },
+        reason,
+      }),
+    );
+    return { ok: true, outcome: "challenged", action: action.name, target, challenge, entry };
+  }
+
+  async function execute(input: OperatorActionInput): Promise<OperatorActionResult> {
+    const correlationId = correlationOf(input);
+    const prepared = prepare(input, correlationId);
+    if (isRefusal(prepared)) {
+      return prepared;
+    }
+    const { action, actor, target, path, reason } = prepared;
+
+    let confirmation: OperatorLedgerConfirmation = NO_CONFIRMATION;
+    if (action.confirmation === "two_step") {
+      const supplied = input.confirmation_token;
+      if (typeof supplied !== "string" || supplied.trim() === "") {
+        return refuse({
+          correlation_id: correlationId,
+          requested_action: action.name,
+          action: action.name,
+          code: "confirmation_required",
+          reason: `${action.name} is two-step: call requestConfirmation first and replay the token`,
+          actor,
+          target,
+          confirmation: { required: true, satisfied: false, token_id: null },
+          auditReason: reason,
+        });
+      }
+      const checked = confirmations.consume({
+        token: supplied,
+        action: action.name,
+        target_id: target.id,
+        actor_id: actor.id,
+        now: now(),
+      });
+      if (!checked.ok) {
+        return refuse({
+          correlation_id: correlationId,
+          requested_action: action.name,
+          action: action.name,
+          code: "confirmation_invalid",
+          reason: checked.reason,
+          actor,
+          target,
+          confirmation: { required: true, satisfied: false, token_id: null },
+          auditReason: reason,
+        });
+      }
+      confirmation = { required: true, satisfied: true, token_id: checked.token_id };
+    }
+
+    try {
+      client.assertCircuitClosed();
+    } catch (err) {
+      if (err instanceof CircuitOpenError) {
+        return refuse({
+          correlation_id: correlationId,
+          requested_action: action.name,
+          action: action.name,
+          code: "circuit_open",
+          reason:
+            "Warmbly connector circuit breaker is open; the operator action was not attempted. " +
+            "Out-of-band fallback for pause: deploy/confenge-vps/pause.sh on the VPS.",
+          actor,
+          target,
+          upstream: { method: "POST", path, status: null },
+          confirmation,
+          auditReason: reason,
+        });
+      }
+      throw err;
+    }
+
+    const body = action.buildBody({ reason });
+    let response;
+    try {
+      response = await client.post(path, body);
+    } catch (err) {
+      if (err instanceof CircuitOpenError) {
+        return refuse({
+          correlation_id: correlationId,
+          requested_action: action.name,
+          action: action.name,
+          code: "circuit_open",
+          reason: err.message,
+          actor,
+          target,
+          upstream: { method: "POST", path, status: null },
+          confirmation,
+          auditReason: reason,
+        });
+      }
+      if (err instanceof OperatorPathNotAllowedError) {
+        return refuse({
+          correlation_id: correlationId,
+          requested_action: action.name,
+          action: action.name,
+          code: "forbidden_path",
+          reason: err.message,
+          actor,
+          target,
+          upstream: { method: "POST", path, status: null },
+          confirmation,
+          auditReason: reason,
+        });
+      }
+      const message =
+        err instanceof OperatorTimeoutError
+          ? err.message
+          : err instanceof Error
+            ? `Warmbly operator transport failure: ${err.name}`
+            : "Warmbly operator transport failure";
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: action.name,
+        action: action.name,
+        code: "transport_error",
+        reason: message,
+        actor,
+        target,
+        upstream: { method: "POST", path, status: null },
+        confirmation,
+        auditReason: reason,
+      });
+    }
+
+    const upstream: OperatorLedgerUpstream = {
+      method: "POST",
+      path: response.path,
+      status: response.status,
+    };
+
+    if (response.status < 200 || response.status > 299) {
+      return refuse({
+        correlation_id: correlationId,
+        requested_action: action.name,
+        action: action.name,
+        code: "upstream_error",
+        reason: `Warmbly refused ${action.name} with HTTP ${response.status}`,
+        actor,
+        target,
+        upstream,
+        confirmation,
+        auditReason: reason,
+      });
+    }
+
+    const entry = record(
+      buildEntry({
+        correlation_id: correlationId,
+        requested_action: action.name,
+        action: action.name,
+        outcome: "executed",
+        refusal_code: null,
+        refusal_reason: null,
+        actor,
+        target,
+        upstream,
+        confirmation,
+        reason,
+      }),
+    );
+    return {
+      ok: true,
+      outcome: "executed",
+      action: action.name,
+      target,
+      upstream_status: response.status,
+      upstream_body: response.json,
+      entry,
+    };
+  }
+
+  return {
+    actions: OPERATOR_ACTION_NAMES,
+    ledger,
+    circuitState: safeCircuitState,
+    requestConfirmation,
+    requestResumeConfirmation: (input) =>
+      requestConfirmation({ ...input, action: "resume_dispatch", target_id: DISPATCH_TARGET_ID }),
+    execute,
+    pauseDispatch: (input) =>
+      execute({ ...input, action: "pause_dispatch", target_id: DISPATCH_TARGET_ID }),
+    resumeDispatch: (input) =>
+      execute({ ...input, action: "resume_dispatch", target_id: DISPATCH_TARGET_ID }),
+    acknowledgeInboundAlert: (input) =>
+      execute({ ...input, action: "acknowledge_inbound_alert" }),
+  };
+}

--- a/control-center/connectors/warmbly/src/operator/channel.ts
+++ b/control-center/connectors/warmbly/src/operator/channel.ts
@@ -4,8 +4,9 @@
  * Narrow by construction: a caller names one of three actions and supplies the
  * raw HTTP request whose Authelia `Remote-*` headers carry the founder. There
  * is no method parameter, no path parameter, and no escape hatch. Every call
- * — executed, refused or challenged — writes exactly one ledger entry before
- * it returns.
+ * — executed, refused, challenged, or unknown — writes exactly one ledger entry
+ * before it returns, under a correlation id minted here rather than supplied by
+ * the caller.
  */
 
 import { randomUUID } from "node:crypto";
@@ -26,6 +27,7 @@ import { classifyOperatorRequest } from "./allowlist.ts";
 import {
   OperatorPathNotAllowedError,
   OperatorTimeoutError,
+  isPreFlightTransportFailure,
   type WarmblyOperatorClient,
 } from "./client.ts";
 import {
@@ -41,17 +43,21 @@ import {
   type TrustedHopPolicy,
 } from "./identity.ts";
 import {
+  OPERATOR_DISPATCH_STATUS_PATH,
   OPERATOR_LEDGER_SCHEMA,
   OPERATOR_LEDGER_SOURCE_KIND,
   OPERATOR_LEDGER_SOURCE_SYSTEM,
+  OPERATOR_UNKNOWN_CODE,
   createMemoryOperatorActionLedger,
   operatorLedgerId,
+  writeOperatorLedgerWal,
   type OperatorActionLedger,
   type OperatorActionLedgerEntry,
   type OperatorLedgerConfirmation,
   type OperatorLedgerTarget,
   type OperatorLedgerUpstream,
   type OperatorRefusalCode,
+  type OperatorUnknownCode,
 } from "./ledger.ts";
 
 export interface OperatorActionInput {
@@ -62,7 +68,12 @@ export interface OperatorActionInput {
   target_id?: string;
   reason?: string;
   confirmation_token?: string;
-  correlation_id?: string;
+  /**
+   * The caller's own reference. It is echoed on the entry and never used as a
+   * key: `correlation_id` and the ledger `id` are minted here, so a replayed
+   * reference can never rewrite an existing record.
+   */
+  client_reference?: string;
 }
 
 export type NamedOperatorActionInput = Omit<OperatorActionInput, "action">;
@@ -94,7 +105,23 @@ export interface OperatorRefused {
   entry: OperatorActionLedgerEntry;
 }
 
-export type OperatorActionResult = OperatorExecuted | OperatorChallenged | OperatorRefused;
+/**
+ * The request reached Warmbly and the answer did not reach us. Not a success
+ * and — critically — not a refusal: the action may have been applied.
+ */
+export interface OperatorUnknown {
+  ok: false;
+  outcome: "unknown";
+  code: OperatorUnknownCode;
+  reason: string;
+  entry: OperatorActionLedgerEntry;
+}
+
+export type OperatorActionResult =
+  | OperatorExecuted
+  | OperatorChallenged
+  | OperatorRefused
+  | OperatorUnknown;
 
 export interface WarmblyOperatorChannelOptions {
   client: WarmblyOperatorClient;
@@ -105,6 +132,11 @@ export interface WarmblyOperatorChannelOptions {
   now?: () => Date;
   newCorrelationId?: () => string;
   logger?: Logger;
+  /**
+   * Durable last resort when `ledger.record` throws. Defaults to a synchronous
+   * stderr WAL line so an executed action is never lost silently.
+   */
+  onLedgerWriteFailure?: (entry: OperatorActionLedgerEntry, err: unknown) => void;
 }
 
 export interface WarmblyOperatorChannel {
@@ -142,17 +174,43 @@ export function createWarmblyOperatorChannel(
   const now = options.now ?? (() => new Date());
   const newCorrelationId = options.newCorrelationId ?? (() => randomUUID());
   const logger = options.logger ?? createStderrLogger();
+  const onLedgerWriteFailure = options.onLedgerWriteFailure ?? writeOperatorLedgerWal;
 
-  function correlationOf(input: OperatorActionInput): string {
-    const raw = typeof input.correlation_id === "string" ? input.correlation_id.trim() : "";
-    if (raw !== "" && /^[A-Za-z0-9._:~-]{1,96}$/.test(raw)) {
-      return raw;
-    }
+  /**
+   * Always minted here. A caller-chosen correlation id would key the ledger
+   * entry (and the agent-activity session), so replaying it would rewrite the
+   * row of an already-executed action — in a record that is the sole
+   * non-repudiation evidence while `paused_by` is missing upstream.
+   */
+  function correlationOf(): string {
     return `cc:warmbly-op:${newCorrelationId()}`;
   }
 
+  /** The caller's value, carried but never used as a key. */
+  function clientReferenceOf(input: OperatorActionInput): string | null {
+    const raw = typeof input.client_reference === "string" ? input.client_reference.trim() : "";
+    return raw !== "" && /^[A-Za-z0-9._:~-]{1,96}$/.test(raw) ? raw : null;
+  }
+
   function record(entry: OperatorActionLedgerEntry): OperatorActionLedgerEntry {
-    ledger.record(entry);
+    try {
+      ledger.record(entry);
+    } catch (err) {
+      // The upstream write may already have happened. An entry lost here is the
+      // non-repudiation failure, so put it somewhere durable before the failure
+      // surfaces to the caller.
+      onLedgerWriteFailure(entry, err);
+      logger({
+        level: "error",
+        msg: "warmbly.operator.ledger_write_failed",
+        correlation_id: entry.correlation_id,
+        requested_action: entry.requested_action,
+        outcome: entry.outcome,
+        upstream_status: entry.upstream.status,
+        error: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      });
+      throw err;
+    }
     logger({
       level: entry.outcome === "executed" ? "info" : "warn",
       msg: "warmbly.operator.recorded",
@@ -170,10 +228,11 @@ export function createWarmblyOperatorChannel(
 
   function buildEntry(parts: {
     correlation_id: string;
+    client_reference: string | null;
     requested_action: string;
     action: OperatorActionName | null;
     outcome: OperatorActionLedgerEntry["outcome"];
-    refusal_code: OperatorRefusalCode | null;
+    refusal_code: OperatorRefusalCode | OperatorUnknownCode | null;
     refusal_reason: string | null;
     actor: OperatorActor | null;
     target: OperatorLedgerTarget;
@@ -186,6 +245,7 @@ export function createWarmblyOperatorChannel(
       schema_version: OPERATOR_LEDGER_SCHEMA,
       id: operatorLedgerId(parts.correlation_id),
       correlation_id: parts.correlation_id,
+      client_reference: parts.client_reference,
       requested_action: parts.requested_action,
       action: parts.action,
       outcome: parts.outcome,
@@ -219,6 +279,7 @@ export function createWarmblyOperatorChannel(
 
   function refuse(parts: {
     correlation_id: string;
+    client_reference: string | null;
     requested_action: string;
     action: OperatorActionName | null;
     code: OperatorRefusalCode;
@@ -232,6 +293,7 @@ export function createWarmblyOperatorChannel(
     const entry = record(
       buildEntry({
         correlation_id: parts.correlation_id,
+        client_reference: parts.client_reference,
         requested_action: parts.requested_action,
         action: parts.action,
         outcome: "refused",
@@ -245,6 +307,45 @@ export function createWarmblyOperatorChannel(
       }),
     );
     return { ok: false, outcome: "refused", code: parts.code, reason: parts.reason, entry };
+  }
+
+  /**
+   * Records an action whose result is genuinely unknown: the POST was written
+   * and no answer came back. The reason points at the one place that can settle
+   * it, because a blind retry of a resume is exactly what must not happen.
+   */
+  function unresolved(parts: {
+    correlation_id: string;
+    client_reference: string | null;
+    action: OperatorActionName;
+    detail: string;
+    actor: OperatorActor;
+    target: OperatorLedgerTarget;
+    path: string;
+    confirmation: OperatorLedgerConfirmation;
+    auditReason: string | null;
+  }): OperatorUnknown {
+    const reason =
+      `${parts.detail}. The request was already written to Warmbly, so ${parts.action} may have ` +
+      `been applied: read GET ${OPERATOR_DISPATCH_STATUS_PATH} before retrying. Any confirmation ` +
+      "token used for this call is spent and a retry needs a fresh confirmation.";
+    const entry = record(
+      buildEntry({
+        correlation_id: parts.correlation_id,
+        client_reference: parts.client_reference,
+        requested_action: parts.action,
+        action: parts.action,
+        outcome: "unknown",
+        refusal_code: OPERATOR_UNKNOWN_CODE,
+        refusal_reason: reason,
+        actor: parts.actor,
+        target: parts.target,
+        upstream: { method: "POST", path: parts.path, status: null },
+        confirmation: parts.confirmation,
+        reason: parts.auditReason,
+      }),
+    );
+    return { ok: false, outcome: "unknown", code: OPERATOR_UNKNOWN_CODE, reason, entry };
   }
 
   interface Prepared {
@@ -263,6 +364,7 @@ export function createWarmblyOperatorChannel(
   function prepare(
     input: OperatorActionInput,
     correlationId: string,
+    clientReference: string | null,
   ): Prepared | OperatorRefused {
     const requested = typeof input.action === "string" ? input.action : String(input.action);
 
@@ -270,6 +372,7 @@ export function createWarmblyOperatorChannel(
     if (!identity.ok) {
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: requested,
         action: null,
         code: "missing_actor",
@@ -283,6 +386,7 @@ export function createWarmblyOperatorChannel(
     if (!action) {
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: requested,
         action: null,
         code: "unknown_action",
@@ -298,6 +402,7 @@ export function createWarmblyOperatorChannel(
     if (rawTarget === null || !isValidTargetId(rawTarget)) {
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: requested,
         action: action.name,
         code: "invalid_target",
@@ -309,6 +414,7 @@ export function createWarmblyOperatorChannel(
     if (!action.target_in_path && rawTarget !== action.default_target_id) {
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: requested,
         action: action.name,
         code: "invalid_target",
@@ -323,6 +429,7 @@ export function createWarmblyOperatorChannel(
     if (action.reason_required && !isValidReason(rawReason)) {
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: requested,
         action: action.name,
         code: "invalid_reason",
@@ -334,6 +441,7 @@ export function createWarmblyOperatorChannel(
     if (rawReason !== "" && !isValidReason(rawReason)) {
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: requested,
         action: action.name,
         code: "invalid_reason",
@@ -351,6 +459,7 @@ export function createWarmblyOperatorChannel(
     if (!classified.allowed) {
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: requested,
         action: action.name,
         code: "forbidden_path",
@@ -370,8 +479,9 @@ export function createWarmblyOperatorChannel(
   }
 
   async function requestConfirmation(input: OperatorActionInput): Promise<OperatorActionResult> {
-    const correlationId = correlationOf(input);
-    const prepared = prepare(input, correlationId);
+    const correlationId = correlationOf();
+    const clientReference = clientReferenceOf(input);
+    const prepared = prepare(input, correlationId, clientReference);
     if (isRefusal(prepared)) {
       return prepared;
     }
@@ -379,6 +489,7 @@ export function createWarmblyOperatorChannel(
     if (action.confirmation !== "two_step") {
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: action.name,
         action: action.name,
         code: "confirmation_not_applicable",
@@ -392,11 +503,13 @@ export function createWarmblyOperatorChannel(
       action: action.name,
       target_id: target.id,
       actor_id: actor.id,
+      reason,
       now: now(),
     });
     const entry = record(
       buildEntry({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: action.name,
         action: action.name,
         outcome: "challenged",
@@ -413,8 +526,9 @@ export function createWarmblyOperatorChannel(
   }
 
   async function execute(input: OperatorActionInput): Promise<OperatorActionResult> {
-    const correlationId = correlationOf(input);
-    const prepared = prepare(input, correlationId);
+    const correlationId = correlationOf();
+    const clientReference = clientReferenceOf(input);
+    const prepared = prepare(input, correlationId, clientReference);
     if (isRefusal(prepared)) {
       return prepared;
     }
@@ -426,6 +540,7 @@ export function createWarmblyOperatorChannel(
       if (typeof supplied !== "string" || supplied.trim() === "") {
         return refuse({
           correlation_id: correlationId,
+          client_reference: clientReference,
           requested_action: action.name,
           action: action.name,
           code: "confirmation_required",
@@ -441,11 +556,13 @@ export function createWarmblyOperatorChannel(
         action: action.name,
         target_id: target.id,
         actor_id: actor.id,
+        reason,
         now: now(),
       });
       if (!checked.ok) {
         return refuse({
           correlation_id: correlationId,
+          client_reference: clientReference,
           requested_action: action.name,
           action: action.name,
           code: "confirmation_invalid",
@@ -465,6 +582,7 @@ export function createWarmblyOperatorChannel(
       if (err instanceof CircuitOpenError) {
         return refuse({
           correlation_id: correlationId,
+          client_reference: clientReference,
           requested_action: action.name,
           action: action.name,
           code: "circuit_open",
@@ -489,6 +607,7 @@ export function createWarmblyOperatorChannel(
       if (err instanceof CircuitOpenError) {
         return refuse({
           correlation_id: correlationId,
+          client_reference: clientReference,
           requested_action: action.name,
           action: action.name,
           code: "circuit_open",
@@ -503,6 +622,7 @@ export function createWarmblyOperatorChannel(
       if (err instanceof OperatorPathNotAllowedError) {
         return refuse({
           correlation_id: correlationId,
+          client_reference: clientReference,
           requested_action: action.name,
           action: action.name,
           code: "forbidden_path",
@@ -520,15 +640,32 @@ export function createWarmblyOperatorChannel(
           : err instanceof Error
             ? `Warmbly operator transport failure: ${err.name}`
             : "Warmbly operator transport failure";
+      // A timeout, or any failure that is not provably pre-flight, means the
+      // POST may already have been applied upstream. Calling that "refused"
+      // would tell the operator dispatch is still paused while Warmbly sends.
+      if (!isPreFlightTransportFailure(err)) {
+        return unresolved({
+          correlation_id: correlationId,
+          client_reference: clientReference,
+          action: action.name,
+          detail: message,
+          actor,
+          target,
+          path,
+          confirmation,
+          auditReason: reason,
+        });
+      }
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: action.name,
         action: action.name,
         code: "transport_error",
-        reason: message,
+        reason: `${message} (the request was never written: nothing was applied upstream)`,
         actor,
         target,
-        upstream: { method: "POST", path, status: null },
+        upstream: { method: null, path: null, status: null },
         confirmation,
         auditReason: reason,
       });
@@ -541,12 +678,17 @@ export function createWarmblyOperatorChannel(
     };
 
     if (response.status < 200 || response.status > 299) {
+      const redirected = response.status >= 300 && response.status <= 399;
       return refuse({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: action.name,
         action: action.name,
         code: "upstream_error",
-        reason: `Warmbly refused ${action.name} with HTTP ${response.status}`,
+        reason: redirected
+          ? `Warmbly answered ${action.name} with HTTP ${response.status}; the operator channel ` +
+            "never follows a redirect, because the Location is not classified by the write allowlist"
+          : `Warmbly refused ${action.name} with HTTP ${response.status}`,
         actor,
         target,
         upstream,
@@ -558,6 +700,7 @@ export function createWarmblyOperatorChannel(
     const entry = record(
       buildEntry({
         correlation_id: correlationId,
+        client_reference: clientReference,
         requested_action: action.name,
         action: action.name,
         outcome: "executed",

--- a/control-center/connectors/warmbly/src/operator/client.ts
+++ b/control-center/connectors/warmbly/src/operator/client.ts
@@ -1,0 +1,216 @@
+/**
+ * POST-only Warmbly client for the three allowed operator controls.
+ *
+ * Deliberately not `WarmblyClient`: that one stays read-only. This one accepts
+ * no caller-supplied method, refuses any path that is not on
+ * `classifyOperatorRequest`, and never retries — a retried acknowledge would
+ * double-acknowledge, and a retried kill-switch call is not worth the ambiguity.
+ */
+
+import { CircuitBreaker, CircuitOpenError, type CircuitState } from "../http/circuit-breaker.ts";
+import {
+  createStderrLogger,
+  redactHeaders,
+  redactSecrets,
+  type Logger,
+} from "../http/redaction.ts";
+import { classifyOperatorRequest } from "./allowlist.ts";
+
+export class OperatorPathNotAllowedError extends Error {
+  readonly code = "OPERATOR_PATH_NOT_ALLOWED" as const;
+  readonly method: string;
+  readonly path: string;
+  constructor(method: string, path: string, reason: string) {
+    super(reason);
+    this.name = "OperatorPathNotAllowedError";
+    this.method = method;
+    this.path = path;
+  }
+}
+
+export class OperatorTimeoutError extends Error {
+  readonly code = "OPERATOR_TIMEOUT" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "OperatorTimeoutError";
+  }
+}
+
+export interface OperatorPostResult {
+  ok: boolean;
+  status: number;
+  path: string;
+  method: "POST";
+  api_version?: string;
+  json: unknown;
+}
+
+export interface WarmblyOperatorClientOptions {
+  baseUrl: string;
+  token: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  logger?: Logger;
+  /** Share the read client's breaker so a degraded upstream blocks writes too. */
+  breaker?: CircuitBreaker;
+  failureThreshold?: number;
+  resetMs?: number;
+  now?: () => number;
+}
+
+function joinUrl(base: string, path: string): string {
+  const trimmed = base.replace(/\/+$/, "");
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${trimmed}${p}`;
+}
+
+export class WarmblyOperatorClient {
+  readonly baseUrl: string;
+  readonly breaker: CircuitBreaker;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger: Logger;
+  hitCount = 0;
+
+  constructor(opts: WarmblyOperatorClientOptions) {
+    if (!opts.baseUrl) {
+      throw new Error("WARMBLY_BASE_URL is required");
+    }
+    if (!opts.token) {
+      throw new Error("WARMBLY_API_TOKEN is required");
+    }
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.token = opts.token;
+    this.timeoutMs = opts.timeoutMs ?? 8_000;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.logger = opts.logger ?? createStderrLogger();
+    this.breaker =
+      opts.breaker ??
+      new CircuitBreaker({
+        failureThreshold: opts.failureThreshold ?? 3,
+        resetMs: opts.resetMs ?? 30_000,
+        now: opts.now,
+      });
+  }
+
+  circuitState(): CircuitState {
+    return this.breaker.getState();
+  }
+
+  assertCircuitClosed(): void {
+    this.breaker.assertClosed();
+  }
+
+  /**
+   * Single POST. Throws `OperatorPathNotAllowedError` before any socket is
+   * opened when the path is not one of the three allowed controls, and
+   * `CircuitOpenError` when the breaker is open.
+   */
+  async post(path: string, body: unknown): Promise<OperatorPostResult> {
+    const classified = classifyOperatorRequest("POST", path);
+    if (!classified.allowed) {
+      this.logger({
+        level: "error",
+        msg: "warmbly.operator.denied",
+        method: "POST",
+        path: classified.path,
+        reason: classified.reason,
+      });
+      throw new OperatorPathNotAllowedError("POST", classified.path, classified.reason);
+    }
+
+    this.breaker.assertClosed();
+
+    const url = joinUrl(this.baseUrl, classified.path);
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      Authorization: `Bearer ${this.token}`,
+      "API-Version": "v1",
+      "Content-Type": "application/json",
+    };
+
+    this.hitCount += 1;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body ?? {}),
+        signal: controller.signal,
+      });
+      let json: unknown = null;
+      const text = await res.text();
+      if (text.length > 0) {
+        try {
+          json = JSON.parse(text) as unknown;
+        } catch {
+          json = { raw: redactSecrets(text.slice(0, 200)) };
+        }
+      }
+      // 4xx is an upstream refusal, not connector degradation: it must not trip
+      // the breaker and lock the operator out of pausing.
+      if (res.status >= 500 || res.status === 429) {
+        this.breaker.recordFailure();
+      } else {
+        this.breaker.recordSuccess();
+      }
+      this.logger({
+        level: res.ok ? "info" : "warn",
+        msg: "warmbly.operator.response",
+        method: "POST",
+        path: classified.path,
+        status: res.status,
+      });
+      return {
+        ok: res.ok,
+        status: res.status,
+        path: classified.path,
+        method: "POST",
+        api_version: res.headers.get("API-Version") ?? undefined,
+        json,
+      };
+    } catch (err) {
+      this.breaker.recordFailure();
+      if (isAbortError(err)) {
+        const timeout = new OperatorTimeoutError(
+          `Warmbly operator request timed out after ${this.timeoutMs}ms on ${classified.path}`,
+        );
+        this.logger({
+          level: "error",
+          msg: "warmbly.operator.timeout",
+          method: "POST",
+          path: classified.path,
+        });
+        throw timeout;
+      }
+      this.logger({
+        level: "error",
+        msg: "warmbly.operator.transport_error",
+        method: "POST",
+        path: classified.path,
+        error: err instanceof Error ? err.name : "error",
+      });
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  describeAuthForLogs(): Record<string, string> {
+    return redactHeaders({ Authorization: `Bearer ${this.token}` });
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    (err instanceof Error && err.name === "AbortError") ||
+    (typeof err === "object" &&
+      err !== null &&
+      "name" in err &&
+      (err as { name: string }).name === "AbortError")
+  );
+}
+
+export { CircuitOpenError };

--- a/control-center/connectors/warmbly/src/operator/client.ts
+++ b/control-center/connectors/warmbly/src/operator/client.ts
@@ -30,10 +30,112 @@ export class OperatorPathNotAllowedError extends Error {
 
 export class OperatorTimeoutError extends Error {
   readonly code = "OPERATOR_TIMEOUT" as const;
+  /**
+   * The request was already written when the clock ran out, so Warmbly may have
+   * applied it. A timeout is never evidence that the action did not happen.
+   */
+  readonly requestWritten = true as const;
   constructor(message: string) {
     super(message);
     this.name = "OperatorTimeoutError";
   }
+}
+
+/**
+ * Errors that prove the request never left this process: name resolution and
+ * connection establishment failed, so no byte of the POST reached Warmbly.
+ * Anything not on this list is treated as "may have been written" — the
+ * conservative direction for a channel that can start outbound email.
+ */
+const PRE_FLIGHT_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EACCES",
+  "ERR_INVALID_URL",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "CERT_HAS_EXPIRED",
+  "ERR_TLS_CERT_ALTNAME_INVALID",
+]);
+
+/**
+ * URL-level rejections. `fetch` throws these before opening a socket and they
+ * carry no `code`, so they are matched on the message the runtime uses.
+ */
+const PRE_FLIGHT_MESSAGES = [
+  "bad port",
+  "unsupported protocol",
+  "invalid url",
+  "failed to parse url",
+];
+
+function errorMessagesOf(err: unknown, depth = 0): string[] {
+  if (depth > 4 || typeof err !== "object" || err === null) {
+    return [];
+  }
+  const messages: string[] = [];
+  const message = (err as { message?: unknown }).message;
+  if (typeof message === "string") {
+    messages.push(message.toLowerCase());
+  }
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause !== undefined) {
+    messages.push(...errorMessagesOf(cause, depth + 1));
+  }
+  const aggregate = (err as { errors?: unknown }).errors;
+  if (Array.isArray(aggregate)) {
+    for (const inner of aggregate) {
+      messages.push(...errorMessagesOf(inner, depth + 1));
+    }
+  }
+  return messages;
+}
+
+function errorCodesOf(err: unknown, depth = 0): string[] {
+  if (depth > 4 || typeof err !== "object" || err === null) {
+    return [];
+  }
+  const codes: string[] = [];
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === "string") {
+    codes.push(code);
+  }
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause !== undefined) {
+    codes.push(...errorCodesOf(cause, depth + 1));
+  }
+  const aggregate = (err as { errors?: unknown }).errors;
+  if (Array.isArray(aggregate)) {
+    for (const inner of aggregate) {
+      codes.push(...errorCodesOf(inner, depth + 1));
+    }
+  }
+  return codes;
+}
+
+/**
+ * True only when the failure happened before anything was written to the
+ * socket. Used by the channel to decide between `refused` (nothing happened
+ * upstream) and `unknown` (it may have).
+ */
+export function isPreFlightTransportFailure(err: unknown): boolean {
+  if (err instanceof OperatorPathNotAllowedError) {
+    return true;
+  }
+  if (err instanceof OperatorTimeoutError) {
+    return false;
+  }
+  if (errorCodesOf(err).some((code) => PRE_FLIGHT_ERROR_CODES.has(code))) {
+    return true;
+  }
+  return errorMessagesOf(err).some((message) =>
+    PRE_FLIGHT_MESSAGES.some((marker) => message.includes(marker)),
+  );
 }
 
 export interface OperatorPostResult {
@@ -139,6 +241,11 @@ export class WarmblyOperatorClient {
         headers,
         body: JSON.stringify(body ?? {}),
         signal: controller.signal,
+        // Never follow a redirect. A 3xx would re-issue this POST — Bearer token,
+        // original body and all — at a Location that was never classified by
+        // `classifyOperatorRequest`, so `dispatch-now` could be executed while
+        // the ledger recorded the allowlisted path.
+        redirect: "manual",
       });
       let json: unknown = null;
       const text = await res.text();
@@ -148,6 +255,15 @@ export class WarmblyOperatorClient {
         } catch {
           json = { raw: redactSecrets(text.slice(0, 200)) };
         }
+      }
+      if (res.status >= 300 && res.status <= 399) {
+        this.logger({
+          level: "error",
+          msg: "warmbly.operator.redirect_refused",
+          method: "POST",
+          path: classified.path,
+          status: res.status,
+        });
       }
       // 4xx is an upstream refusal, not connector degradation: it must not trip
       // the breaker and lock the operator out of pausing.

--- a/control-center/connectors/warmbly/src/operator/confirmation.ts
+++ b/control-center/connectors/warmbly/src/operator/confirmation.ts
@@ -1,0 +1,123 @@
+/**
+ * Two-step confirmation for `resume_dispatch`.
+ *
+ * Releasing the kill switch is the one action that can let traffic flow, so it
+ * takes two calls: `requestConfirmation` mints a single-use, short-lived,
+ * actor-bound and target-bound challenge, and `execute` refuses without it.
+ * Pause never touches this file — it is one step and never confirmation-gated.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { OperatorActionName } from "./actions.ts";
+
+export const DEFAULT_CONFIRMATION_TTL_MS = 120_000;
+
+export interface OperatorConfirmationChallenge {
+  token: string;
+  token_id: string;
+  action: OperatorActionName;
+  target_id: string;
+  actor_id: string;
+  issued_at: string;
+  expires_at: string;
+}
+
+export type ConfirmationCheck =
+  | { ok: true; token_id: string }
+  | { ok: false; reason: string };
+
+export interface ConfirmationStore {
+  issue(input: {
+    action: OperatorActionName;
+    target_id: string;
+    actor_id: string;
+    now: Date;
+  }): OperatorConfirmationChallenge;
+  /** Single-use: a successful consume invalidates the token. */
+  consume(input: {
+    token: unknown;
+    action: OperatorActionName;
+    target_id: string;
+    actor_id: string;
+    now: Date;
+  }): ConfirmationCheck;
+  pending(): OperatorConfirmationChallenge[];
+}
+
+interface StoredChallenge extends OperatorConfirmationChallenge {
+  expires_at_ms: number;
+}
+
+export function createConfirmationStore(options: {
+  ttlMs?: number;
+  newToken?: () => string;
+} = {}): ConfirmationStore {
+  const ttlMs = options.ttlMs ?? DEFAULT_CONFIRMATION_TTL_MS;
+  const newToken = options.newToken ?? (() => `wcnf_${randomUUID()}`);
+  const byToken = new Map<string, StoredChallenge>();
+
+  function sweep(nowMs: number): void {
+    for (const [token, challenge] of byToken) {
+      if (challenge.expires_at_ms <= nowMs) {
+        byToken.delete(token);
+      }
+    }
+  }
+
+  return {
+    issue({ action, target_id, actor_id, now }) {
+      const nowMs = now.getTime();
+      sweep(nowMs);
+      const token = newToken();
+      const expiresMs = nowMs + ttlMs;
+      const challenge: StoredChallenge = {
+        token,
+        token_id: `cnf:${action}:${target_id}`,
+        action,
+        target_id,
+        actor_id,
+        issued_at: new Date(nowMs).toISOString(),
+        expires_at: new Date(expiresMs).toISOString(),
+        expires_at_ms: expiresMs,
+      };
+      byToken.set(token, challenge);
+      const { expires_at_ms: _drop, ...visible } = challenge;
+      void _drop;
+      return visible;
+    },
+
+    consume({ token, action, target_id, actor_id, now }) {
+      const nowMs = now.getTime();
+      sweep(nowMs);
+      if (typeof token !== "string" || token.trim() === "") {
+        return { ok: false, reason: "confirmation token is required to release the kill switch" };
+      }
+      const challenge = byToken.get(token);
+      if (!challenge) {
+        return { ok: false, reason: "confirmation token is unknown, expired, or already used" };
+      }
+      if (challenge.expires_at_ms <= nowMs) {
+        byToken.delete(token);
+        return { ok: false, reason: "confirmation token has expired" };
+      }
+      if (challenge.action !== action) {
+        return { ok: false, reason: "confirmation token was issued for a different action" };
+      }
+      if (challenge.target_id !== target_id) {
+        return { ok: false, reason: "confirmation token was issued for a different target" };
+      }
+      if (challenge.actor_id !== actor_id) {
+        return { ok: false, reason: "confirmation token was issued to a different operator" };
+      }
+      byToken.delete(token);
+      return { ok: true, token_id: challenge.token_id };
+    },
+
+    pending() {
+      return Array.from(byToken.values()).map(({ expires_at_ms: _drop, ...visible }) => {
+        void _drop;
+        return visible;
+      });
+    },
+  };
+}

--- a/control-center/connectors/warmbly/src/operator/confirmation.ts
+++ b/control-center/connectors/warmbly/src/operator/confirmation.ts
@@ -7,14 +7,27 @@
  * Pause never touches this file — it is one step and never confirmation-gated.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { OperatorActionName } from "./actions.ts";
 
 export const DEFAULT_CONFIRMATION_TTL_MS = 120_000;
 
+/**
+ * The audit reason is bound to the challenge by hash, so a token minted for
+ * "incidente resolvido" cannot be spent on a resume that records a different
+ * reason. The hash — not the reason — is what the ledger and the caller see, so
+ * binding costs nothing in disclosure.
+ */
+export function confirmationReasonHash(reason: string | null): string {
+  return createHash("sha256").update(`warmbly-operator-reason:${reason ?? ""}`).digest("hex");
+}
+
 export interface OperatorConfirmationChallenge {
   token: string;
+  /** Unique per challenge: `cnf:<action>:<target_id>:<uuid>`. */
   token_id: string;
+  /** sha256 of the audit reason this challenge was minted for. */
+  reason_hash: string;
   action: OperatorActionName;
   target_id: string;
   actor_id: string;
@@ -31,6 +44,7 @@ export interface ConfirmationStore {
     action: OperatorActionName;
     target_id: string;
     actor_id: string;
+    reason: string | null;
     now: Date;
   }): OperatorConfirmationChallenge;
   /** Single-use: a successful consume invalidates the token. */
@@ -39,6 +53,7 @@ export interface ConfirmationStore {
     action: OperatorActionName;
     target_id: string;
     actor_id: string;
+    reason: string | null;
     now: Date;
   }): ConfirmationCheck;
   pending(): OperatorConfirmationChallenge[];
@@ -51,9 +66,11 @@ interface StoredChallenge extends OperatorConfirmationChallenge {
 export function createConfirmationStore(options: {
   ttlMs?: number;
   newToken?: () => string;
+  newTokenId?: () => string;
 } = {}): ConfirmationStore {
   const ttlMs = options.ttlMs ?? DEFAULT_CONFIRMATION_TTL_MS;
   const newToken = options.newToken ?? (() => `wcnf_${randomUUID()}`);
+  const newTokenId = options.newTokenId ?? (() => randomUUID());
   const byToken = new Map<string, StoredChallenge>();
 
   function sweep(nowMs: number): void {
@@ -65,14 +82,17 @@ export function createConfirmationStore(options: {
   }
 
   return {
-    issue({ action, target_id, actor_id, now }) {
+    issue({ action, target_id, actor_id, reason, now }) {
       const nowMs = now.getTime();
       sweep(nowMs);
       const token = newToken();
       const expiresMs = nowMs + ttlMs;
       const challenge: StoredChallenge = {
         token,
-        token_id: `cnf:${action}:${target_id}`,
+        // Unique per mint: the ledger must show which challenge was spent and
+        // how many were minted and abandoned.
+        token_id: `cnf:${action}:${target_id}:${newTokenId()}`,
+        reason_hash: confirmationReasonHash(reason),
         action,
         target_id,
         actor_id,
@@ -86,7 +106,7 @@ export function createConfirmationStore(options: {
       return visible;
     },
 
-    consume({ token, action, target_id, actor_id, now }) {
+    consume({ token, action, target_id, actor_id, reason, now }) {
       const nowMs = now.getTime();
       sweep(nowMs);
       if (typeof token !== "string" || token.trim() === "") {
@@ -108,6 +128,9 @@ export function createConfirmationStore(options: {
       }
       if (challenge.actor_id !== actor_id) {
         return { ok: false, reason: "confirmation token was issued to a different operator" };
+      }
+      if (challenge.reason_hash !== confirmationReasonHash(reason)) {
+        return { ok: false, reason: "confirmation token was issued for a different audit reason" };
       }
       byToken.delete(token);
       return { ok: true, token_id: challenge.token_id };

--- a/control-center/connectors/warmbly/src/operator/http.ts
+++ b/control-center/connectors/warmbly/src/operator/http.ts
@@ -1,0 +1,165 @@
+/**
+ * Mountable HTTP surface for the operator action channel.
+ *
+ * Three fixed routes, POST only. The request's `Remote-*` headers and socket
+ * address are handed straight to the channel, which resolves the founder via
+ * `control-center/security`. There is no body field that can name a method, a
+ * path, or an actor: identity comes from Authelia and nowhere else.
+ *
+ *   POST /v1/warmbly/operator/dispatch/pause
+ *   POST /v1/warmbly/operator/dispatch/resume/confirm   (step 1, mints a token)
+ *   POST /v1/warmbly/operator/dispatch/resume           (step 2, needs the token)
+ *   POST /v1/warmbly/operator/inbound/acknowledge
+ */
+
+import type { OperatorActionResult, WarmblyOperatorChannel } from "./channel.ts";
+
+export const OPERATOR_HTTP_ROUTES = {
+  pause: "/v1/warmbly/operator/dispatch/pause",
+  resumeConfirm: "/v1/warmbly/operator/dispatch/resume/confirm",
+  resume: "/v1/warmbly/operator/dispatch/resume",
+  acknowledge: "/v1/warmbly/operator/inbound/acknowledge",
+} as const;
+
+export type OperatorHttpRoute = (typeof OPERATOR_HTTP_ROUTES)[keyof typeof OPERATOR_HTTP_ROUTES];
+
+export interface OperatorHttpRequest {
+  method: string | undefined;
+  url: string | undefined;
+  headers: Readonly<Record<string, string | string[] | undefined>>;
+  /** Socket peer address. The trusted-hop check is done against this. */
+  remoteAddress: string | undefined;
+  /** Already-parsed JSON body. The handler never parses a stream itself. */
+  body: unknown;
+}
+
+export interface OperatorHttpResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+function pathOf(url: string | undefined): string {
+  const raw = url ?? "/";
+  const cut = raw.split("?")[0] ?? raw;
+  return cut.length > 1 && cut.endsWith("/") ? cut.slice(0, -1) : cut;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+/** Refusals are 4xx; a refusal is never rendered as a success. */
+function statusFor(result: OperatorActionResult): number {
+  if (result.ok) {
+    return result.outcome === "challenged" ? 202 : 200;
+  }
+  switch (result.code) {
+    case "missing_actor":
+      return 401;
+    case "unknown_action":
+    case "forbidden_path":
+    case "confirmation_not_applicable":
+      return 403;
+    case "invalid_target":
+    case "invalid_reason":
+      return 400;
+    case "confirmation_required":
+    case "confirmation_invalid":
+      return 428;
+    case "circuit_open":
+    case "transport_error":
+      return 503;
+    case "upstream_error":
+      return 502;
+    default:
+      return 403;
+  }
+}
+
+function render(result: OperatorActionResult): OperatorHttpResponse {
+  const base: Record<string, unknown> = {
+    outcome: result.outcome,
+    correlation_id: result.entry.correlation_id,
+    ledger_id: result.entry.id,
+    recorded_at: result.entry.recorded_at,
+  };
+  if (!result.ok) {
+    return { status: statusFor(result), body: { ...base, ok: false, code: result.code, reason: result.reason } };
+  }
+  if (result.outcome === "challenged") {
+    return {
+      status: statusFor(result),
+      body: {
+        ...base,
+        ok: true,
+        action: result.action,
+        confirmation_token: result.challenge.token,
+        expires_at: result.challenge.expires_at,
+      },
+    };
+  }
+  return {
+    status: statusFor(result),
+    body: {
+      ...base,
+      ok: true,
+      action: result.action,
+      target: result.target,
+      upstream_status: result.upstream_status,
+    },
+  };
+}
+
+export function createOperatorHttpHandler(
+  channel: WarmblyOperatorChannel,
+): (req: OperatorHttpRequest) => Promise<OperatorHttpResponse> {
+  return async (req) => {
+    const path = pathOf(req.url);
+    const known = (Object.values(OPERATOR_HTTP_ROUTES) as string[]).includes(path);
+    if (!known) {
+      return { status: 404, body: { ok: false, code: "unknown_route", reason: `no operator route ${path}` } };
+    }
+    if ((req.method ?? "").toUpperCase() !== "POST") {
+      return {
+        status: 405,
+        body: { ok: false, code: "method_not_allowed", reason: "operator routes are POST only" },
+      };
+    }
+    const identity = { remoteAddress: req.remoteAddress ?? "", headers: req.headers };
+    const body = asRecord(req.body);
+    const input = {
+      request: identity,
+      ...(str(body.reason) ? { reason: str(body.reason)! } : {}),
+      ...(str(body.correlation_id) ? { correlation_id: str(body.correlation_id)! } : {}),
+    };
+
+    if (path === OPERATOR_HTTP_ROUTES.pause) {
+      return render(await channel.pauseDispatch(input));
+    }
+    if (path === OPERATOR_HTTP_ROUTES.resumeConfirm) {
+      return render(await channel.requestResumeConfirmation(input));
+    }
+    if (path === OPERATOR_HTTP_ROUTES.resume) {
+      return render(
+        await channel.resumeDispatch({
+          ...input,
+          ...(str(body.confirmation_token)
+            ? { confirmation_token: str(body.confirmation_token)! }
+            : {}),
+        }),
+      );
+    }
+    return render(
+      await channel.acknowledgeInboundAlert({
+        ...input,
+        ...(str(body.target_id) ? { target_id: str(body.target_id)! } : {}),
+      }),
+    );
+  };
+}

--- a/control-center/connectors/warmbly/src/operator/http.ts
+++ b/control-center/connectors/warmbly/src/operator/http.ts
@@ -75,6 +75,10 @@ function statusFor(result: OperatorActionResult): number {
     case "circuit_open":
     case "transport_error":
       return 503;
+    // The write may have been applied upstream. 503 tells the caller the
+    // connector could not resolve it — the body says to read dispatch status.
+    case "transport_unknown":
+      return 503;
     case "upstream_error":
       return 502;
     default:
@@ -85,7 +89,10 @@ function statusFor(result: OperatorActionResult): number {
 function render(result: OperatorActionResult): OperatorHttpResponse {
   const base: Record<string, unknown> = {
     outcome: result.outcome,
+    // Minted by the channel. `client_reference` is the caller's own string and
+    // keys nothing.
     correlation_id: result.entry.correlation_id,
+    client_reference: result.entry.client_reference,
     ledger_id: result.entry.id,
     recorded_at: result.entry.recorded_at,
   };
@@ -133,10 +140,14 @@ export function createOperatorHttpHandler(
     }
     const identity = { remoteAddress: req.remoteAddress ?? "", headers: req.headers };
     const body = asRecord(req.body);
+    // A caller-supplied correlation id is never accepted as one: it is carried
+    // as `client_reference`, which keys nothing. `correlation_id` in the body is
+    // still read, for compatibility, into the same non-key field.
+    const clientReference = str(body.client_reference) ?? str(body.correlation_id);
     const input = {
       request: identity,
       ...(str(body.reason) ? { reason: str(body.reason)! } : {}),
-      ...(str(body.correlation_id) ? { correlation_id: str(body.correlation_id)! } : {}),
+      ...(clientReference ? { client_reference: clientReference } : {}),
     };
 
     if (path === OPERATOR_HTTP_ROUTES.pause) {

--- a/control-center/connectors/warmbly/src/operator/identity.ts
+++ b/control-center/connectors/warmbly/src/operator/identity.ts
@@ -1,0 +1,78 @@
+/**
+ * Founder identity for operator actions.
+ *
+ * There is no second identity path here. This delegates to the existing
+ * ForwardAuth contract in `control-center/security`: Authelia writes
+ * `Remote-User` / `Remote-Groups` / `Remote-Name` / `Remote-Email`, the host
+ * nginx vhost for ops.confenge.com.br blanks any client-supplied copy, and
+ * `parseForwardAuthIdentity` only trusts those headers from a configured
+ * reverse-proxy hop. Anything else (untrusted hop, spoofed, missing, empty,
+ * malformed, wrong group) is a deny — and a deny is a recorded refusal here.
+ */
+
+import {
+  DEFAULT_TRUSTED_HOPS,
+  actorRefFromIdentity,
+  defaultTrustedHopPolicy,
+  parseForwardAuthIdentity,
+} from "@confenge/control-center-security";
+import type {
+  ForwardAuthIdentity,
+  IdentityRequest,
+  IdentityResult,
+  TrustedHopPolicy,
+} from "@confenge/control-center-security";
+
+export type { ForwardAuthIdentity, IdentityRequest, TrustedHopPolicy };
+
+/**
+ * Ledger actor vocabulary. `control-center/security` returns ActorRef kind
+ * "human"; the agent-activity ledger spells the same actor "founder". The map
+ * is documented here so the two vocabularies never drift silently.
+ */
+export interface OperatorActor {
+  readonly kind: "founder";
+  readonly id: string;
+  readonly display_name: string;
+}
+
+export type OperatorIdentityResult =
+  | { ok: true; actor: OperatorActor }
+  | { ok: false; code: string; reason: string };
+
+export function defaultOperatorIdentityPolicy(
+  trustedHops: readonly string[] = DEFAULT_TRUSTED_HOPS,
+): TrustedHopPolicy {
+  return defaultTrustedHopPolicy(trustedHops);
+}
+
+export function operatorActorFromIdentity(identity: ForwardAuthIdentity): OperatorActor {
+  const actor = actorRefFromIdentity(identity);
+  return {
+    kind: "founder",
+    id: actor.id,
+    display_name: actor.display_name ?? actor.id,
+  };
+}
+
+/**
+ * Fail-closed. A caller cannot hand in a pre-built actor: the only input is the
+ * raw request, and the only writer of the headers it reads is Authelia.
+ */
+export function resolveOperatorActor(
+  request: IdentityRequest | undefined,
+  policy: TrustedHopPolicy,
+): OperatorIdentityResult {
+  if (!request || typeof request.remoteAddress !== "string" || request.remoteAddress === "") {
+    return {
+      ok: false,
+      code: "missing_identity",
+      reason: "no authenticated request hop was presented to the operator channel",
+    };
+  }
+  const result: IdentityResult = parseForwardAuthIdentity(request, policy);
+  if (!result.ok) {
+    return { ok: false, code: result.code, reason: result.reason };
+  }
+  return { ok: true, actor: operatorActorFromIdentity(result.identity) };
+}

--- a/control-center/connectors/warmbly/src/operator/index.ts
+++ b/control-center/connectors/warmbly/src/operator/index.ts
@@ -41,14 +41,20 @@ export type {
 } from "./identity.ts";
 
 export {
+  OPERATOR_DISPATCH_STATUS_PATH,
   OPERATOR_LEDGER_SCHEMA,
   OPERATOR_LEDGER_SOURCE_KIND,
   OPERATOR_LEDGER_SOURCE_SYSTEM,
+  OPERATOR_LEDGER_WAL_MARKER,
   OPERATOR_OUTCOMES,
   OPERATOR_REFUSAL_CODES,
+  OPERATOR_UNKNOWN_CODE,
   createFanOutOperatorActionLedger,
   createMemoryOperatorActionLedger,
+  defaultOperatorSinkErrorHandler,
   operatorLedgerId,
+  operatorLedgerWalLine,
+  writeOperatorLedgerWal,
 } from "./ledger.ts";
 export type {
   OperatorActionLedger,
@@ -58,10 +64,12 @@ export type {
   OperatorLedgerUpstream,
   OperatorOutcome,
   OperatorRefusalCode,
+  OperatorUnknownCode,
 } from "./ledger.ts";
 
 export {
   DEFAULT_CONFIRMATION_TTL_MS,
+  confirmationReasonHash,
   createConfirmationStore,
 } from "./confirmation.ts";
 export type {
@@ -74,6 +82,7 @@ export {
   OperatorPathNotAllowedError,
   OperatorTimeoutError,
   WarmblyOperatorClient,
+  isPreFlightTransportFailure,
 } from "./client.ts";
 export type { OperatorPostResult, WarmblyOperatorClientOptions } from "./client.ts";
 
@@ -85,6 +94,7 @@ export type {
   OperatorChallenged,
   OperatorExecuted,
   OperatorRefused,
+  OperatorUnknown,
   WarmblyOperatorChannel,
   WarmblyOperatorChannelOptions,
 } from "./channel.ts";

--- a/control-center/connectors/warmbly/src/operator/index.ts
+++ b/control-center/connectors/warmbly/src/operator/index.ts
@@ -1,0 +1,105 @@
+export {
+  DISPATCH_TARGET_ID,
+  OPERATOR_ACTIONS,
+  OPERATOR_ACTION_NAMES,
+  OPERATOR_FORBIDDEN_ACTIONS,
+  REASON_PATTERN,
+  TARGET_ID_PATTERN,
+  isOperatorActionName,
+  isValidReason,
+  isValidTargetId,
+  resolveOperatorAction,
+} from "./actions.ts";
+export type {
+  OperatorActionDefinition,
+  OperatorActionName,
+  OperatorConfirmationMode,
+  OperatorTargetKind,
+} from "./actions.ts";
+
+export {
+  OPERATOR_ACK_PREFIX,
+  OPERATOR_ACK_SUFFIX,
+  OPERATOR_PAUSE_PATH,
+  OPERATOR_RESUME_PATH,
+  classifyOperatorRequest,
+  isAllowedOperatorWrite,
+} from "./allowlist.ts";
+export type { AllowedOperatorRequest } from "./allowlist.ts";
+
+export {
+  defaultOperatorIdentityPolicy,
+  operatorActorFromIdentity,
+  resolveOperatorActor,
+} from "./identity.ts";
+export type {
+  ForwardAuthIdentity,
+  IdentityRequest,
+  OperatorActor,
+  OperatorIdentityResult,
+  TrustedHopPolicy,
+} from "./identity.ts";
+
+export {
+  OPERATOR_LEDGER_SCHEMA,
+  OPERATOR_LEDGER_SOURCE_KIND,
+  OPERATOR_LEDGER_SOURCE_SYSTEM,
+  OPERATOR_OUTCOMES,
+  OPERATOR_REFUSAL_CODES,
+  createFanOutOperatorActionLedger,
+  createMemoryOperatorActionLedger,
+  operatorLedgerId,
+} from "./ledger.ts";
+export type {
+  OperatorActionLedger,
+  OperatorActionLedgerEntry,
+  OperatorLedgerConfirmation,
+  OperatorLedgerTarget,
+  OperatorLedgerUpstream,
+  OperatorOutcome,
+  OperatorRefusalCode,
+} from "./ledger.ts";
+
+export {
+  DEFAULT_CONFIRMATION_TTL_MS,
+  createConfirmationStore,
+} from "./confirmation.ts";
+export type {
+  ConfirmationCheck,
+  ConfirmationStore,
+  OperatorConfirmationChallenge,
+} from "./confirmation.ts";
+
+export {
+  OperatorPathNotAllowedError,
+  OperatorTimeoutError,
+  WarmblyOperatorClient,
+} from "./client.ts";
+export type { OperatorPostResult, WarmblyOperatorClientOptions } from "./client.ts";
+
+export { createWarmblyOperatorChannel } from "./channel.ts";
+export type {
+  NamedOperatorActionInput,
+  OperatorActionInput,
+  OperatorActionResult,
+  OperatorChallenged,
+  OperatorExecuted,
+  OperatorRefused,
+  WarmblyOperatorChannel,
+  WarmblyOperatorChannelOptions,
+} from "./channel.ts";
+
+export { OPERATOR_HTTP_ROUTES, createOperatorHttpHandler } from "./http.ts";
+export type {
+  OperatorHttpRequest,
+  OperatorHttpResponse,
+  OperatorHttpRoute,
+} from "./http.ts";
+
+export {
+  OPERATOR_LEDGER_AGENT_ID,
+  OPERATOR_LEDGER_AGENT_PROVIDER,
+  OPERATOR_LEDGER_REPO,
+  createAgentActivityLedgerSink,
+} from "./agent-activity-sink.ts";
+export type { AgentLedgerLike } from "./agent-activity-sink.ts";

--- a/control-center/connectors/warmbly/src/operator/ledger.ts
+++ b/control-center/connectors/warmbly/src/operator/ledger.ts
@@ -2,16 +2,20 @@
  * Operator-action audit record.
  *
  * Every call through the channel produces exactly one entry — executed,
- * refused, or challenged. There is no path that returns without recording, so
- * an operator action is reconstructible after the fact from actor, action,
- * target, upstream status and timestamp alone.
+ * refused, challenged, or unknown. There is no path that returns without
+ * recording, so an operator action is reconstructible after the fact from
+ * actor, action, target, upstream status and timestamp alone. When the record
+ * itself cannot be persisted, the entry still goes to a durable WAL line
+ * (`writeOperatorLedgerWal`) before the failure surfaces.
  *
  * The shape carries the same provenance keys as the rest of the Control Center
  * (`source` / `observed_at` / `freshness_status` / `confidence`) so it lands in
  * the agent-activity ledger without reshaping — see `agent-activity-sink.ts`.
  */
 
+import { writeSync } from "node:fs";
 import type { CircuitState } from "../http/circuit-breaker.ts";
+import { createStderrLogger, type Logger } from "../http/redaction.ts";
 import type { OperatorActionName, OperatorTargetKind } from "./actions.ts";
 import type { OperatorActor } from "./identity.ts";
 
@@ -20,8 +24,24 @@ export const OPERATOR_LEDGER_SCHEMA = "control-center.warmbly-operator-action.v1
 export const OPERATOR_LEDGER_SOURCE_SYSTEM = "control-center" as const;
 export const OPERATOR_LEDGER_SOURCE_KIND = "warmbly-operator-action" as const;
 
-export const OPERATOR_OUTCOMES = ["executed", "refused", "challenged"] as const;
+/**
+ * `unknown` is not a refusal. It is the honest answer when the POST was already
+ * written to the wire and the answer never arrived: Warmbly may have applied
+ * the action. Recording such a call as `refused` would tell the operator the
+ * kill switch is still engaged while outbound is in fact sending.
+ */
+export const OPERATOR_OUTCOMES = ["executed", "refused", "challenged", "unknown"] as const;
 export type OperatorOutcome = (typeof OPERATOR_OUTCOMES)[number];
+
+/**
+ * Carried in `refusal_code` when `outcome === "unknown"`. Deliberately not a
+ * member of OPERATOR_REFUSAL_CODES: nothing was refused.
+ */
+export const OPERATOR_UNKNOWN_CODE = "transport_unknown" as const;
+export type OperatorUnknownCode = typeof OPERATOR_UNKNOWN_CODE;
+
+/** Read this before retrying an `unknown` — it is the only source of truth. */
+export const OPERATOR_DISPATCH_STATUS_PATH = "/v1/confenge/dispatch/status" as const;
 
 export const OPERATOR_REFUSAL_CODES = [
   "missing_actor",
@@ -58,12 +78,18 @@ export interface OperatorLedgerConfirmation {
 export interface OperatorActionLedgerEntry {
   schema_version: typeof OPERATOR_LEDGER_SCHEMA;
   id: string;
+  /** Minted by the channel. Never caller-supplied: it keys this record. */
   correlation_id: string;
+  /**
+   * The caller's own reference, echoed verbatim for their correlation. It keys
+   * nothing: a replay cannot collide with, or rewrite, an existing entry.
+   */
+  client_reference: string | null;
   /** Requested action name verbatim — kept even when it is not on the allowlist. */
   requested_action: string;
   action: OperatorActionName | null;
   outcome: OperatorOutcome;
-  refusal_code: OperatorRefusalCode | null;
+  refusal_code: OperatorRefusalCode | OperatorUnknownCode | null;
   refusal_reason: string | null;
   actor: OperatorActor | null;
   target: OperatorLedgerTarget;
@@ -101,30 +127,93 @@ export function createMemoryOperatorActionLedger(): OperatorActionLedger {
 }
 
 /**
- * Fan-out that keeps the in-process record authoritative. A failing downstream
- * sink must never swallow the audit trail, so sink errors are captured and
- * surfaced on the in-memory entry list rather than thrown at the operator.
+ * Fan-out that keeps the in-process record authoritative.
+ *
+ * `onSinkError` is required, not optional: a mirror that fails silently is how
+ * an executed resume ends up with no visible timeline row and no error. Pass
+ * `defaultOperatorSinkErrorHandler()` unless you have something better.
+ *
+ * `primary.record` is guarded too. When the authoritative store throws, the
+ * sinks are still offered the entry — some record is better than none — and the
+ * primary failure is then rethrown so the caller can never mistake it for a
+ * durable write.
  */
 export function createFanOutOperatorActionLedger(
   primary: OperatorActionLedger,
   sinks: readonly OperatorActionLedger[],
-  onSinkError?: (err: unknown, entry: OperatorActionLedgerEntry) => void,
+  onSinkError: (err: unknown, entry: OperatorActionLedgerEntry) => void,
 ): OperatorActionLedger {
   return {
     record(entry) {
-      primary.record(entry);
+      let primaryError: unknown;
+      let primaryFailed = false;
+      try {
+        primary.record(entry);
+      } catch (err) {
+        primaryFailed = true;
+        primaryError = err;
+        onSinkError(err, entry);
+      }
       for (const sink of sinks) {
         try {
           sink.record(entry);
         } catch (err) {
-          onSinkError?.(err, entry);
+          onSinkError(err, entry);
         }
+      }
+      if (primaryFailed) {
+        throw primaryError;
       }
     },
     list() {
       return primary.list();
     },
   };
+}
+
+/**
+ * Default mirror-failure handler: error level, full entry serialized. The entry
+ * carries no secret (no token, no Remote-Email), so serializing it whole is
+ * what makes the lost row recoverable from the log.
+ */
+export function defaultOperatorSinkErrorHandler(
+  logger: Logger = createStderrLogger(),
+): (err: unknown, entry: OperatorActionLedgerEntry) => void {
+  return (err, entry) => {
+    logger({
+      level: "error",
+      msg: "warmbly.operator.ledger_sink_failed",
+      error: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      correlation_id: entry.correlation_id,
+      outcome: entry.outcome,
+      entry: JSON.stringify(entry),
+    });
+  };
+}
+
+export const OPERATOR_LEDGER_WAL_MARKER = "cc.warmbly.operator-action.wal" as const;
+
+/** One self-contained JSON line: the entry that could not be persisted. */
+export function operatorLedgerWalLine(entry: OperatorActionLedgerEntry, err: unknown): string {
+  return `${JSON.stringify({
+    wal: OPERATOR_LEDGER_WAL_MARKER,
+    error: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+    entry,
+  })}\n`;
+}
+
+/**
+ * Durable last resort when the ledger itself fails after the write already
+ * happened. Written synchronously to fd 2 so it survives a process that is
+ * about to die with the exception we are re-throwing.
+ */
+export function writeOperatorLedgerWal(entry: OperatorActionLedgerEntry, err: unknown): void {
+  const line = operatorLedgerWalLine(entry, err);
+  try {
+    writeSync(2, line);
+  } catch {
+    // Nothing left to fall back to; never mask the original failure.
+  }
 }
 
 export function operatorLedgerId(correlationId: string): string {

--- a/control-center/connectors/warmbly/src/operator/ledger.ts
+++ b/control-center/connectors/warmbly/src/operator/ledger.ts
@@ -1,0 +1,133 @@
+/**
+ * Operator-action audit record.
+ *
+ * Every call through the channel produces exactly one entry — executed,
+ * refused, or challenged. There is no path that returns without recording, so
+ * an operator action is reconstructible after the fact from actor, action,
+ * target, upstream status and timestamp alone.
+ *
+ * The shape carries the same provenance keys as the rest of the Control Center
+ * (`source` / `observed_at` / `freshness_status` / `confidence`) so it lands in
+ * the agent-activity ledger without reshaping — see `agent-activity-sink.ts`.
+ */
+
+import type { CircuitState } from "../http/circuit-breaker.ts";
+import type { OperatorActionName, OperatorTargetKind } from "./actions.ts";
+import type { OperatorActor } from "./identity.ts";
+
+export const OPERATOR_LEDGER_SCHEMA = "control-center.warmbly-operator-action.v1" as const;
+
+export const OPERATOR_LEDGER_SOURCE_SYSTEM = "control-center" as const;
+export const OPERATOR_LEDGER_SOURCE_KIND = "warmbly-operator-action" as const;
+
+export const OPERATOR_OUTCOMES = ["executed", "refused", "challenged"] as const;
+export type OperatorOutcome = (typeof OPERATOR_OUTCOMES)[number];
+
+export const OPERATOR_REFUSAL_CODES = [
+  "missing_actor",
+  "unknown_action",
+  "invalid_target",
+  "invalid_reason",
+  "confirmation_required",
+  "confirmation_invalid",
+  "confirmation_not_applicable",
+  "forbidden_path",
+  "circuit_open",
+  "upstream_error",
+  "transport_error",
+] as const;
+export type OperatorRefusalCode = (typeof OPERATOR_REFUSAL_CODES)[number];
+
+export interface OperatorLedgerTarget {
+  kind: OperatorTargetKind | "unknown";
+  id: string;
+}
+
+export interface OperatorLedgerUpstream {
+  method: "POST" | null;
+  path: string | null;
+  status: number | null;
+}
+
+export interface OperatorLedgerConfirmation {
+  required: boolean;
+  satisfied: boolean;
+  token_id: string | null;
+}
+
+export interface OperatorActionLedgerEntry {
+  schema_version: typeof OPERATOR_LEDGER_SCHEMA;
+  id: string;
+  correlation_id: string;
+  /** Requested action name verbatim — kept even when it is not on the allowlist. */
+  requested_action: string;
+  action: OperatorActionName | null;
+  outcome: OperatorOutcome;
+  refusal_code: OperatorRefusalCode | null;
+  refusal_reason: string | null;
+  actor: OperatorActor | null;
+  target: OperatorLedgerTarget;
+  upstream: OperatorLedgerUpstream;
+  confirmation: OperatorLedgerConfirmation;
+  circuit_state: CircuitState;
+  reason: string | null;
+  recorded_at: string;
+  source: {
+    system: typeof OPERATOR_LEDGER_SOURCE_SYSTEM;
+    kind: typeof OPERATOR_LEDGER_SOURCE_KIND;
+    locator: string;
+  };
+  observed_at: string;
+  freshness_status: "FRESH";
+  confidence: number;
+}
+
+/** Persistence port. The in-process store is the default; sinks fan out. */
+export interface OperatorActionLedger {
+  record(entry: OperatorActionLedgerEntry): void;
+  list(): OperatorActionLedgerEntry[];
+}
+
+export function createMemoryOperatorActionLedger(): OperatorActionLedger {
+  const entries: OperatorActionLedgerEntry[] = [];
+  return {
+    record(entry) {
+      entries.push(structuredClone(entry));
+    },
+    list() {
+      return entries.map((entry) => structuredClone(entry));
+    },
+  };
+}
+
+/**
+ * Fan-out that keeps the in-process record authoritative. A failing downstream
+ * sink must never swallow the audit trail, so sink errors are captured and
+ * surfaced on the in-memory entry list rather than thrown at the operator.
+ */
+export function createFanOutOperatorActionLedger(
+  primary: OperatorActionLedger,
+  sinks: readonly OperatorActionLedger[],
+  onSinkError?: (err: unknown, entry: OperatorActionLedgerEntry) => void,
+): OperatorActionLedger {
+  return {
+    record(entry) {
+      primary.record(entry);
+      for (const sink of sinks) {
+        try {
+          sink.record(entry);
+        } catch (err) {
+          onSinkError?.(err, entry);
+        }
+      }
+    },
+    list() {
+      return primary.list();
+    },
+  };
+}
+
+export function operatorLedgerId(correlationId: string): string {
+  const slug = correlationId.replace(/[^A-Za-z0-9._~-]+/g, "-").slice(0, 96);
+  return `cc:warmbly-operator-action:${slug}`;
+}

--- a/control-center/connectors/warmbly/src/stub-server.ts
+++ b/control-center/connectors/warmbly/src/stub-server.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { pathnameOf } from "./http/allowlist.ts";
+import { isAllowedOperatorWrite } from "./operator/allowlist.ts";
 import type { WarmblyPayload } from "./contracts/warmbly-payload.ts";
 
 export type RecordedCall = {
@@ -15,12 +16,24 @@ export type StubOptions = {
   failStatus?: number;
   failAfter?: number;
   token?: string;
+  /**
+   * Opt-in only. Serves the three allowed operator write routes so the operator
+   * channel can be tested end to end. Off by default: the collect path must
+   * never find a writable stub.
+   */
+  operatorWrites?: boolean;
+  /** Status the operator write routes answer with (default 200). */
+  operatorWriteStatus?: number;
 };
+
+export type RecordedOperatorCall = RecordedCall & { body: string };
 
 export type FixtureStub = {
   server: Server;
   url: string;
   calls: RecordedCall[];
+  /** Operator write routes that were actually served (empty unless opted in). */
+  operatorCalls: RecordedOperatorCall[];
   close: () => Promise<void>;
 };
 
@@ -106,6 +119,7 @@ function routeBody(payload: WarmblyPayload, pathname: string): unknown | undefin
 
 export async function startFixtureStub(opts: StubOptions): Promise<FixtureStub> {
   const calls: RecordedCall[] = [];
+  const operatorCalls: RecordedOperatorCall[] = [];
   const hide = new Set(opts.hide ?? []);
   let hits = 0;
   const stateChanged = { value: false };
@@ -130,7 +144,13 @@ export async function startFixtureStub(opts: StubOptions): Promise<FixtureStub> 
         return;
       }
       if (method === "POST") {
-        void readBody(req).then(() => {
+        void readBody(req).then((raw) => {
+          if (opts.operatorWrites && isAllowedOperatorWrite("POST", path)) {
+            operatorCalls.push({ method, path, url, body: raw });
+            const status = opts.operatorWriteStatus ?? 200;
+            json(res, status, { data: { path, accepted: status >= 200 && status <= 299 } });
+            return;
+          }
           if (
             path === "/v1/contacts/search" ||
             path === "/v1/crm/deals/search" ||
@@ -185,6 +205,7 @@ export async function startFixtureStub(opts: StubOptions): Promise<FixtureStub> 
     server,
     url,
     calls,
+    operatorCalls,
     close: () =>
       new Promise((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));

--- a/control-center/connectors/warmbly/tests/operator-actions.test.ts
+++ b/control-center/connectors/warmbly/tests/operator-actions.test.ts
@@ -1,0 +1,896 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createAgentLedger } from "@confenge/control-center-agent-activity";
+import { classifyRequest } from "../src/http/allowlist.ts";
+import { CircuitBreaker } from "../src/http/circuit-breaker.ts";
+import { WarmblyClient } from "../src/http/client.ts";
+import { startFixtureStub } from "../src/stub-server.ts";
+import {
+  DISPATCH_TARGET_ID,
+  OPERATOR_ACTIONS,
+  OPERATOR_ACTION_NAMES,
+  OPERATOR_FORBIDDEN_ACTIONS,
+  WarmblyOperatorClient,
+  classifyOperatorRequest,
+  createAgentActivityLedgerSink,
+  createFanOutOperatorActionLedger,
+  createMemoryOperatorActionLedger,
+  createOperatorHttpHandler,
+  createWarmblyOperatorChannel,
+  defaultOperatorIdentityPolicy,
+  OPERATOR_HTTP_ROUTES,
+  resolveOperatorAction,
+  type OperatorActionLedgerEntry,
+  type WarmblyOperatorChannel,
+} from "../src/operator/index.ts";
+import { capturingLogger, loadFixture } from "./helpers.ts";
+
+const TOKEN = "wmbly_super_secret_operator_token_do_not_log";
+const TRUSTED_HOP = "10.89.0.2";
+
+const AUTHELIA_HEADERS = {
+  "Remote-User": "founder",
+  "Remote-Groups": "operators",
+  "Remote-Name": "Founder Confenge",
+  "Remote-Email": "founder@confenge.invalid",
+};
+
+function founderRequest(headers: Record<string, string | string[] | undefined> = AUTHELIA_HEADERS) {
+  return { remoteAddress: TRUSTED_HOP, headers };
+}
+
+type Harness = {
+  channel: WarmblyOperatorChannel;
+  ledger: ReturnType<typeof createMemoryOperatorActionLedger>;
+  stub: Awaited<ReturnType<typeof startFixtureStub>>;
+  fetchHits: Array<{ method: string; url: string }>;
+  close: () => Promise<void>;
+};
+
+async function harness(
+  options: {
+    operatorWrites?: boolean;
+    operatorWriteStatus?: number;
+    breaker?: CircuitBreaker;
+    confirmationTtlMs?: number;
+    now?: () => Date;
+    extraLedgers?: ReturnType<typeof createMemoryOperatorActionLedger>[];
+    sink?: ReturnType<typeof createAgentActivityLedgerSink>;
+  } = {},
+): Promise<Harness> {
+  const stub = await startFixtureStub({
+    payload: loadFixture("commercial-runtime.json"),
+    token: TOKEN,
+    operatorWrites: options.operatorWrites ?? true,
+    ...(options.operatorWriteStatus === undefined
+      ? {}
+      : { operatorWriteStatus: options.operatorWriteStatus }),
+  });
+  const fetchHits: Array<{ method: string; url: string }> = [];
+  const client = new WarmblyOperatorClient({
+    baseUrl: stub.url,
+    token: TOKEN,
+    timeoutMs: 2_000,
+    logger: () => undefined,
+    ...(options.breaker ? { breaker: options.breaker } : {}),
+    fetchImpl: async (input, init) => {
+      fetchHits.push({ method: init?.method ?? "GET", url: String(input) });
+      return fetch(input, init);
+    },
+  });
+  const memory = createMemoryOperatorActionLedger();
+  const ledger = options.sink
+    ? createFanOutOperatorActionLedger(memory, [options.sink])
+    : memory;
+  const channel = createWarmblyOperatorChannel({
+    client,
+    ledger,
+    identityPolicy: defaultOperatorIdentityPolicy(),
+    logger: () => undefined,
+    ...(options.confirmationTtlMs === undefined
+      ? {}
+      : { confirmationTtlMs: options.confirmationTtlMs }),
+    ...(options.now ? { now: options.now } : {}),
+  });
+  return {
+    channel,
+    ledger: memory,
+    stub,
+    fetchHits,
+    close: () => stub.close(),
+  };
+}
+
+function onlyEntry(entries: OperatorActionLedgerEntry[]): OperatorActionLedgerEntry {
+  assert.equal(entries.length, 1, `expected exactly one ledger entry, got ${entries.length}`);
+  return entries[0]!;
+}
+
+describe("operator action allowlist", () => {
+  it("names exactly three actions and no send/dispatch/enroll/financial verb", () => {
+    assert.deepEqual([...OPERATOR_ACTION_NAMES], [
+      "pause_dispatch",
+      "resume_dispatch",
+      "acknowledge_inbound_alert",
+    ]);
+    for (const forbidden of OPERATOR_FORBIDDEN_ACTIONS) {
+      assert.equal(resolveOperatorAction(forbidden), undefined, forbidden);
+    }
+    assert.equal(OPERATOR_ACTIONS.pause_dispatch.confirmation, "none");
+    assert.equal(OPERATOR_ACTIONS.resume_dispatch.confirmation, "two_step");
+    assert.equal(OPERATOR_ACTIONS.acknowledge_inbound_alert.confirmation, "none");
+  });
+
+  it("allows POST on exactly the three operational controls", () => {
+    assert.equal(classifyOperatorRequest("POST", "/v1/confenge/dispatch/pause").allowed, true);
+    assert.equal(classifyOperatorRequest("POST", "/v1/confenge/dispatch/resume").allowed, true);
+    assert.equal(
+      classifyOperatorRequest("POST", "/v1/confenge/inbound/lead-42/acknowledge").allowed,
+      true,
+    );
+  });
+
+  it("denies every other method and every other path", () => {
+    for (const method of ["GET", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS"]) {
+      assert.equal(
+        classifyOperatorRequest(method, "/v1/confenge/dispatch/pause").allowed,
+        false,
+        method,
+      );
+    }
+    const forbiddenPaths = [
+      "/v1/confenge/dispatch/now",
+      "/v1/confenge/cohorts/abc/dispatch",
+      "/v1/confenge/import",
+      "/v1/confenge/crm/bootstrap",
+      "/v1/confenge/inbound/lead-42/outcome",
+      "/v1/confenge/inbound/lead-42/resolve",
+      "/v1/confenge/drafts/1/send",
+      "/v1/campaigns/abc/start",
+      "/v1/campaigns/abc/stop",
+      "/v1/unibox/reply",
+      "/v1/crm/deals",
+      "/v1/contacts",
+      "/v1/confenge/inbound/../../campaigns/abc/start/acknowledge",
+      "/v1/confenge/inbound/%2e%2e%2fstart/acknowledge",
+      "/v1/confenge/inbound//acknowledge",
+      "/v1/confenge/inbound/lead-42/acknowledge/extra",
+    ];
+    for (const path of forbiddenPaths) {
+      assert.equal(classifyOperatorRequest("POST", path).allowed, false, path);
+    }
+  });
+
+  it("leaves the read allowlist read-only: the operator paths stay denied there", () => {
+    assert.equal(classifyRequest("POST", "/v1/confenge/dispatch/pause").allowed, false);
+    assert.equal(classifyRequest("POST", "/v1/confenge/dispatch/resume").allowed, false);
+    assert.equal(
+      classifyRequest("POST", "/v1/confenge/inbound/lead-42/acknowledge").allowed,
+      false,
+    );
+  });
+
+  it("refuses an unknown action name and records the refusal", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.execute({
+        action: "send_campaign",
+        request: founderRequest(),
+        reason: "operator asked",
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "unknown_action");
+      const entry = onlyEntry(h.ledger.list());
+      assert.equal(entry.outcome, "refused");
+      assert.equal(entry.requested_action, "send_campaign");
+      assert.equal(entry.action, null);
+      assert.equal(entry.actor?.id, "founder");
+      assert.equal(h.fetchHits.length, 0);
+      assert.equal(h.stub.operatorCalls.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("operator identity", () => {
+  it("refuses when no Remote-* identity is present", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: { remoteAddress: TRUSTED_HOP, headers: {} },
+        reason: "kill switch drill",
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "missing_actor");
+      const entry = onlyEntry(h.ledger.list());
+      assert.equal(entry.outcome, "refused");
+      assert.equal(entry.refusal_code, "missing_actor");
+      assert.equal(entry.actor, null);
+      assert.equal(h.fetchHits.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses Remote-* headers presented from an untrusted hop (spoofed identity)", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: { remoteAddress: "203.0.113.9", headers: AUTHELIA_HEADERS },
+        reason: "kill switch drill",
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "missing_actor");
+      assert.match(result.reason, /spoofed_identity/);
+      assert.equal(h.fetchHits.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses a founder without the required operator group", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: founderRequest({ ...AUTHELIA_HEADERS, "Remote-Groups": "guests" }),
+        reason: "kill switch drill",
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "missing_actor");
+      assert.equal(onlyEntry(h.ledger.list()).actor, null);
+      assert.equal(h.fetchHits.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("derives the actor from Remote-User and never from Remote-Email", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: founderRequest(),
+        reason: "kill switch drill",
+      });
+      assert.equal(result.ok, true);
+      const entry = onlyEntry(h.ledger.list());
+      assert.equal(entry.actor?.kind, "founder");
+      assert.equal(entry.actor?.id, "founder");
+      assert.equal(entry.actor?.display_name, "Founder Confenge");
+      assert.equal(JSON.stringify(entry).includes("founder@confenge.invalid"), false);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("pause dispatch (one step, always offered)", () => {
+  it("engages the kill switch in one call and records the upstream status", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: founderRequest(),
+        reason: "spike de bounce",
+      });
+      assert.equal(result.ok, true);
+      if (!result.ok || result.outcome !== "executed") return;
+      assert.equal(result.action, "pause_dispatch");
+      assert.equal(result.upstream_status, 200);
+      assert.equal(h.stub.operatorCalls.length, 1);
+      assert.equal(h.stub.operatorCalls[0]!.path, "/v1/confenge/dispatch/pause");
+      assert.equal(h.stub.operatorCalls[0]!.method, "POST");
+      assert.deepEqual(JSON.parse(h.stub.operatorCalls[0]!.body), { reason: "spike de bounce" });
+
+      const entry = onlyEntry(h.ledger.list());
+      assert.equal(entry.outcome, "executed");
+      assert.equal(entry.action, "pause_dispatch");
+      assert.equal(entry.target.kind, "dispatch");
+      assert.equal(entry.target.id, DISPATCH_TARGET_ID);
+      assert.equal(entry.upstream.method, "POST");
+      assert.equal(entry.upstream.path, "/v1/confenge/dispatch/pause");
+      assert.equal(entry.upstream.status, 200);
+      assert.equal(entry.confirmation.required, false);
+      assert.match(entry.recorded_at, /^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("never accepts a confirmation-token flow for pause", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.requestResumeConfirmation({
+        request: founderRequest(),
+        reason: "x",
+      });
+      assert.equal(result.ok, true);
+      const notApplicable = await h.channel.requestConfirmation({
+        action: "pause_dispatch",
+        request: founderRequest(),
+        reason: "spike de bounce",
+      });
+      assert.equal(notApplicable.ok, false);
+      if (notApplicable.ok) return;
+      assert.equal(notApplicable.code, "confirmation_not_applicable");
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses a pause without an audit reason", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.pauseDispatch({ request: founderRequest() });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "invalid_reason");
+      assert.equal(h.stub.operatorCalls.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("resume dispatch (two step)", () => {
+  it("refuses a one-step resume and records confirmation_required", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "confirmation_required");
+      const entry = onlyEntry(h.ledger.list());
+      assert.equal(entry.outcome, "refused");
+      assert.equal(entry.confirmation.required, true);
+      assert.equal(entry.confirmation.satisfied, false);
+      assert.equal(h.stub.operatorCalls.length, 0);
+      assert.equal(h.fetchHits.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("executes only after an explicit confirmation token is replayed", async () => {
+    const h = await harness();
+    try {
+      const step1 = await h.channel.requestResumeConfirmation({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      assert.equal(step1.ok, true);
+      if (!step1.ok || step1.outcome !== "challenged") return;
+      assert.equal(h.stub.operatorCalls.length, 0, "step 1 must not call Warmbly");
+
+      const step2 = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+        confirmation_token: step1.challenge.token,
+      });
+      assert.equal(step2.ok, true);
+      if (!step2.ok || step2.outcome !== "executed") return;
+      assert.equal(step2.upstream_status, 200);
+      assert.equal(h.stub.operatorCalls.length, 1);
+      assert.equal(h.stub.operatorCalls[0]!.path, "/v1/confenge/dispatch/resume");
+
+      const entries = h.ledger.list();
+      assert.equal(entries.length, 2);
+      assert.equal(entries[0]!.outcome, "challenged");
+      assert.equal(entries[1]!.outcome, "executed");
+      assert.equal(entries[1]!.confirmation.satisfied, true);
+      assert.equal(entries[1]!.confirmation.token_id, step1.challenge.token_id);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses a forged, reused, or expired confirmation token", async () => {
+    let clock = new Date("2026-08-22T10:00:00.000Z");
+    const h = await harness({ confirmationTtlMs: 60_000, now: () => clock });
+    try {
+      const forged = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+        confirmation_token: "wcnf_not-a-real-token",
+      });
+      assert.equal(forged.ok, false);
+      if (!forged.ok) assert.equal(forged.code, "confirmation_invalid");
+
+      const challenge = await h.channel.requestResumeConfirmation({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      assert.equal(challenge.ok, true);
+      if (!challenge.ok || challenge.outcome !== "challenged") return;
+      const token = challenge.challenge.token;
+
+      const first = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+        confirmation_token: token,
+      });
+      assert.equal(first.ok, true);
+      const replay = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+        confirmation_token: token,
+      });
+      assert.equal(replay.ok, false);
+      if (!replay.ok) assert.equal(replay.code, "confirmation_invalid");
+
+      const second = await h.channel.requestResumeConfirmation({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      assert.equal(second.ok, true);
+      if (!second.ok || second.outcome !== "challenged") return;
+      clock = new Date("2026-08-22T10:05:00.000Z");
+      const expired = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+        confirmation_token: second.challenge.token,
+      });
+      assert.equal(expired.ok, false);
+      if (!expired.ok) assert.equal(expired.code, "confirmation_invalid");
+
+      assert.equal(h.stub.operatorCalls.length, 1, "only the confirmed resume reached Warmbly");
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses a confirmation token minted for a different operator", async () => {
+    const h = await harness();
+    try {
+      const challenge = await h.channel.requestResumeConfirmation({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      assert.equal(challenge.ok, true);
+      if (!challenge.ok || challenge.outcome !== "challenged") return;
+      const other = await h.channel.resumeDispatch({
+        request: founderRequest({ ...AUTHELIA_HEADERS, "Remote-User": "otheroperator" }),
+        reason: "incidente resolvido",
+        confirmation_token: challenge.challenge.token,
+      });
+      assert.equal(other.ok, false);
+      if (!other.ok) assert.equal(other.code, "confirmation_invalid");
+      assert.equal(h.stub.operatorCalls.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("acknowledge inbound alert", () => {
+  it("acknowledges one lead by id and never widens the path", async () => {
+    const h = await harness();
+    try {
+      const ok = await h.channel.acknowledgeInboundAlert({
+        request: founderRequest(),
+        target_id: "lead-2f7c",
+      });
+      assert.equal(ok.ok, true);
+      if (!ok.ok || ok.outcome !== "executed") return;
+      assert.equal(h.stub.operatorCalls[0]!.path, "/v1/confenge/inbound/lead-2f7c/acknowledge");
+      assert.equal(ok.entry.target.kind, "inbound_alert");
+      assert.equal(ok.entry.target.id, "lead-2f7c");
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses traversal, separators, and route-smuggling target ids before any socket opens", async () => {
+    const h = await harness();
+    try {
+      const evil = [
+        "../../campaigns/abc/start",
+        "lead/../../dispatch/now",
+        "lead%2f..%2fstart",
+        "lead-42/acknowledge/../../import",
+        "lead 42",
+        "",
+      ];
+      for (const target_id of evil) {
+        const result = await h.channel.acknowledgeInboundAlert({
+          request: founderRequest(),
+          target_id,
+        });
+        assert.equal(result.ok, false, target_id);
+        if (result.ok) continue;
+        assert.equal(result.code, "invalid_target", target_id);
+      }
+      assert.equal(h.fetchHits.length, 0);
+      assert.equal(h.stub.operatorCalls.length, 0);
+      assert.equal(h.ledger.list().length, evil.length);
+      for (const entry of h.ledger.list()) {
+        assert.equal(entry.outcome, "refused");
+        assert.equal(entry.refusal_code, "invalid_target");
+      }
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses a non-singleton target on the dispatch kill switch", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.execute({
+        action: "pause_dispatch",
+        request: founderRequest(),
+        target_id: "some-other-org",
+        reason: "spike de bounce",
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "invalid_target");
+      assert.equal(h.stub.operatorCalls.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("fail-closed upstream and breaker", () => {
+  it("records a refusal on a non-2xx upstream instead of reporting success", async () => {
+    const h = await harness({ operatorWriteStatus: 403 });
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: founderRequest(),
+        reason: "spike de bounce",
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "upstream_error");
+      const entry = onlyEntry(h.ledger.list());
+      assert.equal(entry.outcome, "refused");
+      assert.equal(entry.upstream.status, 403);
+      assert.equal(entry.upstream.path, "/v1/confenge/dispatch/pause");
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses without calling Warmbly when the connector circuit breaker is open", async () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 1, resetMs: 60_000 });
+    breaker.recordFailure();
+    assert.equal(breaker.getState(), "open");
+    const h = await harness({ breaker });
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: founderRequest(),
+        reason: "spike de bounce",
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "circuit_open");
+      assert.match(result.reason, /pause\.sh/);
+      const entry = onlyEntry(h.ledger.list());
+      assert.equal(entry.circuit_state, "open");
+      assert.equal(entry.upstream.status, null);
+      assert.equal(h.fetchHits.length, 0);
+      assert.equal(h.stub.operatorCalls.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("shares the read client breaker so a degraded Warmbly blocks operator writes too", async () => {
+    const read = new WarmblyClient({
+      baseUrl: "http://127.0.0.1:1",
+      token: TOKEN,
+      failureThreshold: 1,
+      logger: () => undefined,
+    });
+    read.breaker.recordFailure();
+    const h = await harness({ breaker: read.breaker });
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: founderRequest(),
+        reason: "spike de bounce",
+      });
+      assert.equal(result.ok, false);
+      if (!result.ok) assert.equal(result.code, "circuit_open");
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("records a transport refusal when Warmbly is unreachable", async () => {
+    const client = new WarmblyOperatorClient({
+      baseUrl: "http://127.0.0.1:1",
+      token: TOKEN,
+      timeoutMs: 500,
+      logger: () => undefined,
+    });
+    const ledger = createMemoryOperatorActionLedger();
+    const channel = createWarmblyOperatorChannel({ client, ledger, logger: () => undefined });
+    const result = await channel.pauseDispatch({
+      request: founderRequest(),
+      reason: "spike de bounce",
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.code, "transport_error");
+    const entry = onlyEntry(ledger.list());
+    assert.equal(entry.outcome, "refused");
+    assert.equal(entry.upstream.status, null);
+  });
+
+  it("does not leak the Warmbly token in operator logs", async () => {
+    const stub = await startFixtureStub({
+      payload: loadFixture("commercial-runtime.json"),
+      token: TOKEN,
+      operatorWrites: true,
+    });
+    const logger = capturingLogger();
+    try {
+      const client = new WarmblyOperatorClient({
+        baseUrl: stub.url,
+        token: TOKEN,
+        logger: logger.logger,
+      });
+      const channel = createWarmblyOperatorChannel({ client, logger: logger.logger });
+      await channel.pauseDispatch({ request: founderRequest(), reason: "spike de bounce" });
+      const blob = `${logger.blob()}\n${JSON.stringify(client.describeAuthForLogs())}`;
+      assert.equal(blob.includes(TOKEN), false);
+    } finally {
+      await stub.close();
+    }
+  });
+});
+
+describe("no forbidden method or path is reachable through the channel", () => {
+  it("only ever issues POST to the three allowed paths, whatever the caller asks", async () => {
+    const h = await harness();
+    try {
+      const attempts = [
+        { action: "send", target_id: "lead-1" },
+        { action: "dispatch_now", target_id: DISPATCH_TARGET_ID },
+        { action: "enroll", target_id: "lead-1" },
+        { action: "approve_content", target_id: "draft-1" },
+        { action: "campaign_start", target_id: "camp-1" },
+        { action: "charge", target_id: "cust-1" },
+        { action: "refund", target_id: "pay-1" },
+        { action: "POST /v1/confenge/import", target_id: "x" },
+        { action: "DELETE /v1/crm/tasks/1", target_id: "x" },
+        { action: "acknowledge_inbound_alert/../../import", target_id: "x" },
+      ];
+      for (const attempt of attempts) {
+        const result = await h.channel.execute({
+          ...attempt,
+          request: founderRequest(),
+          reason: "tentativa",
+        });
+        assert.equal(result.ok, false, attempt.action);
+      }
+      // Only the legitimate calls below may touch the wire.
+      await h.channel.pauseDispatch({ request: founderRequest(), reason: "spike" });
+      await h.channel.acknowledgeInboundAlert({ request: founderRequest(), target_id: "lead-9" });
+
+      assert.equal(h.fetchHits.length, 2);
+      for (const hit of h.fetchHits) {
+        assert.equal(hit.method, "POST");
+      }
+      const paths = h.stub.operatorCalls.map((c) => c.path);
+      assert.deepEqual(paths, [
+        "/v1/confenge/dispatch/pause",
+        "/v1/confenge/inbound/lead-9/acknowledge",
+      ]);
+      const everyPath = h.stub.calls.map((c) => `${c.method} ${c.path}`);
+      for (const call of everyPath) {
+        assert.doesNotMatch(call, /\/(import|bootstrap|start|stop|send|enroll|dispatch\/now)\b/);
+        assert.doesNotMatch(call, /^(GET|PUT|PATCH|DELETE|HEAD) /);
+        assert.doesNotMatch(call, /asaas|checkout|refund|cobranca/i);
+      }
+      assert.equal(h.ledger.list().filter((e) => e.outcome === "refused").length, attempts.length);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("ledger recording", () => {
+  it("writes exactly one entry per call, on success and on refusal alike", async () => {
+    const h = await harness();
+    try {
+      await h.channel.pauseDispatch({ request: founderRequest(), reason: "spike" });
+      await h.channel.execute({ action: "nope", request: founderRequest(), reason: "spike" });
+      await h.channel.pauseDispatch({ request: { remoteAddress: TRUSTED_HOP, headers: {} }, reason: "spike" });
+      const entries = h.ledger.list();
+      assert.equal(entries.length, 3);
+      assert.deepEqual(
+        entries.map((e) => e.outcome),
+        ["executed", "refused", "refused"],
+      );
+      for (const entry of entries) {
+        assert.equal(entry.schema_version, "control-center.warmbly-operator-action.v1");
+        assert.ok(entry.id.startsWith("cc:warmbly-operator-action:"));
+        assert.ok(entry.correlation_id.length > 0);
+        assert.equal(entry.source.system, "control-center");
+        assert.equal(entry.source.kind, "warmbly-operator-action");
+        assert.equal(entry.freshness_status, "FRESH");
+        assert.match(entry.recorded_at, /Z$/);
+        assert.ok("upstream" in entry && "status" in entry.upstream);
+      }
+      assert.equal(entries[0]!.upstream.status, 200);
+      assert.equal(entries[1]!.upstream.status, null);
+      assert.equal(entries[2]!.actor, null);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("lands both the executed action and the refusal in the agent-activity ledger", async () => {
+    const agentLedger = createAgentLedger();
+    const sink = createAgentActivityLedgerSink(agentLedger);
+    const h = await harness({ sink });
+    try {
+      const executed = await h.channel.pauseDispatch({
+        request: founderRequest(),
+        reason: "spike de bounce",
+      });
+      assert.equal(executed.ok, true);
+      const refused = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      assert.equal(refused.ok, false);
+
+      const timeline = agentLedger.timeline({
+        from: "2000-01-01T00:00:00Z",
+        to: "2100-01-01T00:00:00Z",
+      });
+      assert.equal(timeline.length, 2);
+      const statuses = timeline.map((row) => row.status).sort();
+      assert.deepEqual(statuses, ["BLOCKED", "DONE"]);
+      for (const row of timeline) {
+        assert.equal(row.actor.kind, "founder");
+        assert.equal(row.actor.id, "founder");
+        assert.equal(row.agent.id, "cc-warmbly-operator-channel");
+        assert.equal(row.repo, "confenge/warmbly");
+        assert.ok(row.goal.startsWith("warmbly operator action "));
+        assert.ok(row.evidence.some((line) => line.startsWith("upstream=")));
+        assert.ok(row.evidence.some((line) => line.startsWith("circuit=")));
+      }
+      const done = timeline.find((row) => row.status === "DONE")!;
+      assert.ok(done.evidence.includes("upstream=POST /v1/confenge/dispatch/pause 200"));
+      const blocked = timeline.find((row) => row.status === "BLOCKED")!;
+      assert.ok(blocked.evidence.includes("refusal_code=confirmation_required"));
+      assert.equal(blocked.blockers.length, 1);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("mountable HTTP surface", () => {
+  it("exposes four POST-only routes and refuses anything else", async () => {
+    const h = await harness();
+    const handle = createOperatorHttpHandler(h.channel);
+    try {
+      const notFound = await handle({
+        method: "POST",
+        url: "/v1/warmbly/operator/dispatch/now",
+        headers: AUTHELIA_HEADERS,
+        remoteAddress: TRUSTED_HOP,
+        body: {},
+      });
+      assert.equal(notFound.status, 404);
+
+      for (const method of ["GET", "PUT", "PATCH", "DELETE"]) {
+        const wrong = await handle({
+          method,
+          url: OPERATOR_HTTP_ROUTES.pause,
+          headers: AUTHELIA_HEADERS,
+          remoteAddress: TRUSTED_HOP,
+          body: {},
+        });
+        assert.equal(wrong.status, 405, method);
+      }
+      assert.equal(h.stub.operatorCalls.length, 0);
+      assert.equal(h.ledger.list().length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("takes identity from Remote-* headers only and 401s without them", async () => {
+    const h = await harness();
+    const handle = createOperatorHttpHandler(h.channel);
+    try {
+      const anonymous = await handle({
+        method: "POST",
+        url: OPERATOR_HTTP_ROUTES.pause,
+        headers: { "x-actor-id": "founder", "x-actor-kind": "human" },
+        remoteAddress: TRUSTED_HOP,
+        body: { reason: "spike" },
+      });
+      assert.equal(anonymous.status, 401);
+      assert.equal(anonymous.body.ok, false);
+      assert.equal(anonymous.body.code, "missing_actor");
+      assert.equal(onlyEntry(h.ledger.list()).actor, null);
+      assert.equal(h.stub.operatorCalls.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("runs the two-step resume over HTTP: 428 without a token, 202 challenge, 200 confirmed", async () => {
+    const h = await harness();
+    const handle = createOperatorHttpHandler(h.channel);
+    const req = (url: string, body: unknown) => ({
+      method: "POST",
+      url,
+      headers: AUTHELIA_HEADERS,
+      remoteAddress: TRUSTED_HOP,
+      body,
+    });
+    try {
+      const oneStep = await handle(req(OPERATOR_HTTP_ROUTES.resume, { reason: "incidente resolvido" }));
+      assert.equal(oneStep.status, 428);
+
+      const challenge = await handle(
+        req(OPERATOR_HTTP_ROUTES.resumeConfirm, { reason: "incidente resolvido" }),
+      );
+      assert.equal(challenge.status, 202);
+      const token = challenge.body.confirmation_token as string;
+      assert.ok(token.length > 0);
+
+      const confirmed = await handle(
+        req(OPERATOR_HTTP_ROUTES.resume, {
+          reason: "incidente resolvido",
+          confirmation_token: token,
+        }),
+      );
+      assert.equal(confirmed.status, 200);
+      assert.equal(confirmed.body.upstream_status, 200);
+      assert.equal(h.stub.operatorCalls.length, 1);
+      assert.equal(h.stub.operatorCalls[0]!.path, "/v1/confenge/dispatch/resume");
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("pauses in one HTTP call and returns 502 when Warmbly refuses", async () => {
+    const ok = await harness();
+    try {
+      const handle = createOperatorHttpHandler(ok.channel);
+      const res = await handle({
+        method: "POST",
+        url: OPERATOR_HTTP_ROUTES.pause,
+        headers: AUTHELIA_HEADERS,
+        remoteAddress: TRUSTED_HOP,
+        body: { reason: "spike de bounce" },
+      });
+      assert.equal(res.status, 200);
+      assert.equal(res.body.action, "pause_dispatch");
+      assert.ok(String(res.body.ledger_id).startsWith("cc:warmbly-operator-action:"));
+    } finally {
+      await ok.close();
+    }
+
+    const bad = await harness({ operatorWriteStatus: 500 });
+    try {
+      const handle = createOperatorHttpHandler(bad.channel);
+      const res = await handle({
+        method: "POST",
+        url: OPERATOR_HTTP_ROUTES.pause,
+        headers: AUTHELIA_HEADERS,
+        remoteAddress: TRUSTED_HOP,
+        body: { reason: "spike de bounce" },
+      });
+      assert.equal(res.status, 502);
+      assert.equal(res.body.ok, false);
+      assert.equal(onlyEntry(bad.ledger.list()).upstream.status, 500);
+    } finally {
+      await bad.close();
+    }
+  });
+});

--- a/control-center/connectors/warmbly/tests/operator-actions.test.ts
+++ b/control-center/connectors/warmbly/tests/operator-actions.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { describe, it } from "node:test";
 import { createAgentLedger } from "@confenge/control-center-agent-activity";
 import { classifyRequest } from "../src/http/allowlist.ts";
@@ -18,8 +19,12 @@ import {
   createOperatorHttpHandler,
   createWarmblyOperatorChannel,
   defaultOperatorIdentityPolicy,
+  defaultOperatorSinkErrorHandler,
   OPERATOR_HTTP_ROUTES,
+  OPERATOR_LEDGER_WAL_MARKER,
+  operatorLedgerWalLine,
   resolveOperatorAction,
+  type OperatorActionLedger,
   type OperatorActionLedgerEntry,
   type WarmblyOperatorChannel,
 } from "../src/operator/index.ts";
@@ -44,6 +49,7 @@ type Harness = {
   ledger: ReturnType<typeof createMemoryOperatorActionLedger>;
   stub: Awaited<ReturnType<typeof startFixtureStub>>;
   fetchHits: Array<{ method: string; url: string }>;
+  sinkErrors: Array<{ err: unknown; entry: OperatorActionLedgerEntry }>;
   close: () => Promise<void>;
 };
 
@@ -56,6 +62,7 @@ async function harness(
     now?: () => Date;
     extraLedgers?: ReturnType<typeof createMemoryOperatorActionLedger>[];
     sink?: ReturnType<typeof createAgentActivityLedgerSink>;
+    onSinkError?: (err: unknown, entry: OperatorActionLedgerEntry) => void;
   } = {},
 ): Promise<Harness> {
   const stub = await startFixtureStub({
@@ -79,8 +86,14 @@ async function harness(
     },
   });
   const memory = createMemoryOperatorActionLedger();
+  const sinkErrors: Array<{ err: unknown; entry: OperatorActionLedgerEntry }> = [];
+  const onSinkError =
+    options.onSinkError ??
+    ((err: unknown, entry: OperatorActionLedgerEntry) => {
+      sinkErrors.push({ err, entry });
+    });
   const ledger = options.sink
-    ? createFanOutOperatorActionLedger(memory, [options.sink])
+    ? createFanOutOperatorActionLedger(memory, [options.sink], onSinkError)
     : memory;
   const channel = createWarmblyOperatorChannel({
     client,
@@ -97,8 +110,71 @@ async function harness(
     ledger: memory,
     stub,
     fetchHits,
+    sinkErrors,
     close: () => stub.close(),
   };
+}
+
+type UpstreamCall = { method: string; path: string; auth: string; body: string };
+
+type ScriptedUpstream = {
+  url: string;
+  calls: UpstreamCall[];
+  close: () => Promise<void>;
+};
+
+/**
+ * A Warmbly stand-in that records what actually arrived on the wire — headers
+ * and body included — so a test can prove whether a second, unclassified hop
+ * was ever issued and whether the Bearer token travelled with it.
+ */
+async function startScriptedUpstream(
+  respond: (call: UpstreamCall, res: ServerResponse, index: number) => void,
+): Promise<ScriptedUpstream> {
+  const calls: UpstreamCall[] = [];
+  const server: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const call: UpstreamCall = {
+        method: (req.method ?? "GET").toUpperCase(),
+        path: (req.url ?? "/").split("?")[0] ?? "/",
+        auth: String(req.headers.authorization ?? ""),
+        body: Buffer.concat(chunks).toString("utf8"),
+      };
+      calls.push(call);
+      respond(call, res, calls.length - 1);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    throw new Error("scripted upstream failed to bind");
+  }
+  return {
+    url: `http://127.0.0.1:${addr.port}`,
+    calls,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.closeAllConnections();
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+function operatorChannelAgainst(
+  baseUrl: string,
+  options: { timeoutMs?: number; ledger?: OperatorActionLedger } = {},
+): { channel: WarmblyOperatorChannel; ledger: OperatorActionLedger } {
+  const client = new WarmblyOperatorClient({
+    baseUrl,
+    token: TOKEN,
+    timeoutMs: options.timeoutMs ?? 2_000,
+    logger: () => undefined,
+  });
+  const ledger = options.ledger ?? createMemoryOperatorActionLedger();
+  const channel = createWarmblyOperatorChannel({ client, ledger, logger: () => undefined });
+  return { channel, ledger };
 }
 
 function onlyEntry(entries: OperatorActionLedgerEntry[]): OperatorActionLedgerEntry {
@@ -891,6 +967,494 @@ describe("mountable HTTP surface", () => {
       assert.equal(onlyEntry(bad.ledger.list()).upstream.status, 500);
     } finally {
       await bad.close();
+    }
+  });
+});
+
+describe("unknown outcome: the request was written and the answer never came", () => {
+  it("records unknown, never refused, when Warmbly answers slower than the timeout", async () => {
+    const upstream = await startScriptedUpstream((_call, res) => {
+      setTimeout(() => {
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ data: { resumed: true } }));
+      }, 500);
+    });
+    try {
+      const { channel, ledger } = operatorChannelAgainst(upstream.url, { timeoutMs: 120 });
+      const handle = createOperatorHttpHandler(channel);
+      const challenge = await handle({
+        method: "POST",
+        url: OPERATOR_HTTP_ROUTES.resumeConfirm,
+        headers: AUTHELIA_HEADERS,
+        remoteAddress: TRUSTED_HOP,
+        body: { reason: "incidente resolvido" },
+      });
+      assert.equal(challenge.status, 202);
+      const token = challenge.body.confirmation_token as string;
+
+      const resumed = await handle({
+        method: "POST",
+        url: OPERATOR_HTTP_ROUTES.resume,
+        headers: AUTHELIA_HEADERS,
+        remoteAddress: TRUSTED_HOP,
+        body: { reason: "incidente resolvido", confirmation_token: token },
+      });
+
+      // The POST reached Warmbly: it may well have resumed dispatch.
+      assert.equal(upstream.calls.length, 1);
+      assert.equal(upstream.calls[0]!.path, "/v1/confenge/dispatch/resume");
+
+      assert.equal(resumed.status, 503);
+      assert.equal(resumed.body.ok, false);
+      assert.equal(resumed.body.outcome, "unknown");
+      assert.equal(resumed.body.code, "transport_unknown");
+      assert.match(String(resumed.body.reason), /GET \/v1\/confenge\/dispatch\/status/);
+
+      const entries = ledger.list();
+      assert.deepEqual(
+        entries.map((e) => e.outcome),
+        ["challenged", "unknown"],
+      );
+      const unknown = entries[1]!;
+      assert.notEqual(unknown.outcome, "refused");
+      assert.equal(unknown.refusal_code, "transport_unknown");
+      assert.equal(unknown.action, "resume_dispatch");
+      assert.equal(unknown.upstream.method, "POST");
+      assert.equal(unknown.upstream.path, "/v1/confenge/dispatch/resume");
+      assert.equal(unknown.upstream.status, null);
+      assert.equal(unknown.confirmation.satisfied, true);
+      assert.ok(String(unknown.confirmation.token_id).startsWith("cnf:resume_dispatch:"));
+    } finally {
+      await upstream.close();
+    }
+  });
+
+  it("keeps a spent confirmation token spent after an unknown outcome", async () => {
+    // Decision: the burned token stays burned. Re-arming it would turn one
+    // observed token into a replayable resume; the operator reads dispatch
+    // status and, if still paused, mints a fresh confirmation.
+    const upstream = await startScriptedUpstream((_call, res) => {
+      setTimeout(() => {
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ data: { resumed: true } }));
+      }, 500);
+    });
+    try {
+      const { channel, ledger } = operatorChannelAgainst(upstream.url, { timeoutMs: 120 });
+      const step1 = await channel.requestResumeConfirmation({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      if (!step1.ok || step1.outcome !== "challenged") {
+        throw new Error("expected a challenge");
+      }
+      const unknown = await channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+        confirmation_token: step1.challenge.token,
+      });
+      assert.equal(unknown.ok, false);
+      if (unknown.ok) return;
+      assert.equal(unknown.outcome, "unknown");
+      assert.match(unknown.reason, /fresh confirmation/);
+
+      const retry = await channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+        confirmation_token: step1.challenge.token,
+      });
+      assert.equal(retry.ok, false);
+      if (retry.ok) return;
+      assert.equal(retry.outcome, "refused");
+      assert.equal(retry.code, "confirmation_invalid");
+      assert.equal(upstream.calls.length, 1, "the retry must not re-POST the resume");
+      assert.deepEqual(
+        ledger.list().map((e) => e.outcome),
+        ["challenged", "unknown", "refused"],
+      );
+    } finally {
+      await upstream.close();
+    }
+  });
+
+  it("still refuses — nothing was written — when the connection itself never opens", async () => {
+    const { channel, ledger } = operatorChannelAgainst("http://127.0.0.1:1", { timeoutMs: 500 });
+    const result = await channel.pauseDispatch({
+      request: founderRequest(),
+      reason: "spike de bounce",
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.outcome, "refused");
+    assert.equal(result.code, "transport_error");
+    const entry = onlyEntry(ledger.list());
+    assert.equal(entry.outcome, "refused");
+    assert.equal(entry.upstream.status, null);
+    assert.equal(entry.upstream.path, null);
+  });
+});
+
+describe("redirects are never followed", () => {
+  it("refuses a 3xx instead of re-POSTing the write with the Bearer token at the Location", async () => {
+    const upstream = await startScriptedUpstream((_call, res, index) => {
+      if (index === 0) {
+        res.statusCode = 307;
+        res.setHeader("Location", "/v1/confenge/dispatch/dispatch-now");
+        res.end();
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ data: { dispatched: true } }));
+    });
+    try {
+      const { channel, ledger } = operatorChannelAgainst(upstream.url);
+      const result = await channel.pauseDispatch({
+        request: founderRequest(),
+        reason: "spike de bounce",
+      });
+
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "upstream_error");
+      assert.match(result.reason, /redirect/);
+
+      assert.equal(upstream.calls.length, 1, "the redirect must not be followed");
+      assert.equal(upstream.calls[0]!.path, "/v1/confenge/dispatch/pause");
+      assert.equal(
+        upstream.calls.some((call) => call.path.includes("dispatch-now")),
+        false,
+      );
+      for (const call of upstream.calls) {
+        assert.equal(classifyOperatorRequest(call.method, call.path).allowed, true, call.path);
+      }
+
+      const entry = onlyEntry(ledger.list());
+      assert.equal(entry.outcome, "refused");
+      assert.equal(entry.upstream.path, "/v1/confenge/dispatch/pause");
+      assert.equal(entry.upstream.status, 307);
+    } finally {
+      await upstream.close();
+    }
+  });
+});
+
+describe("the ledger key is minted here, never by the caller", () => {
+  it("keeps an executed entry when a client_reference is replayed by a later refusal", async () => {
+    const agentLedger = createAgentLedger();
+    const sink = createAgentActivityLedgerSink(agentLedger);
+    const h = await harness({ sink });
+    const handle = createOperatorHttpHandler(h.channel);
+    const CLIENT_REF = "cc.op.2026-08-22";
+    try {
+      const executed = await handle({
+        method: "POST",
+        url: OPERATOR_HTTP_ROUTES.pause,
+        headers: AUTHELIA_HEADERS,
+        remoteAddress: TRUSTED_HOP,
+        body: { reason: "spike de bounce", correlation_id: CLIENT_REF },
+      });
+      assert.equal(executed.status, 200);
+      assert.equal(executed.body.client_reference, CLIENT_REF);
+      assert.notEqual(executed.body.correlation_id, CLIENT_REF);
+
+      const replay = await handle({
+        method: "POST",
+        url: OPERATOR_HTTP_ROUTES.acknowledge,
+        headers: AUTHELIA_HEADERS,
+        remoteAddress: TRUSTED_HOP,
+        body: { target_id: "lead 42", correlation_id: CLIENT_REF },
+      });
+      assert.equal(replay.status, 400);
+
+      const entries = h.ledger.list();
+      assert.equal(entries.length, 2);
+      assert.equal(entries[0]!.outcome, "executed");
+      assert.equal(entries[1]!.outcome, "refused");
+      assert.notEqual(entries[0]!.id, entries[1]!.id);
+      assert.notEqual(entries[0]!.correlation_id, entries[1]!.correlation_id);
+      for (const entry of entries) {
+        assert.equal(entry.client_reference, CLIENT_REF);
+        assert.ok(entry.correlation_id.startsWith("cc:warmbly-op:"));
+        assert.equal(entry.correlation_id.includes(CLIENT_REF), false);
+        assert.equal(entry.id.includes(CLIENT_REF), false);
+      }
+
+      const timeline = agentLedger.timeline({
+        from: "2000-01-01T00:00:00Z",
+        to: "2100-01-01T00:00:00Z",
+      });
+      assert.equal(timeline.length, 2, "the replay must not revise the executed row");
+      const done = timeline.find((row) => row.status === "DONE");
+      assert.ok(done, "the executed resume must still be on the timeline");
+      assert.ok(done!.evidence.includes("upstream=POST /v1/confenge/dispatch/pause 200"));
+      assert.equal(h.sinkErrors.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("a ledger failure after the write is never silent", () => {
+  it("emits the executed entry to the durable fallback before rethrowing", async () => {
+    const stub = await startFixtureStub({
+      payload: loadFixture("commercial-runtime.json"),
+      token: TOKEN,
+      operatorWrites: true,
+    });
+    const failures: Array<{ entry: OperatorActionLedgerEntry; err: unknown }> = [];
+    const exploding: OperatorActionLedger = {
+      record() {
+        throw new Error("ledger volume is read-only");
+      },
+      list: () => [],
+    };
+    try {
+      const client = new WarmblyOperatorClient({
+        baseUrl: stub.url,
+        token: TOKEN,
+        timeoutMs: 2_000,
+        logger: () => undefined,
+      });
+      const channel = createWarmblyOperatorChannel({
+        client,
+        ledger: exploding,
+        logger: () => undefined,
+        onLedgerWriteFailure: (entry, err) => failures.push({ entry, err }),
+      });
+      await assert.rejects(
+        () => channel.pauseDispatch({ request: founderRequest(), reason: "spike de bounce" }),
+        /read-only/,
+      );
+
+      assert.equal(stub.operatorCalls.length, 1, "the write did reach Warmbly");
+      assert.equal(failures.length, 1);
+      const lost = failures[0]!;
+      assert.equal(lost.entry.outcome, "executed");
+      assert.equal(lost.entry.action, "pause_dispatch");
+      assert.equal(lost.entry.upstream.status, 200);
+
+      const line = operatorLedgerWalLine(lost.entry, lost.err);
+      assert.ok(line.endsWith("\n"));
+      const parsed = JSON.parse(line) as { wal: string; error: string; entry: { outcome: string } };
+      assert.equal(parsed.wal, OPERATOR_LEDGER_WAL_MARKER);
+      assert.match(parsed.error, /read-only/);
+      assert.equal(parsed.entry.outcome, "executed");
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("fans out to the sinks and rethrows when the primary ledger throws", async () => {
+    const h = await harness();
+    try {
+      await h.channel.pauseDispatch({ request: founderRequest(), reason: "spike de bounce" });
+      const entry = onlyEntry(h.ledger.list());
+
+      const mirrored: OperatorActionLedgerEntry[] = [];
+      const seen: unknown[] = [];
+      const fanned = createFanOutOperatorActionLedger(
+        {
+          record() {
+            throw new Error("primary ledger is down");
+          },
+          list: () => [],
+        },
+        [
+          {
+            record(e) {
+              mirrored.push(e);
+            },
+            list: () => [],
+          },
+        ],
+        (err) => seen.push(err),
+      );
+      assert.throws(() => fanned.record(entry), /primary ledger is down/);
+      assert.equal(mirrored.length, 1, "the mirror still gets the entry");
+      assert.equal(seen.length, 1);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("agent-activity mirror failures are loud", () => {
+  it("reports a rejected timeline row through the required onSinkError handler", async () => {
+    // 100 emoji: 100 code points passes the security NAME_RE, 200 UTF-16 units
+    // fails agent-activity's display_name max(128).
+    const display = "\u{1F642}".repeat(100);
+    const agentLedger = createAgentLedger();
+    const sink = createAgentActivityLedgerSink(agentLedger);
+    const logger = capturingLogger();
+    const h = await harness({ sink, onSinkError: defaultOperatorSinkErrorHandler(logger.logger) });
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: founderRequest({ ...AUTHELIA_HEADERS, "Remote-Name": display }),
+        reason: "spike de bounce",
+      });
+      assert.equal(result.ok, true);
+      const entry = onlyEntry(h.ledger.list());
+      assert.equal(entry.outcome, "executed");
+      assert.equal(
+        agentLedger.timeline({ from: "2000-01-01T00:00:00Z", to: "2100-01-01T00:00:00Z" }).length,
+        0,
+        "reproduces the invisible row",
+      );
+
+      const errors = logger.entries.filter(
+        (line) => line.level === "error" && line.msg === "warmbly.operator.ledger_sink_failed",
+      );
+      assert.equal(errors.length, 1);
+      const serialized = String(errors[0]!.entry);
+      assert.ok(serialized.includes(entry.correlation_id));
+      assert.ok(serialized.includes('"outcome":"executed"'));
+      assert.ok(serialized.includes('"status":200'));
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("duplicated identity headers fail closed", () => {
+  it("refuses an array-valued Remote-User instead of trusting the first copy", async () => {
+    const h = await harness();
+    try {
+      const result = await h.channel.pauseDispatch({
+        request: {
+          remoteAddress: TRUSTED_HOP,
+          headers: {
+            "remote-user": ["evil", "founder"],
+            "remote-name": "Founder Confenge",
+            "remote-groups": "operators",
+            "remote-email": "founder@confenge.invalid",
+          },
+        },
+        reason: "spike de bounce",
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, "missing_actor");
+      assert.equal(onlyEntry(h.ledger.list()).actor, null);
+      assert.equal(h.fetchHits.length, 0);
+      assert.equal(h.stub.operatorCalls.length, 0);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses a duplicated Remote-Groups too, and still accepts a single-valued array", async () => {
+    const h = await harness();
+    try {
+      const duplicated = await h.channel.pauseDispatch({
+        request: {
+          remoteAddress: TRUSTED_HOP,
+          headers: {
+            "remote-user": "founder",
+            "remote-name": "Founder Confenge",
+            "remote-groups": ["guests", "operators"],
+            "remote-email": "founder@confenge.invalid",
+          },
+        },
+        reason: "spike de bounce",
+      });
+      assert.equal(duplicated.ok, false);
+      if (!duplicated.ok) assert.equal(duplicated.code, "missing_actor");
+      assert.equal(h.stub.operatorCalls.length, 0);
+
+      const single = await h.channel.pauseDispatch({
+        request: {
+          remoteAddress: TRUSTED_HOP,
+          headers: {
+            "remote-user": ["founder"],
+            "remote-name": ["Founder Confenge"],
+            "remote-groups": ["operators"],
+            "remote-email": ["founder@confenge.invalid"],
+          },
+        },
+        reason: "spike de bounce",
+      });
+      assert.equal(single.ok, true);
+      assert.equal(h.stub.operatorCalls.length, 1);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("confirmation challenges are individually identifiable and reason-bound", () => {
+  it("mints a unique token_id per challenge so the ledger shows which one was spent", async () => {
+    const h = await harness();
+    try {
+      const first = await h.channel.requestResumeConfirmation({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      const second = await h.channel.requestResumeConfirmation({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      if (!first.ok || first.outcome !== "challenged") throw new Error("expected a challenge");
+      if (!second.ok || second.outcome !== "challenged") throw new Error("expected a challenge");
+
+      const prefix = "cnf:resume_dispatch:confenge-dispatch:";
+      assert.ok(first.challenge.token_id.startsWith(prefix));
+      assert.ok(second.challenge.token_id.startsWith(prefix));
+      assert.notEqual(first.challenge.token_id, second.challenge.token_id);
+
+      const executed = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+        confirmation_token: second.challenge.token,
+      });
+      assert.equal(executed.ok, true);
+
+      const entries = h.ledger.list();
+      const challenged = entries
+        .filter((e) => e.outcome === "challenged")
+        .map((e) => e.confirmation.token_id);
+      assert.deepEqual(challenged, [first.challenge.token_id, second.challenge.token_id]);
+      assert.equal(new Set(challenged).size, 2, "minted-and-abandoned must be countable");
+      const spent = entries.find((e) => e.outcome === "executed")!;
+      assert.equal(spent.confirmation.token_id, second.challenge.token_id);
+      assert.notEqual(spent.confirmation.token_id, first.challenge.token_id);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("refuses a token confirmed under one reason and executed under another", async () => {
+    const h = await harness();
+    try {
+      const challenge = await h.channel.requestResumeConfirmation({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+      });
+      if (!challenge.ok || challenge.outcome !== "challenged") throw new Error("expected a challenge");
+
+      const swapped = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "teste de rotina",
+        confirmation_token: challenge.challenge.token,
+      });
+      assert.equal(swapped.ok, false);
+      if (swapped.ok) return;
+      assert.equal(swapped.code, "confirmation_invalid");
+      assert.match(swapped.reason, /audit reason/);
+      assert.equal(h.stub.operatorCalls.length, 0);
+      assert.equal(h.fetchHits.length, 0);
+
+      const matching = await h.channel.resumeDispatch({
+        request: founderRequest(),
+        reason: "incidente resolvido",
+        confirmation_token: challenge.challenge.token,
+      });
+      assert.equal(matching.ok, true);
+      assert.equal(h.stub.operatorCalls.length, 1);
+    } finally {
+      await h.close();
     }
   });
 });

--- a/control-center/package-lock.json
+++ b/control-center/package-lock.json
@@ -190,11 +190,15 @@
     "connectors/warmbly": {
       "name": "@confenge/control-center-warmbly-connector",
       "version": "0.1.0",
+      "dependencies": {
+        "@confenge/control-center-security": "*"
+      },
       "bin": {
         "cc-connector-canary": "src/canary.ts",
         "warmbly-collect": "src/cli.ts"
       },
       "devDependencies": {
+        "@confenge/control-center-agent-activity": "*",
         "@types/node": "^24.3.0",
         "tsx": "^4.20.5",
         "typescript": "^5.9.2"

--- a/control-center/security/ADAPTER.md
+++ b/control-center/security/ADAPTER.md
@@ -15,6 +15,12 @@ After Caddy `forward_auth` to Authelia `/api/authz/forward-auth` succeeds, the p
 
 Trust those headers **only** from `CC_TRUSTED_PROXY_CIDRS` (immediate TCP peer). Deny otherwise.
 
+Duplicated identity headers fail closed. A `Remote-*` header that arrives more
+than once (an array-valued header from a mount that does not join duplicates)
+yields no value at all, so a client-supplied copy can never beat the value the
+proxy appends — Node's own `http` server joins duplicates into one string and is
+denied for the same reason.
+
 Public unauthenticated paths: `/healthz`, `/livez`. Payload from `healthPayload()` → `{"status":"ok"}`.
 
 ## Suggested call

--- a/control-center/security/src/identity.ts
+++ b/control-center/security/src/identity.ts
@@ -22,8 +22,15 @@ function headerValue(
       continue;
     }
     if (Array.isArray(raw)) {
-      const first = raw[0];
-      return first === undefined ? undefined : first;
+      // Fail closed on any duplicate. Taking the first value lets a client-sent
+      // copy of an identity header win over the one the proxy appends; Node's
+      // own http server joins duplicates into one string and denies, and a
+      // mount that hands us arrays must not behave differently.
+      if (raw.length !== 1) {
+        return undefined;
+      }
+      const only = raw[0];
+      return only === undefined ? undefined : only;
     }
     return raw;
   }

--- a/control-center/security/tests/identity.test.ts
+++ b/control-center/security/tests/identity.test.ts
@@ -136,6 +136,47 @@ describe("parseForwardAuthIdentity", () => {
     }
   });
 
+  it("denies a duplicated identity header instead of trusting the first copy", () => {
+    // A mount that hands headers through as arrays (Node's own http server
+    // joins them into one string) must not let a client-supplied copy win over
+    // the value the proxy appends.
+    const duplicated = parseForwardAuthIdentity(
+      request("10.89.0.2", {
+        ...trustedHeaders,
+        "Remote-User": ["evil", "operator"],
+      }),
+      policy,
+    );
+    assert.equal(duplicated.ok, false);
+    if (!duplicated.ok) {
+      assert.equal(duplicated.code, "missing_identity");
+    }
+
+    const duplicatedGroups = parseForwardAuthIdentity(
+      request("10.89.0.2", {
+        ...trustedHeaders,
+        "Remote-Groups": ["operators", "operators"],
+      }),
+      policy,
+    );
+    assert.equal(duplicatedGroups.ok, false);
+
+    // A single-valued array is still a single value.
+    const single = parseForwardAuthIdentity(
+      request("10.89.0.2", {
+        "Remote-User": ["operator"],
+        "Remote-Groups": ["operators"],
+        "Remote-Name": ["Control Center Operator"],
+        "Remote-Email": ["ops@example.invalid"],
+      }),
+      policy,
+    );
+    assert.equal(single.ok, true);
+    if (single.ok) {
+      assert.equal(single.identity.user, "operator");
+    }
+  });
+
   it("fail-closes when no trusted hops are configured", () => {
     const result = parseForwardAuthIdentity(request("10.89.0.2"), {
       trustedHops: [],


### PR DESCRIPTION
Fecha a issue #48 do lado do código. **Não monta nada** — o handler existe e é testado, mas nada o registra ainda, então `ops.confenge.com.br` continua sem botão de pause.

## O que é

Emenda deliberada a uma fronteira que era somente-leitura. O `connectors/warmbly/README.md` registrava: "Forbidden: PATCH/PUT/DELETE, creating contacts/deals/tasks, campaign start/stop/send, Confenge import/enroll/bootstrap/dispatch, unibox reply/compose, any Asaas/financial mutation."

Três ações de escrita, cada uma tipada individualmente — sem proxy genérico, sem método ou caminho vindo do chamador:

| Ação | Upstream | Confirmação |
| --- | --- | --- |
| `pause_dispatch` | `POST /v1/confenge/dispatch/pause` | um passo |
| `resume_dispatch` | `POST /v1/confenge/dispatch/resume` | **dois passos**, token ligado ao operador emissor |
| `acknowledge_inbound_alert` | `POST /v1/confenge/inbound/{lead_id}/acknowledge` | um passo |

Identidade vem dos headers `Remote-*` da Authelia via `parseForwardAuthIdentity`. O allowlist de leitura em `src/http/` permanece intocado e continua negando os três caminhos; há teste afirmando isso. Toda chamada — executada, recusada ou desafiada — grava uma entrada `control-center.warmbly-operator-action.v1` espelhada em `domains/agent-activity`.

## Revisão adversarial: sete achados, todos corrigidos

Este é um plano de controle que liga e desliga e-mail de saída para uma empresa com dispatch pausado e zero clientes. Um `resume` falso é o pior resultado do sistema, então revisei antes de considerar montar.

**Um `resume` com timeout era gravado como `refused` enquanto o Warmbly resumia de fato.** Reproduzido: o upstream aplica a mudança e responde depois dos 8s; o operador vê `503 {"outcome":"refused"}`, o ledger diz `refused` com `upstream.status: null`, e o envio está ligado. Não havia como dizer "foi para o fio, resultado desconhecido". Pior, o token era queimado, então o movimento natural era reconfirmar e re-POSTar — ligando duas vezes com o ledger negando as duas.

Corrigido com um quarto outcome `unknown`. `isPreFlightTransportFailure()` distingue a falha que **prova** que nada foi escrito (`ECONNREFUSED`, `ENOTFOUND`, TLS, porta inválida) de tudo o mais; timeout explicitamente não é pre-flight, e o inclassificável assume que pode ter sido escrito. O token continua gasto: re-armá-lo transformaria um token observado num resume replayável e quebraria o uso único em que o gate de dois passos inteiro se apoia.

**O `fetch` seguia 3xx.** Um `307 Location: /v1/confenge/dispatch/dispatch-now` fazia o canal POSTar `dispatch-now` — que está em `OPERATOR_FORBIDDEN_ACTIONS` — com o Bearer token e o corpo original, sem consultar o allowlist no segundo hop, e o ledger registrava `pause 200 executed`. Nada em `src/` mencionava `redirect`. Agora `redirect: "manual"` e qualquer 3xx é recusa.

Os outros cinco: `correlation_id` vinha do corpo e chaveava a sessão do agent-activity, deixando o próprio ator reescrever a linha de um resume executado; falha do ledger depois da escrita deixava o sistema resumido sem registro; falhas do espelho eram descartadas em silêncio; `raw[0]` num header em array deixava a cópia do cliente vencer a do proxy; e `token_id` constante impedia ligar um resume ao desafio que o autorizou.

Detalhe de cada um em [#48](https://github.com/tjsasakifln/Governance/issues/48#issuecomment-5379938229).

## Verificação

Rodada por mim, não só pelo agente: conector **70/70**, pacote `security` **38/38**, convergência **55/55**, `tsc --noEmit` limpo nos dois pacotes. Os 58 testes que já existiam continuam passando; os 12 novos cobrem cada achado e falham com sua própria correção revertida.

`security/src/identity.ts` é compartilhado; verifiquei os outros consumidores e nenhum passa headers em array nem depende de first-wins.

## O que falta para `ops.confenge.com.br`

Só registrar `createOperatorHttpHandler(channel)` no `services/context` e pôr o controle no `web-shell`. O hop do Caddy que eu havia reportado como bloqueio **já existe**: `handle /v1/*` faz `copy_headers Remote-User Remote-Groups Remote-Name Remote-Email` e encaminha para `context:8080`, confirmado ao vivo no `ec-prod`.

## Rollback

Aditivo. O único código compartilhado tocado é `security/src/identity.ts`, cuja mudança fecha em qualquer header duplicado e deve ser mantida mesmo num rollback do canal.