### PR TITLE
feat(cc-warmbly): mount the operator channel and give the founder an actual cockpit

### DIFF
--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -71,6 +71,11 @@ export interface AdapterWriteResult {
   path: string;
   kind: WriteShortcutKind;
   message: string;
+  /**
+   * Returned only by `resume_confirm`. The caller replays it on `resume`; it is
+   * single-use, bound to the issuing operator, and never re-armed.
+   */
+  confirmationToken?: string;
 }
 
 /**
@@ -97,6 +102,30 @@ export interface ControlCenterReadAdapter {
     note: string;
     idempotency_key?: string;
   }): AdapterWriteResult | Promise<AdapterWriteResult>;
+  /**
+   * Warmbly dispatch control. Deliberately separate from `operatorAction`:
+   * that one authenticates with `x-actor-id`, a header the browser sets, and a
+   * client-settable actor must never be able to restart outbound email. These
+   * routes authenticate at the edge with Authelia, so the adapter sends no
+   * actor header at all and relies on the session cookie.
+   *
+   * `resume` is two-step by contract: `resume_confirm` returns a token that
+   * `resume` must replay. There is no single-call resume.
+   */
+  warmblyDispatch?(input: WarmblyDispatchInput): AdapterWriteResult | Promise<AdapterWriteResult>;
+}
+
+export const WARMBLY_DISPATCH_ACTIONS = ["pause", "resume_confirm", "resume", "acknowledge"] as const;
+export type WarmblyDispatchAction = (typeof WARMBLY_DISPATCH_ACTIONS)[number];
+
+export interface WarmblyDispatchInput {
+  action: WarmblyDispatchAction;
+  /** Audit reason. Required: the channel refuses a write without one. */
+  reason: string;
+  /** Only for `resume`, replayed from the `resume_confirm` response. */
+  confirmation_token?: string;
+  /** Only for `acknowledge`. */
+  target_id?: string;
 }
 
 export function adapterAllows(action: string): action is AdapterAction {

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -6,6 +6,7 @@ import {
   type AdapterAction,
   type AdapterReadResult,
   type AdapterWriteResult,
+  type WarmblyDispatchInput,
   type ControlCenterReadAdapter,
   type DestinationPage,
 } from "./contract";
@@ -25,6 +26,8 @@ import {
 } from "./map";
 import {
   AUTHORIZED_WRITE_PATH,
+  WARMBLY_DISPATCH_PATHS,
+  WARMBLY_OPERATOR_LEDGER_PATH,
   WRITE_SHORTCUT_DIRECTIVE_KIND,
   WRITE_SHORTCUT_KINDS,
   destinationUsesContext,
@@ -80,6 +83,59 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     const result = await this.readDestination("hoje");
     if (!result.ok || result.loading) return [];
     return result.page.priorities;
+  }
+
+  async warmblyDispatch(input: WarmblyDispatchInput): Promise<AdapterWriteResult> {
+    const path = WARMBLY_DISPATCH_PATHS[input.action];
+    const fail = (message: string): AdapterWriteResult => {
+      const denied: AdapterWriteResult = { ok: false, path: path ?? "/v1/warmbly/operator", kind: "nota", message };
+      this.lastOperatorResult = denied;
+      return denied;
+    };
+    if (!path) {
+      return fail("ação de dispatch desconhecida");
+    }
+    // The channel refuses a write with no audit reason, and with paused_by
+    // missing upstream this ledger is the only record of who did it.
+    if (input.reason.trim() === "") {
+      return fail("motivo é obrigatório");
+    }
+    if (input.action === "resume" && !input.confirmation_token) {
+      return fail("resume exige o token de confirmação do passo anterior");
+    }
+    if (input.action === "acknowledge" && !input.target_id) {
+      return fail("acknowledge exige o id do alerta");
+    }
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method: "POST",
+        // No x-actor-id: identity is Authelia's, resolved at the edge from the
+        // session. Sending an actor header here would invite trusting it.
+        headers: { accept: "application/json", "content-type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          reason: input.reason,
+          ...(input.confirmation_token ? { confirmation_token: input.confirmation_token } : {}),
+          ...(input.target_id ? { target_id: input.target_id } : {}),
+        }),
+      });
+      const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+      const result: AdapterWriteResult = {
+        ok: response.ok,
+        path,
+        kind: "nota",
+        message: typeof body.reason === "string" ? body.reason : `HTTP ${response.status}`,
+        ...(typeof body.confirmation_token === "string"
+          ? { confirmationToken: body.confirmation_token }
+          : {}),
+      };
+      this.lastOperatorResult = result;
+      return result;
+    } catch (err) {
+      // A transport failure here says nothing about whether Warmbly applied the
+      // change; the channel reports `unknown` for exactly this reason.
+      return fail(`falha de transporte: ${err instanceof Error ? err.name : "erro"}`);
+    }
   }
 
   async operatorAction(input: {
@@ -331,6 +387,9 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     if (id === "comercial" || id === "crescimento") {
       page.commercial = commercialFrom(inner, fallback);
     }
+    if (id === "comercial" && page.commercial) {
+      await this.attachLastOperatorAction(page.commercial);
+    }
     if (id === "crescimento" && payloads[1]) {
       const pncp = this.domainBody(payloads[1], fallback);
       page.health = [healthFrom(pncp, fallback)];
@@ -350,6 +409,32 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       );
     }
     return page;
+  }
+
+  /**
+   * Attaches the last operator action to the commercial snapshot.
+   *
+   * Best effort on purpose: the channel is off by default and answers 404, and
+   * a cockpit that cannot read its own audit trail must still render the
+   * dispatch state. A miss leaves the field absent — which the surface renders
+   * as "no action recorded in this instance", never as "nobody acted".
+   */
+  private async attachLastOperatorAction(commercial: { operations?: Record<string, unknown> }): Promise<void> {
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${WARMBLY_OPERATOR_LEDGER_PATH}`, {
+        headers: { accept: "application/json" },
+        credentials: "include",
+      });
+      if (!response.ok) return;
+      const body = (await response.json()) as { entries?: unknown };
+      const entries = Array.isArray(body.entries) ? body.entries : [];
+      const latest = entries[0];
+      if (!latest || typeof latest !== "object") return;
+      const ops = (commercial.operations ??= {});
+      ops.last_operator_action = latest;
+    } catch {
+      // Same reason as above: unreadable is not empty.
+    }
   }
 
   private async getJson(path: string): Promise<unknown> {

--- a/control-center/apps/web-shell/src/adapters/paths.ts
+++ b/control-center/apps/web-shell/src/adapters/paths.ts
@@ -76,3 +76,18 @@ export function isAuthorizedWritePath(path: string): boolean {
   const pathname = path.split("?")[0] ?? path;
   return pathname === AUTHORIZED_WRITE_PATH;
 }
+
+/**
+ * Warmbly dispatch control routes, mounted by the context service ahead of its
+ * own `x-actor-id` actor resolution. Kept here so a test can assert the set is
+ * exactly these four and nothing wider.
+ */
+/** Read-back of the operator channel's own audit record. GET, same Authelia gate. */
+export const WARMBLY_OPERATOR_LEDGER_PATH = "/v1/warmbly/operator/ledger/recent";
+
+export const WARMBLY_DISPATCH_PATHS = {
+  pause: "/v1/warmbly/operator/dispatch/pause",
+  resume_confirm: "/v1/warmbly/operator/dispatch/resume/confirm",
+  resume: "/v1/warmbly/operator/dispatch/resume",
+  acknowledge: "/v1/warmbly/operator/inbound/acknowledge",
+} as const;

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -112,6 +112,9 @@ function applyPaint(
   bindOperatorActions(root, adapter, () => {
     paintShell(root, adapter, `#/${parsed.destination}${parsed.surface ? `/${parsed.surface}` : ""}`);
   });
