### PR TITLE
fix(cc-warmbly): the operator channel trusted the whole edge network, and a half-configured flag crashed boot

### DIFF
--- a/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
+++ b/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
@@ -197,6 +197,11 @@ services:
       CONTROL_CENTER_FOUNDER_ACTOR_ID: "${CONTROL_CENTER_FOUNDER_ACTOR_ID:?CONTROL_CENTER_FOUNDER_ACTOR_ID must be set}"
       CONTROL_CENTER_ENV: production
       CC_TRUSTED_PROXY_CIDRS: "${CC_TRUSTED_PROXY_CIDRS:?CC_TRUSTED_PROXY_CIDRS must be set}"
+      # Narrower than CC_TRUSTED_PROXY_CIDRS on purpose. That one is the whole
+      # cc_edge /24, which holds web, mcp, collector and context beside caddy;
+      # any of them could forge Remote-* and get a resume executed as the
+      # founder. Only caddy terminates Authelia, so only caddy may present it.
+      CC_WARMBLY_OPERATOR_TRUSTED_HOPS: "${CC_WARMBLY_OPERATOR_TRUSTED_HOPS:-10.89.0.2/32}"
     networks:
       cc_edge:
         ipv4_address: 10.89.0.4

--- a/control-center/services/context/README.md
+++ b/control-center/services/context/README.md
@@ -125,3 +125,39 @@ Fora de escopo aqui: UI, MCP, collectors, Warmbly, Asaas, `commercial/`, PR Gove
 - campos desconhecidos rejeitados
 - `created_by` é sempre o ator autenticado
 - IDs `cc:<type-kebab>:<ulid-or-slug>`
+
+
+## Warmbly operator channel
+
+Off unless every one of these is set. Missing any of them leaves the channel
+unmounted and every `/v1/warmbly/operator/*` route answering `404`.
+
+| Variable | Meaning |
+| --- | --- |
+| `CC_WARMBLY_OPERATOR_ENABLED` | exactly `true`; anything else keeps it off |
+| `CC_WARMBLY_BASE_URL` | Warmbly base URL for the write client |
+| `CC_WARMBLY_OPERATOR_TOKEN` | bearer for those writes |
+| `CC_WARMBLY_OPERATOR_TRUSTED_HOPS` | comma-separated CIDRs allowed to present `Remote-*` |
+
+`CC_WARMBLY_OPERATOR_TRUSTED_HOPS` is deliberately **not** `CC_TRUSTED_PROXY_CIDRS`
+and has no default. The shared value is `10.89.0.0/24`, which is the whole
+`cc_edge` network: `caddy` sits there at `10.89.0.2`, but so do `authelia`,
+`context`, `web`, `mcp` and `collector`. Reads have lived behind that CIDR for a
+while and that is a defensible tradeoff. A write that resumes outbound cold email
+is not: any container on the network could forge `Remote-User: tiago` and get a
+resume executed and ledgered as the founder, without Authelia ever being asked.
+
+In the production-edge overlay the correct value is the caddy address alone:
+
+```
+CC_WARMBLY_OPERATOR_TRUSTED_HOPS=10.89.0.2/32
+```
+
+If it is unset the channel refuses to mount and logs
+`warmbly.operator.trusted_hop_required`. Failing closed is the intended
+behaviour: the hop that may speak for Authelia has to be named on purpose.
+
+Operator writes also require `content-type: application/json`. A cross-origin
+`<form enctype="text/plain">` POST is CORS-simple, so no preflight runs and the
+`same_site: lax` session cookie is still sent from any `*.confenge.com.br` page;
+requiring JSON is what a form cannot satisfy.

--- a/control-center/services/context/src/http.ts
+++ b/control-center/services/context/src/http.ts
@@ -183,6 +183,21 @@ async function handle(
         });
         return;
       }
