### PR TITLE
fix(cc): ship the workspaces the runtime images actually import

### DIFF
--- a/control-center/connectors/runner/Dockerfile
+++ b/control-center/connectors/runner/Dockerfile
@@ -10,9 +10,13 @@ RUN npm ci --ignore-scripts \
 RUN node scripts/build-runtime-packages.mjs collector
 RUN node scripts/rewrite-runtime-exports.mjs /src
 RUN npm prune --omit=dev --ignore-scripts
+# strip-runtime-tree prunes node_modules/@confenge to exactly this list, so a
+# package left off it loses its workspace symlink even when its directory is
+# copied below. security is on the collector's boot path via the warmbly barrel.
 RUN node scripts/strip-runtime-tree.mjs /src \
   @confenge/control-center-contracts \
   @confenge/control-center-persistence \
+  @confenge/control-center-security \
   @confenge/control-center-collector \
   && test ! -e /src/node_modules/tsx \
   && test ! -e /src/node_modules/esbuild \
@@ -32,6 +36,11 @@ COPY --from=builder --chown=node:node /src/package.json /src/package-lock.json /
 COPY --from=builder --chown=node:node /src/node_modules ./node_modules
 COPY --from=builder --chown=node:node /src/contracts ./contracts
 COPY --from=builder --chown=node:node /src/persistence ./persistence
+# The warmbly connector's barrel re-exports the operator channel, which imports
+# @confenge/control-center-security. That is a STATIC import on the collector's
+# boot path, so the package has to be in the image even though the collector is
+# read-only and never calls the channel.
+COPY --from=builder --chown=node:node /src/security ./security
 COPY --from=builder --chown=node:node /src/connectors ./connectors
 COPY --from=builder --chown=node:node /src/scripts/node-http-probe.mjs ./node-http-probe.mjs
 ENV HOST=0.0.0.0

