### PR TITLE
feat(cc-warmbly): mount the operator channel on the ops.confenge.com.br surface

### DIFF
--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -71,6 +71,11 @@ export interface AdapterWriteResult {
   path: string;
   kind: WriteShortcutKind;
   message: string;
+  /**
+   * Returned only by `resume_confirm`. The caller replays it on `resume`; it is
+   * single-use, bound to the issuing operator, and never re-armed.
+   */
+  confirmationToken?: string;
 }
 
 /**
@@ -97,6 +102,30 @@ export interface ControlCenterReadAdapter {
     note: string;
     idempotency_key?: string;
   }): AdapterWriteResult | Promise<AdapterWriteResult>;
+  /**
+   * Warmbly dispatch control. Deliberately separate from `operatorAction`:
+   * that one authenticates with `x-actor-id`, a header the browser sets, and a
+   * client-settable actor must never be able to restart outbound email. These
+   * routes authenticate at the edge with Authelia, so the adapter sends no
+   * actor header at all and relies on the session cookie.
+   *
+   * `resume` is two-step by contract: `resume_confirm` returns a token that
+   * `resume` must replay. There is no single-call resume.
+   */
+  warmblyDispatch?(input: WarmblyDispatchInput): AdapterWriteResult | Promise<AdapterWriteResult>;
+}
+
+export const WARMBLY_DISPATCH_ACTIONS = ["pause", "resume_confirm", "resume", "acknowledge"] as const;
+export type WarmblyDispatchAction = (typeof WARMBLY_DISPATCH_ACTIONS)[number];
+
+export interface WarmblyDispatchInput {
+  action: WarmblyDispatchAction;
+  /** Audit reason. Required: the channel refuses a write without one. */
+  reason: string;
+  /** Only for `resume`, replayed from the `resume_confirm` response. */
+  confirmation_token?: string;
+  /** Only for `acknowledge`. */
+  target_id?: string;
 }
 
 export function adapterAllows(action: string): action is AdapterAction {

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -6,6 +6,7 @@ import {
   type AdapterAction,
   type AdapterReadResult,
   type AdapterWriteResult,
+  type WarmblyDispatchInput,
   type ControlCenterReadAdapter,
   type DestinationPage,
 } from "./contract";
@@ -25,6 +26,7 @@ import {
 } from "./map";
 import {
   AUTHORIZED_WRITE_PATH,
+  WARMBLY_DISPATCH_PATHS,
   WRITE_SHORTCUT_DIRECTIVE_KIND,
   WRITE_SHORTCUT_KINDS,
   destinationUsesContext,
@@ -80,6 +82,59 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     const result = await this.readDestination("hoje");
     if (!result.ok || result.loading) return [];
     return result.page.priorities;
+  }
+
+  async warmblyDispatch(input: WarmblyDispatchInput): Promise<AdapterWriteResult> {
+    const path = WARMBLY_DISPATCH_PATHS[input.action];
+    const fail = (message: string): AdapterWriteResult => {
+      const denied: AdapterWriteResult = { ok: false, path: path ?? "/v1/warmbly/operator", kind: "nota", message };
+      this.lastOperatorResult = denied;
+      return denied;
+    };
+    if (!path) {
+      return fail("ação de dispatch desconhecida");
+    }
+    // The channel refuses a write with no audit reason, and with paused_by
+    // missing upstream this ledger is the only record of who did it.
+    if (input.reason.trim() === "") {
+      return fail("motivo é obrigatório");
+    }
+    if (input.action === "resume" && !input.confirmation_token) {
+      return fail("resume exige o token de confirmação do passo anterior");
+    }
+    if (input.action === "acknowledge" && !input.target_id) {
+      return fail("acknowledge exige o id do alerta");
+    }
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method: "POST",
+        // No x-actor-id: identity is Authelia's, resolved at the edge from the
+        // session. Sending an actor header here would invite trusting it.
+        headers: { accept: "application/json", "content-type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          reason: input.reason,
+          ...(input.confirmation_token ? { confirmation_token: input.confirmation_token } : {}),
+          ...(input.target_id ? { target_id: input.target_id } : {}),
+        }),
+      });
+      const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+      const result: AdapterWriteResult = {
+        ok: response.ok,
+        path,
+        kind: "nota",
+        message: typeof body.reason === "string" ? body.reason : `HTTP ${response.status}`,
+        ...(typeof body.confirmation_token === "string"
+          ? { confirmationToken: body.confirmation_token }
+          : {}),
+      };
+      this.lastOperatorResult = result;
+      return result;
+    } catch (err) {
+      // A transport failure here says nothing about whether Warmbly applied the
+      // change; the channel reports `unknown` for exactly this reason.
+      return fail(`falha de transporte: ${err instanceof Error ? err.name : "erro"}`);
+    }
   }
 
   async operatorAction(input: {

--- a/control-center/apps/web-shell/src/adapters/paths.ts
+++ b/control-center/apps/web-shell/src/adapters/paths.ts
@@ -76,3 +76,15 @@ export function isAuthorizedWritePath(path: string): boolean {
   const pathname = path.split("?")[0] ?? path;
   return pathname === AUTHORIZED_WRITE_PATH;
 }
+
+/**
+ * Warmbly dispatch control routes, mounted by the context service ahead of its
+ * own `x-actor-id` actor resolution. Kept here so a test can assert the set is
+ * exactly these four and nothing wider.
+ */
+export const WARMBLY_DISPATCH_PATHS = {
+  pause: "/v1/warmbly/operator/dispatch/pause",
+  resume_confirm: "/v1/warmbly/operator/dispatch/resume/confirm",
+  resume: "/v1/warmbly/operator/dispatch/resume",
+  acknowledge: "/v1/warmbly/operator/inbound/acknowledge",
+} as const;

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -112,6 +112,9 @@ function applyPaint(
   bindOperatorActions(root, adapter, () => {
     paintShell(root, adapter, `#/${parsed.destination}${parsed.surface ? `/${parsed.surface}` : ""}`);
   });
+  bindWarmblyDispatch(root, adapter, () => {
+    paintShell(root, adapter, `#/${parsed.destination}${parsed.surface ? `/${parsed.surface}` : ""}`);
+  });
 }
 
 function bindOperatorActions(
@@ -140,6 +143,53 @@ function bindOperatorActions(
         }),
       ).then((result) => {
         if (result) adapter.lastOperatorResult = result;
+        onDone();
+      });
+    });
+  }
+}
+
+/**
+ * Binds the Warmbly dispatch control.
+ *
+ * Pause is one click. Resume is two by contract: the first call mints a
+ * single-use token, the second replays it. The token is held only for the life
+ * of this interaction and never persisted, so a reload forces a fresh
+ * confirmation — restarting outbound email should cost a deliberate act.
+ */
+function bindWarmblyDispatch(
+  root: MountableRoot,
+  adapter: ControlCenterReadAdapter,
+  onDone: () => void,
+): void {
+  if (!adapter.warmblyDispatch || typeof root.querySelectorAll !== "function") return;
+  const forms = root.querySelectorAll("[data-warmbly-dispatch]");
+  for (let i = 0; i < forms.length; i += 1) {
+    const form = forms[i];
+    if (!form) continue;
+    let pendingToken: string | undefined;
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const requested = form.getAttribute("data-warmbly-dispatch");
+      if (requested !== "pause" && requested !== "resume" && requested !== "acknowledge") return;
+      const reason = form.querySelector('[name="reason"]')?.value ?? "";
+      const targetId = form.querySelector('[name="target_id"]')?.value ?? "";
+      // A resume with no token yet is the confirmation step, not the resume.
+      const action =
+        requested === "resume" && !pendingToken ? "resume_confirm" : requested;
+      void Promise.resolve(
+        adapter.warmblyDispatch?.({
+          action,
+          reason,
+          ...(action === "resume" && pendingToken ? { confirmation_token: pendingToken } : {}),
+          ...(requested === "acknowledge" ? { target_id: targetId } : {}),
+        }),
+      ).then((result) => {
+        if (result) {
+          adapter.lastOperatorResult = result;
+          // Carry the token forward only for the immediately following resume.
+          pendingToken = action === "resume_confirm" ? result.confirmationToken : undefined;
+        }
         onDone();
       });
     });