+      // A cross-origin <form enctype="text/plain"> POST is CORS-simple, so no
+      // preflight runs and Authelia's lax cookie is still sent from any
+      // *.confenge.com.br page. Requiring JSON is what stops it: a form cannot
+      // set this content type.
+      if (method === "POST") {
+        const contentType = String(req.headers["content-type"] ?? "");
+        if (!contentType.toLowerCase().startsWith("application/json")) {
+          send(res, 415, {
+            ok: false,
+            code: "unsupported_media_type",
+            reason: "operator writes require content-type: application/json",
+          });
+          return;
+        }
+      }
       const result = await deps.warmblyOperator({
         method,
         url: url.pathname,

--- a/control-center/services/context/src/warmbly-operator/from-env.ts
+++ b/control-center/services/context/src/warmbly-operator/from-env.ts
@@ -72,13 +72,32 @@ export async function createWarmblyOperatorHandlerFromEnv(
   }
   const baseUrl = required(env, "CC_WARMBLY_BASE_URL");
   const token = required(env, "CC_WARMBLY_OPERATOR_TOKEN");
+  // The hop that may speak for Authelia must be named explicitly. The library
+  // default is DEFAULT_TRUSTED_HOPS, which contains the whole cc_edge /24 — and
+  // that network holds web, mcp, collector and context alongside caddy. Trusting
+  // it would let any of them forge Remote-* and execute a resume, restarting
+  // outbound email, ledgered as the founder. Reads have lived behind that CIDR
+  // for a while; a write must not.
+  const trustedHops = (required(env, "CC_WARMBLY_OPERATOR_TRUSTED_HOPS") ?? "")
+    .split(",")
+    .map((hop) => hop.trim())
+    .filter((hop) => hop !== "");
+  if (trustedHops.length === 0) {
+    deps.logger.error("warmbly.operator.trusted_hop_required", {
+      msg: "CC_WARMBLY_OPERATOR_TRUSTED_HOPS must name the single proxy that may present Remote-* (for example the caddy address), and it must be narrower than the edge network",
+    });
+    return undefined;
+  }
   if (!baseUrl || !token) {
     // Enabled but not configured is a misconfiguration, not a reason to run
     // half-wired: say so and stay off.
     deps.logger.error("warmbly.operator.not_configured", {
       msg: "CC_WARMBLY_OPERATOR_ENABLED=true requires CC_WARMBLY_BASE_URL and CC_WARMBLY_OPERATOR_TOKEN",
       has_base_url: Boolean(baseUrl),
-      has_token: Boolean(token),
+      // The service logger refuses any field NAME matching /token/i and throws,
+      // so `has_token` — and `token_present` — turn a misconfiguration into a
+      // boot crash loop. The name must not contain the word at all.
+      credential_present: Boolean(token),
     });
     return undefined;
   }
@@ -122,6 +141,11 @@ export async function createWarmblyOperatorHandlerFromEnv(
     defaultOperatorSinkErrorHandler(log),
   );
 
-  const channel = createWarmblyOperatorChannel({ client, ledger, logger: log });
+  const channel = createWarmblyOperatorChannel({
+    client,
+    ledger,
+    logger: log,
+    identityPolicy: connector.defaultOperatorIdentityPolicy(trustedHops),
+  });
   return createOperatorHttpHandler(channel) as WarmblyOperatorHandler;
 }

--- a/control-center/services/context/test/warmbly-operator-mount.test.ts
+++ b/control-center/services/context/test/warmbly-operator-mount.test.ts
@@ -74,7 +74,11 @@ test("the channel receives the socket peer address so its trusted-hop check is r
     return { status: 202, body: { ok: true } };
   };
   await withServer(handler, async (base) => {
-    await fetch(`${base}${PAUSE}`, { method: "POST", body: "{}" });
+    await fetch(`${base}${PAUSE}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
   });
   assert.ok(seen?.remoteAddress, "remoteAddress must be forwarded, not left undefined");
 });
@@ -111,7 +115,12 @@ test("mounting is off by default and stays off when enabled but unconfigured", a
   );
   assert.notEqual(
     await createWarmblyOperatorHandlerFromEnv(
-      { CC_WARMBLY_OPERATOR_ENABLED: "true", CC_WARMBLY_BASE_URL: "http://x", CC_WARMBLY_OPERATOR_TOKEN: "t" },
+      {
+        CC_WARMBLY_OPERATOR_ENABLED: "true",
+        CC_WARMBLY_BASE_URL: "http://x",
+        CC_WARMBLY_OPERATOR_TOKEN: "t",
+        CC_WARMBLY_OPERATOR_TRUSTED_HOPS: "10.89.0.2/32",
+      },
       { logger: silentLogger },
     ),
     undefined,
@@ -143,4 +152,100 @@ test("the mount does not shadow the service's own routes", async () => {
     const body = (await res.json()) as { service?: string };
     assert.equal(body.service, "control-center-context");
   });
+});
+
+// --- Regressions from the second adversarial review -------------------------
+
+test("a half-configured flag does not crash boot through the logger", async () => {
+  // `has_token` matched the service logger's secret-NAME regex, which throws.
+  // The branch meant to say "stay off" instead took the whole service down in a
+  // restart loop, taking /healthz and every read with it.
+  const thrown: unknown[] = [];
+  const strictLogger = {
+    info() {},
+    warn() {},
+    error(_msg: string, fields?: Record<string, string | number | boolean | null>) {
+      for (const key of Object.keys(fields ?? {})) {
+        if (/pass(word)?|secret|token|authorization|cookie/i.test(key)) {
+          const err = new Error("refusing to log a secret-bearing field name");
+          thrown.push(err);
+          throw err;
+        }
+      }
+    },
+  };
+  const handler = await createWarmblyOperatorHandlerFromEnv(
+    { CC_WARMBLY_OPERATOR_ENABLED: "true", CC_WARMBLY_OPERATOR_TRUSTED_HOPS: "10.89.0.2/32" },
+    { logger: strictLogger },
+  );
+  assert.equal(handler, undefined);
+  assert.deepEqual(thrown, [], "no field name may trip the logger's secret guard");
+});
+
+test("the channel refuses to mount without an explicitly narrowed trusted hop", async () => {
+  // The library default trusts 10.89.0.0/24, which in production is the whole
+  // cc_edge network: web, mcp, collector and context sit there beside caddy.
+  // Any of them could forge Remote-* and execute a resume.
+  assert.equal(
+    await createWarmblyOperatorHandlerFromEnv(
+      {
+        CC_WARMBLY_OPERATOR_ENABLED: "true",
+        CC_WARMBLY_BASE_URL: "http://x",
+        CC_WARMBLY_OPERATOR_TOKEN: "t",
+      },
+      { logger: silentLogger },
+    ),
+    undefined,
+    "a missing trusted hop must fail closed, never fall back to the edge network",
+  );
+  assert.notEqual(
+    await createWarmblyOperatorHandlerFromEnv(
+      {
+        CC_WARMBLY_OPERATOR_ENABLED: "true",
+        CC_WARMBLY_BASE_URL: "http://x",
+        CC_WARMBLY_OPERATOR_TOKEN: "t",
+        CC_WARMBLY_OPERATOR_TRUSTED_HOPS: "10.89.0.2/32",
+      },
+      { logger: silentLogger },
+    ),
+    undefined,
+  );
+});
+
+test("an operator write refuses a non-JSON content type", async () => {
+  // <form enctype="text/plain"> is CORS-simple, so no preflight runs and the
+  // lax session cookie is still sent from any *.confenge.com.br page.
+  let reached = false;
+  const handler = async () => {
+    reached = true;
+    return { status: 200, body: { ok: true } };
+  };
+  await withServer(handler, async (base) => {
+    const res = await fetch(`${base}${PAUSE}`, {
+      method: "POST",
+      headers: { "content-type": "text/plain;charset=UTF-8" },
+      body: '{"reason":"pausado pelo atacante"}',
+    });
+    assert.equal(res.status, 415);
+    const body = (await res.json()) as { code?: string };
+    assert.equal(body.code, "unsupported_media_type");
+  });
+  assert.equal(reached, false, "the channel must never see a cross-origin form body");
+});
+
+test("a JSON operator write still reaches the channel", async () => {
+  let reached = false;
+  const handler = async () => {
+    reached = true;
+    return { status: 200, body: { ok: true } };
+  };
+  await withServer(handler, async (base) => {
+    const res = await fetch(`${base}${PAUSE}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ reason: "bounce spike" }),
+    });
+    assert.equal(res.status, 200);
+  });
+  assert.equal(reached, true);
 });


