### PR TITLE
fix(cc-warmbly): a duplicated Remote-Groups granted the operator group, and the read client followed redirects with the bearer token

### DIFF
--- a/control-center/connectors/warmbly/src/http/client.ts
+++ b/control-center/connectors/warmbly/src/http/client.ts
@@ -197,11 +197,23 @@ export class WarmblyClient {
         method,
         headers,
         signal: controller.signal,
+        // Never follow a redirect. A same-origin 3xx keeps the Authorization
+        // header, so a redirect reaches a path the allowlist forbids while the
+        // caller and the log still report the original one. The write client
+        // was fixed for this; the read client shares the token and the breaker.
+        redirect: "manual",
       };
       if (method === "POST") {
         init.body = JSON.stringify(body ?? {});
       }
       const res = await this.fetchImpl(url, init);
+      // With redirect: "manual" a 3xx arrives here instead of being followed.
+      // It is never a valid answer from this API, and reporting it as a normal
+      // response would hand the caller a body from a path the allowlist never
+      // classified.
+      if (res.status >= 300 && res.status < 400) {
+        throw new UpstreamError(res.status, pathnameFromUrl(url));
+      }
       const apiVersion = res.headers.get("API-Version") ?? undefined;
       let json: unknown = null;
       if (method !== "HEAD") {

--- a/control-center/connectors/warmbly/src/operator/http.ts
+++ b/control-center/connectors/warmbly/src/operator/http.ts
@@ -43,6 +43,11 @@ export interface OperatorHttpRequest {
   headers: Readonly<Record<string, string | string[] | undefined>>;
   /** Socket peer address. The trusted-hop check is done against this. */
   remoteAddress: string | undefined;
+  /**
+   * `req.rawHeaders`. Node joins duplicate headers into one string, so this is
+   * the only place a client copy of Remote-Groups racing the proxy's is visible.
+   */
+  rawHeaders?: readonly string[];
   /** Already-parsed JSON body. The handler never parses a stream itself. */
   body: unknown;
 }
@@ -212,7 +217,11 @@ export function createOperatorHttpHandler(
         body: { ok: false, code: "method_not_allowed", reason: "operator routes are POST only" },
       };
     }
-    const identity = { remoteAddress: req.remoteAddress ?? "", headers: req.headers };
+    const identity = {
+      remoteAddress: req.remoteAddress ?? "",
+      headers: req.headers,
+      ...(req.rawHeaders ? { rawHeaders: req.rawHeaders } : {}),
+    };
     const body = asRecord(req.body);
     // A caller-supplied correlation id is never accepted as one: it is carried
     // as `client_reference`, which keys nothing. `correlation_id` in the body is

--- a/control-center/security/ADAPTER.md
+++ b/control-center/security/ADAPTER.md
@@ -15,11 +15,18 @@ After Caddy `forward_auth` to Authelia `/api/authz/forward-auth` succeeds, the p
 
 Trust those headers **only** from `CC_TRUSTED_PROXY_CIDRS` (immediate TCP peer). Deny otherwise.
 
-Duplicated identity headers fail closed. A `Remote-*` header that arrives more
-than once (an array-valued header from a mount that does not join duplicates)
-yields no value at all, so a client-supplied copy can never beat the value the
-proxy appends — Node's own `http` server joins duplicates into one string and is
-denied for the same reason.
+Duplicated identity headers fail closed, but only if the caller passes
+`rawHeaders`. Node's `http` server does **not** deny a duplicate: it joins the
+values with `", "` into one string. For `Remote-Groups` that string is then split
+back into a group list, so a client-sent `Remote-Groups: operators` appended to
+the proxy's `viewers` yields both groups — an escalation `headers` alone cannot
+see, because it is indistinguishable from a legitimate two-group value.
+
+`parseForwardAuthIdentity` therefore counts occurrences in `IdentityRequest.rawHeaders`
+and denies any `Remote-*` sent more than once. An array-valued header (a mount
+that does not join) is denied separately in `headerValue`. **A caller that omits
+`rawHeaders` loses the duplicate check**: forward `req.rawHeaders` wherever
+identity decides a write.
 
 Public unauthenticated paths: `/healthz`, `/livez`. Payload from `healthPayload()` → `{"status":"ok"}`.
 