--- a/control-center/apps/web-shell/tests/warmbly-dispatch.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-dispatch.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { WARMBLY_DISPATCH_PATHS } from "../src/adapters/paths";
+import { WARMBLY_DISPATCH_ACTIONS } from "../src/adapters/contract";
+import { HttpControlCenterAdapter } from "../src/adapters/http";
+
+type Call = { url: string; init: RequestInit };
+
+function adapterWith(
+  responder: (url: string, init: RequestInit) => { status: number; body: unknown },
+): { adapter: HttpControlCenterAdapter; calls: Call[] } {
+  const calls: Call[] = [];
+  const fetchImpl = (async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    const { status, body } = responder(url, init);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "https://ops.confenge.com.br",
+    fetchImpl,
+    operator: { id: "founder", kind: "human" },
+  } as never);
+  return { adapter, calls };
+}
+
+test("the dispatch surface is exactly four routes and nothing wider", () => {
+  assert.deepEqual(Object.keys(WARMBLY_DISPATCH_PATHS).sort(), [...WARMBLY_DISPATCH_ACTIONS].sort());
+  for (const path of Object.values(WARMBLY_DISPATCH_PATHS)) {
+    assert.ok(path.startsWith("/v1/warmbly/operator/"), `${path} escapes the operator prefix`);
+  }
+});
+
+test("no actor header is sent: a client-settable actor must not reach a dispatch write", async () => {
+  const { adapter, calls } = adapterWith(() => ({ status: 200, body: { ok: true, reason: "paused" } }));
+  await adapter.warmblyDispatch({ action: "pause", reason: "bounce spike" });
+  assert.equal(calls.length, 1);
+  const headers = (calls[0]!.init.headers ?? {}) as Record<string, string>;
+  assert.equal(headers["x-actor-id"], undefined);
+  assert.equal(headers["x-actor-kind"], undefined);
+  assert.equal((calls[0]!.init as { credentials?: string }).credentials, "include");
+});
+
+test("resume without a confirmation token never reaches the wire", async () => {
+  const { adapter, calls } = adapterWith(() => ({ status: 200, body: { ok: true } }));
+  const result = await adapter.warmblyDispatch({ action: "resume", reason: "incident resolved" });
+  assert.equal(result.ok, false);
+  assert.match(result.message, /token de confirmação/);
+  assert.equal(calls.length, 0, "the resume must not be attempted without the second step");
+});
+
+test("a write with no audit reason never reaches the wire", async () => {
+  const { adapter, calls } = adapterWith(() => ({ status: 200, body: { ok: true } }));
+  for (const action of ["pause", "resume_confirm", "acknowledge"] as const) {
+    const result = await adapter.warmblyDispatch({ action, reason: "   ", target_id: "lead-1" });
+    assert.equal(result.ok, false, `${action} accepted an empty reason`);
+  }
+  assert.equal(calls.length, 0);
+});
+
+test("resume_confirm surfaces the token so the caller can replay exactly one resume", async () => {
+  const { adapter, calls } = adapterWith((url) =>
+    url.endsWith("/resume/confirm")
+      ? { status: 202, body: { ok: false, confirmation_token: "tok-1", reason: "confirmation required" } }
+      : { status: 200, body: { ok: true, reason: "resumed" } },
+  );
+  const confirmed = await adapter.warmblyDispatch({ action: "resume_confirm", reason: "incident resolved" });
+  assert.equal(confirmed.confirmationToken, "tok-1");
+  const resumed = await adapter.warmblyDispatch({
+    action: "resume",
+    reason: "incident resolved",
+    confirmation_token: "tok-1",
+  });
+  assert.equal(resumed.ok, true);
+  assert.equal(calls.length, 2);
+  assert.ok(calls[1]!.url.endsWith(WARMBLY_DISPATCH_PATHS.resume));
+  assert.match(String(calls[1]!.init.body), /tok-1/);
+});
+
+test("acknowledge without a target never reaches the wire", async () => {
+  const { adapter, calls } = adapterWith(() => ({ status: 200, body: { ok: true } }));
+  const result = await adapter.warmblyDispatch({ action: "acknowledge", reason: "seen" });
+  assert.equal(result.ok, false);
+  assert.equal(calls.length, 0);
+});
+
+test("a transport failure is reported as a failure, never as a silent success", async () => {
+  const calls: Call[] = [];
+  const fetchImpl = (async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    throw new Error("boom");
+  }) as unknown as typeof fetch;
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "https://ops.confenge.com.br",
+    fetchImpl,
+    operator: { id: "founder", kind: "human" },
+  } as never);
+  const result = await adapter.warmblyDispatch({ action: "pause", reason: "bounce spike" });
+  assert.equal(result.ok, false);
+  assert.match(result.message, /transporte/);
+});