### PR DESCRIPTION
Três defeitos no canal do operador **já mesclado no `main`** (#51). Encontrados numa revisão adversarial do próprio mount, que nunca tinha sido atacado. Dois são meus, do #50.

## O pior: a propriedade de identidade não se sustentava

O commit afirmava que identidade vem só da Authelia. A afirmação literal — que um `x-actor-id` do cliente não autentica — é verdadeira. A outra não era.

`from-env.ts` construía o canal **sem `identityPolicy`**, caindo em `DEFAULT_TRUSTED_HOPS = ["10.89.0.0/24", …]`. E no overlay de produção esse `/24` é a rede `cc_edge` inteira:

| Container | Endereço |
| --- | --- |
| caddy | `10.89.0.2` |
| authelia | `10.89.0.3` |
| context | `10.89.0.4` |
| web | `10.89.0.5` |
| mcp | `10.89.0.6` |
| collector | `10.89.0.7` |

Só o caddy termina a Authelia. Os outros cinco eram confiados do mesmo jeito. Reproduzido a partir de um par na rede, sem Authelia nenhuma no caminho:

```
POST /v1/warmbly/operator/dispatch/resume/confirm
Remote-User: tiago   Remote-Groups: operators
→ 202 {"confirmation_token":"wcnf_684f2b49-…"}

POST /v1/warmbly/operator/dispatch/resume   (mesmos headers forjados + token)
→ 200 {"action":"resume_dispatch","outcome":"executed"}
UPSTREAM WRITE: POST /v1/confenge/dispatch/resume
```

Um **resume falso**: e-mail frio religado, registrado no ledger como o fundador, por um chamador que nunca falou com a Authelia.

Leituras vivem atrás desse CIDR há tempo e isso é um tradeoff defensável. Uma escrita que religa envio não é. O que mudou não foi o CIDR — foi eu ter colocado uma escrita atrás dele.

Agora o canal exige `CC_WARMBLY_OPERATOR_TRUSTED_HOPS` explícito e **recusa montar sem ele**, em vez de cair no default largo. No overlay o valor é o endereço do caddy sozinho, `10.89.0.2/32`.

## Um flag meio configurado derrubava o serviço inteiro

O ramo que deveria dizer "desligado, siga em frente" logava `has_token: Boolean(token)`. O logger do serviço recusa **nomes** de campo casando `/token/i` e **lança**. Com `CC_WARMBLY_OPERATOR_ENABLED=true` e o token faltando, `startServer` rejeitava, `server.ts` fazia `process.exit(1)`, e com `restart: unless-stopped` isso é loop de reinício levando junto `/healthz`, `/ready`, `/v1/context` e as diretivas.

Exatamente a classe de falha que o commit anterior existia para eliminar, reintroduzida pelo logger. O teste não pegou porque usava `silentLogger`, que não tem a guarda.

Renomear para `token_present` **não resolvia** — meu próprio teste novo pegou isso, porque `token_present` também casa `/token/i`. O campo agora é `credential_present`.

## Um formulário de outra origem conseguia pausar o envio

`readBody` aceitava qualquer corpo POST, independente do content-type. Um `<form enctype="text/plain">` numa página qualquer é CORS-simple, então o `cors_deny` do Caddy (que responde ao OPTIONS) nunca roda, e o cookie `same_site: lax` da Authelia é permissivo entre subdomínios:

```
POST /v1/warmbly/operator/dispatch/pause
Content-Type: text/plain;charset=UTF-8
Origin: https://evil.example
→ 200   UPSTREAM WRITE: POST /v1/confenge/dispatch/pause
```

Resume falso não é alcançável assim (o token do 202 é ilegível sem CORS), mas pause e acknowledge eram — e pause é uma parada de receita. Escritas agora exigem `application/json`, que um formulário não consegue produzir.

## O que a revisão confirmou como sólido

Guarda de prefixo contra `//v1/…`, barra final, `%2f`, traversal nos dois sentidos, request-target absoluto, fragmento, query e `;x=1`: nenhuma rota alcançável sem identidade e nenhuma rota alheia engolida pelo prefixo. `x-actor-id` forjado → 401. `readBody` com cap de 32 KiB. `remoteAddress` ausente falha fechado. Import dinâmico roda uma vez no boot e um erro dele 404a as rotas. Nenhum segredo chega ao logger.

Um quarto achado (o token de confirmação preso no closure de um formulário destruído pelo repaint, tornando o resume impossível de completar) já havia sido corrigido no #51.

## Verificação

`services/context` **61/61**, typecheck limpo. `deploy` **20/20**. Quatro testes novos, cada um verificado falhando sem sua correção.