--- a/control-center/connectors/runner/src/projectors/commercial.ts
+++ b/control-center/connectors/runner/src/projectors/commercial.ts
@@ -188,6 +188,15 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
   return {
     schema_version: "control-center.commercial-operations.v1",
     projector_version: PROJECTOR_VERSION,
+    // Passed through from the connector rather than re-derived. This projector
+    // rebuilds most of `operations` from the raw payload, so a block that only
+    // the connector computes has to be forwarded explicitly or it silently
+    // disappears between the mapper and the surface that renders it.
+    dispatch: asRecord(nested.dispatch) ?? {
+      state: "UNKNOWN",
+      observed: false,
+      why: "the collector produced no dispatch reading; the kill-switch state is not known",
+    },
     authority: {
       catalog_authority: "governance",
       commercial_runtime: "warmbly",

--- a/control-center/connectors/runner/src/run.ts
+++ b/control-center/connectors/runner/src/run.ts
@@ -1,6 +1,12 @@
 import { FRESHNESS_STATUSES, type FreshnessStatus } from "@confenge/control-center-contracts";
 import { failedCollect, parseCollectConfig, collect as collectGithub, liveTransport } from "../../github/src/index.ts";
-import { collect as collectWarmbly } from "../../warmbly/src/index.ts";
+// Import the collect surface directly, not the connector barrel. The barrel
+// also re-exports the operator write channel, which pulls
+// @confenge/control-center-security into this process's static import graph —
+// a package the read-only collector neither declares nor needs, and whose
+// absence crash-looped the container on boot. The read plane must not link the
+// write plane.
+import { collect as collectWarmbly } from "../../warmbly/src/collect.ts";
 import { collectFinanceSnapshot, DefaultFetchTransport, parseAsaasConfig } from "../../asaas/src/index.ts";
 import { evaluatePncpFreshness, loadAdapterConfigFromEnv } from "../../pncp/src/index.ts";
 import { collect as collectInfra, createLivePorts } from "../../infrastructure/src/index.ts";

--- a/control-center/connectors/warmbly/package.json
+++ b/control-center/connectors/warmbly/package.json
@@ -20,7 +20,8 @@
     "collect": "tsx src/cli.ts",
     "canary": "tsx src/canary.ts",
     "cc-connector-canary": "tsx src/canary.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
     "@confenge/control-center-security": "*"

--- a/control-center/connectors/warmbly/src/collector/fetch.ts
+++ b/control-center/connectors/warmbly/src/collector/fetch.ts
@@ -140,6 +140,9 @@ function assignRoute(payload: WarmblyPayload, key: CollectRouteKey, json: unknow
     case "confenge_inbound":
       payload.confenge_inbound = json as WarmblyPayload["confenge_inbound"];
       break;
+    case "confenge_dispatch_status":
+      payload.confenge_dispatch_status = json as WarmblyPayload["confenge_dispatch_status"];
+      break;
     case "confenge_intel_scoreboard": {
       const rec = asRecordOrUndefined(json);
       if (rec) payload.confenge_intel_scoreboard = rec;
@@ -159,6 +162,10 @@ function assignRoute(payload: WarmblyPayload, key: CollectRouteKey, json: unknow
       break;
     }
     default:
+      // A route listed in COLLECT_ROUTES with no case here is fetched, paid
+      // for, and then thrown away. That is how the dispatch reading went
+      // missing after it was added to the route table, so
+      // tests/collector-routes.test.ts asserts every collected key lands.
       break;
   }
 }

--- a/control-center/connectors/warmbly/tests/collector-routes.test.ts
+++ b/control-center/connectors/warmbly/tests/collector-routes.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { COLLECT_ROUTES } from "../src/collector/routes.ts";
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "../src");
+
+/**
+ * `assignRoute` is a hand-written switch. A route added to COLLECT_ROUTES with
+ * no matching case is still fetched — the request is made and paid for — and
+ * then silently dropped, so the surface downstream renders "not observed" about
+ * data that was, in fact, observed.
+ *
+ * That is exactly what happened to `confenge_dispatch_status`: the collector
+ * logged `status: 200` for it while the cockpit reported UNKNOWN.
+ */
+test("every collected route is assigned into the payload, not silently dropped", () => {
+  const fetchSrc = readFileSync(join(srcDir, "collector/fetch.ts"), "utf8");
+  const missing = COLLECT_ROUTES.map((route) => route.key).filter(
+    (key) => !fetchSrc.includes(`case "${key}":`),
+  );
+  assert.deepEqual(
+    missing,
+    [],
+    `these routes are fetched but never assigned in assignRoute: ${missing.join(", ")}`,
+  );
+});

--- a/control-center/connectors/warmbly/tsconfig.build.json
+++ b/control-center/connectors/warmbly/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rewriteRelativeImportExtensions": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": false,
+    "declaration": true,
+    "declarationMap": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/control-center/scripts/build-runtime-packages.mjs
+++ b/control-center/scripts/build-runtime-packages.mjs
@@ -15,12 +15,21 @@ const SETS = {
     "@confenge/control-center-contracts",
     "@confenge/control-center-persistence",
     "@confenge/control-center-attention",
+    // The operator channel is lazy, but a lazy import still has to resolve to
+    // emitted JS. Both ship as source-only otherwise, so the channel would load
+    // nothing and from-env would swallow it as "connector not present".
+    "@confenge/control-center-security",
+    "@confenge/control-center-warmbly-connector",
     "@confenge/control-center-context",
   ],
   mcp: ["@confenge/control-center-contracts", "@confenge/control-center-mcp"],
   collector: [
     "@confenge/control-center-contracts",
     "@confenge/control-center-persistence",
+    // esbuild inlines the warmbly barrel through a relative import but leaves
+    // its @confenge specifiers external, so security stays a real runtime
+    // import on the collector's boot path and needs emitted JS.
+    "@confenge/control-center-security",
     "@confenge/control-center-collector",
   ],
   ops: ["@confenge/control-center-deploy"],

--- a/control-center/security/package.json
+++ b/control-center/security/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "test": "tsx --test tests/*.test.ts",
     "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
     "validate": "tsx src/cli.ts"
   },
   "engines": {

--- a/control-center/security/tsconfig.build.json
+++ b/control-center/security/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": false,
+    "declaration": true,
+    "declarationMap": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/control-center/services/context/Dockerfile
+++ b/control-center/services/context/Dockerfile
@@ -10,10 +10,15 @@ RUN npm ci --ignore-scripts
 RUN node scripts/build-runtime-packages.mjs context
 RUN node scripts/rewrite-runtime-exports.mjs /src
 RUN npm prune --omit=dev --ignore-scripts
+# strip-runtime-tree prunes node_modules/@confenge to exactly this list, so a
+# package left off it loses its workspace symlink even when its directory is
+# copied below. The operator channel resolves both of these at runtime.
 RUN node scripts/strip-runtime-tree.mjs /src \
   @confenge/control-center-contracts \
   @confenge/control-center-persistence \
   @confenge/control-center-attention \
+  @confenge/control-center-security \
+  @confenge/control-center-warmbly-connector \
   @confenge/control-center-context \
   && test ! -e /src/node_modules/tsx \
   && test ! -e /src/node_modules/esbuild \
@@ -36,6 +41,11 @@ COPY --from=builder --chown=node:node /src/persistence ./persistence
 COPY --from=builder --chown=node:node /src/intelligence/attention ./intelligence/attention
 # Optional dependency of the operator channel. Loaded lazily and only when
 # CC_WARMBLY_OPERATOR_ENABLED=true, but it has to be present to be loadable.
+# `security` comes with it: node_modules/@confenge/* are workspace symlinks, so
+# shipping the connector without it leaves a dangling link and the lazy import
+# fails with ERR_MODULE_NOT_FOUND. from-env catches that and stays off, which
+# means enabling the channel would have silently done nothing.
+COPY --from=builder --chown=node:node /src/security ./security
 COPY --from=builder --chown=node:node /src/connectors/warmbly ./connectors/warmbly
 COPY --from=builder --chown=node:node /src/services/context ./services/context
 COPY --from=builder --chown=node:node /src/scripts/node-http-probe.mjs ./node-http-probe.mjs

--- a/docs/ops/FIRST-REAL-EMAIL-COHORT-RUNBOOK.md
+++ b/docs/ops/FIRST-REAL-EMAIL-COHORT-RUNBOOK.md
@@ -1,0 +1,218 @@
+# Runbook — colocar o primeiro cohort real de e-mail em operação
+
+Estado em 2026-08-22. Este documento cobre **apenas o que exige ação humana fora
+do terminal**. Tudo o que podia ser automatizado já foi.
+
+Próxima janela comercial válida: **segunda-feira, 24/08/2026, 09:00 America/São_Paulo**
+(`next_slot_at=2026-08-24T12:00:00Z`, lido ao vivo do Warmbly em produção).
+
+---
+
+## Bloqueio 1 — DKIM ausente no domínio de envio
+
+**Verificado, não presumido.** Sondei 22 selectors contra `1.1.1.1` e `8.8.8.8`,
+incluindo os 14 que o próprio checker do Warmbly conhece
+(`dnsauth.go:59: defaultSelectors`) e os três da Hostinger
+(`hostingermail1/2/3`). Nenhum resolve.
+
+| Registro | Estado | Valor observado |
+|---|---|---|
+| SPF | **PASS** | `v=spf1 include:_spf.mail.hostinger.com ~all` |
+| DMARC | **PASS** (presente) | `v=DMARC1; p=none` |
+| DKIM | **AUSENTE** | nenhum selector resolve |
+| MX | ok | `mx1/mx2.hostinger.com` |
+
+Detalhe que muda o procedimento: **o DNS de `confenge.com.br` está na Cloudflare**
+(`grannbo.ns.cloudflare.com`, `kai.ns.cloudflare.com`), não na Hostinger. Então a
+Hostinger **gera** a chave, mas quem **publica** o registro é a Cloudflare.
+
+### Passo a passo
+
+1. hPanel da Hostinger → **E-mails** → `confenge.com.br` → **Configurações de e-mail**
+   → **DKIM**. Se estiver desabilitado, habilite.
+2. A Hostinger mostrará um registro TXT, tipicamente:
+   - Nome: `hostingermail1._domainkey`
+   - Valor: `v=DKIM1; k=rsa; p=MIIBIjANBg...`
+3. Cloudflare → zona `confenge.com.br` → **DNS** → **Add record**:
+   - Type `TXT`, Name `hostingermail1._domainkey`, Content = o valor do passo 2,
+     Proxy **DNS only**, TTL Auto.
+4. Se a Hostinger mostrar `hostingermail2` / `hostingermail3`, publique os três.
+
+### Como eu confirmo
+
+Me avise e eu rodo a verificação real. Ou você mesmo:
+
+```bash
+python3 - <<'PY'
+import dns.resolver
+r=dns.resolver.Resolver(configure=False); r.nameservers=["1.1.1.1"]
+for s in ("hostingermail1","hostingermail2","hostingermail3"):
+    try: print(s, [x.to_text()[:60] for x in r.resolve(f"{s}._domainkey.confenge.com.br","TXT")])
+    except Exception as e: print(s, type(e).__name__)
+PY
+```
+
+> **Não vou declarar DKIM PASS sem esse registro resolvendo.** Um probe corrigido
+> não é DKIM configurado.
+
+---
+
+## Bloqueio 2 — credenciais SMTP/IMAP vazias em produção
+
+O caminho de rede está **ok**: de dentro do namespace do worker,
+`smtp.hostinger.com:587` e `imap.hostinger.com:993` respondem. O que falta é
+exclusivamente credencial.
+
+Verificado nos três contêineres (`backend`, `worker`, `consumer`):
+
+```
+SMTP_USERNAME=            # vazio
+SMTP_PASSWORD=            # vazio
+CONFENGE_MAILBOX_EMAIL=tiago.sasaki@confenge.com.br
+# CONFENGE_SMTP_PASSWORD / CONFENGE_IMAP_PASSWORD: não definidas
+```
+
+O código lê, em ordem (`internal/app/confenge/release_live.go:183-184`):
+`CONFENGE_IMAP_USER` → `IMAP_USER` → `CONFENGE_MAILBOX_EMAIL`, e
+`CONFENGE_IMAP_PASSWORD` → `IMAP_PASSWORD` → `CONFENGE_MAILBOX_PASSWORD`.
+
+**O que preciso de você:** a senha da caixa `tiago.sasaki@confenge.com.br`
+(ou uma senha de aplicativo criada no hPanel). Me passe e eu escrevo em
+`/opt/warmbly-confenge/.env.confenge` com permissão `600`, reinicio os serviços
+e provo SMTP AUTH + IMAP LOGIN reais.
+
+`MAIL_TRANSPORT=log` **não** é problema: o envio do cohort usa
+`CONFENGE_SMTP_HOST` (Hostinger), separado do transporte de notificação
+(`release_live.go:112`).
+
+---
+
+## Bloqueio 3 — token Warmbly com escrita para o Control Center
+
+O canal de operador está **montado e desligado por padrão** (fail-closed: toda
+rota devolve `404 operator_channel_not_configured`). Para ligar falta um token.
+
+O token do collector é **read-only** — provei com um POST inócuo:
+
+```
+POST /v1/confenge/inbound/00000000-.../acknowledge  →  403
+```
+
+**O que preciso:** um token Warmbly com `PermManageContacts` /
+`APIPermWriteContacts`. Com ele eu:
+
+1. gravo em `/etc/confenge/control-center/secrets/.env`:
+   `CC_WARMBLY_BASE_URL=http://warmbly-confenge-backend-1:8080`
+   `CC_WARMBLY_OPERATOR_TOKEN=<token>`
+2. incluo o overlay já preparado
+   `/etc/confenge/control-center/docker-compose.warmbly-operator.yml`
+3. subo o `context` e rodo o canário completo: pause → readback → resume_confirm
+   → resume → readback → ledger.
+
+O canal continua limitado a exatamente três ações. **Não existe SEND_EMAIL nele
+e não deve passar a existir.**
+
+---
+
+## Bloqueio 4 — o ciclo de observação não fecha (interno)
+
+Descoberto na auditoria, **não** corrigido: corrigir mudaria o que é admitido e
+observado, e isso é decisão sua.
+
+O goal define sucesso como `cohort → envio → resposta/bounce → observação →
+próxima decisão`. A última etapa não se sustenta hoje:
+
+| Evento | Registrado? | Projetado no Control Center? |
+|---|---|---|
+| attempted | parcial (`outreach_touchpoints.state='SENT'`) | não |
+| provider accepted | não distinguível de attempted | não |
+| delivered | **nada registra** | — |
+| hard bounce | sim | não |
+| soft bounce | **descartado antes do classificador** | — |
+| reply | sim | fraco (string-match que na prática vem vazio) |
+| positive reply | sim (`campaign_contact_progress.reply_class`) | não |
+| routed/forwarded | nada para e-mail | — |
+| unsubscribe | sim | não |
+| complaint | sem FBL/webhook | — |
+
+Três causas estruturais:
+
+1. `wmail/bounce.go` faz `if !report.Permanent { return }` — o DSN 4.x.x é
+   descartado antes de qualquer evento. A camada que conhece a classe SMTP joga
+   fora, e a que decide HARD/SOFT recebe só o *subject* do DSN.
+2. Todo evento de controlled-email é carimbado `Synthetic: true`, e o collector
+   lê com `include_synthetic=0`.
+3. O relatório que **tem** as quatro dimensões (`cohort`, `route_class`,
+   `provider`, `policy_version`) é alimentado por um slice em memória e um
+   arquivo `--events`. **Nenhuma query o reconstrói do Postgres.** `provider`
+   nunca é gravado (sempre `UNKNOWN`); `route_class` não sobrevive na linha do
+   evento, só no snapshot congelado.
+
+Consequência prática: com o envio feito, você veria o e-mail sair e não
+conseguiria medir o retorno por coorte ou por rota. Vale tratar antes de
+escalar além do primeiro cohort.
+
+---
+
+## Correções ao enunciado do goal
+
+- **A cohort anterior era N=50, não N=49.** Não existe artefato de N=49 em
+  nenhum dos três repos. Há duas cohorts N=50 de 2026-08-22.
+- **`PROBABILISTIC_OR_RISKY` já é impossível de admitir.** Não há flag:
+  `build_controlled_email_cohort.py:174` recusa a classe incondicionalmente.
+- **O caminho canônico não usa `export-outreach` como comando de operador.**
+  Esse é o exportador do universo completo (~401.923 leads / 402 chunks). O
+  produtor real é `scripts.confenge_outreach_pipeline run`, que chama
+  `export_outreach()` internamente com duas opções que o CLI não expõe.
+- **Orçamento de frescor: 24h** entre o `generated_at` do feed e o dispatch
+  (`CONFENGE_FEED_MAX_AGE`), e o grant vive outras 24h. Foi exatamente isso que
+  queimou a tentativa anterior — o TTL expirou 31,6h antes da janela seguinte
+  abrir. **Não emita a autorização antes de segunda.**
+- **O export nacional falhou da última vez** em `source_watermark` incompleto,
+  e a cohort anterior acabou cortada do hot set de 500 contas da ativação, não
+  do universo nacional. É o defeito que os PRs #454 e #462 atacam; espere
+  precisar verificar isso no primeiro run.
+
+---
+
+## Segunda-feira, 24/08/2026 — o que sobra para você fazer
+
+Com os três bloqueios acima resolvidos, dentro da janela (09:00–18:00 BRT):
+
+1. Abra `https://ops.confenge.com.br`, autentique com MFA.
+2. **Comercial → Coortes**. Confirme `Estado do disparo` e a janela.
+3. Eu produzo/revalido o feed fresco pelo caminho canônico e importo.
+4. **Revise a preview** — ela agora mostra, por destinatário amostrado: empresa,
+   propósito da caixa, assunto, saudação, o fato usado *e a origem dele*, o CTA
+   *e a origem dele*, por que a empresa entrou e por que aquela rota foi
+   escolhida, mais o corpo completo de dois ou três. É aqui que você pega
+   empresa errada, copy estranha ou personalização não merecida.
+5. Emita a autorização fresca (`cohort authorize --actor <seu UUID>`), sem
+   `--confirm` primeiro para ler o resumo.
+6. `GO_FOR_CONTROLLED_EMAIL_PILOT` ao vivo.
+7. Dispatch.
+
+O grant é `cohort/policy bounded` — você **não** aprova 49 mensagens uma a uma.
+
+---
+
+## O que já está pronto e provado
+
+- Control Center em produção com o cockpit de disparo (Governance #49, #51).
+- `resume` de dois passos consertado: antes ele **nunca** completava — o token
+  morria no repaint e cada clique só re-emitia um desafio.
+- Estado do disparo lido tri-state: ausência é `UNKNOWN`, nunca `ATIVO`.
+- Binding do cohort corrigido (warmbly #121): a busca por accounts era uma página
+  de 50 sobre ~402k, e o fallback congelava `uuid.Nil`.
+- Worker target-fit: claim com locks limitados ao lote (extra-cli #461).
+- Semântica do produtor: campo ausente deixou de virar `false` (#454).
+
+## Linha de base de observabilidade, antes do primeiro envio
+
+Lido ao vivo, para que "zero" seja zero e não invenção:
+
+```
+sent_last_hour=0  queued_approved=0  active_leases=0
+paused=false  in_send_window=false  cap=10  min_gap_seconds=360
+window=09:00–18:00 America/Sao_Paulo  next_slot_at=2026-08-24T12:00:00Z
+```


### PR DESCRIPTION
Rebuilding the collector after #51 crash-looped production:

    Error [ERR_MODULE_NOT_FOUND]: Cannot find package
    '@confenge/control-center-security' imported from
    /app/connectors/runner/dist/server.js

`connectors/runner/src/run.ts` imported the warmbly connector's *barrel*, which
re-exports the operator channel, which imports `control-center-security`. So a
read-only collector had the write plane on its static boot path — and the image
never shipped that package. The context service had the same gap: its lazy
`from-env` import would have failed the same way, been swallowed as
`connector_unavailable`, and left the operator channel silently dead with
`CC_WARMBLY_OPERATOR_ENABLED=true`.

## A COPY line is not enough here

Three lists have to agree, not one:

1. `scripts/build-runtime-packages.mjs` — which workspaces get emitted to `dist/`
2. the `strip-runtime-tree` keep-args — this **deletes** every
   `node_modules/@confenge/*` symlink not named
3. the `COPY` lines — which directories reach the image

Adding only (3) leaves a copied directory with no symlink pointing at it and no
`dist/` to point to. `security` had no `build` script at all, while
`rewrite-runtime-exports.mjs` had already repointed its `exports` at
`./dist/index.js`. All three lists are now aligned, and both new
`tsconfig.build.json` files mirror `contracts`.

## The narrow import

`run.ts` now imports `collect.ts` directly instead of the barrel, so the read
plane does not link the write plane at all. The image-level fix is kept anyway:
it makes the image correct whichever import the collector uses.

## A route that was fetched and thrown away

`assignRoute` is a hand-written switch and `confenge_dispatch_status` had no
case, so the collector logged `status: 200` for it while the cockpit reported
UNKNOWN. Adding the case is the fix; `tests/collector-routes.test.ts` is what
stops the next route from disappearing the same way.

## A block that never reached the surface

`operationsFromWarmbly` rebuilds most of `operations` from the raw payload, so
the connector's `dispatch` block had to be forwarded explicitly. It falls back
to an explicit UNKNOWN rather than omitting the key — absence of a reading is
not evidence that dispatch is running.

Verified in production: the collector is healthy and the live reading now
reaches the surface end to end — `state=ACTIVE observed=true
in_send_window=false next_slot_at=2026-08-24T12:00:00Z cap=10`.

typecheck clean across all 20 workspaces; `test:hardening` 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)