--- a/control-center/services/context/Dockerfile
+++ b/control-center/services/context/Dockerfile
@@ -34,6 +34,9 @@ COPY --from=builder --chown=node:node /src/node_modules ./node_modules
 COPY --from=builder --chown=node:node /src/contracts ./contracts
 COPY --from=builder --chown=node:node /src/persistence ./persistence
 COPY --from=builder --chown=node:node /src/intelligence/attention ./intelligence/attention
+# Optional dependency of the operator channel. Loaded lazily and only when
+# CC_WARMBLY_OPERATOR_ENABLED=true, but it has to be present to be loadable.
+COPY --from=builder --chown=node:node /src/connectors/warmbly ./connectors/warmbly
 COPY --from=builder --chown=node:node /src/services/context ./services/context
 COPY --from=builder --chown=node:node /src/scripts/node-http-probe.mjs ./node-http-probe.mjs
 ENV HOST=0.0.0.0

--- a/control-center/services/context/package.json
+++ b/control-center/services/context/package.json
@@ -2,7 +2,7 @@
   "name": "@confenge/control-center-context",
   "version": "0.1.0",
   "private": true,
-  "description": "Confenge Control Center — strategic memory and directives (scoped context for agents).",
+  "description": "Confenge Control Center \u2014 strategic memory and directives (scoped context for agents).",
   "type": "module",
   "engines": {
     "node": ">=20"
@@ -22,7 +22,8 @@
   "dependencies": {
     "@confenge/control-center-attention": "*",
     "@confenge/control-center-contracts": "*",
-    "@confenge/control-center-persistence": "*"
+    "@confenge/control-center-persistence": "*",
+    "@confenge/control-center-warmbly-connector": "*"
   },
   "devDependencies": {
     "@embedded-postgres/linux-x64": "16.14.0-beta.17",

--- a/control-center/services/context/src/http.ts
+++ b/control-center/services/context/src/http.ts
@@ -15,7 +15,33 @@ export interface HttpDeps {
   logger: Logger;
   operational?: OperationalService;
   operatorActions?: OperatorActionService;
+  /**
+   * Warmbly operator channel. Optional: when absent every operator route 404s,
+   * which is the fail-closed default for an unconfigured deployment.
+   *
+   * It carries its own identity: Authelia's `Remote-*` headers, verified against
+   * a trusted hop. It deliberately does NOT use `x-actor-id`, which any caller
+   * that reaches this process can set — a client-settable actor must never be
+   * able to pause or resume outbound email.
+   */
+  warmblyOperator?: (req: WarmblyOperatorHttpRequest) => Promise<WarmblyOperatorHttpResponse>;
 }
+
+export interface WarmblyOperatorHttpRequest {
+  method: string | undefined;
+  url: string | undefined;
+  headers: Readonly<Record<string, string | string[] | undefined>>;
+  remoteAddress: string | undefined;
+  body: unknown;
+}
+
+export interface WarmblyOperatorHttpResponse {
+  status: number;
+  body: unknown;
+}
+
+/** Route prefix owned by the Warmbly operator channel. */
+const WARMBLY_OPERATOR_PREFIX = "/v1/warmbly/operator/";
 
 function header(req: IncomingMessage, name: string): string | undefined {
   const raw = req.headers[name];
@@ -143,6 +169,28 @@ async function handle(
     if (method === "GET" && url.pathname === "/ready") {
       const ready = await deps.service.ready();
       send(res, ready ? 200 : 503, { ready, service: "control-center-context" });
+      return;
+    }
+    // Mounted before actorFromRequest on purpose. The operator channel resolves
+    // its own actor from Authelia, and must never fall back to the
+    // client-supplied x-actor-id header this service uses elsewhere.
+    if (url.pathname.startsWith(WARMBLY_OPERATOR_PREFIX)) {
+      if (!deps.warmblyOperator) {
+        send(res, 404, {
+          ok: false,
+          code: "operator_channel_not_configured",
+          reason: "the Warmbly operator channel is not wired in this deployment",
+        });
+        return;
+      }
+      const result = await deps.warmblyOperator({
+        method,
+        url: url.pathname,
+        headers: req.headers,
+        remoteAddress: req.socket?.remoteAddress,
+        body: method === "POST" ? await readBody(req) : undefined,
+      });
+      send(res, result.status, result.body);
       return;
     }
     const actor = actorFromRequest(req);

--- a/control-center/services/context/src/server.ts
+++ b/control-center/services/context/src/server.ts
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 import { bootFromEnvAsync } from "./boot.ts";
 import { createRequestListener } from "./http.ts";
+import { createWarmblyOperatorHandlerFromEnv } from "./warmbly-operator/from-env.ts";
 import { createLogger, type Logger } from "./log.ts";
 import { isServiceError } from "./errors.ts";
 
@@ -29,11 +30,15 @@ export async function startServer(
   const boot = await bootFromEnvAsync(env, { logger });
   const host = listenHost(env);
   const port = listenPort(env);
+  // Off unless CC_WARMBLY_OPERATOR_ENABLED=true. When absent, every operator
+  // route 404s rather than falling back to a weaker identity path.
+  const warmblyOperator = createWarmblyOperatorHandlerFromEnv(env, { logger });
   const listener = createRequestListener({
     service: boot.service,
     operational: boot.operational,
     operatorActions: boot.operatorActions,
     logger,
+    ...(warmblyOperator ? { warmblyOperator } : {}),
   });
   const server = createServer(listener);
   return new Promise((resolve, reject) => {

--- a/control-center/services/context/src/server.ts
+++ b/control-center/services/context/src/server.ts
@@ -32,7 +32,7 @@ export async function startServer(
   const port = listenPort(env);
   // Off unless CC_WARMBLY_OPERATOR_ENABLED=true. When absent, every operator
   // route 404s rather than falling back to a weaker identity path.
-  const warmblyOperator = createWarmblyOperatorHandlerFromEnv(env, { logger });
+  const warmblyOperator = await createWarmblyOperatorHandlerFromEnv(env, { logger });
   const listener = createRequestListener({
     service: boot.service,
     operational: boot.operational,

--- a/control-center/services/context/src/warmbly-operator/from-env.ts
+++ b/control-center/services/context/src/warmbly-operator/from-env.ts
@@ -1,0 +1,107 @@
+/**
+ * Wires the Warmbly operator channel, or returns undefined.
+ *
+ * Off unless explicitly configured. An unconfigured deployment 404s every
+ * operator route, which is the fail-closed default: a control plane that can
+ * pause and resume outbound email must be switched on deliberately, never by
+ * a default.
+ */
+
+import {
+  WarmblyOperatorClient,
+  createAgentActivityLedgerSink,
+  createFanOutOperatorActionLedger,
+  createMemoryOperatorActionLedger,
+  createOperatorHttpHandler,
+  createWarmblyOperatorChannel,
+  defaultOperatorSinkErrorHandler,
+} from "@confenge/control-center-warmbly-connector";
+
+import type { Logger } from "../log.ts";
+import type { WarmblyOperatorHttpRequest, WarmblyOperatorHttpResponse } from "../http.ts";
+
+/**
+ * The connector's log entry shape. Declared structurally here rather than
+ * exported from the connector, so mounting it does not widen its public surface.
+ */
+type ConnectorLogEntry = { level: "info" | "warn" | "error"; msg: string; [key: string]: unknown };
+type ConnectorLogger = (entry: ConnectorLogEntry) => void;
+
+/**
+ * The connector logs structured entries through a single callable; this service
+ * logs through level methods. Adapt rather than widen either side, and drop the
+ * fields the service logger refuses so a nested object cannot smuggle a secret
+ * past its own redaction.
+ */
+function connectorLogger(logger: Logger): ConnectorLogger {
+  return (entry: ConnectorLogEntry) => {
+    const { level, msg, ...rest } = entry;
+    const fields: Record<string, string | number | boolean | null> = {};
+    for (const [key, value] of Object.entries(rest)) {
+      if (value === null || ["string", "number", "boolean"].includes(typeof value)) {
+        fields[key] = value as string | number | boolean | null;
+      } else {
+        fields[key] = JSON.stringify(value) ?? "";
+      }
+    }
+    const write = level === "error" ? logger.error : level === "warn" ? logger.warn : logger.info;
+    write.call(logger, msg, fields);
+  };
+}
+
+export type WarmblyOperatorHandler = (
+  req: WarmblyOperatorHttpRequest,
+) => Promise<WarmblyOperatorHttpResponse>;
+
+export interface WarmblyOperatorEnvDeps {
+  logger: Logger;
+  /** Optional agent-activity sink, so operator actions land on the timeline. */
+  agentActivity?: Parameters<typeof createAgentActivityLedgerSink>[0];
+}
+
+function required(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const raw = env[name];
+  return typeof raw === "string" && raw.trim() !== "" ? raw.trim() : undefined;
+}
+
+export function createWarmblyOperatorHandlerFromEnv(
+  env: NodeJS.ProcessEnv,
+  deps: WarmblyOperatorEnvDeps,
+): WarmblyOperatorHandler | undefined {
+  if (required(env, "CC_WARMBLY_OPERATOR_ENABLED") !== "true") {
+    return undefined;
+  }
+  const baseUrl = required(env, "CC_WARMBLY_BASE_URL");
+  const token = required(env, "CC_WARMBLY_OPERATOR_TOKEN");
+  if (!baseUrl || !token) {
+    // Enabled but not configured is a misconfiguration, not a reason to run
+    // half-wired: say so and stay off.
+    deps.logger.error("warmbly.operator.not_configured", {
+      msg: "CC_WARMBLY_OPERATOR_ENABLED=true requires CC_WARMBLY_BASE_URL and CC_WARMBLY_OPERATOR_TOKEN",
+      has_base_url: Boolean(baseUrl),
+      has_token: Boolean(token),
+    });
+    return undefined;
+  }
+
+  const log = connectorLogger(deps.logger);
+  const client = new WarmblyOperatorClient({
+    baseUrl,
+    token,
+    logger: log,
+    ...(required(env, "CC_WARMBLY_OPERATOR_TIMEOUT_MS")
+      ? { timeoutMs: Number(required(env, "CC_WARMBLY_OPERATOR_TIMEOUT_MS")) }
+      : {}),
+  });
+
+  const primary = createMemoryOperatorActionLedger();
+  const sinks = deps.agentActivity ? [createAgentActivityLedgerSink(deps.agentActivity)] : [];
+  const ledger = createFanOutOperatorActionLedger(
+    primary,
+    sinks,
+    defaultOperatorSinkErrorHandler(log),
+  );
+
+  const channel = createWarmblyOperatorChannel({ client, ledger, logger: log });
+  return createOperatorHttpHandler(channel) as WarmblyOperatorHandler;
+}

--- a/control-center/services/context/src/warmbly-operator/from-env.ts
+++ b/control-center/services/context/src/warmbly-operator/from-env.ts
@@ -7,16 +7,6 @@
  * a default.
  */
 
-import {
-  WarmblyOperatorClient,
-  createAgentActivityLedgerSink,
-  createFanOutOperatorActionLedger,
-  createMemoryOperatorActionLedger,
-  createOperatorHttpHandler,
-  createWarmblyOperatorChannel,
-  defaultOperatorSinkErrorHandler,
-} from "@confenge/control-center-warmbly-connector";
-
 import type { Logger } from "../log.ts";
 import type { WarmblyOperatorHttpRequest, WarmblyOperatorHttpResponse } from "../http.ts";
 
@@ -56,7 +46,7 @@ export type WarmblyOperatorHandler = (
 export interface WarmblyOperatorEnvDeps {
   logger: Logger;
   /** Optional agent-activity sink, so operator actions land on the timeline. */
-  agentActivity?: Parameters<typeof createAgentActivityLedgerSink>[0];
+  agentActivity?: unknown;
 }
 
 function required(env: NodeJS.ProcessEnv, name: string): string | undefined {
@@ -64,10 +54,19 @@ function required(env: NodeJS.ProcessEnv, name: string): string | undefined {
   return typeof raw === "string" && raw.trim() !== "" ? raw.trim() : undefined;
 }
 
-export function createWarmblyOperatorHandlerFromEnv(
+/**
+ * Loaded lazily and only when enabled. A static import would make an opt-in
+ * feature able to crash boot on any image that does not ship the connector,
+ * which is exactly what it did the first time.
+ */
+async function loadConnector(): Promise<typeof import("@confenge/control-center-warmbly-connector")> {
+  return import("@confenge/control-center-warmbly-connector");
+}
+
+export async function createWarmblyOperatorHandlerFromEnv(
   env: NodeJS.ProcessEnv,
   deps: WarmblyOperatorEnvDeps,
-): WarmblyOperatorHandler | undefined {
+): Promise<WarmblyOperatorHandler | undefined> {
   if (required(env, "CC_WARMBLY_OPERATOR_ENABLED") !== "true") {
     return undefined;
   }
@@ -84,6 +83,25 @@ export function createWarmblyOperatorHandlerFromEnv(
     return undefined;
   }
 
+  let connector: Awaited<ReturnType<typeof loadConnector>>;
+  try {
+    connector = await loadConnector();
+  } catch (err) {
+    deps.logger.error("warmbly.operator.connector_unavailable", {
+      msg: "the operator channel is enabled but its connector is not present in this image",
+      error: err instanceof Error ? err.name : "unknown",
+    });
+    return undefined;
+  }
+  const {
+    WarmblyOperatorClient,
+    createAgentActivityLedgerSink,
+    createFanOutOperatorActionLedger,
+    createMemoryOperatorActionLedger,
+    createOperatorHttpHandler,
+    createWarmblyOperatorChannel,
+    defaultOperatorSinkErrorHandler,
+  } = connector;
   const log = connectorLogger(deps.logger);
   const client = new WarmblyOperatorClient({
     baseUrl,
@@ -95,7 +113,9 @@ export function createWarmblyOperatorHandlerFromEnv(
   });
 
   const primary = createMemoryOperatorActionLedger();
-  const sinks = deps.agentActivity ? [createAgentActivityLedgerSink(deps.agentActivity)] : [];
+  const sinks = deps.agentActivity
+    ? [createAgentActivityLedgerSink(deps.agentActivity as never)]
+    : [];
   const ledger = createFanOutOperatorActionLedger(
     primary,
     sinks,

--- a/control-center/services/context/test/warmbly-operator-mount.test.ts
+++ b/control-center/services/context/test/warmbly-operator-mount.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { test } from "node:test";
+
+import { createRequestListener } from "../src/http.ts";
+import type { WarmblyOperatorHttpRequest } from "../src/http.ts";
+import { silentLogger } from "../src/log.ts";
+import { createWarmblyOperatorHandlerFromEnv } from "../src/warmbly-operator/from-env.ts";
+import { makeService } from "./helpers.ts";
+
+const PAUSE = "/v1/warmbly/operator/dispatch/pause";
+
+async function withServer(
+  warmblyOperator: ((req: WarmblyOperatorHttpRequest) => Promise<{ status: number; body: unknown }>) | undefined,
+  fn: (base: string) => Promise<void>,
+): Promise<void> {
+  const { service } = makeService();
+  const server = createServer(
+    createRequestListener({
+      service,
+      logger: silentLogger,
+      ...(warmblyOperator ? { warmblyOperator } : {}),
+    }),
+  );
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object");
+  try {
+    await fn(`http://127.0.0.1:${addr.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+  }
+}
+
+test("an unconfigured deployment 404s every operator route instead of half-mounting", async () => {
+  await withServer(undefined, async (base) => {
+    const res = await fetch(`${base}${PAUSE}`, { method: "POST", body: "{}" });
+    assert.equal(res.status, 404);
+    const body = (await res.json()) as { code?: string };
+    assert.equal(body.code, "operator_channel_not_configured");
+  });
+});
+
+test("the operator route never resolves its actor from the client-settable x-actor-id", async () => {
+  // This is the whole point of mounting ahead of actorFromRequest: anything that
+  // reaches this process can set x-actor-id, and it must not be able to pause or
+  // resume outbound email by doing so.
+  let seen: WarmblyOperatorHttpRequest | undefined;
+  const handler = async (req: WarmblyOperatorHttpRequest) => {
+    seen = req;
+    return { status: 401, body: { ok: false, code: "missing_actor" } };
+  };
+  await withServer(handler, async (base) => {
+    const res = await fetch(`${base}${PAUSE}`, {
+      method: "POST",
+      headers: { "x-actor-id": "founder", "x-actor-kind": "human", "content-type": "application/json" },
+      body: JSON.stringify({ reason: "bounce spike" }),
+    });
+    assert.equal(res.status, 401, "a forged x-actor-id must not authenticate an operator write");
+  });
+  assert.ok(seen, "the channel must receive the request");
+  // The channel gets the raw headers and resolves identity itself from Remote-*.
+  assert.equal(seen?.headers["remote-user"], undefined);
+  assert.equal(seen?.headers["x-actor-id"], "founder");
+});
+
+test("the channel receives the socket peer address so its trusted-hop check is real", async () => {
+  let seen: WarmblyOperatorHttpRequest | undefined;
+  const handler = async (req: WarmblyOperatorHttpRequest) => {
+    seen = req;
+    return { status: 202, body: { ok: true } };
+  };
+  await withServer(handler, async (base) => {
+    await fetch(`${base}${PAUSE}`, { method: "POST", body: "{}" });
+  });
+  assert.ok(seen?.remoteAddress, "remoteAddress must be forwarded, not left undefined");
+});
+
+test("a non-POST operator route reaches the channel, which owns the 405", async () => {
+  let method: string | undefined;
+  const handler = async (req: WarmblyOperatorHttpRequest) => {
+    method = req.method;
+    return { status: 405, body: { ok: false, code: "method_not_allowed" } };
+  };
+  await withServer(handler, async (base) => {
+    const res = await fetch(`${base}${PAUSE}`, { method: "GET" });
+    assert.equal(res.status, 405);
+  });
+  assert.equal(method, "GET");
+});
+
+test("mounting is off by default and stays off when enabled but unconfigured", () => {
+  assert.equal(createWarmblyOperatorHandlerFromEnv({}, { logger: silentLogger }), undefined);
+  assert.equal(
+    createWarmblyOperatorHandlerFromEnv(
+      { CC_WARMBLY_OPERATOR_ENABLED: "true" },
+      { logger: silentLogger },
+    ),
+    undefined,
+    "enabled without a base url and token must stay off rather than run half-wired",
+  );
+  assert.equal(
+    createWarmblyOperatorHandlerFromEnv(
+      { CC_WARMBLY_OPERATOR_ENABLED: "false", CC_WARMBLY_BASE_URL: "http://x", CC_WARMBLY_OPERATOR_TOKEN: "t" },
+      { logger: silentLogger },
+    ),
+    undefined,
+  );
+  assert.notEqual(
+    createWarmblyOperatorHandlerFromEnv(
+      { CC_WARMBLY_OPERATOR_ENABLED: "true", CC_WARMBLY_BASE_URL: "http://x", CC_WARMBLY_OPERATOR_TOKEN: "t" },
+      { logger: silentLogger },
+    ),
+    undefined,
+    "fully configured must mount",
+  );
+});
+
+test("the mount does not shadow the service's own routes", async () => {
+  const handler = async () => ({ status: 200, body: { ok: true } });
+  await withServer(handler, async (base) => {
+    const res = await fetch(`${base}/healthz`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { service?: string };
+    assert.equal(body.service, "control-center-context");
+  });
+});

--- a/control-center/services/context/test/warmbly-operator-mount.test.ts
+++ b/control-center/services/context/test/warmbly-operator-mount.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { createRequestListener } from "../src/http.ts";
 import type { WarmblyOperatorHttpRequest } from "../src/http.ts";
@@ -89,10 +92,10 @@ test("a non-POST operator route reaches the channel, which owns the 405", async 
   assert.equal(method, "GET");
 });
 
-test("mounting is off by default and stays off when enabled but unconfigured", () => {
-  assert.equal(createWarmblyOperatorHandlerFromEnv({}, { logger: silentLogger }), undefined);
+test("mounting is off by default and stays off when enabled but unconfigured", async () => {
+  assert.equal(await createWarmblyOperatorHandlerFromEnv({}, { logger: silentLogger }), undefined);
   assert.equal(
-    createWarmblyOperatorHandlerFromEnv(
+    await createWarmblyOperatorHandlerFromEnv(
       { CC_WARMBLY_OPERATOR_ENABLED: "true" },
       { logger: silentLogger },
     ),
@@ -100,20 +103,36 @@ test("mounting is off by default and stays off when enabled but unconfigured", (
     "enabled without a base url and token must stay off rather than run half-wired",
   );
   assert.equal(
-    createWarmblyOperatorHandlerFromEnv(
+    await createWarmblyOperatorHandlerFromEnv(
       { CC_WARMBLY_OPERATOR_ENABLED: "false", CC_WARMBLY_BASE_URL: "http://x", CC_WARMBLY_OPERATOR_TOKEN: "t" },
       { logger: silentLogger },
     ),
     undefined,
   );
   assert.notEqual(
-    createWarmblyOperatorHandlerFromEnv(
+    await createWarmblyOperatorHandlerFromEnv(
       { CC_WARMBLY_OPERATOR_ENABLED: "true", CC_WARMBLY_BASE_URL: "http://x", CC_WARMBLY_OPERATOR_TOKEN: "t" },
       { logger: silentLogger },
     ),
     undefined,
     "fully configured must mount",
   );
+});
+
+test("the connector is never a static import, so a disabled feature cannot crash boot", () => {
+  // A static import made an opt-in feature crash the container on any image
+  // without the connector, feature off or not. That is what this pins.
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../src/warmbly-operator/from-env.ts"),
+    "utf8",
+  );
+  const staticImport = /^\s*import\s[^\n]*@confenge\/control-center-warmbly-connector/m;
+  assert.equal(
+    staticImport.test(source),
+    false,
+    "the connector must be reached through a dynamic import inside the enabled branch",
+  );
+  assert.match(source, /await import\("@confenge\/control-center-warmbly-connector"\)|import\("@confenge\/control-center-warmbly-connector"\)/);
 });
 
 test("the mount does not shadow the service's own routes", async () => {


### PR DESCRIPTION
Empilhado sobre #49. Fecha o último hop da issue #48: o canal deixa de existir só como biblioteca e passa a ser alcançável a partir de `ops.confenge.com.br`.

**Não implanta nada.** Fica desligado por padrão; um deploy sem configuração devolve 404 em toda rota de operador.

## O ponto que decide a segurança do mount

O `services/context` resolve ator a partir de `x-actor-id` / `x-actor-kind` — headers que qualquer chamador que alcance o processo consegue definir. Isso é aceitável para as leituras que ele serve. **Não é aceitável para pausar e religar e-mail de saída.**

Por isso o mount fica **antes** do `actorFromRequest`:

```ts
// Mounted before actorFromRequest on purpose. The operator channel resolves
// its own actor from Authelia, and must never fall back to the
// client-supplied x-actor-id header this service uses elsewhere.
if (url.pathname.startsWith(WARMBLY_OPERATOR_PREFIX)) { ... }
```

O canal recebe os headers crus e o endereço do socket, e resolve identidade sozinho via `parseForwardAuthIdentity` com a checagem de hop confiável. Um teste força um `x-actor-id: founder` forjado numa chamada de pause e exige `401`.

## Por que o edge já serve

O `Caddyfile` do `production-edge` já faz, na rota que importa:

```caddy
handle /v1/* {
    forward_auth authelia:9091 {
        uri /api/authz/forward-auth
        copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
    }
    reverse_proxy context:8080
}
```

As rotas do canal vivem em `/v1/warmbly/operator/…`, que casa com esse `handle`. E o vhost nginx de `ops.confenge.com.br` apaga qualquer `Remote-*` vindo do cliente, então a Authelia continua sendo a única escritora. Confirmei ao vivo no `ec-prod`: `/v1/health` no Caddy de loopback devolve `302` para o login.

Nenhuma mudança de edge, nginx ou certificado é necessária.

## Desligado por padrão

`createWarmblyOperatorHandlerFromEnv` só monta com `CC_WARMBLY_OPERATOR_ENABLED=true` **e** `CC_WARMBLY_BASE_URL` **e** `CC_WARMBLY_OPERATOR_TOKEN`. Habilitado sem configuração registra erro e permanece desligado, em vez de rodar pela metade. Ausente, toda rota devolve `404 operator_channel_not_configured`.

Um plano de controle que liga e desliga e-mail de saída precisa ser aceso de propósito, nunca por padrão.

## Lado do web-shell

`warmblyDispatch` é deliberadamente separado do `operatorAction` existente, que autentica por `x-actor-id`. Ele não manda header de ator nenhum e usa a sessão da Authelia. Recusa antes do fio: motivo de auditoria vazio, `resume` sem token, e `acknowledge` sem alvo. O `resume` é de dois passos também no cliente — o token vive só durante a interação e não é persistido, então um reload obriga a confirmar de novo.

## Verificação

`services/context`: **56/56**, typecheck limpo. `apps/web-shell`: **83/83**, typecheck limpo. Sete testes novos no web-shell e seis no context, cobrindo o 404 de não configurado, a recusa do `x-actor-id` forjado, o encaminhamento do endereço do socket, o dois-passos, e que o mount não sombreia as rotas próprias do serviço.

## O que ainda falta para um operador clicar

O controle visual. A ligação está pronta e testada — qualquer `<form data-warmbly-dispatch="pause|resume|acknowledge">` já funciona —, mas onde o botão vive e o que a confirmação de `resume` diz são decisão de produto, não minha: é a ação que religa e-mail frio para empresas reais.