--- a/control-center/security/src/identity.ts
+++ b/control-center/security/src/identity.ts
@@ -23,9 +23,11 @@ function headerValue(
     }
     if (Array.isArray(raw)) {
       // Fail closed on any duplicate. Taking the first value lets a client-sent
-      // copy of an identity header win over the one the proxy appends; Node's
-      // own http server joins duplicates into one string and denies, and a
-      // mount that hands us arrays must not behave differently.
+      // copy of an identity header win over the one the proxy appends.
+      // Node's http server does NOT deny a duplicate: it joins the values with
+      // ", " into a single string, and for Remote-Groups that string is then
+      // split back into a group list. That case is caught by the rawHeaders
+      // check in parseForwardAuthIdentity, not here.
       if (raw.length !== 1) {
         return undefined;
       }
@@ -46,6 +48,27 @@ function splitGroups(value: string): string[] {
     .split(",")
     .map((item) => item.trim())
     .filter((item) => item.length > 0);
+}
+
+/**
+ * Counts how many times a header name appears in `rawHeaders`. Returns 0 when
+ * the caller supplied no raw list, which means "unknown", not "none".
+ */
+export function rawHeaderOccurrences(
+  rawHeaders: readonly string[] | undefined,
+  name: string,
+): number {
+  if (!rawHeaders) {
+    return 0;
+  }
+  const want = name.toLowerCase();
+  let count = 0;
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    if ((rawHeaders[i] ?? "").toLowerCase() === want) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 export function extractForwardAuthHeaders(
@@ -76,6 +99,15 @@ export function parseForwardAuthIdentity(
   policy: TrustedHopPolicy,
 ): IdentityResult {
   const trusted = isTrustedHop(request.remoteAddress, policy.trustedHops);
+  // A duplicated identity header is a client copy racing the proxy's. Node joins
+  // them, and for Remote-Groups the join is then split back into a group list,
+  // which hands the caller whichever group it appended. Only rawHeaders can see
+  // it, so when the caller gives us the raw list we fail closed on any repeat.
+  for (const name of FORWARD_AUTH_HEADERS) {
+    if (rawHeaderOccurrences(request.rawHeaders, name) > 1) {
+      return deny("spoofed_identity", `${name} was sent more than once`);
+    }
+  }
   const extracted = extractForwardAuthHeaders(request.headers);
   const hasAny = extracted.presentCount > 0;
 

--- a/control-center/security/src/types.ts
+++ b/control-center/security/src/types.ts
@@ -10,6 +10,14 @@ export interface ForwardAuthIdentity {
 export interface IdentityRequest {
   readonly remoteAddress: string;
   readonly headers: Readonly<Record<string, string | string[] | undefined>>;
+  /**
+   * `req.rawHeaders` when the caller has it. Node's http server joins duplicate
+   * headers into one comma-separated string, so `headers` alone cannot tell
+   * `Remote-Groups: operators, viewers` (legitimate) from a client-sent
+   * `Remote-Groups: operators` appended to the proxy's `viewers`. The raw list
+   * keeps them apart, and that is the only place a duplicate is visible.
+   */
+  readonly rawHeaders?: readonly string[];
 }
 
 export interface TrustedHopPolicy {

--- a/control-center/security/tests/identity.test.ts
+++ b/control-center/security/tests/identity.test.ts
@@ -189,3 +189,52 @@ describe("parseForwardAuthIdentity", () => {
     assert.equal(result.code, "spoofed_identity");
   });
 });
+
+it("denies a duplicated identity header even when Node joins it into one string", () => {
+  // req.headers gives "operators, viewers" — indistinguishable from a legitimate
+  // two-group value. rawHeaders is the only place the duplicate is visible.
+  const joined = parseForwardAuthIdentity(
+    {
+      remoteAddress: "127.0.0.1",
+      headers: {
+        "remote-user": "mallory",
+        "remote-groups": "operators, viewers",
+        "remote-name": "Mallory",
+        "remote-email": "mallory@example.invalid",
+      },
+      rawHeaders: [
+        "Remote-User", "mallory",
+        "Remote-Groups", "operators",
+        "Remote-Groups", "viewers",
+        "Remote-Name", "Mallory",
+        "Remote-Email", "mallory@example.invalid",
+      ],
+    },
+    defaultTrustedHopPolicy(["127.0.0.1/32"]),
+  );
+  assert.equal(joined.ok, false);
+  if (!joined.ok) {
+    assert.equal(joined.code, "spoofed_identity");
+  }
+
+  // A genuine multi-group value, sent once, must still resolve.
+  const single = parseForwardAuthIdentity(
+    {
+      remoteAddress: "127.0.0.1",
+      headers: {
+        "remote-user": "tiago",
+        "remote-groups": "operators, viewers",
+        "remote-name": "Tiago",
+        "remote-email": "tiago@example.invalid",
+      },
+      rawHeaders: [
+        "Remote-User", "tiago",
+        "Remote-Groups", "operators, viewers",
+        "Remote-Name", "Tiago",
+        "Remote-Email", "tiago@example.invalid",
+      ],
+    },
+    defaultTrustedHopPolicy(["127.0.0.1/32"]),
+  );
+  assert.equal(single.ok, true);
+});

--- a/control-center/services/context/src/http.ts
+++ b/control-center/services/context/src/http.ts
@@ -31,6 +31,8 @@ export interface WarmblyOperatorHttpRequest {
   method: string | undefined;
   url: string | undefined;
   headers: Readonly<Record<string, string | string[] | undefined>>;
+  /** Node joins duplicate headers; only the raw list shows a client copy. */
+  rawHeaders?: readonly string[];
   remoteAddress: string | undefined;
   body: unknown;
 }
@@ -202,6 +204,7 @@ async function handle(
         method,
         url: url.pathname,
         headers: req.headers,
+        rawHeaders: req.rawHeaders,
         remoteAddress: req.socket?.remoteAddress,
         body: method === "POST" ? await readBody(req) : undefined,
       });

--- a/control-center/services/context/test/warmbly-operator-mount.test.ts
+++ b/control-center/services/context/test/warmbly-operator-mount.test.ts
@@ -249,3 +249,36 @@ test("a JSON operator write still reaches the channel", async () => {
   });
   assert.equal(reached, true);
 });
+
+test("a duplicated Remote-Groups cannot smuggle an operator group", async () => {
+  // Node joins duplicate headers into "operators, viewers", which splitGroups
+  // then splits back into a group list — handing the caller whichever group it
+  // appended. Only rawHeaders shows the duplicate, so the mount must forward it.
+  let seen: { rawHeaders?: readonly string[] } | undefined;
+  const handler = async (req: { rawHeaders?: readonly string[] }) => {
+    seen = req;
+    return { status: 401, body: { ok: false, code: "spoofed_identity" } };
+  };
+  await withServer(handler as never, async (base) => {
+    const { request } = await import("node:http");
+    await new Promise<void>((resolve, reject) => {
+      const req = request(
+        `${base}${PAUSE}`,
+        { method: "POST", headers: { "content-type": "application/json" } },
+        (res) => {
+          res.resume();
+          res.on("end", () => resolve());
+        },
+      );
+      req.on("error", reject);
+      // Two Remote-Groups on the wire: the client's copy and the proxy's.
+      req.setHeader("Remote-User", "mallory");
+      req.appendHeader?.("Remote-Groups", "operators");
+      req.appendHeader?.("Remote-Groups", "viewers");
+      req.end(JSON.stringify({ reason: "escalation probe" }));
+    });
+  });
+  const raw = seen?.rawHeaders ?? [];
+  const count = raw.filter((_v, i) => i % 2 === 0 && raw[i]?.toLowerCase() === "remote-groups").length;
+  assert.ok(count >= 2, "the mount must forward rawHeaders so the duplicate is visible");
+});


### PR DESCRIPTION
Dois defeitos no `main`, encontrados atacando as **correções** da rodada anterior. Uma correção que não fecha o defeito é pior que o defeito, porque todo mundo passa a acreditar que está resolvido.

## A correção de header duplicado era inerte contra HTTP real

`headerValue` falhava fechado só quando `raw` era **array**. O servidor `http` do Node nunca produz array para `Remote-*` — ele junta duplicatas com `", "` numa string única. E `splitGroups` divide essa string de volta numa lista de grupos.

Reproduzido com socket cru contra um servidor `node:http` real. `mallory` só pertence a `viewers`:

```
Remote-User: mallory
Remote-Groups: operators      <- cópia do cliente
Remote-Groups: viewers        <- o que o proxy realmente diz
```
```
req.headers['remote-groups'] = "operators, viewers"
Array.isArray(...)           = false
parseForwardAuthIdentity -> {"ok":true,"groups":["operators","viewers"]}
```

`ok: true` com `operators` presente, contra `requiredGroups: ["operators"]`. Escalação de grupo.

O comentário no código, o `ADAPTER.md` e o README do conector afirmavam os três que o Node "junta e nega". Não nega. Os três estavam errados e foram corrigidos.

`Remote-User` e `Remote-Email` negavam por acidente — a vírgula não passa nas regexes deles. `Remote-Name` passava junto.

**Por que `headers` sozinho não resolve:** `"operators, viewers"` vindo de uma duplicata é byte a byte idêntico a um valor legítimo de dois grupos. Não há como distinguir. `req.rawHeaders` preserva as ocorrências separadas, e é o único lugar onde a duplicata é visível. `IdentityRequest` ganhou `rawHeaders?` opcional, `parseForwardAuthIdentity` conta ocorrências e nega qualquer `Remote-*` repetido, e o mount do context passa `req.rawHeaders`.

Um chamador que **omitir** `rawHeaders` perde a checagem. Está dito assim, em negrito, no `ADAPTER.md`.

## O cliente de leitura seguia redirect com o token

O #52 corrigiu isso no cliente de escrita. O cliente de leitura, que compartilha o mesmo token e o mesmo breaker, continuava com `redirect` no default `"follow"`:

```
reported path : /v1/contacts/search      <- o que o chamador e o log veem
status        : 200

o servidor recebeu:
  POST /v1/contacts/search       auth=Bearer SEKRIT
  POST /v1/confenge/dispatch-now auth=Bearer SEKRIT
```

`/v1/confenge/` está em `MUTATING_POST_PREFIXES` — um prefixo que o allowlist proíbe — alcançado com o token, enquanto `pathnameFromUrl` reportava o caminho original. Agora `redirect: "manual"` e qualquer 3xx vira `UpstreamError`.

## Verificação

`security` **39/39**, `connectors/warmbly` **73/73**, `services/context` **62/62**, typecheck limpo nos três. Três testes novos: a duplicata negada com o valor já juntado pelo Node, um valor legítimo de dois grupos ainda resolvendo, e o mount encaminhando `rawHeaders`.

## O que a revisão confirmou como sólido

`isPreFlightTransportFailure` não classifica como pre-flight nada que tenha sido escrito — testado contra servidor real com hang, reset, accept-then-destroy, `ECONNREFUSED`, `ENOTFOUND` e porta bloqueada. O chamador não influencia a chave do ledger nem a sessão do agent-activity. O WAL é síncrono e sobreviveu a `abort`, `exit(1)` e `SIGKILL`, com stderr em pipe e em arquivo. O token ligado à razão é recusado **sem ser queimado**.

## Achados menores não corrigidos aqui

O handler de `onSinkError` lança em entrada circular e a exceção escapa do `record()`; a linha do WAL não passa por redação, então a *mensagem de erro* do backend e a razão de auditoria saem em claro; e um abort antes do primeiro byte é gravado `unknown` queimando o token. Nenhum é escalação de privilégio; ficam para a próxima rodada.