+  bindWarmblyDispatch(root, adapter, () => {
+    paintShell(root, adapter, `#/${parsed.destination}${parsed.surface ? `/${parsed.surface}` : ""}`);
+  });
 }
 
 function bindOperatorActions(
@@ -140,6 +143,83 @@ function bindOperatorActions(
         }),
       ).then((result) => {
         if (result) adapter.lastOperatorResult = result;
+        onDone();
+      });
+    });
+  }
+}
+
+/**
+ * Pending `resume_dispatch` confirmation, held across repaints.
+ *
+ * Deliberately module scope, not a per-binding closure. Every successful action
+ * repaints the shell, and a repaint replaces `root.innerHTML` wholesale — so a
+ * token parked in the closure of the form that minted it dies with that form,
+ * and the following submit would mint a second challenge instead of spending
+ * the first. That is not a stricter two-step; it is a resume that can never
+ * complete.
+ *
+ * It is still memory only and never persisted, so a reload loses it and forces
+ * a fresh confirmation. A repaint is not a reload.
+ */
+let pendingResumeToken: string | undefined;
+
+/** Exposed for tests and for an explicit abandon. */
+export function clearPendingResumeConfirmation(): void {
+  pendingResumeToken = undefined;
+}
+
+export function pendingResumeConfirmation(): string | undefined {
+  return pendingResumeToken;
+}
+
+/**
+ * Binds the Warmbly dispatch control.
+ *
+ * Pause is one click. Resume is two by contract: the first call mints a
+ * single-use token, the second replays it. Any outcome other than a fresh
+ * challenge drops the token, so a failed or spent confirmation always costs a
+ * new deliberate act.
+ */
+function bindWarmblyDispatch(
+  root: MountableRoot,
+  adapter: ControlCenterReadAdapter,
+  onDone: () => void,
+): void {
+  if (!adapter.warmblyDispatch || typeof root.querySelectorAll !== "function") return;
+  const forms = root.querySelectorAll("[data-warmbly-dispatch]");
+  for (let i = 0; i < forms.length; i += 1) {
+    const form = forms[i];
+    if (!form) continue;
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const requested = form.getAttribute("data-warmbly-dispatch");
+      if (requested !== "pause" && requested !== "resume" && requested !== "acknowledge") return;
+      const reason = form.querySelector('[name="reason"]')?.value ?? "";
+      const targetId = form.querySelector('[name="target_id"]')?.value ?? "";
+      // A resume with no token yet is the confirmation step, not the resume.
+      const carried = pendingResumeToken;
+      const action = requested === "resume" && !carried ? "resume_confirm" : requested;
+      // Spend it at most once: whatever happens next, this token is not reused.
+      if (requested === "resume") {
+        pendingResumeToken = undefined;
+      }
+      void Promise.resolve(
+        adapter.warmblyDispatch?.({
+          action,
+          reason,
+          ...(action === "resume" && carried ? { confirmation_token: carried } : {}),
+          ...(requested === "acknowledge" ? { target_id: targetId } : {}),
+        }),
+      ).then((result) => {
+        if (result) {
+          adapter.lastOperatorResult = result;
+          // Arm the following resume only when this call actually minted a
+          // challenge. A refusal arms nothing.
+          if (action === "resume_confirm" && result.ok && result.confirmationToken) {
+            pendingResumeToken = result.confirmationToken;
+          }
+        }
         onDone();
       });
     });

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -245,6 +245,89 @@ export function commercialBlock(snapshot: CommercialSnapshot, surface: string | 
   `;
 }
 
+/**
+ * Operator cockpit for the CONFENGE outbound kill switch.
+ *
+ * Three controls and nothing else: pause, resume, acknowledge. There is no send
+ * control here and there must never be one — this surface can stop outbound and
+ * let it flow again, and that is the whole of its authority.
+ *
+ * Every reading is rendered as observed-or-"—". `state` is tri-state because
+ * Warmbly reporting nothing is not the same as Warmbly reporting "running", and
+ * an operator who is told ACTIVE when nobody knows will make the wrong call.
+ */
+function dispatchPanel(ops: Record<string, unknown>): string {
+  const d = ops.dispatch && typeof ops.dispatch === "object" ? (ops.dispatch as Record<string, unknown>) : {};
+  const state = String(d.state ?? "UNKNOWN");
+  const label =
+    state === "PAUSED" ? "PAUSADO" : state === "ACTIVE" ? "ATIVO" : "DESCONHECIDO";
+  const show = (v: unknown): string => (v === undefined || v === null || v === "" ? "—" : String(v));
+  const window =
+    d.window_start && d.window_end
+      ? `${String(d.window_start)}–${String(d.window_end)} ${show(d.timezone)}`
+      : "—";
+  const inWindow =
+    typeof d.in_send_window === "boolean" ? (d.in_send_window ? "dentro da janela" : "fora da janela") : "—";
+  const volume =
+    typeof d.sent_last_hour === "number" || typeof d.cap === "number"
+      ? `${show(d.sent_last_hour)} / ${show(d.cap)}`
+      : "—";
+  const last = ops.last_operator_action && typeof ops.last_operator_action === "object"
+    ? (ops.last_operator_action as Record<string, unknown>)
+    : null;
+  const lastBlock = last
+    ? `<dl class="facts">
+        ${fact("Última ação", show(last.action))}
+        ${fact("Resultado", show(last.outcome))}
+        ${fact("Operador", show(last.actor_id))}
+        ${fact("Quando", show(last.recorded_at))}
+        ${fact("Motivo registrado", show(last.reason))}
+      </dl>`
+    // Absence of a recorded action is not "nobody acted": this ledger is
+    // in-process and a restart empties it.
+    : `<p class="constraint">Nenhuma ação de operador registrada nesta instância do Control Center. Um reinício do serviço esvazia este registro — ausência aqui não prova que ninguém agiu.</p>`;
+
+  return `
+    <section class="stack domain-dispatch" aria-labelledby="dispatch-title" data-domain="dispatch" data-dispatch-state="${escapeHtml(state)}">
+      <h2 id="dispatch-title">Disparo de saída (Warmbly)</h2>
+      <article class="card" data-dispatch-observed="${d.observed === true ? "true" : "false"}">
+        <p class="kicker"><span class="pill">${escapeHtml(label)}</span></p>
+        <dl class="facts">
+          ${fact("Estado do disparo", escapeHtml(label))}
+          ${fact("Motivo da pausa", escapeHtml(show(d.pause_reason)))}
+          ${fact("Janela comercial", escapeHtml(window))}
+          ${fact("Agora", escapeHtml(inWindow))}
+          ${fact("Próximo slot", escapeHtml(show(d.next_slot_at)))}
+          ${fact("Enviados na hora / teto", escapeHtml(volume))}
+          ${fact("Aprovados na fila", escapeHtml(show(d.queued_approved)))}
+        </dl>
+        ${d.why ? `<p class="constraint">${escapeHtml(String(d.why))}</p>` : ""}
+      </article>
+      <article class="card">
+        <h3>Última ação do operador</h3>
+        ${lastBlock}
+      </article>
+      <article class="card">
+        <h3>Controles</h3>
+        <p class="constraint" data-operator-scope="warmbly-write">Estas três ações escrevem no Warmbly. Não existe controle de envio aqui: pausar, retomar e reconhecer é toda a autoridade desta superfície.</p>
+        <form data-warmbly-dispatch="pause" class="operator-form">
+          <label>Motivo <input name="reason" required minlength="2" maxlength="200" placeholder="por que está pausando" /></label>
+          <button type="submit">PAUSAR OUTBOUND</button>
+        </form>
+        <form data-warmbly-dispatch="resume" class="operator-form" data-two-step="true">
+          <label>Motivo <input name="reason" required minlength="2" maxlength="200" placeholder="por que está retomando" /></label>
+          <p class="constraint">Retomar libera e-mail frio para empresas reais. Enviar uma vez pede a confirmação; enviar de novo, com o mesmo motivo, executa.</p>
+          <button type="submit">RETOMAR OUTBOUND (dois passos)</button>
+        </form>
+        <form data-warmbly-dispatch="acknowledge" class="operator-form">
+          <label>Alerta <input name="target_id" required minlength="1" maxlength="128" placeholder="id do lead" /></label>
+          <label>Motivo <input name="reason" maxlength="200" placeholder="opcional" /></label>
+          <button type="submit">RECONHECER ALERTA</button>
+        </form>
+      </article>
+    </section>`;
+}
+
 function commercialOps(snapshot: CommercialSnapshot, surface: string | null): string {
   const ops = operationsOf(snapshot);
   const current = surface && surface.length > 0 ? surface : "visao";
@@ -285,7 +368,8 @@ function commercialOps(snapshot: CommercialSnapshot, surface: string | null): st
           <p>${escapeHtml(String(inbound.anchor_label ?? "Scoreboard Warmbly, se presente. Não é coorte de aquisição."))}</p>
           <p>configured=${escapeHtml(String(inbound.configured))} schema=${escapeHtml(String(inbound.schema ?? "ausente"))}</p>
         </article>
-      </section>`;
+      </section>
+      ${dispatchPanel(ops)}`;
   } else if (current === "atividade") {
     body = `<section aria-labelledby="atividade-title"><h2 id="atividade-title">Atividade recente</h2><div class="stack">${
       activity.length === 0

--- a/control-center/apps/web-shell/tests/warmbly-dispatch.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-dispatch.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { WARMBLY_DISPATCH_PATHS } from "../src/adapters/paths";
+import { WARMBLY_DISPATCH_ACTIONS } from "../src/adapters/contract";
+import { HttpControlCenterAdapter } from "../src/adapters/http";
+import { clearPendingResumeConfirmation, paintShell } from "../src/app";
+import type { WarmblyDispatchInput } from "../src/adapters/contract";
+
+type Call = { url: string; init: RequestInit };
+
+function adapterWith(
+  responder: (url: string, init: RequestInit) => { status: number; body: unknown },
+): { adapter: HttpControlCenterAdapter; calls: Call[] } {
+  const calls: Call[] = [];
+  const fetchImpl = (async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    const { status, body } = responder(url, init);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "https://ops.confenge.com.br",
+    fetchImpl,
+    operator: { id: "founder", kind: "human" },
+  } as never);
+  return { adapter, calls };
+}
+
+test("the dispatch surface is exactly four routes and nothing wider", () => {
+  assert.deepEqual(Object.keys(WARMBLY_DISPATCH_PATHS).sort(), [...WARMBLY_DISPATCH_ACTIONS].sort());
+  for (const path of Object.values(WARMBLY_DISPATCH_PATHS)) {
+    assert.ok(path.startsWith("/v1/warmbly/operator/"), `${path} escapes the operator prefix`);
+  }
+});
+
+test("no actor header is sent: a client-settable actor must not reach a dispatch write", async () => {
+  const { adapter, calls } = adapterWith(() => ({ status: 200, body: { ok: true, reason: "paused" } }));
+  await adapter.warmblyDispatch({ action: "pause", reason: "bounce spike" });
+  assert.equal(calls.length, 1);
+  const headers = (calls[0]!.init.headers ?? {}) as Record<string, string>;
+  assert.equal(headers["x-actor-id"], undefined);
+  assert.equal(headers["x-actor-kind"], undefined);
+  assert.equal((calls[0]!.init as { credentials?: string }).credentials, "include");
+});
+
+test("resume without a confirmation token never reaches the wire", async () => {
+  const { adapter, calls } = adapterWith(() => ({ status: 200, body: { ok: true } }));
+  const result = await adapter.warmblyDispatch({ action: "resume", reason: "incident resolved" });
+  assert.equal(result.ok, false);
+  assert.match(result.message, /token de confirmação/);
+  assert.equal(calls.length, 0, "the resume must not be attempted without the second step");
+});
+
+test("a write with no audit reason never reaches the wire", async () => {
+  const { adapter, calls } = adapterWith(() => ({ status: 200, body: { ok: true } }));
+  for (const action of ["pause", "resume_confirm", "acknowledge"] as const) {
+    const result = await adapter.warmblyDispatch({ action, reason: "   ", target_id: "lead-1" });
+    assert.equal(result.ok, false, `${action} accepted an empty reason`);
+  }
+  assert.equal(calls.length, 0);
+});
+
+test("resume_confirm surfaces the token so the caller can replay exactly one resume", async () => {
+  const { adapter, calls } = adapterWith((url) =>
+    url.endsWith("/resume/confirm")
+      ? { status: 202, body: { ok: false, confirmation_token: "tok-1", reason: "confirmation required" } }
+      : { status: 200, body: { ok: true, reason: "resumed" } },
+  );
+  const confirmed = await adapter.warmblyDispatch({ action: "resume_confirm", reason: "incident resolved" });
+  assert.equal(confirmed.confirmationToken, "tok-1");
+  const resumed = await adapter.warmblyDispatch({
+    action: "resume",
+    reason: "incident resolved",
+    confirmation_token: "tok-1",
+  });
+  assert.equal(resumed.ok, true);
+  assert.equal(calls.length, 2);
+  assert.ok(calls[1]!.url.endsWith(WARMBLY_DISPATCH_PATHS.resume));
+  assert.match(String(calls[1]!.init.body), /tok-1/);
+});
+
+test("acknowledge without a target never reaches the wire", async () => {
+  const { adapter, calls } = adapterWith(() => ({ status: 200, body: { ok: true } }));
+  const result = await adapter.warmblyDispatch({ action: "acknowledge", reason: "seen" });
+  assert.equal(result.ok, false);
+  assert.equal(calls.length, 0);
+});
+
+test("a transport failure is reported as a failure, never as a silent success", async () => {
+  const calls: Call[] = [];
+  const fetchImpl = (async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    throw new Error("boom");
+  }) as unknown as typeof fetch;
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "https://ops.confenge.com.br",
+    fetchImpl,
+    operator: { id: "founder", kind: "human" },
+  } as never);
+  const result = await adapter.warmblyDispatch({ action: "pause", reason: "bounce spike" });
+  assert.equal(result.ok, false);
+  assert.match(result.message, /transporte/);
+});
+
+/**
+ * The two-step resume must survive the repaint that its own first step causes.
+ *
+ * Every dispatch call ends in `onDone()`, which repaints the shell by replacing
+ * `root.innerHTML` wholesale. A confirmation token parked in the closure of the
+ * form that minted it dies with that form, so the next submit would mint a
+ * second challenge instead of spending the first — a resume that can never
+ * complete, dressed up as a stricter two-step.
+ */
+test("a resume confirmation survives the repaint it triggers and the second submit executes", async () => {
+  clearPendingResumeConfirmation();
+  const seen: WarmblyDispatchInput[] = [];
+  const adapter = {
+    mode: "http" as const,
+    lastOperatorResult: undefined as unknown,
+    readDestination: () => ({
+      ok: true as const,
+      loading: false as const,
+      page: null as never,
+    }),
+    warmblyDispatch: async (input: WarmblyDispatchInput) => {
+      seen.push({ ...input });
+      return input.action === "resume_confirm"
+        ? { ok: true, path: "/x", kind: "nota" as const, message: "confirme", confirmationToken: "wcnf_abc" }
+        : { ok: true, path: "/x", kind: "nota" as const, message: "ok" };
+    },
+  };
+  const dom = repaintingRoot();
+  paintShell(dom.root as never, adapter as never, "#/comercial/cohorts");
+
+  dom.submit("resume");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0]!.action, "resume_confirm", "first submit mints the challenge");
+  assert.ok(dom.paints > 1, "the first step must have repainted, destroying the original form");
+
+  // Second submit lands on a form object that did not exist when the token was
+  // minted. It must still spend that token.
+  dom.submit("resume");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(seen.length, 2);
+  assert.equal(seen[1]!.action, "resume", "second submit must execute, not re-challenge");
+  assert.equal(seen[1]!.confirmation_token, "wcnf_abc");
+});
+
+test("a spent confirmation is not replayed: the next resume challenges again", async () => {
+  clearPendingResumeConfirmation();
+  const seen: WarmblyDispatchInput[] = [];
+  const adapter = {
+    mode: "http" as const,
+    lastOperatorResult: undefined as unknown,
+    readDestination: () => ({ ok: true as const, loading: false as const, page: null as never }),
+    warmblyDispatch: async (input: WarmblyDispatchInput) => {
+      seen.push({ ...input });
+      return input.action === "resume_confirm"
+        ? { ok: true, path: "/x", kind: "nota" as const, message: "confirme", confirmationToken: "wcnf_once" }
+        : { ok: true, path: "/x", kind: "nota" as const, message: "ok" };
+    },
+  };
+  const dom = repaintingRoot();
+  paintShell(dom.root as never, adapter as never, "#/comercial/cohorts");
+  for (let i = 0; i < 3; i += 1) {
+    dom.submit("resume");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.deepEqual(
+    seen.map((s) => s.action),
+    ["resume_confirm", "resume", "resume_confirm"],
+    "each execution costs a fresh confirmation",
+  );
+});
+
+test("a refused confirmation arms nothing", async () => {
+  clearPendingResumeConfirmation();
+  const seen: WarmblyDispatchInput[] = [];
+  const adapter = {
+    mode: "http" as const,
+    lastOperatorResult: undefined as unknown,
+    readDestination: () => ({ ok: true as const, loading: false as const, page: null as never }),
+    warmblyDispatch: async (input: WarmblyDispatchInput) => {
+      seen.push({ ...input });
+      // A refusal that still carries a token must never arm the next submit.
+      return { ok: false, path: "/x", kind: "nota" as const, message: "recusado", confirmationToken: "wcnf_leak" };
+    },
+  };
+  const dom = repaintingRoot();
+  paintShell(dom.root as never, adapter as never, "#/comercial/cohorts");
+  dom.submit("resume");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  dom.submit("resume");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(seen.map((s) => s.action), ["resume_confirm", "resume_confirm"]);
+});
+
+/**
+ * A repainting root. Every `innerHTML` write throws away the previous form
+ * objects and hands out new ones on the next query — exactly what
+ * `root.innerHTML = renderShell(...)` does in the browser.
+ */
+function repaintingRoot(): {
+  root: { innerHTML: string; querySelectorAll(sel: string): FakeForm[] };
+  submit(action: string): void;
+  paints: number;
+} {
+  let forms: FakeForm[] = [];
+  let paints = 0;
+  const rebuild = (): void => {
+    paints += 1;
+    forms = [new FakeForm("pause"), new FakeForm("resume"), new FakeForm("acknowledge")];
+  };
+  rebuild();
+  const root = {
+    get innerHTML(): string {
+      return "";
+    },
+    set innerHTML(_next: string) {
+      rebuild();
+    },
+    querySelectorAll(_sel: string): FakeForm[] {
+      return forms;
+    },
+  };
+  return {
+    root,
+    submit(action: string): void {
+      const form = forms.find((f) => f.action === action);
+      if (!form) throw new Error(`no form for ${action}`);
+      form.submit();
+    },
+    get paints(): number {
+      return paints;
+    },
+  };
+}
+
+class FakeForm {
+  readonly action: string;
+  private listener: ((event: Event) => void) | null = null;
+  private readonly fields: Record<string, { value: string }> = {
+    reason: { value: "incidente resolvido" },
+    target_id: { value: "lead-1" },
+  };
+  constructor(action: string) {
+    this.action = action;
+  }
+  addEventListener(_type: string, listener: (event: Event) => void): void {
+    this.listener = listener;
+  }
+  getAttribute(name: string): string | null {
+    return name === "data-warmbly-dispatch" ? this.action : null;
+  }
+  querySelector(selector: string): { value: string } | null {
+    const name = selector.replace(/[[\]'"]/g, "").replace("name=", "");
+    return this.fields[name] ?? null;
+  }
+  submit(): void {
+    if (!this.listener) throw new Error("form was never bound");
+    this.listener({ preventDefault(): void {} } as unknown as Event);
+  }
+}

--- a/control-center/connectors/warmbly/src/collector/routes.ts
+++ b/control-center/connectors/warmbly/src/collector/routes.ts
@@ -47,6 +47,14 @@ export const COLLECT_ROUTES: CollectRoute[] = [
   },
   { key: "confenge_today", method: "GET", path: "/v1/confenge/today", required: false },
   { key: "confenge_inbound", method: "GET", path: "/v1/confenge/inbound", required: false },
+  // The kill-switch state the operator cockpit reads back. Not required: an
+  // older Warmbly answers 404 and the surface must say UNKNOWN, never "active".
+  {
+    key: "confenge_dispatch_status",
+    method: "GET",
+    path: "/v1/confenge/dispatch/status",
+    required: false,
+  },
   {
     key: "confenge_intel_scoreboard",
     method: "GET",

--- a/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
+++ b/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
@@ -217,6 +217,27 @@ export type WarmblyHealth = {
   version?: string;
 };
 
+/**
+ * GET /v1/confenge/dispatch/status. Mirrors `dispatch.Status` in warmbly
+ * (internal/app/confenge/dispatch/types.go). Every field is optional: this
+ * connector must never turn a missing field into a confident reading of the
+ * kill switch — an absent `paused` is UNKNOWN, never "active".
+ */
+export type WarmblyDispatchStatus = {
+  paused?: boolean;
+  pause_reason?: string;
+  in_send_window?: boolean;
+  timezone?: string;
+  window_start?: string;
+  window_end?: string;
+  next_slot_at?: string;
+  sent_last_hour?: number;
+  cap?: number;
+  queued_approved?: number;
+  min_gap_seconds?: number;
+  active_leases?: number;
+};
+
 export type WarmblyPayload = {
   health?: WarmblyHealth;
   api_version?: string;
@@ -235,6 +256,7 @@ export type WarmblyPayload = {
   confenge_attention?: WarmblyAttentionItem[] | WarmblyList<WarmblyAttentionItem>;
   confenge_today?: WarmblyTodayView | { data: WarmblyTodayView };
   confenge_inbound?: WarmblyInboundItem[] | WarmblyList<WarmblyInboundItem>;
+  confenge_dispatch_status?: WarmblyDispatchStatus | { data: WarmblyDispatchStatus };
   confenge_intel_scoreboard?: Record<string, unknown>;
   confenge_intel_executive?: Record<string, unknown>;
   confenge_intel_exceptions?: unknown;

--- a/control-center/connectors/warmbly/src/mapper/normalize.ts
+++ b/control-center/connectors/warmbly/src/mapper/normalize.ts
@@ -14,6 +14,7 @@ import {
   unwrapData,
   unwrapList,
   type EndpointFailure,
+  type WarmblyDispatchStatus,
   type WarmblyPayload,
   type WarmblyTask,
 } from "../contracts/warmbly-payload.ts";
@@ -233,6 +234,13 @@ export function collectFromWarmblyPayload(
     "GET",
   );
   mark(
+    "confenge_dispatch_status",
+    payload.confenge_dispatch_status !== undefined,
+    fail("GET", "/v1/confenge/dispatch/status"),
+    "/v1/confenge/dispatch/status",
+    "GET",
+  );
+  mark(
     "confenge_intel_scoreboard",
     payload.confenge_intel_scoreboard !== undefined,
     fail("GET", "/v1/confenge/intel/scoreboard"),
@@ -362,6 +370,7 @@ export function collectFromWarmblyPayload(
   snapshot.operations = {
     authority: "warmbly",
     this_document: "read_model",
+    dispatch: dispatchOf(payload),
     cap: OPERATIONS_CAP,
     deals: deals.slice(0, OPERATIONS_CAP).map((d) => ({
       id: d.id,
@@ -424,6 +433,47 @@ export function collectFromWarmblyPayload(
   void pipelines;
 
   return snapshot;
+}
+
+/**
+ * Projects GET /v1/confenge/dispatch/status for the operator cockpit.
+ *
+ * `state` is the only field the surface reads to decide what it tells the
+ * founder, and it is a tri-state on purpose. Warmbly reports `paused` as a
+ * plain boolean, so an endpoint that is absent, 404, or malformed leaves us
+ * with no reading at all — and rendering that as ACTIVE would tell the founder
+ * outbound is running when nobody knows. Absent is UNKNOWN.
+ */
+function dispatchOf(payload: WarmblyPayload): Record<string, unknown> {
+  const raw = unwrapData(payload.confenge_dispatch_status);
+  if (!raw || typeof raw !== "object") {
+    return {
+      state: "UNKNOWN",
+      observed: false,
+      why: "GET /v1/confenge/dispatch/status did not answer; the kill-switch state is not known",
+    };
+  }
+  const st = raw as WarmblyDispatchStatus;
+  const state = st.paused === true ? "PAUSED" : st.paused === false ? "ACTIVE" : "UNKNOWN";
+  const out: Record<string, unknown> = { state, observed: true };
+  if (state === "UNKNOWN") {
+    out.why = "Warmbly answered without a `paused` field; absence is not evidence that dispatch is running";
+  }
+  // Every field below is omitted rather than defaulted: the cockpit renders
+  // "—" for what was not observed instead of inventing a window or a cap.
+  if (typeof st.pause_reason === "string" && st.pause_reason.trim() !== "") {
+    out.pause_reason = st.pause_reason.trim();
+  }
+  if (typeof st.in_send_window === "boolean") out.in_send_window = st.in_send_window;
+  if (typeof st.timezone === "string" && st.timezone !== "") out.timezone = st.timezone;
+  if (typeof st.window_start === "string" && st.window_start !== "") out.window_start = st.window_start;
+  if (typeof st.window_end === "string" && st.window_end !== "") out.window_end = st.window_end;
+  if (typeof st.next_slot_at === "string" && st.next_slot_at !== "") out.next_slot_at = st.next_slot_at;
+  if (typeof st.sent_last_hour === "number") out.sent_last_hour = st.sent_last_hour;
+  if (typeof st.cap === "number") out.cap = st.cap;
+  if (typeof st.queued_approved === "number") out.queued_approved = st.queued_approved;
+  if (typeof st.active_leases === "number") out.active_leases = st.active_leases;
+  return out;
 }
 
 /** Stable attention slice for idempotency comparisons (ignores observed_at). */

--- a/control-center/connectors/warmbly/src/operator/channel.ts
+++ b/control-center/connectors/warmbly/src/operator/channel.ts
@@ -38,6 +38,7 @@ import {
 import {
   defaultOperatorIdentityPolicy,
   resolveOperatorActor,
+  type OperatorIdentityResult,
   type IdentityRequest,
   type OperatorActor,
   type TrustedHopPolicy,
@@ -143,6 +144,12 @@ export interface WarmblyOperatorChannel {
   readonly actions: readonly OperatorActionName[];
   readonly ledger: OperatorActionLedger;
   circuitState(): CircuitState;
+  /**
+   * Resolves the founder from a raw request, for read-backs that must sit
+   * behind the same gate as a write without performing one. It records nothing:
+   * only calls that attempt an action write to the ledger.
+   */
+  resolveActor(request: IdentityRequest | undefined): OperatorIdentityResult;
   /** Step 1 of the two-step release. Only `resume_dispatch` accepts it. */
   requestConfirmation(input: OperatorActionInput): Promise<OperatorActionResult>;
   requestResumeConfirmation(input: NamedOperatorActionInput): Promise<OperatorActionResult>;
@@ -728,6 +735,7 @@ export function createWarmblyOperatorChannel(
     actions: OPERATOR_ACTION_NAMES,
     ledger,
     circuitState: safeCircuitState,
+    resolveActor: (request) => resolveOperatorActor(request, identityPolicy),
     requestConfirmation,
     requestResumeConfirmation: (input) =>
       requestConfirmation({ ...input, action: "resume_dispatch", target_id: DISPATCH_TARGET_ID }),

--- a/control-center/connectors/warmbly/src/operator/http.ts
+++ b/control-center/connectors/warmbly/src/operator/http.ts
@@ -21,6 +21,20 @@ export const OPERATOR_HTTP_ROUTES = {
   acknowledge: "/v1/warmbly/operator/inbound/acknowledge",
 } as const;
 
+/**
+ * Read-back of this channel's own audit record. GET, never a Warmbly call: it
+ * answers "who last touched the kill switch, and what came of it" — which
+ * nothing upstream can answer, because Warmbly's dispatch status carries no
+ * `paused_by`.
+ *
+ * Same identity gate as the writes. The stored token never leaves this process;
+ * only the token *id* is disclosed.
+ */
+export const OPERATOR_LEDGER_ROUTE = "/v1/warmbly/operator/ledger/recent" as const;
+
+/** Never more than this, whatever a caller asks for. */
+export const OPERATOR_LEDGER_MAX = 20;
+
 export type OperatorHttpRoute = (typeof OPERATOR_HTTP_ROUTES)[keyof typeof OPERATOR_HTTP_ROUTES];
 
 export interface OperatorHttpRequest {
@@ -31,6 +45,19 @@ export interface OperatorHttpRequest {
   remoteAddress: string | undefined;
   /** Already-parsed JSON body. The handler never parses a stream itself. */
   body: unknown;
+}
+
+/** Ledger projection. Deliberately not the stored entry: no token, no raw headers. */
+export interface OperatorLedgerView {
+  action: string;
+  outcome: string;
+  actor_id: string | null;
+  target: string;
+  reason: string | null;
+  refusal_code: string | null;
+  upstream_status: number | null;
+  recorded_at: string;
+  correlation_id: string;
 }
 
 export interface OperatorHttpResponse {
@@ -123,11 +150,58 @@ function render(result: OperatorActionResult): OperatorHttpResponse {
   };
 }
 
+/** Newest first, capped, and projected down to what an operator needs to read. */
+function recentLedgerView(channel: WarmblyOperatorChannel): OperatorLedgerView[] {
+  let entries;
+  try {
+    entries = channel.ledger.list();
+  } catch {
+    // A ledger that cannot be read is not an empty ledger. Say nothing rather
+    // than claim nobody acted.
+    return [];
+  }
+  return entries
+    .slice(-OPERATOR_LEDGER_MAX)
+    .reverse()
+    .map((entry) => ({
+      action: entry.requested_action,
+      outcome: entry.outcome,
+      actor_id: entry.actor?.id ?? null,
+      target: `${entry.target.kind}:${entry.target.id}`,
+      reason: entry.reason,
+      refusal_code: entry.refusal_code,
+      upstream_status: entry.upstream.status,
+      recorded_at: entry.recorded_at,
+      correlation_id: entry.correlation_id,
+    }));
+}
+
 export function createOperatorHttpHandler(
   channel: WarmblyOperatorChannel,
 ): (req: OperatorHttpRequest) => Promise<OperatorHttpResponse> {
   return async (req) => {
     const path = pathOf(req.url);
+    if (path === OPERATOR_LEDGER_ROUTE) {
+      if ((req.method ?? "").toUpperCase() !== "GET") {
+        return {
+          status: 405,
+          body: { ok: false, code: "method_not_allowed", reason: "the operator ledger is read-only" },
+        };
+      }
+      // Same founder gate as a write: the audit trail names the operator, so it
+      // is not public just because it does not mutate anything.
+      const identity = channel.resolveActor({
+        remoteAddress: req.remoteAddress ?? "",
+        headers: req.headers,
+      });
+      if (!identity.ok) {
+        return {
+          status: 401,
+          body: { ok: false, code: identity.code, reason: identity.reason },
+        };
+      }
+      return { status: 200, body: { ok: true, entries: recentLedgerView(channel) } };
+    }
     const known = (Object.values(OPERATOR_HTTP_ROUTES) as string[]).includes(path);
     if (!known) {
       return { status: 404, body: { ok: false, code: "unknown_route", reason: `no operator route ${path}` } };

--- a/control-center/connectors/warmbly/src/operator/index.ts
+++ b/control-center/connectors/warmbly/src/operator/index.ts
@@ -99,11 +99,17 @@ export type {
   WarmblyOperatorChannelOptions,
 } from "./channel.ts";
 
-export { OPERATOR_HTTP_ROUTES, createOperatorHttpHandler } from "./http.ts";
+export {
+  OPERATOR_HTTP_ROUTES,
+  OPERATOR_LEDGER_MAX,
+  OPERATOR_LEDGER_ROUTE,
+  createOperatorHttpHandler,
+} from "./http.ts";
 export type {
   OperatorHttpRequest,
   OperatorHttpResponse,
   OperatorHttpRoute,
+  OperatorLedgerView,
 } from "./http.ts";
 
 export {

--- a/control-center/connectors/warmbly/tests/operator-actions.test.ts
+++ b/control-center/connectors/warmbly/tests/operator-actions.test.ts
@@ -17,6 +17,7 @@ import {
   createFanOutOperatorActionLedger,
   createMemoryOperatorActionLedger,
   createOperatorHttpHandler,
+  OPERATOR_LEDGER_ROUTE,
   createWarmblyOperatorChannel,
   defaultOperatorIdentityPolicy,
   defaultOperatorSinkErrorHandler,
@@ -840,6 +841,79 @@ describe("ledger recording", () => {
       const blocked = timeline.find((row) => row.status === "BLOCKED")!;
       assert.ok(blocked.evidence.includes("refusal_code=confirmation_required"));
       assert.equal(blocked.blockers.length, 1);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe("operator ledger read-back", () => {
+  it("is gated by the same founder identity as a write, and never leaks a token", async () => {
+    const h = await harness();
+    const handle = createOperatorHttpHandler(h.channel);
+    try {
+      // An unauthenticated read is refused before it can disclose who acted.
+      const anon = await handle({
+        method: "GET",
+        url: OPERATOR_LEDGER_ROUTE,
+        headers: {},
+        remoteAddress: TRUSTED_HOP,
+        body: undefined,
+      });
+      assert.equal(anon.status, 401);
+      assert.equal((anon.body as { entries?: unknown }).entries, undefined);
+
+      // A spoofed hop is refused too: Authelia headers only count from a
+      // trusted reverse-proxy hop.
+      const spoofed = await handle({
+        method: "GET",
+        url: OPERATOR_LEDGER_ROUTE,
+        headers: AUTHELIA_HEADERS,
+        remoteAddress: "203.0.113.9",
+        body: undefined,
+      });
+      assert.equal(spoofed.status, 401);
+
+      await h.channel.pauseDispatch({ request: founderRequest(), reason: "pico de bounce" });
+      const read = await handle({
+        method: "GET",
+        url: OPERATOR_LEDGER_ROUTE,
+        headers: AUTHELIA_HEADERS,
+        remoteAddress: TRUSTED_HOP,
+        body: undefined,
+      });
+      assert.equal(read.status, 200);
+      const entries = (read.body as { entries: Array<Record<string, unknown>> }).entries;
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0]!.action, "pause_dispatch");
+      assert.equal(entries[0]!.outcome, "executed");
+      assert.equal(entries[0]!.actor_id, "founder");
+      assert.equal(entries[0]!.reason, "pico de bounce");
+      // The projection carries no token and no raw header material.
+      const serialized = JSON.stringify(read.body);
+      assert.ok(!serialized.includes(TOKEN), "the Warmbly bearer token must never appear");
+      assert.ok(!serialized.includes("wcnf_"), "a confirmation token must never appear");
+      assert.ok(!serialized.includes("founder@confenge.invalid"), "Remote-Email must never appear");
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("is read-only: a write verb on the ledger route is refused", async () => {
+    const h = await harness();
+    const handle = createOperatorHttpHandler(h.channel);
+    try {
+      for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+        const wrong = await handle({
+          method,
+          url: OPERATOR_LEDGER_ROUTE,
+          headers: AUTHELIA_HEADERS,
+          remoteAddress: TRUSTED_HOP,
+          body: {},
+        });
+        assert.equal(wrong.status, 405, method);
+      }
+      assert.equal(h.stub.operatorCalls.length, 0);
     } finally {
       await h.close();
     }

--- a/control-center/package-lock.json
+++ b/control-center/package-lock.json
@@ -2697,7 +2697,8 @@
       "dependencies": {
         "@confenge/control-center-attention": "*",
         "@confenge/control-center-contracts": "*",
-        "@confenge/control-center-persistence": "*"
+        "@confenge/control-center-persistence": "*",
+        "@confenge/control-center-warmbly-connector": "*"
       },
       "devDependencies": {
         "@embedded-postgres/linux-x64": "16.14.0-beta.17",

--- a/control-center/services/context/Dockerfile
+++ b/control-center/services/context/Dockerfile
@@ -34,6 +34,9 @@ COPY --from=builder --chown=node:node /src/node_modules ./node_modules
 COPY --from=builder --chown=node:node /src/contracts ./contracts
 COPY --from=builder --chown=node:node /src/persistence ./persistence
 COPY --from=builder --chown=node:node /src/intelligence/attention ./intelligence/attention
+# Optional dependency of the operator channel. Loaded lazily and only when
+# CC_WARMBLY_OPERATOR_ENABLED=true, but it has to be present to be loadable.
+COPY --from=builder --chown=node:node /src/connectors/warmbly ./connectors/warmbly
 COPY --from=builder --chown=node:node /src/services/context ./services/context
 COPY --from=builder --chown=node:node /src/scripts/node-http-probe.mjs ./node-http-probe.mjs
 ENV HOST=0.0.0.0

--- a/control-center/services/context/package.json
+++ b/control-center/services/context/package.json
@@ -2,7 +2,7 @@
   "name": "@confenge/control-center-context",
   "version": "0.1.0",
   "private": true,
-  "description": "Confenge Control Center — strategic memory and directives (scoped context for agents).",
+  "description": "Confenge Control Center \u2014 strategic memory and directives (scoped context for agents).",
   "type": "module",
   "engines": {
     "node": ">=20"
@@ -22,7 +22,8 @@
   "dependencies": {
     "@confenge/control-center-attention": "*",
     "@confenge/control-center-contracts": "*",
-    "@confenge/control-center-persistence": "*"
+    "@confenge/control-center-persistence": "*",
+    "@confenge/control-center-warmbly-connector": "*"
   },
   "devDependencies": {
     "@embedded-postgres/linux-x64": "16.14.0-beta.17",

--- a/control-center/services/context/src/http.ts
+++ b/control-center/services/context/src/http.ts
@@ -15,7 +15,33 @@ export interface HttpDeps {
   logger: Logger;
   operational?: OperationalService;
   operatorActions?: OperatorActionService;
+  /**
+   * Warmbly operator channel. Optional: when absent every operator route 404s,
+   * which is the fail-closed default for an unconfigured deployment.
+   *
+   * It carries its own identity: Authelia's `Remote-*` headers, verified against
+   * a trusted hop. It deliberately does NOT use `x-actor-id`, which any caller
+   * that reaches this process can set — a client-settable actor must never be
+   * able to pause or resume outbound email.
+   */
+  warmblyOperator?: (req: WarmblyOperatorHttpRequest) => Promise<WarmblyOperatorHttpResponse>;
 }
+
+export interface WarmblyOperatorHttpRequest {
+  method: string | undefined;
+  url: string | undefined;
+  headers: Readonly<Record<string, string | string[] | undefined>>;
+  remoteAddress: string | undefined;
+  body: unknown;
+}
+
+export interface WarmblyOperatorHttpResponse {
+  status: number;
+  body: unknown;
+}
+
+/** Route prefix owned by the Warmbly operator channel. */
+const WARMBLY_OPERATOR_PREFIX = "/v1/warmbly/operator/";
 
 function header(req: IncomingMessage, name: string): string | undefined {
   const raw = req.headers[name];
@@ -143,6 +169,28 @@ async function handle(
     if (method === "GET" && url.pathname === "/ready") {
       const ready = await deps.service.ready();
       send(res, ready ? 200 : 503, { ready, service: "control-center-context" });
+      return;
+    }
+    // Mounted before actorFromRequest on purpose. The operator channel resolves
+    // its own actor from Authelia, and must never fall back to the
+    // client-supplied x-actor-id header this service uses elsewhere.
+    if (url.pathname.startsWith(WARMBLY_OPERATOR_PREFIX)) {
+      if (!deps.warmblyOperator) {
+        send(res, 404, {
+          ok: false,
+          code: "operator_channel_not_configured",
+          reason: "the Warmbly operator channel is not wired in this deployment",
+        });
+        return;
+      }
+      const result = await deps.warmblyOperator({
+        method,
+        url: url.pathname,
+        headers: req.headers,
+        remoteAddress: req.socket?.remoteAddress,
+        body: method === "POST" ? await readBody(req) : undefined,
+      });
+      send(res, result.status, result.body);
       return;
     }
     const actor = actorFromRequest(req);

--- a/control-center/services/context/src/server.ts
+++ b/control-center/services/context/src/server.ts
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 import { bootFromEnvAsync } from "./boot.ts";
 import { createRequestListener } from "./http.ts";
+import { createWarmblyOperatorHandlerFromEnv } from "./warmbly-operator/from-env.ts";
 import { createLogger, type Logger } from "./log.ts";
 import { isServiceError } from "./errors.ts";
 
@@ -29,11 +30,15 @@ export async function startServer(
   const boot = await bootFromEnvAsync(env, { logger });
   const host = listenHost(env);
   const port = listenPort(env);
+  // Off unless CC_WARMBLY_OPERATOR_ENABLED=true. When absent, every operator
+  // route 404s rather than falling back to a weaker identity path.
+  const warmblyOperator = await createWarmblyOperatorHandlerFromEnv(env, { logger });
   const listener = createRequestListener({
     service: boot.service,
     operational: boot.operational,
     operatorActions: boot.operatorActions,
     logger,
+    ...(warmblyOperator ? { warmblyOperator } : {}),
   });
   const server = createServer(listener);
   return new Promise((resolve, reject) => {

--- a/control-center/services/context/src/warmbly-operator/from-env.ts
+++ b/control-center/services/context/src/warmbly-operator/from-env.ts
@@ -1,0 +1,127 @@
+/**
+ * Wires the Warmbly operator channel, or returns undefined.
+ *
+ * Off unless explicitly configured. An unconfigured deployment 404s every
+ * operator route, which is the fail-closed default: a control plane that can
+ * pause and resume outbound email must be switched on deliberately, never by
+ * a default.
+ */
+
+import type { Logger } from "../log.ts";
+import type { WarmblyOperatorHttpRequest, WarmblyOperatorHttpResponse } from "../http.ts";
+
+/**
+ * The connector's log entry shape. Declared structurally here rather than
+ * exported from the connector, so mounting it does not widen its public surface.
+ */
+type ConnectorLogEntry = { level: "info" | "warn" | "error"; msg: string; [key: string]: unknown };
+type ConnectorLogger = (entry: ConnectorLogEntry) => void;
+
+/**
+ * The connector logs structured entries through a single callable; this service
+ * logs through level methods. Adapt rather than widen either side, and drop the
+ * fields the service logger refuses so a nested object cannot smuggle a secret
+ * past its own redaction.
+ */
+function connectorLogger(logger: Logger): ConnectorLogger {
+  return (entry: ConnectorLogEntry) => {
+    const { level, msg, ...rest } = entry;
+    const fields: Record<string, string | number | boolean | null> = {};
+    for (const [key, value] of Object.entries(rest)) {
+      if (value === null || ["string", "number", "boolean"].includes(typeof value)) {
+        fields[key] = value as string | number | boolean | null;
+      } else {
+        fields[key] = JSON.stringify(value) ?? "";
+      }
+    }
+    const write = level === "error" ? logger.error : level === "warn" ? logger.warn : logger.info;
+    write.call(logger, msg, fields);
+  };
+}
+
+export type WarmblyOperatorHandler = (
+  req: WarmblyOperatorHttpRequest,
+) => Promise<WarmblyOperatorHttpResponse>;
+
+export interface WarmblyOperatorEnvDeps {
+  logger: Logger;
+  /** Optional agent-activity sink, so operator actions land on the timeline. */
+  agentActivity?: unknown;
+}
+
+function required(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const raw = env[name];
+  return typeof raw === "string" && raw.trim() !== "" ? raw.trim() : undefined;
+}
+
+/**
+ * Loaded lazily and only when enabled. A static import would make an opt-in
+ * feature able to crash boot on any image that does not ship the connector,
+ * which is exactly what it did the first time.
+ */
+async function loadConnector(): Promise<typeof import("@confenge/control-center-warmbly-connector")> {
+  return import("@confenge/control-center-warmbly-connector");
+}
+
+export async function createWarmblyOperatorHandlerFromEnv(
+  env: NodeJS.ProcessEnv,
+  deps: WarmblyOperatorEnvDeps,
+): Promise<WarmblyOperatorHandler | undefined> {
+  if (required(env, "CC_WARMBLY_OPERATOR_ENABLED") !== "true") {
+    return undefined;
+  }
+  const baseUrl = required(env, "CC_WARMBLY_BASE_URL");
+  const token = required(env, "CC_WARMBLY_OPERATOR_TOKEN");
+  if (!baseUrl || !token) {
+    // Enabled but not configured is a misconfiguration, not a reason to run
+    // half-wired: say so and stay off.
+    deps.logger.error("warmbly.operator.not_configured", {
+      msg: "CC_WARMBLY_OPERATOR_ENABLED=true requires CC_WARMBLY_BASE_URL and CC_WARMBLY_OPERATOR_TOKEN",
+      has_base_url: Boolean(baseUrl),
+      has_token: Boolean(token),
+    });
+    return undefined;
+  }
+
+  let connector: Awaited<ReturnType<typeof loadConnector>>;
+  try {
+    connector = await loadConnector();
+  } catch (err) {
+    deps.logger.error("warmbly.operator.connector_unavailable", {
+      msg: "the operator channel is enabled but its connector is not present in this image",
+      error: err instanceof Error ? err.name : "unknown",
+    });
+    return undefined;
+  }
+  const {
+    WarmblyOperatorClient,
+    createAgentActivityLedgerSink,
+    createFanOutOperatorActionLedger,
+    createMemoryOperatorActionLedger,
+    createOperatorHttpHandler,
+    createWarmblyOperatorChannel,
+    defaultOperatorSinkErrorHandler,
+  } = connector;
+  const log = connectorLogger(deps.logger);
+  const client = new WarmblyOperatorClient({
+    baseUrl,
+    token,
+    logger: log,
+    ...(required(env, "CC_WARMBLY_OPERATOR_TIMEOUT_MS")
+      ? { timeoutMs: Number(required(env, "CC_WARMBLY_OPERATOR_TIMEOUT_MS")) }
+      : {}),
+  });
+
+  const primary = createMemoryOperatorActionLedger();
+  const sinks = deps.agentActivity
+    ? [createAgentActivityLedgerSink(deps.agentActivity as never)]
+    : [];
+  const ledger = createFanOutOperatorActionLedger(
+    primary,
+    sinks,
+    defaultOperatorSinkErrorHandler(log),
+  );
+
+  const channel = createWarmblyOperatorChannel({ client, ledger, logger: log });
+  return createOperatorHttpHandler(channel) as WarmblyOperatorHandler;
+}

--- a/control-center/services/context/test/warmbly-operator-mount.test.ts
+++ b/control-center/services/context/test/warmbly-operator-mount.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createRequestListener } from "../src/http.ts";
+import type { WarmblyOperatorHttpRequest } from "../src/http.ts";
+import { silentLogger } from "../src/log.ts";
+import { createWarmblyOperatorHandlerFromEnv } from "../src/warmbly-operator/from-env.ts";
+import { makeService } from "./helpers.ts";
+
+const PAUSE = "/v1/warmbly/operator/dispatch/pause";
+
+async function withServer(
+  warmblyOperator: ((req: WarmblyOperatorHttpRequest) => Promise<{ status: number; body: unknown }>) | undefined,
+  fn: (base: string) => Promise<void>,
+): Promise<void> {
+  const { service } = makeService();
+  const server = createServer(
+    createRequestListener({
+      service,
+      logger: silentLogger,
+      ...(warmblyOperator ? { warmblyOperator } : {}),
+    }),
+  );
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object");
+  try {
+    await fn(`http://127.0.0.1:${addr.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+  }
+}
+
+test("an unconfigured deployment 404s every operator route instead of half-mounting", async () => {
+  await withServer(undefined, async (base) => {
+    const res = await fetch(`${base}${PAUSE}`, { method: "POST", body: "{}" });
+    assert.equal(res.status, 404);
+    const body = (await res.json()) as { code?: string };
+    assert.equal(body.code, "operator_channel_not_configured");
+  });
+});
+
+test("the operator route never resolves its actor from the client-settable x-actor-id", async () => {
+  // This is the whole point of mounting ahead of actorFromRequest: anything that
+  // reaches this process can set x-actor-id, and it must not be able to pause or
+  // resume outbound email by doing so.
+  let seen: WarmblyOperatorHttpRequest | undefined;
+  const handler = async (req: WarmblyOperatorHttpRequest) => {
+    seen = req;
+    return { status: 401, body: { ok: false, code: "missing_actor" } };
+  };
+  await withServer(handler, async (base) => {
+    const res = await fetch(`${base}${PAUSE}`, {
+      method: "POST",
+      headers: { "x-actor-id": "founder", "x-actor-kind": "human", "content-type": "application/json" },
+      body: JSON.stringify({ reason: "bounce spike" }),
+    });
+    assert.equal(res.status, 401, "a forged x-actor-id must not authenticate an operator write");
+  });
+  assert.ok(seen, "the channel must receive the request");
+  // The channel gets the raw headers and resolves identity itself from Remote-*.
+  assert.equal(seen?.headers["remote-user"], undefined);
+  assert.equal(seen?.headers["x-actor-id"], "founder");
+});
+
+test("the channel receives the socket peer address so its trusted-hop check is real", async () => {
+  let seen: WarmblyOperatorHttpRequest | undefined;
+  const handler = async (req: WarmblyOperatorHttpRequest) => {
+    seen = req;
+    return { status: 202, body: { ok: true } };
+  };
+  await withServer(handler, async (base) => {
+    await fetch(`${base}${PAUSE}`, { method: "POST", body: "{}" });
+  });
+  assert.ok(seen?.remoteAddress, "remoteAddress must be forwarded, not left undefined");
+});
+
+test("a non-POST operator route reaches the channel, which owns the 405", async () => {
+  let method: string | undefined;
+  const handler = async (req: WarmblyOperatorHttpRequest) => {
+    method = req.method;
+    return { status: 405, body: { ok: false, code: "method_not_allowed" } };
+  };
+  await withServer(handler, async (base) => {
+    const res = await fetch(`${base}${PAUSE}`, { method: "GET" });
+    assert.equal(res.status, 405);
+  });
+  assert.equal(method, "GET");
+});
+
+test("mounting is off by default and stays off when enabled but unconfigured", async () => {
+  assert.equal(await createWarmblyOperatorHandlerFromEnv({}, { logger: silentLogger }), undefined);
+  assert.equal(
+    await createWarmblyOperatorHandlerFromEnv(
+      { CC_WARMBLY_OPERATOR_ENABLED: "true" },
+      { logger: silentLogger },
+    ),
+    undefined,
+    "enabled without a base url and token must stay off rather than run half-wired",
+  );
+  assert.equal(
+    await createWarmblyOperatorHandlerFromEnv(
+      { CC_WARMBLY_OPERATOR_ENABLED: "false", CC_WARMBLY_BASE_URL: "http://x", CC_WARMBLY_OPERATOR_TOKEN: "t" },
+      { logger: silentLogger },
+    ),
+    undefined,
+  );
+  assert.notEqual(
+    await createWarmblyOperatorHandlerFromEnv(
+      { CC_WARMBLY_OPERATOR_ENABLED: "true", CC_WARMBLY_BASE_URL: "http://x", CC_WARMBLY_OPERATOR_TOKEN: "t" },
+      { logger: silentLogger },
+    ),
+    undefined,
+    "fully configured must mount",
+  );
+});
+
+test("the connector is never a static import, so a disabled feature cannot crash boot", () => {
+  // A static import made an opt-in feature crash the container on any image
+  // without the connector, feature off or not. That is what this pins.
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../src/warmbly-operator/from-env.ts"),
+    "utf8",
+  );
+  const staticImport = /^\s*import\s[^\n]*@confenge\/control-center-warmbly-connector/m;
+  assert.equal(
+    staticImport.test(source),
+    false,
+    "the connector must be reached through a dynamic import inside the enabled branch",
+  );
+  assert.match(source, /await import\("@confenge\/control-center-warmbly-connector"\)|import\("@confenge\/control-center-warmbly-connector"\)/);
+});
+
+test("the mount does not shadow the service's own routes", async () => {
+  const handler = async () => ({ status: 200, body: { ok: true } });
+  await withServer(handler, async (base) => {
+    const res = await fetch(`${base}/healthz`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { service?: string };
+    assert.equal(body.service, "control-center-context");
+  });
+});


### PR DESCRIPTION
Carries #50's mount (auto-closed when #49's branch was deleted on squash-merge;
its commits are here unchanged) and adds the instrument panel that made the
channel usable — plus a fix for a resume that could never have run.

## The resume could never complete

`bindWarmblyDispatch` parked the confirmation token in the closure of the form
that minted it. Every dispatch call ends in `onDone()`, which repaints by
replacing `root.innerHTML` wholesale, so that form and its closure are gone
before the operator can submit the second step. The next submit saw no token
and minted a second challenge. Forever.

That is not a stricter two-step; it is a resume that never runs, and it is the
one action that lets outbound email flow again. The token now lives at module
scope: it survives a repaint, still dies on a reload, is dropped after one use,
and a refusal arms nothing. Reverting the fix makes two of the three new tests
fail with the exact re-challenge loop.

## Nothing could read the kill switch

`/v1/confenge/dispatch/status` was on the read allowlist and never fetched. The
collector reads it now and the mapper projects it tri-state on purpose: Warmbly
answering nothing is not Warmbly answering "running", so absence is UNKNOWN,
never ACTIVE. Every field is omitted rather than defaulted — the surface shows
what was observed, not an invented window or cap.

## Nothing could read who acted

Warmbly's dispatch status carries no `paused_by`, so this channel's ledger is
the only record of who touched the switch — and it had no reader. Adds GET
`/v1/warmbly/operator/ledger/recent` behind the same Authelia gate as a write,
projected down to action/outcome/actor/target/reason. No bearer token, no
confirmation token, no Remote-Email. A write verb on it is 405.

## The cockpit

Comercial → Coortes gains the dispatch state, its pause reason, the send window,
the last operator action, and three controls: pause, resume (two steps),
acknowledge. There is no send control and there must never be one.

Also regenerates package-lock for the connector dependency #50 added to
services/context, which the lockfile had not recorded — the context image
declares it and would have built without it pinned.

Full control-center suite: 809 passing, 0 failing, typecheck clean across all
20 workspaces.

Supersedes #50, which GitHub auto-closed when #49's branch was deleted on squash-merge. #50's commits are carried here unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)