### PR TITLE
fix(control-center): denominate the pipeline from evidence, not from an upstream default (#69)

### DIFF
--- a/control-center/apps/web-shell/src/adapters/map.ts
+++ b/control-center/apps/web-shell/src/adapters/map.ts
@@ -273,7 +273,13 @@ export function commercialFrom(row: Record<string, unknown>, fallback: Provenanc
     const split = row.pipeline_nominal_by_currency
       .map((item) => moneyOf(item))
       .filter((money): money is Money => money !== undefined);
-    if (split.length > 1) snap.pipeline_nominal_by_currency = split;
+    if (split.length > 1) {
+      snap.pipeline_nominal_by_currency = split;
+    } else if (split.length === 1 && !snap.pipeline_nominal) {
+      // One readable currency left is a total, not a split, and not absence.
+      const only = split[0];
+      if (only) snap.pipeline_nominal = only;
+    }
   }
   if (weighted && weighted.probability_reliable === true) {
     const money = moneyOf(weighted);

--- a/control-center/apps/web-shell/src/adapters/map.ts
+++ b/control-center/apps/web-shell/src/adapters/map.ts
@@ -269,6 +269,12 @@ export function commercialFrom(row: Record<string, unknown>, fallback: Provenanc
   }
   const nominal = moneyOf(row.pipeline_nominal);
   if (nominal) snap.pipeline_nominal = nominal;
+  if (Array.isArray(row.pipeline_nominal_by_currency)) {
+    const split = row.pipeline_nominal_by_currency
+      .map((item) => moneyOf(item))
+      .filter((money): money is Money => money !== undefined);
+    if (split.length > 1) snap.pipeline_nominal_by_currency = split;
+  }
   if (weighted && weighted.probability_reliable === true) {
     const money = moneyOf(weighted);
     if (money) snap.pipeline_weighted = { ...money, probability_reliable: true };

--- a/control-center/apps/web-shell/src/types.ts
+++ b/control-center/apps/web-shell/src/types.ts
@@ -239,6 +239,8 @@ export interface CommercialSnapshot {
   };
   funnel?: CommercialFunnel;
   pipeline_nominal?: Money;
+  /** Separate totals per currency. Present only when the pipeline spans more than one. */
+  pipeline_nominal_by_currency?: Money[];
   pipeline_weighted?: WeightedPipeline;
   aging_count?: number;
   stalled_count?: number;

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -74,23 +74,18 @@ function pipelineNominalFact(snapshot: CommercialSnapshot): string {
 }
 
 /**
- * A deal amount is only shown in a currency the payload actually stated. An
- * amount whose currency is missing or unreadable reads "sem dados" rather than
- * borrowing BRL from the catalog and looking like a confirmed figure.
+ * A deal amount is only shown in a currency the read model actually stated.
+ * It no longer borrows BRL from the catalog, which used to make an
+ * undenominated figure look confirmed. An amount that cannot be read shows no
+ * money line; giving absence a visible word here belongs to the zero/ausente
+ * vocabulary in #62, not to this fix.
  */
-function dealMoneyLine(value: unknown, withheld: unknown): string {
+function dealMoneyLine(value: unknown): string {
   const money = readableMoney(value);
-  if (money) {
-    return `<p class="money" data-currency="${escapeHtml(money.currency)}">${escapeHtml(formatMoney(money))}</p>`;
-  }
-  // Only when the read model says an amount existed and could not be
-  // denominated. A deal that simply never named a value shows no money line.
-  if (withheld !== undefined && withheld !== null) {
-    return `<p class="money" data-no-data="true" data-withheld="${escapeHtml(String(withheld))}">sem dados</p>`;
-  }
-  return value === undefined || value === null ? "" : `<p class="money" data-no-data="true">sem dados</p>`;
+  return money
+    ? `<p class="money" data-currency="${escapeHtml(money.currency)}">${escapeHtml(formatMoney(money))}</p>`
+    : "";
 }
-
 function listFact(label: string, items: string[] | undefined): string {
   if (!items || items.length === 0) return "";
   return fact(label, escapeHtml(items.join(", ")));
@@ -457,7 +452,7 @@ function commercialOps(snapshot: CommercialSnapshot, surface: string | null): st
               return `<article class="card" data-stale="${row.stale === true ? "true" : "false"}">
                 <p class="kicker">${escapeHtml(String(row.stage ?? row.status ?? ""))} ${row.stale === true ? "· stale" : ""}</p>
                 <h3>${escapeHtml(String(row.display_name ?? row.id ?? "deal"))}</h3>
-                ${dealMoneyLine(row.value, row.value_unavailable)}
+                ${dealMoneyLine(row.value)}
                 <dl class="facts">
                   ${fact("Próxima ação", String(row.next_action ?? "ausente"))}
                   ${fact("Idade (s)", String(row.age_seconds ?? "—"))}

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -78,12 +78,17 @@ function pipelineNominalFact(snapshot: CommercialSnapshot): string {
  * amount whose currency is missing or unreadable reads "sem dados" rather than
  * borrowing BRL from the catalog and looking like a confirmed figure.
  */
-function dealMoneyLine(value: unknown): string {
-  if (value === undefined || value === null) return "";
+function dealMoneyLine(value: unknown, withheld: unknown): string {
   const money = readableMoney(value);
-  return money
-    ? `<p class="money" data-currency="${escapeHtml(money.currency)}">${escapeHtml(formatMoney(money))}</p>`
-    : `<p class="money" data-no-data="true">sem dados</p>`;
+  if (money) {
+    return `<p class="money" data-currency="${escapeHtml(money.currency)}">${escapeHtml(formatMoney(money))}</p>`;
+  }
+  // Only when the read model says an amount existed and could not be
+  // denominated. A deal that simply never named a value shows no money line.
+  if (withheld !== undefined && withheld !== null) {
+    return `<p class="money" data-no-data="true" data-withheld="${escapeHtml(String(withheld))}">sem dados</p>`;
+  }
+  return value === undefined || value === null ? "" : `<p class="money" data-no-data="true">sem dados</p>`;
 }
 
 function listFact(label: string, items: string[] | undefined): string {
@@ -248,7 +253,7 @@ export function commercialBlock(snapshot: CommercialSnapshot, surface: string | 
   const weighted =
     snapshot.pipeline_weighted && snapshot.pipeline_weighted.probability_reliable
       ? moneyFact("Pipeline ponderado (probabilidade confiável)", snapshot.pipeline_weighted)
-      : fact("Pipeline ponderado", "omitido — probabilidade não confiável");
+      : fact("Pipeline ponderado", "omitido — sem base confiável para ponderar");
   const extra = snapshot.extra_historical
     ? fact(
         snapshot.extra_historical.label ?? "Extra histórica",
@@ -452,7 +457,7 @@ function commercialOps(snapshot: CommercialSnapshot, surface: string | null): st
               return `<article class="card" data-stale="${row.stale === true ? "true" : "false"}">
                 <p class="kicker">${escapeHtml(String(row.stage ?? row.status ?? ""))} ${row.stale === true ? "· stale" : ""}</p>
                 <h3>${escapeHtml(String(row.display_name ?? row.id ?? "deal"))}</h3>
-                ${dealMoneyLine(row.value)}
+                ${dealMoneyLine(row.value, row.value_unavailable)}
                 <dl class="facts">
                   ${fact("Próxima ação", String(row.next_action ?? "ausente"))}
                   ${fact("Idade (s)", String(row.age_seconds ?? "—"))}

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -35,6 +35,57 @@ function moneyFact(label: string, money: { amount_cents: number; currency: strin
   `;
 }
 
+const ISO_4217 = /^[A-Z]{3}$/;
+
+/**
+ * A value the read model could not denominate is unknown, and an unknown reads
+ * "sem dados". It must never be painted as `0,00`, which looks measured.
+ */
+function noDataFact(label: string): string {
+  return fact(label, "sem dados", ` data-absent="true" data-no-data="true"`);
+}
+
+function readableMoney(value: unknown): { amount_cents: number; currency: string } | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const rec = value as { amount_cents?: unknown; currency?: unknown };
+  if (!Number.isInteger(rec.amount_cents)) return undefined;
+  if (typeof rec.currency !== "string" || !ISO_4217.test(rec.currency)) return undefined;
+  return { amount_cents: rec.amount_cents as number, currency: rec.currency };
+}
+
+/**
+ * Pipeline nominal. Multi-currency pipelines are shown as separate totals per
+ * currency — never added together, because the Control Center has no rate
+ * source with a date to convert with.
+ */
+function pipelineNominalFact(snapshot: CommercialSnapshot): string {
+  const split = (snapshot.pipeline_nominal_by_currency ?? [])
+    .map((money) => readableMoney(money))
+    .filter((money): money is { amount_cents: number; currency: string } => money !== undefined);
+  if (split.length > 1) {
+    return fact(
+      "Pipeline nominal",
+      split.map((money) => escapeHtml(formatMoney(money))).join(" · "),
+      ` data-currency-split="${split.length}"`,
+    );
+  }
+  const single = readableMoney(snapshot.pipeline_nominal) ?? split[0];
+  return single ? moneyFact("Pipeline nominal", single) : noDataFact("Pipeline nominal");
+}
+
+/**
+ * A deal amount is only shown in a currency the payload actually stated. An
+ * amount whose currency is missing or unreadable reads "sem dados" rather than
+ * borrowing BRL from the catalog and looking like a confirmed figure.
+ */
+function dealMoneyLine(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  const money = readableMoney(value);
+  return money
+    ? `<p class="money" data-currency="${escapeHtml(money.currency)}">${escapeHtml(formatMoney(money))}</p>`
+    : `<p class="money" data-no-data="true">sem dados</p>`;
+}
+
 function listFact(label: string, items: string[] | undefined): string {
   if (!items || items.length === 0) return "";
   return fact(label, escapeHtml(items.join(", ")));
@@ -225,7 +276,7 @@ export function commercialBlock(snapshot: CommercialSnapshot, surface: string | 
         ${optionalCount("Oportunidades", funnel?.opportunities)}
         ${optionalCount("Propostas", funnel?.proposals)}
         ${optionalCount("Clientes", funnel?.clients)}
-        ${snapshot.pipeline_nominal ? moneyFact("Pipeline nominal", snapshot.pipeline_nominal) : ""}
+        ${pipelineNominalFact(snapshot)}
         ${weighted}
         ${typeof snapshot.aging_count === "number" ? fact("Aging", String(snapshot.aging_count)) : ""}
         ${typeof snapshot.missing_next_action_count === "number" ? fact("Missing next action", String(snapshot.missing_next_action_count)) : ""}
@@ -398,11 +449,10 @@ function commercialOps(snapshot: CommercialSnapshot, surface: string | null): st
         : pipeline
             .map((item) => {
               const row = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
-              const value = row.value && typeof row.value === "object" ? (row.value as { amount_cents?: number; currency?: string }) : null;
               return `<article class="card" data-stale="${row.stale === true ? "true" : "false"}">
                 <p class="kicker">${escapeHtml(String(row.stage ?? row.status ?? ""))} ${row.stale === true ? "· stale" : ""}</p>
                 <h3>${escapeHtml(String(row.display_name ?? row.id ?? "deal"))}</h3>
-                ${value && typeof value.amount_cents === "number" ? `<p class="money">${escapeHtml(formatMoney({ amount_cents: value.amount_cents, currency: value.currency ?? "BRL" }))}</p>` : ""}
+                ${dealMoneyLine(row.value)}
                 <dl class="facts">
                   ${fact("Próxima ação", String(row.next_action ?? "ausente"))}
                   ${fact("Idade (s)", String(row.age_seconds ?? "—"))}

--- a/control-center/apps/web-shell/tests/domain-fields.test.ts
+++ b/control-center/apps/web-shell/tests/domain-fields.test.ts
@@ -216,5 +216,5 @@ test("weighted pipeline without reliable probability is omitted", () => {
       },
     },
   });
-  assert.match(html, /omitido — probabilidade não confiável/);
+  assert.match(html, /omitido — sem base confiável para ponderar/);
 });

--- a/control-center/apps/web-shell/tests/pipeline-currency.test.ts
+++ b/control-center/apps/web-shell/tests/pipeline-currency.test.ts
@@ -107,10 +107,9 @@ test("a pipeline whose currency the read model could not parse is not painted", 
   assert.doesNotMatch(html, /reais/);
 });
 
-test("deal cards use each deal's own currency and mark a withheld amount", () => {
-  // These are the three shapes the commercial projector actually emits for
-  // `operations.pipeline[].value`: a denominated amount, no amount at all, and
-  // an amount it refused to denominate (flagged with `value_unavailable`).
+test("deal cards use each deal's own currency instead of a blanket BRL", () => {
+  // The shapes the commercial projector actually emits for
+  // `operations.pipeline[].value`: a denominated amount, or none at all.
   const html = commercialBlock(
     {
       schema_version: "control-center.commercial-snapshot.v1",
@@ -132,20 +131,17 @@ test("deal cards use each deal's own currency and mark a withheld amount", () =>
         pipeline: [
           { id: "d1", display_name: "Em BRL", status: "open", value: { amount_cents: 100, currency: "BRL" } },
           { id: "d2", display_name: "Em USD", status: "open", value: { amount_cents: 5000, currency: "USD" } },
-          { id: "d3", display_name: "Retido", status: "open", value_unavailable: "unreadable_currency" },
-          { id: "d4", display_name: "Sem valor", status: "open" },
+          { id: "d3", display_name: "Sem valor", status: "open" },
         ],
       },
     } as unknown as CommercialSnapshot,
     "pipeline",
   );
-  // Each card carries the currency of its own deal, not a blanket BRL.
   assert.match(html, /BRL 1,00/);
   assert.match(html, /USD 50,00/);
+  // The USD deal must not be restamped in the catalog currency.
   assert.doesNotMatch(html, /BRL 50,00/);
-  // The withheld amount says so; the deal that never named one stays silent.
-  assert.equal([...html.matchAll(/data-withheld="unreadable_currency">sem dados/g)].length, 1);
-  assert.equal([...html.matchAll(/class="money"/g)].length, 3);
+  assert.equal([...html.matchAll(/class="money"/g)].length, 2);
 });
 
 test("commercialFrom carries per-currency totals through only when there is more than one", () => {

--- a/control-center/apps/web-shell/tests/pipeline-currency.test.ts
+++ b/control-center/apps/web-shell/tests/pipeline-currency.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { renderShell } from "../src/ui/render";
+import { commercialBlock } from "../src/ui/domains";
+import { commercialFrom, fallbackProvenance } from "../src/adapters/map";
+import type { CommercialSnapshot } from "../src/types";
+
+const FALLBACK = fallbackProvenance("test", "2026-08-20T18:00:00.000Z");
+
+function comercial(commercial: Record<string, unknown>): string {
+  return renderShell({
+    destination: "comercial",
+    viewKind: "ready",
+    mockScenario: "http",
+    adapterMode: "http",
+    view: {
+      kind: "ready",
+      data: {
+        id: "comercial",
+        label: "Comercial",
+        scope: "commercial",
+        generated_at: "2026-08-20T18:00:00Z",
+        operator: { kind: "human", id: "human:operator" },
+        headline: "x",
+        attention: [],
+        priorities: [],
+        commercial: {
+          schema_version: "control-center.commercial-snapshot.v1",
+          id: "cc:commercial-snapshot:currency",
+          scope: "commercial",
+          generated_at: "2026-08-20T18:00:00Z",
+          provenance: {
+            source: { system: "warmbly", kind: "crm-read-model", locator: "x" },
+            observed_at: "2026-08-20T18:00:00Z",
+            freshness_status: "FRESH",
+            confidence: 1,
+          },
+          authority: {
+            catalog_authority: "governance",
+            commercial_runtime: "warmbly",
+            this_document: "read_model",
+          },
+          pipeline_open_count: 0,
+          ...commercial,
+        } as unknown as CommercialSnapshot,
+      },
+    },
+  });
+}
+
+test("a BRL catalog pipeline is shown in BRL", () => {
+  const html = comercial({ pipeline_nominal: { amount_cents: 4_800_000, currency: "BRL" } });
+  assert.match(html, /Pipeline nominal[\s\S]{0,200}BRL 48\.000,00/);
+  assert.doesNotMatch(html, /USD/);
+});
+
+test("an absent pipeline reads sem dados, never 0,00", () => {
+  const html = comercial({});
+  assert.match(html, /Pipeline nominal[\s\S]{0,200}sem dados/);
+  assert.doesNotMatch(html, /Pipeline nominal[\s\S]{0,200}0,00/);
+});
+
+test("a multi-currency pipeline shows a total per currency and never a merged one", () => {
+  const html = comercial({
+    pipeline_nominal_by_currency: [
+      { amount_cents: 10_000, currency: "BRL" },
+      { amount_cents: 5_000, currency: "USD" },
+    ],
+  });
+  assert.match(html, /data-currency-split="2"/);
+  assert.match(html, /BRL 100,00/);
+  assert.match(html, /USD 50,00/);
+  // 150,00 would be BRL and USD added together, which no rate here justifies.
+  assert.doesNotMatch(html, /150,00/);
+});
+
+test("a pipeline whose currency the read model could not parse is not painted", () => {
+  const html = comercial({ pipeline_nominal: { amount_cents: 100, currency: "reais" } });
+  assert.match(html, /Pipeline nominal[\s\S]{0,200}sem dados/);
+  assert.doesNotMatch(html, /reais/);
+});
+
+test("an open deal with no readable currency reads sem dados instead of borrowing BRL", () => {
+  const html = commercialBlock(
+    {
+      schema_version: "control-center.commercial-snapshot.v1",
+      id: "cc:commercial-snapshot:deals",
+      scope: "commercial",
+      generated_at: "2026-08-20T18:00:00Z",
+      provenance: {
+        source: { system: "warmbly", kind: "crm-read-model", locator: "x" },
+        observed_at: "2026-08-20T18:00:00Z",
+        freshness_status: "FRESH",
+        confidence: 1,
+      },
+      authority: {
+        catalog_authority: "governance",
+        commercial_runtime: "warmbly",
+        this_document: "read_model",
+      },
+      operations: {
+        pipeline: [
+          { id: "d1", display_name: "Com moeda", status: "open", value: { amount_cents: 100, currency: "BRL" } },
+          { id: "d2", display_name: "Sem moeda", status: "open", value: { amount_cents: 100 } },
+          { id: "d3", display_name: "Moeda ilegível", status: "open", value: { amount_cents: 100, currency: "reais" } },
+        ],
+      },
+    } as unknown as CommercialSnapshot,
+    "pipeline",
+  );
+  assert.match(html, /BRL 1,00/);
+  assert.equal([...html.matchAll(/data-no-data="true">sem dados/g)].length, 2);
+  assert.doesNotMatch(html, /reais/);
+});
+
+test("commercialFrom carries per-currency totals through only when there is more than one", () => {
+  const row = {
+    id: "cc:commercial-snapshot:split",
+    scope: "commercial",
+    generated_at: "2026-08-20T18:00:00Z",
+    provenance: {
+      source: { system: "warmbly", kind: "crm-read-model", locator: "x" },
+      observed_at: "2026-08-20T18:00:00Z",
+      freshness_status: "FRESH",
+      confidence: 1,
+    },
+    authority: {
+      catalog_authority: "governance",
+      commercial_runtime: "warmbly",
+      this_document: "read_model",
+    },
+  };
+  const split = commercialFrom(
+    {
+      ...row,
+      pipeline_nominal_by_currency: [
+        { amount_cents: 10_000, currency: "BRL" },
+        { amount_cents: 5_000, currency: "USD" },
+      ],
+    },
+    FALLBACK,
+  );
+  assert.equal(split.pipeline_nominal_by_currency?.length, 2);
+  const single = commercialFrom(
+    { ...row, pipeline_nominal_by_currency: [{ amount_cents: 10_000, currency: "BRL" }] },
+    FALLBACK,
+  );
+  assert.equal(single.pipeline_nominal_by_currency, undefined);
+});

--- a/control-center/apps/web-shell/tests/pipeline-currency.test.ts
+++ b/control-center/apps/web-shell/tests/pipeline-currency.test.ts
@@ -60,6 +60,33 @@ test("an absent pipeline reads sem dados, never 0,00", () => {
   assert.doesNotMatch(html, /Pipeline nominal[\s\S]{0,200}0,00/);
 });
 
+test("a single readable currency left in a split is shown, not dropped", () => {
+  // A split whose unreadable sibling was rejected still holds real money.
+  const snap = commercialFrom(
+    {
+      id: "cc:commercial-snapshot:promote",
+      scope: "commercial",
+      generated_at: "2026-08-20T18:00:00Z",
+      provenance: {
+        source: { system: "warmbly", kind: "crm-read-model", locator: "x" },
+        observed_at: "2026-08-20T18:00:00Z",
+        freshness_status: "FRESH",
+        confidence: 1,
+      },
+      authority: {
+        catalog_authority: "governance",
+        commercial_runtime: "warmbly",
+        this_document: "read_model",
+      },
+      pipeline_nominal_by_currency: [{ amount_cents: 10_000, currency: "BRL" }],
+    },
+    FALLBACK,
+  );
+  assert.deepEqual(snap.pipeline_nominal, { amount_cents: 10_000, currency: "BRL" });
+  assert.equal(snap.pipeline_nominal_by_currency, undefined);
+  assert.match(comercial({ pipeline_nominal: snap.pipeline_nominal }), /BRL 100,00/);
+});
+
 test("a multi-currency pipeline shows a total per currency and never a merged one", () => {
   const html = comercial({
     pipeline_nominal_by_currency: [
@@ -80,7 +107,10 @@ test("a pipeline whose currency the read model could not parse is not painted", 
   assert.doesNotMatch(html, /reais/);
 });
 
-test("an open deal with no readable currency reads sem dados instead of borrowing BRL", () => {
+test("deal cards use each deal's own currency and mark a withheld amount", () => {
+  // These are the three shapes the commercial projector actually emits for
+  // `operations.pipeline[].value`: a denominated amount, no amount at all, and
+  // an amount it refused to denominate (flagged with `value_unavailable`).
   const html = commercialBlock(
     {
       schema_version: "control-center.commercial-snapshot.v1",
@@ -100,17 +130,22 @@ test("an open deal with no readable currency reads sem dados instead of borrowin
       },
       operations: {
         pipeline: [
-          { id: "d1", display_name: "Com moeda", status: "open", value: { amount_cents: 100, currency: "BRL" } },
-          { id: "d2", display_name: "Sem moeda", status: "open", value: { amount_cents: 100 } },
-          { id: "d3", display_name: "Moeda ilegível", status: "open", value: { amount_cents: 100, currency: "reais" } },
+          { id: "d1", display_name: "Em BRL", status: "open", value: { amount_cents: 100, currency: "BRL" } },
+          { id: "d2", display_name: "Em USD", status: "open", value: { amount_cents: 5000, currency: "USD" } },
+          { id: "d3", display_name: "Retido", status: "open", value_unavailable: "unreadable_currency" },
+          { id: "d4", display_name: "Sem valor", status: "open" },
         ],
       },
     } as unknown as CommercialSnapshot,
     "pipeline",
   );
+  // Each card carries the currency of its own deal, not a blanket BRL.
   assert.match(html, /BRL 1,00/);
-  assert.equal([...html.matchAll(/data-no-data="true">sem dados/g)].length, 2);
-  assert.doesNotMatch(html, /reais/);
+  assert.match(html, /USD 50,00/);
+  assert.doesNotMatch(html, /BRL 50,00/);
+  // The withheld amount says so; the deal that never named one stays silent.
+  assert.equal([...html.matchAll(/data-withheld="unreadable_currency">sem dados/g)].length, 1);
+  assert.equal([...html.matchAll(/class="money"/g)].length, 3);
 });
 
 test("commercialFrom carries per-currency totals through only when there is more than one", () => {

--- a/control-center/connectors/runner/src/projectors/commercial.ts
+++ b/control-center/connectors/runner/src/projectors/commercial.ts
@@ -70,9 +70,6 @@ function centsOf(
   return undefined;
 }
 
-/** At most this many currency buckets, matching `maxItems` on the schema field. */
-const MAX_CURRENCY_BUCKETS = 8;
-
 function centsListOf(value: unknown): { amount_cents: number; currency: string }[] {
   if (!Array.isArray(value)) return [];
   const out: { amount_cents: number; currency: string }[] = [];
@@ -83,7 +80,7 @@ function centsListOf(value: unknown): { amount_cents: number; currency: string }
     seen.add(money.currency);
     out.push(money);
   }
-  return out.sort((a, b) => a.currency.localeCompare(b.currency)).slice(0, MAX_CURRENCY_BUCKETS);
+  return out.sort((a, b) => a.currency.localeCompare(b.currency));
 }
 
 function parseTime(value: unknown): number | undefined {
@@ -172,14 +169,10 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
         // cards whose own record said USD, and cards the total had already
         // refused to denominate. The deal's stated code decides, and an
         // unreadable one withholds the amount instead of guessing.
-        const rawValue = row.value ?? row.amount_cents ?? row.deal_value;
         const dealCurrency = currencyOf(row.currency, CATALOG_CURRENCY);
-        const money = dealCurrency ? centsOf(rawValue, dealCurrency) : undefined;
-        // "The deal never named an amount" and "the amount could not be
-        // denominated" are different facts. Dropping `value` for both would let
-        // a withheld figure vanish from the card silently; the marker lets the
-        // surface say "sem dados" for the second one.
-        const valueWithheld = !money && rawValue !== undefined && rawValue !== null;
+        const money = dealCurrency
+          ? centsOf(row.value ?? row.amount_cents ?? row.deal_value, dealCurrency)
+          : undefined;
         const updated = isoOr(row.updated_at, observedAt);
         const ageMs = now - (parseTime(updated) ?? now);
         const status = typeof row.status === "string" ? row.status.toLowerCase() : "unknown";
@@ -194,7 +187,6 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
           age_seconds: Math.max(0, Math.floor(ageMs / 1000)),
           stale: ageMs >= 14 * 24 * 60 * 60 * 1000 && status === "open",
           ...(money ? { value: money } : {}),
-          ...(valueWithheld ? { value_unavailable: "unreadable_currency" } : {}),
         };
       }),
   );
@@ -595,9 +587,13 @@ export function projectCommercial(envelope: CollectorEnvelope): ProjectedSnapsho
   }
   const byCurrency = centsListOf(inner.deal_value_open_by_currency ?? inner.pipeline_nominal_by_currency);
   if (byCurrency.length > 1) {
-    // Plain money, no per-entry provenance: the snapshot already carries it,
-    // and the contract types these buckets as `unsigned_money`.
-    body.pipeline_nominal_by_currency = byCurrency;
+    body.pipeline_nominal_by_currency = byCurrency.map((money) => ({
+      ...money,
+      source: envelope.source,
+      observed_at: envelope.observed_at,
+      freshness_status: freshness,
+      confidence: envelope.confidence,
+    }));
   } else if (byCurrency.length === 1 && body.pipeline_nominal === undefined) {
     // Filtering an unreadable sibling out of a split must not take the readable
     // total with it.

--- a/control-center/connectors/runner/src/projectors/commercial.ts
+++ b/control-center/connectors/runner/src/projectors/commercial.ts
@@ -27,16 +27,57 @@ const WINDOW_MS: Record<Exclude<CohortWindow, "open">, number> = {
   "90d": 90 * 24 * 60 * 60 * 1000,
 };
 
-function centsOf(value: unknown, currencyFallback = "BRL"): { amount_cents: number; currency: string } | undefined {
+/**
+ * The CONFENGE catalog is contracted in BRL and Governance is its authority.
+ * An amount that arrives with no currency is denominated in it; an amount that
+ * arrives with a different code keeps that code and is never converted.
+ */
+const CATALOG_CURRENCY = "BRL";
+const ISO_4217 = /^[A-Z]{3}$/;
+
+/**
+ * Absent currency resolves to the contractual catalog currency.
+ * Present-but-unreadable fails closed, so a payload cannot smuggle a bad code
+ * past the projector by being merely wrong instead of merely missing.
+ */
+function currencyOf(raw: unknown, fallback: string): string | undefined {
+  if (raw === undefined || raw === null) {
+    return fallback;
+  }
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const code = raw.trim().toUpperCase();
+  if (code === "") {
+    return fallback;
+  }
+  return ISO_4217.test(code) ? code : undefined;
+}
+
+function centsOf(
+  value: unknown,
+  currencyFallback = CATALOG_CURRENCY,
+): { amount_cents: number; currency: string } | undefined {
   const rec = asRecord(value);
   if (rec && typeof rec.amount_cents === "number" && Number.isInteger(rec.amount_cents)) {
-    const currency = typeof rec.currency === "string" ? rec.currency : currencyFallback;
+    const currency = currencyOf(rec.currency, currencyFallback);
+    if (!currency) return undefined;
     return { amount_cents: rec.amount_cents, currency };
   }
   if (typeof value === "number" && Number.isFinite(value)) {
     return { amount_cents: Math.round(value * 100), currency: currencyFallback };
   }
   return undefined;
+}
+
+function centsListOf(value: unknown): { amount_cents: number; currency: string }[] {
+  if (!Array.isArray(value)) return [];
+  const out: { amount_cents: number; currency: string }[] = [];
+  for (const item of value) {
+    const money = centsOf(item);
+    if (money) out.push(money);
+  }
+  return out;
 }
 
 function parseTime(value: unknown): number | undefined {
@@ -519,7 +560,11 @@ export function projectCommercial(envelope: CollectorEnvelope): ProjectedSnapsho
     body.funnel = funnel;
   }
   const nominal = centsOf(inner.deal_value_open ?? inner.pipeline_nominal);
-  if (nominal) {
+  // A nominal pipeline of exactly zero carries no currency evidence: nothing
+  // denominated contributed to it. Emitting it would print `<currency> 0,00`
+  // and make an unknown look like a measured zero, so it is omitted and the
+  // surface reads "sem dados". `pipeline_open_count` still carries the count.
+  if (nominal && nominal.amount_cents !== 0) {
     body.pipeline_nominal = {
       ...nominal,
       source: envelope.source,
@@ -527,6 +572,16 @@ export function projectCommercial(envelope: CollectorEnvelope): ProjectedSnapsho
       freshness_status: freshness,
       confidence: envelope.confidence,
     };
+  }
+  const byCurrency = centsListOf(inner.deal_value_open_by_currency ?? inner.pipeline_nominal_by_currency);
+  if (byCurrency.length > 1) {
+    body.pipeline_nominal_by_currency = byCurrency.map((money) => ({
+      ...money,
+      source: envelope.source,
+      observed_at: envelope.observed_at,
+      freshness_status: freshness,
+      confidence: envelope.confidence,
+    }));
   }
   if (integerOrUndefined(counts.deals_stalled) !== undefined) {
     body.stalled_count = counts.deals_stalled;

--- a/control-center/connectors/runner/src/projectors/commercial.ts
+++ b/control-center/connectors/runner/src/projectors/commercial.ts
@@ -70,14 +70,20 @@ function centsOf(
   return undefined;
 }
 
+/** At most this many currency buckets, matching `maxItems` on the schema field. */
+const MAX_CURRENCY_BUCKETS = 8;
+
 function centsListOf(value: unknown): { amount_cents: number; currency: string }[] {
   if (!Array.isArray(value)) return [];
   const out: { amount_cents: number; currency: string }[] = [];
+  const seen = new Set<string>();
   for (const item of value) {
     const money = centsOf(item);
-    if (money) out.push(money);
+    if (!money || seen.has(money.currency)) continue;
+    seen.add(money.currency);
+    out.push(money);
   }
-  return out;
+  return out.sort((a, b) => a.currency.localeCompare(b.currency)).slice(0, MAX_CURRENCY_BUCKETS);
 }
 
 function parseTime(value: unknown): number | undefined {
@@ -160,7 +166,20 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
       .map((item) => asRecord(item))
       .filter((row): row is Record<string, unknown> => row !== null)
       .map((row) => {
-        const money = centsOf(row.value ?? row.amount_cents ?? row.deal_value);
+        // Warmbly sends a deal's amount as a bare major-unit number with the
+        // currency in a *sibling* field, so the amount alone cannot denominate
+        // itself. Reading only the amount stamped every card BRL — including
+        // cards whose own record said USD, and cards the total had already
+        // refused to denominate. The deal's stated code decides, and an
+        // unreadable one withholds the amount instead of guessing.
+        const rawValue = row.value ?? row.amount_cents ?? row.deal_value;
+        const dealCurrency = currencyOf(row.currency, CATALOG_CURRENCY);
+        const money = dealCurrency ? centsOf(rawValue, dealCurrency) : undefined;
+        // "The deal never named an amount" and "the amount could not be
+        // denominated" are different facts. Dropping `value` for both would let
+        // a withheld figure vanish from the card silently; the marker lets the
+        // surface say "sem dados" for the second one.
+        const valueWithheld = !money && rawValue !== undefined && rawValue !== null;
         const updated = isoOr(row.updated_at, observedAt);
         const ageMs = now - (parseTime(updated) ?? now);
         const status = typeof row.status === "string" ? row.status.toLowerCase() : "unknown";
@@ -175,6 +194,7 @@ function operationsFromWarmbly(payload: Record<string, unknown>, observedAt: str
           age_seconds: Math.max(0, Math.floor(ageMs / 1000)),
           stale: ageMs >= 14 * 24 * 60 * 60 * 1000 && status === "open",
           ...(money ? { value: money } : {}),
+          ...(valueWithheld ? { value_unavailable: "unreadable_currency" } : {}),
         };
       }),
   );
@@ -575,13 +595,22 @@ export function projectCommercial(envelope: CollectorEnvelope): ProjectedSnapsho
   }
   const byCurrency = centsListOf(inner.deal_value_open_by_currency ?? inner.pipeline_nominal_by_currency);
   if (byCurrency.length > 1) {
-    body.pipeline_nominal_by_currency = byCurrency.map((money) => ({
-      ...money,
-      source: envelope.source,
-      observed_at: envelope.observed_at,
-      freshness_status: freshness,
-      confidence: envelope.confidence,
-    }));
+    // Plain money, no per-entry provenance: the snapshot already carries it,
+    // and the contract types these buckets as `unsigned_money`.
+    body.pipeline_nominal_by_currency = byCurrency;
+  } else if (byCurrency.length === 1 && body.pipeline_nominal === undefined) {
+    // Filtering an unreadable sibling out of a split must not take the readable
+    // total with it.
+    const only = byCurrency[0];
+    if (only && only.amount_cents !== 0) {
+      body.pipeline_nominal = {
+        ...only,
+        source: envelope.source,
+        observed_at: envelope.observed_at,
+        freshness_status: freshness,
+        confidence: envelope.confidence,
+      };
+    }
   }
   if (integerOrUndefined(counts.deals_stalled) !== undefined) {
     body.stalled_count = counts.deals_stalled;

--- a/control-center/connectors/runner/src/projectors/finance.ts
+++ b/control-center/connectors/runner/src/projectors/finance.ts
@@ -9,14 +9,38 @@ import {
   type ProjectedSnapshot,
 } from "./types.ts";
 
+/**
+ * CONFENGE is contracted in BRL and Governance is the catalog authority.
+ * An amount with no currency is denominated in it; an amount whose currency is
+ * present but unreadable fails closed rather than being relabelled as BRL.
+ */
+const CATALOG_CURRENCY = "BRL";
+const ISO_4217 = /^[A-Z]{3}$/;
+
+function currencyOf(raw: unknown): string | undefined {
+  if (raw === undefined || raw === null) {
+    return CATALOG_CURRENCY;
+  }
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const code = raw.trim().toUpperCase();
+  if (code === "") {
+    return CATALOG_CURRENCY;
+  }
+  return ISO_4217.test(code) ? code : undefined;
+}
+
 function moneyFromBucket(value: unknown): { amount_cents: number; currency: string } | undefined {
   const rec = asRecord(value);
   if (!rec) return undefined;
+  const currency = currencyOf(rec.currency);
+  if (!currency) return undefined;
   if (typeof rec.amount_cents === "number" && Number.isInteger(rec.amount_cents)) {
-    return { amount_cents: rec.amount_cents, currency: typeof rec.currency === "string" ? rec.currency : "BRL" };
+    return { amount_cents: rec.amount_cents, currency };
   }
   if (typeof rec.cents === "number" && Number.isInteger(rec.cents)) {
-    return { amount_cents: rec.cents, currency: typeof rec.currency === "string" ? rec.currency : "BRL" };
+    return { amount_cents: rec.cents, currency };
   }
   return undefined;
 }

--- a/control-center/connectors/runner/tests/projectors.test.ts
+++ b/control-center/connectors/runner/tests/projectors.test.ts
@@ -515,3 +515,98 @@ test("empty collector payload is NO_DATA not a healthy zero funnel", () => {
   assert.equal(commercial.availability, "NO_DATA");
   assert.equal(commercial.payload.funnel, undefined);
 });
+
+const CURRENCY_SOURCE = { system: "warmbly", kind: "collector-runner", locator: "warmbly" };
+
+function commercialPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const projected = projectCollector({
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: now,
+    source: CURRENCY_SOURCE,
+    confidence: 0.8,
+    payload: { counts: { deals_open: 0, inbound_now: 0 }, ...payload },
+  });
+  const commercial = projected.find((row) => row.snapshot_kind === "commercial");
+  assert.ok(commercial);
+  return commercial.payload;
+}
+
+test("commercial projector denominates an undenominated pipeline in the BRL catalog currency", () => {
+  const body = commercialPayload({ deal_value_open: { amount_cents: 480_000 } });
+  assert.deepEqual(body.pipeline_nominal, {
+    amount_cents: 480_000,
+    currency: "BRL",
+    source: CURRENCY_SOURCE,
+    observed_at: now,
+    freshness_status: "FRESH",
+    confidence: 0.8,
+  });
+});
+
+test("commercial projector omits a zero pipeline instead of stamping it with a currency", () => {
+  // The reported bug: Warmbly's deals_summary reported a zero open value in its
+  // own default currency, and the surface printed "Pipeline nominal USD 0,00".
+  assert.equal(commercialPayload({ deal_value_open: { amount_cents: 0, currency: "USD" } }).pipeline_nominal, undefined);
+  assert.equal(commercialPayload({ deal_value_open: { amount_cents: 0 } }).pipeline_nominal, undefined);
+});
+
+test("commercial projector fails closed on a pipeline currency that is not ISO-4217", () => {
+  assert.equal(
+    commercialPayload({ deal_value_open: { amount_cents: 100, currency: "reais" } }).pipeline_nominal,
+    undefined,
+  );
+});
+
+test("commercial projector forwards per-currency totals without merging them", () => {
+  const body = commercialPayload({
+    deal_value_open_by_currency: [
+      { amount_cents: 10_000, currency: "BRL" },
+      { amount_cents: 5_000, currency: "USD" },
+    ],
+  });
+  const split = body.pipeline_nominal_by_currency as Array<{ amount_cents: number; currency: string }>;
+  assert.equal(split.length, 2);
+  assert.deepEqual(
+    split.map((m) => [m.currency, m.amount_cents]),
+    [
+      ["BRL", 10_000],
+      ["USD", 5_000],
+    ],
+  );
+  assert.equal(body.pipeline_nominal, undefined);
+});
+
+test("commercial projector keeps a deal value undenominated rather than guessing when the code is unreadable", () => {
+  const body = commercialPayload({
+    operations: {
+      deals: [
+        { id: "d1", status: "open", value: { amount_cents: 100, currency: "BRL" }, updated_at: now },
+        { id: "d2", status: "open", value: { amount_cents: 100, currency: "reais" }, updated_at: now },
+      ],
+    },
+  });
+  const ops = body.operations as { pipeline: Array<Record<string, unknown>> };
+  assert.deepEqual(ops.pipeline[0]?.value, { amount_cents: 100, currency: "BRL" });
+  assert.equal(ops.pipeline[1]?.value, undefined);
+});
+
+test("finance projector fails closed on an unreadable bucket currency and defaults an absent one to BRL", () => {
+  const projected = projectCollector({
+    collector: "asaas",
+    freshness_status: "FRESH",
+    observed_at: now,
+    source: { system: "asaas", kind: "collector-runner", locator: "asaas" },
+    confidence: 0.8,
+    payload: {
+      contracted: { amount_cents: 5_000_000 },
+      billed: { amount_cents: 4_000_000, currency: "reais" },
+      paid: { amount_cents: 2_500_000, currency: "brl" },
+    },
+  });
+  const finance = projected.find((row) => row.snapshot_kind === "finance");
+  assert.ok(finance);
+  assert.deepEqual(finance.payload.contracted, { amount_cents: 5_000_000, currency: "BRL" });
+  assert.equal(finance.payload.billed, undefined);
+  assert.deepEqual(finance.payload.paid, { amount_cents: 2_500_000, currency: "BRL" });
+});

--- a/control-center/connectors/runner/tests/projectors.test.ts
+++ b/control-center/connectors/runner/tests/projectors.test.ts
@@ -532,20 +532,6 @@ function commercialPayload(payload: Record<string, unknown>): Record<string, unk
   return commercial.payload;
 }
 
-// Guard, not a regression test: this passed before the fix too. It pins the
-// contractual default so a later change cannot quietly move it off BRL.
-test("commercial projector denominates an undenominated pipeline in the BRL catalog currency", () => {
-  const body = commercialPayload({ deal_value_open: { amount_cents: 480_000 } });
-  assert.deepEqual(body.pipeline_nominal, {
-    amount_cents: 480_000,
-    currency: "BRL",
-    source: CURRENCY_SOURCE,
-    observed_at: now,
-    freshness_status: "FRESH",
-    confidence: 0.8,
-  });
-});
-
 test("commercial projector omits a zero pipeline instead of stamping it with a currency", () => {
   // The reported bug: Warmbly's deals_summary reported a zero open value in its
   // own default currency, and the surface printed "Pipeline nominal USD 0,00".
@@ -567,10 +553,14 @@ test("commercial projector forwards per-currency totals without merging them", (
       { amount_cents: 5_000, currency: "USD" },
     ],
   });
-  assert.deepEqual(body.pipeline_nominal_by_currency, [
-    { amount_cents: 10_000, currency: "BRL" },
-    { amount_cents: 5_000, currency: "USD" },
-  ]);
+  const split = body.pipeline_nominal_by_currency as Array<{ amount_cents: number; currency: string }>;
+  assert.deepEqual(
+    split.map((m) => [m.currency, m.amount_cents]),
+    [
+      ["BRL", 10_000],
+      ["USD", 5_000],
+    ],
+  );
   assert.equal(body.pipeline_nominal, undefined);
 });
 
@@ -602,15 +592,13 @@ test("commercial projector denominates each deal by its own currency, not by BRL
   const commercial = projected.find((row) => row.snapshot_kind === "commercial");
   assert.ok(commercial);
   const ops = commercial.payload.operations as {
-    pipeline: Array<{ id: string; value?: { amount_cents: number; currency: string }; value_unavailable?: string }>;
+    pipeline: Array<{ id: string; value?: { amount_cents: number; currency: string } }>;
   };
   const byId = new Map(ops.pipeline.map((row) => [row.id, row]));
   assert.deepEqual(byId.get("brl")?.value, { amount_cents: 10_000, currency: "BRL" });
   assert.deepEqual(byId.get("usd")?.value, { amount_cents: 5_000, currency: "USD" });
-  // Unreadable code: withheld, and marked so the card can say "sem dados"
-  // instead of the amount silently disappearing.
+  // Unreadable code: withheld rather than stamped with the catalog currency.
   assert.equal(byId.get("bad")?.value, undefined);
-  assert.equal(byId.get("bad")?.value_unavailable, "unreadable_currency");
   // No code stated at all: the contractual catalog currency.
   assert.deepEqual(byId.get("none")?.value, { amount_cents: 2_500, currency: "BRL" });
 });
@@ -642,11 +630,14 @@ test("a zero bucket keeps its siblings: the currency had a denominated contribut
       { amount_cents: 0, currency: "USD" },
     ],
   });
-  const split = body.pipeline_nominal_by_currency as Array<{ amount_cents: number; currency: string }>;
-  assert.deepEqual(split, [
-    { amount_cents: 10_000, currency: "BRL" },
-    { amount_cents: 0, currency: "USD" },
-  ]);
+  const zeroSplit = body.pipeline_nominal_by_currency as Array<{ amount_cents: number; currency: string }>;
+  assert.deepEqual(
+    zeroSplit.map((m) => [m.currency, m.amount_cents]),
+    [
+      ["BRL", 10_000],
+      ["USD", 0],
+    ],
+  );
 });
 
 test("finance projector fails closed on an unreadable bucket currency and defaults an absent one to BRL", () => {

--- a/control-center/connectors/runner/tests/projectors.test.ts
+++ b/control-center/connectors/runner/tests/projectors.test.ts
@@ -532,6 +532,8 @@ function commercialPayload(payload: Record<string, unknown>): Record<string, unk
   return commercial.payload;
 }
 
+// Guard, not a regression test: this passed before the fix too. It pins the
+// contractual default so a later change cannot quietly move it off BRL.
 test("commercial projector denominates an undenominated pipeline in the BRL catalog currency", () => {
   const body = commercialPayload({ deal_value_open: { amount_cents: 480_000 } });
   assert.deepEqual(body.pipeline_nominal, {
@@ -565,30 +567,86 @@ test("commercial projector forwards per-currency totals without merging them", (
       { amount_cents: 5_000, currency: "USD" },
     ],
   });
-  const split = body.pipeline_nominal_by_currency as Array<{ amount_cents: number; currency: string }>;
-  assert.equal(split.length, 2);
-  assert.deepEqual(
-    split.map((m) => [m.currency, m.amount_cents]),
-    [
-      ["BRL", 10_000],
-      ["USD", 5_000],
-    ],
-  );
+  assert.deepEqual(body.pipeline_nominal_by_currency, [
+    { amount_cents: 10_000, currency: "BRL" },
+    { amount_cents: 5_000, currency: "USD" },
+  ]);
   assert.equal(body.pipeline_nominal, undefined);
 });
 
-test("commercial projector keeps a deal value undenominated rather than guessing when the code is unreadable", () => {
-  const body = commercialPayload({
-    operations: {
+test("commercial projector denominates each deal by its own currency, not by BRL", () => {
+  // Warmbly sends `value` as a bare major-unit number with `currency` beside
+  // it. Reading only the number stamped every card BRL, so a USD deal and a
+  // deal the total had refused to denominate both rendered "BRL 100,00".
+  const snapshot = collectFromWarmblyPayload(
+    {
+      health: { status: "ok" },
+      api_version: "v1",
       deals: [
-        { id: "d1", status: "open", value: { amount_cents: 100, currency: "BRL" }, updated_at: now },
-        { id: "d2", status: "open", value: { amount_cents: 100, currency: "reais" }, updated_at: now },
+        { id: "brl", name: "BRL", status: "open", value: 100, currency: "BRL", created_at: now, updated_at: now },
+        { id: "usd", name: "USD", status: "open", value: 50, currency: "USD", created_at: now, updated_at: now },
+        { id: "bad", name: "Bad", status: "open", value: 100, currency: "R$", created_at: now, updated_at: now },
+        { id: "none", name: "None", status: "open", value: 25, created_at: now, updated_at: now },
       ],
-    },
+    } as never,
+    { now: new Date(now) },
+  );
+  const projected = projectCollector({
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: now,
+    source: CURRENCY_SOURCE,
+    confidence: 0.8,
+    payload: snapshot as unknown as Record<string, unknown>,
   });
-  const ops = body.operations as { pipeline: Array<Record<string, unknown>> };
-  assert.deepEqual(ops.pipeline[0]?.value, { amount_cents: 100, currency: "BRL" });
-  assert.equal(ops.pipeline[1]?.value, undefined);
+  const commercial = projected.find((row) => row.snapshot_kind === "commercial");
+  assert.ok(commercial);
+  const ops = commercial.payload.operations as {
+    pipeline: Array<{ id: string; value?: { amount_cents: number; currency: string }; value_unavailable?: string }>;
+  };
+  const byId = new Map(ops.pipeline.map((row) => [row.id, row]));
+  assert.deepEqual(byId.get("brl")?.value, { amount_cents: 10_000, currency: "BRL" });
+  assert.deepEqual(byId.get("usd")?.value, { amount_cents: 5_000, currency: "USD" });
+  // Unreadable code: withheld, and marked so the card can say "sem dados"
+  // instead of the amount silently disappearing.
+  assert.equal(byId.get("bad")?.value, undefined);
+  assert.equal(byId.get("bad")?.value_unavailable, "unreadable_currency");
+  // No code stated at all: the contractual catalog currency.
+  assert.deepEqual(byId.get("none")?.value, { amount_cents: 2_500, currency: "BRL" });
+});
+
+test("a readable total is not destroyed by an unreadable sibling currency", () => {
+  // The split filters down to one entry; that entry is a real denominated
+  // total and must be promoted, not discarded as "not a split".
+  const body = commercialPayload({
+    deal_value_open_by_currency: [
+      { amount_cents: 10_000, currency: "BRL" },
+      { amount_cents: 5_000, currency: "reais" },
+    ],
+  });
+  assert.deepEqual(body.pipeline_nominal, {
+    amount_cents: 10_000,
+    currency: "BRL",
+    source: CURRENCY_SOURCE,
+    observed_at: now,
+    freshness_status: "FRESH",
+    confidence: 0.8,
+  });
+  assert.equal(body.pipeline_nominal_by_currency, undefined);
+});
+
+test("a zero bucket keeps its siblings: the currency had a denominated contributor", () => {
+  const body = commercialPayload({
+    deal_value_open_by_currency: [
+      { amount_cents: 10_000, currency: "BRL" },
+      { amount_cents: 0, currency: "USD" },
+    ],
+  });
+  const split = body.pipeline_nominal_by_currency as Array<{ amount_cents: number; currency: string }>;
+  assert.deepEqual(split, [
+    { amount_cents: 10_000, currency: "BRL" },
+    { amount_cents: 0, currency: "USD" },
+  ]);
 });
 
 test("finance projector fails closed on an unreadable bucket currency and defaults an absent one to BRL", () => {

--- a/control-center/connectors/warmbly/src/contracts/required-upstream.ts
+++ b/control-center/connectors/warmbly/src/contracts/required-upstream.ts
@@ -32,40 +32,6 @@ export const LEADS_LIST_CONTRACT: RequiredUpstreamContract = {
   },
 };
 
-/**
- * Declared only when the summary says the open pipeline mixes currencies but
- * gives no per-currency breakdown.
- *
- * That is the shape the CONFENGE incident arrived in: an empty `deals[]` and a
- * summary-only reading. With no per-deal rows to group and no breakdown from
- * the summary, per-currency separation is not something the Control Center can
- * derive — and it will not convert. So the gap is named as an upstream
- * contract instead of being papered over with an invented total.
- */
-export const DEALS_SUMMARY_CURRENCY_CONTRACT: RequiredUpstreamContract = {
-  id: "POST /v1/crm/deals/summary#open_value_by_currency",
-  method: "POST",
-  path: "/v1/crm/deals/summary",
-  reason:
-    "When the open pipeline spans more than one currency, the summary must report a per-currency breakdown. A single open_value with mixed_currency=true cannot be separated by currency and must not be converted: the Control Center has no rate source carrying a source and a date. Without the breakdown the nominal pipeline stays withheld.",
-  min_request: {
-    method: "POST",
-    path: "/v1/crm/deals/summary",
-    headers: AUTH_HEADERS,
-    body: { status: "open" },
-  },
-  min_response: {
-    status: 200,
-    body: {
-      open_count: 0,
-      open_value: 0,
-      currency: "BRL",
-      mixed_currency: false,
-      open_value_by_currency: [{ currency: "BRL", value: 0 }],
-    },
-  },
-};
-
 export function contractForUnavailable(path: string, method: string): RequiredUpstreamContract {
   const normalized = path.split("?")[0] ?? path;
   if (normalized === "/v1/confenge/attention") {

--- a/control-center/connectors/warmbly/src/contracts/required-upstream.ts
+++ b/control-center/connectors/warmbly/src/contracts/required-upstream.ts
@@ -32,6 +32,40 @@ export const LEADS_LIST_CONTRACT: RequiredUpstreamContract = {
   },
 };
 
+/**
+ * Declared only when the summary says the open pipeline mixes currencies but
+ * gives no per-currency breakdown.
+ *
+ * That is the shape the CONFENGE incident arrived in: an empty `deals[]` and a
+ * summary-only reading. With no per-deal rows to group and no breakdown from
+ * the summary, per-currency separation is not something the Control Center can
+ * derive — and it will not convert. So the gap is named as an upstream
+ * contract instead of being papered over with an invented total.
+ */
+export const DEALS_SUMMARY_CURRENCY_CONTRACT: RequiredUpstreamContract = {
+  id: "POST /v1/crm/deals/summary#open_value_by_currency",
+  method: "POST",
+  path: "/v1/crm/deals/summary",
+  reason:
+    "When the open pipeline spans more than one currency, the summary must report a per-currency breakdown. A single open_value with mixed_currency=true cannot be separated by currency and must not be converted: the Control Center has no rate source carrying a source and a date. Without the breakdown the nominal pipeline stays withheld.",
+  min_request: {
+    method: "POST",
+    path: "/v1/crm/deals/summary",
+    headers: AUTH_HEADERS,
+    body: { status: "open" },
+  },
+  min_response: {
+    status: 200,
+    body: {
+      open_count: 0,
+      open_value: 0,
+      currency: "BRL",
+      mixed_currency: false,
+      open_value_by_currency: [{ currency: "BRL", value: 0 }],
+    },
+  },
+};
+
 export function contractForUnavailable(path: string, method: string): RequiredUpstreamContract {
   const normalized = path.split("?")[0] ?? path;
   if (normalized === "/v1/confenge/attention") {

--- a/control-center/connectors/warmbly/src/contracts/snapshot.ts
+++ b/control-center/connectors/warmbly/src/contracts/snapshot.ts
@@ -112,6 +112,12 @@ export type CommercialSnapshot = {
   health: ConnectorHealth;
   counts: CommercialCounts;
   deal_value_open?: Money;
+  /**
+   * Per-currency open pipeline totals, present only when the open deals span
+   * more than one currency. The totals are never summed and never converted:
+   * the Control Center has no rate source with a date and a provenance.
+   */
+  deal_value_open_by_currency?: Money[];
   attention: CommercialAttentionItem[];
   observations: SourceObservation[];
   required_upstream_contract: RequiredUpstreamContract[];

--- a/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
+++ b/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
@@ -58,8 +58,6 @@ export type WarmblyDealsSummary = {
   lost_value?: number;
   currency?: string;
   mixed_currency?: boolean;
-  /** Per-currency open totals in major units. The only honest reading of a mixed-currency pipeline. */
-  open_value_by_currency?: Array<{ currency?: string; value?: number }>;
 };
 
 export type WarmblyTask = {

--- a/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
+++ b/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
@@ -58,6 +58,8 @@ export type WarmblyDealsSummary = {
   lost_value?: number;
   currency?: string;
   mixed_currency?: boolean;
+  /** Per-currency open totals in major units. The only honest reading of a mixed-currency pipeline. */
+  open_value_by_currency?: Array<{ currency?: string; value?: number }>;
 };
 
 export type WarmblyTask = {

--- a/control-center/connectors/warmbly/src/mapper/money.ts
+++ b/control-center/connectors/warmbly/src/mapper/money.ts
@@ -111,6 +111,35 @@ export function openDealTotals(deals: readonly OpenDealInput[]): OpenDealTotals 
 }
 
 /**
+ * Per-currency totals a `deals_summary` declared for itself.
+ *
+ * Only used when there are no per-deal rows to group. Entries whose currency
+ * is not ISO-4217 are dropped rather than folded into the catalog currency.
+ */
+export function summaryTotalsByCurrency(summary: {
+  open_value_by_currency?: Array<{ currency?: string; value?: number }>;
+}): Money[] {
+  const rows = summary.open_value_by_currency;
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+  const byCurrency = new Map<string, number>();
+  for (const row of rows) {
+    if (!row || typeof row.value !== "number" || !Number.isFinite(row.value)) {
+      continue;
+    }
+    const currency = resolveCurrency(row.currency);
+    if (!currency) {
+      continue;
+    }
+    byCurrency.set(currency, (byCurrency.get(currency) ?? 0) + Math.round(row.value * 100));
+  }
+  return [...byCurrency.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([currency, amount_cents]) => ({ amount_cents, currency }));
+}
+
+/**
  * Single-currency open pipeline total, or `undefined` when the deals mix
  * currencies (see `openDealTotals` for the per-currency breakdown).
  */

--- a/control-center/connectors/warmbly/src/mapper/money.ts
+++ b/control-center/connectors/warmbly/src/mapper/money.ts
@@ -111,35 +111,6 @@ export function openDealTotals(deals: readonly OpenDealInput[]): OpenDealTotals 
 }
 
 /**
- * Per-currency totals a `deals_summary` declared for itself.
- *
- * Only used when there are no per-deal rows to group. Entries whose currency
- * is not ISO-4217 are dropped rather than folded into the catalog currency.
- */
-export function summaryTotalsByCurrency(summary: {
-  open_value_by_currency?: Array<{ currency?: string; value?: number }>;
-}): Money[] {
-  const rows = summary.open_value_by_currency;
-  if (!Array.isArray(rows)) {
-    return [];
-  }
-  const byCurrency = new Map<string, number>();
-  for (const row of rows) {
-    if (!row || typeof row.value !== "number" || !Number.isFinite(row.value)) {
-      continue;
-    }
-    const currency = resolveCurrency(row.currency);
-    if (!currency) {
-      continue;
-    }
-    byCurrency.set(currency, (byCurrency.get(currency) ?? 0) + Math.round(row.value * 100));
-  }
-  return [...byCurrency.entries()]
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([currency, amount_cents]) => ({ amount_cents, currency }));
-}
-
-/**
  * Single-currency open pipeline total, or `undefined` when the deals mix
  * currencies (see `openDealTotals` for the per-currency breakdown).
  */

--- a/control-center/connectors/warmbly/src/mapper/money.ts
+++ b/control-center/connectors/warmbly/src/mapper/money.ts
@@ -1,6 +1,43 @@
 import type { Money } from "../contracts/snapshot.ts";
 
-const DEFAULT_CURRENCY = "BRL";
+/**
+ * The CONFENGE catalog is contracted in BRL and Governance is its authority.
+ *
+ * This is the *contractual* currency, not a convenience default: an amount
+ * that arrives with no currency at all is denominated in it, but an amount
+ * that arrives carrying a different code is never rewritten into it and never
+ * summed with it. Conversion would need an explicit rate with a source and a
+ * date; the Control Center has none, so it does not convert.
+ */
+export const CATALOG_CURRENCY = "BRL";
+
+const ISO_4217 = /^[A-Z]{3}$/;
+
+/** Trim + uppercase. Anything that is not an ISO-4217 alpha code is rejected. */
+export function normalizeCurrency(raw: unknown): string | undefined {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const code = raw.trim().toUpperCase();
+  return ISO_4217.test(code) ? code : undefined;
+}
+
+/**
+ * Resolve the currency of one observed amount.
+ *
+ * Absent (undefined / null / empty string) resolves to the contractual
+ * catalog currency. Present-but-unreadable fails closed as `undefined` so the
+ * caller withholds the amount instead of denominating it in a guess.
+ */
+export function resolveCurrency(raw: unknown): string | undefined {
+  if (raw === undefined || raw === null) {
+    return CATALOG_CURRENCY;
+  }
+  if (typeof raw === "string" && raw.trim() === "") {
+    return CATALOG_CURRENCY;
+  }
+  return normalizeCurrency(raw);
+}
 
 /**
  * Warmbly deal.value is a major-unit float (e.g. 1500.50 BRL).
@@ -10,27 +47,74 @@ export function majorUnitsToCents(value: number, currency?: string): Money {
   if (!Number.isFinite(value)) {
     throw new Error("deal value is not a finite number");
   }
+  const code = resolveCurrency(currency);
+  if (!code) {
+    throw new Error(`deal currency ${JSON.stringify(currency)} is not an ISO-4217 code`);
+  }
   return {
     amount_cents: Math.round(value * 100),
-    currency: (currency && currency.trim()) || DEFAULT_CURRENCY,
+    currency: code,
   };
 }
 
-export function sumOpenDealValue(
-  deals: Array<{ status: string; value?: number | null; currency?: string }>,
-): Money | undefined {
-  const open = deals.filter((d) => d.status.toLowerCase() === "open" && d.value != null);
-  if (open.length === 0) {
-    return undefined;
+export type OpenDealInput = { status: string; value?: number | null; currency?: string };
+
+export type OpenDealTotals = {
+  /** One total per observed currency, sorted by code. Never summed across codes. */
+  totals: Money[];
+  /** Open deals whose currency could not be read as ISO-4217; excluded from every total. */
+  unreadable_currency: number;
+  /** Currency codes observed that are not the contractual catalog currency. */
+  foreign_currencies: string[];
+};
+
+function isOpen(deal: OpenDealInput): boolean {
+  return deal.status.toLowerCase() === "open" && deal.value != null;
+}
+
+/**
+ * Per-currency totals for the open pipeline.
+ *
+ * Amounts in different currencies are kept apart rather than added: the
+ * Control Center has no rate source, so a merged total would be an invented
+ * number. A deal whose currency is present but unreadable is dropped from the
+ * totals and counted, so the caller can raise it instead of silently
+ * absorbing it into the catalog currency.
+ */
+export function openDealTotals(deals: readonly OpenDealInput[]): OpenDealTotals {
+  const byCurrency = new Map<string, number>();
+  let unreadable = 0;
+  for (const deal of deals) {
+    if (!isOpen(deal)) {
+      continue;
+    }
+    const currency = resolveCurrency(deal.currency);
+    if (!currency) {
+      unreadable += 1;
+      continue;
+    }
+    const cents = Math.round((deal.value as number) * 100);
+    if (!Number.isFinite(cents)) {
+      unreadable += 1;
+      continue;
+    }
+    byCurrency.set(currency, (byCurrency.get(currency) ?? 0) + cents);
   }
-  const currencies = new Set(open.map((d) => (d.currency && d.currency.trim()) || DEFAULT_CURRENCY));
-  if (currencies.size !== 1) {
-    return undefined;
-  }
-  const currency = [...currencies][0] ?? DEFAULT_CURRENCY;
-  let cents = 0;
-  for (const d of open) {
-    cents += majorUnitsToCents(d.value as number, currency).amount_cents;
-  }
-  return { amount_cents: cents, currency };
+  const totals = [...byCurrency.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([currency, amount_cents]) => ({ amount_cents, currency }));
+  return {
+    totals,
+    unreadable_currency: unreadable,
+    foreign_currencies: totals.map((m) => m.currency).filter((code) => code !== CATALOG_CURRENCY),
+  };
+}
+
+/**
+ * Single-currency open pipeline total, or `undefined` when the deals mix
+ * currencies (see `openDealTotals` for the per-currency breakdown).
+ */
+export function sumOpenDealValue(deals: readonly OpenDealInput[]): Money | undefined {
+  const { totals } = openDealTotals(deals);
+  return totals.length === 1 ? totals[0] : undefined;
 }

--- a/control-center/connectors/warmbly/src/mapper/normalize.ts
+++ b/control-center/connectors/warmbly/src/mapper/normalize.ts
@@ -10,7 +10,6 @@ import {
 } from "../contracts/snapshot.ts";
 import {
   contractForUnavailable,
-  DEALS_SUMMARY_CURRENCY_CONTRACT,
   LEADS_LIST_CONTRACT,
 } from "../contracts/required-upstream.ts";
 import {
@@ -35,13 +34,7 @@ import {
   type AttentionContext,
 } from "./attention.ts";
 import { provenance, rollupFreshness } from "./freshness.ts";
-import {
-  CATALOG_CURRENCY,
-  majorUnitsToCents,
-  openDealTotals,
-  resolveCurrency,
-  summaryTotalsByCurrency,
-} from "./money.ts";
+import { CATALOG_CURRENCY, majorUnitsToCents, openDealTotals, resolveCurrency } from "./money.ts";
 
 const OPERATIONS_CAP = 50;
 
@@ -326,39 +319,29 @@ export function collectFromWarmblyPayload(
   // codes are kept apart, never summed, because there is no rate source here.
   const openTotals = openDealTotals(deals);
   let dealValueByCurrency: Money[] = openTotals.totals;
-  // Keyed by anomaly, not by position: the same anomaly must keep the same id
-  // whichever siblings happen to fire alongside it, or dedupe and any operator
-  // acknowledgement keyed on the id both break.
-  const currencyNotes = new Map<string, string>();
+  const currencyNotes: string[] = [];
   if (openTotals.unreadable_currency > 0) {
-    currencyNotes.set(
-      "unreadable_deal_currency",
+    currencyNotes.push(
       `${openTotals.unreadable_currency} open deal(s) carry a currency that is not an ISO-4217 code; they are excluded from the nominal pipeline rather than denominated in ${CATALOG_CURRENCY}`,
     );
   }
 
   const summary = payload.deals_summary;
   if (dealValueByCurrency.length === 0 && summary) {
-    const declared = summaryTotalsByCurrency(summary);
-    if (declared.length > 0) {
-      // The summary named its own per-currency totals: use them as given.
-      dealValueByCurrency = declared;
-    } else if (summary.mixed_currency === true) {
-      // The incident shape: summary-only, mixed, no breakdown. Nothing here can
-      // be separated by currency and nothing may be converted, so the gap is
-      // declared as an upstream contract rather than filled with a guess.
-      currencyNotes.set(
-        "summary_mixed_without_breakdown",
-        "deals_summary reports mixed currencies with no per-currency breakdown; the nominal pipeline is withheld rather than summed across currencies (see required upstream contract POST /v1/crm/deals/summary#open_value_by_currency)",
+    if (summary.mixed_currency === true) {
+      // Summary-only and mixed, with no per-currency breakdown to read. Nothing
+      // here can be separated by currency and nothing may be converted, so the
+      // total is withheld. Deriving the split from a summary that does not
+      // carry it needs an upstream contract change: see issue #69 follow-up.
+      currencyNotes.push(
+        "deals_summary reports mixed currencies without per-currency totals; the nominal pipeline is withheld rather than summed across currencies",
       );
-      contracts.push(DEALS_SUMMARY_CURRENCY_CONTRACT);
     } else if (typeof summary.open_value === "number" && summary.open_value > 0) {
       const currency = resolveCurrency(summary.currency);
       if (currency) {
         dealValueByCurrency = [majorUnitsToCents(summary.open_value, currency)];
       } else {
-        currencyNotes.set(
-          "summary_currency_unreadable",
+        currencyNotes.push(
           `deals_summary.currency ${JSON.stringify(summary.currency)} is not an ISO-4217 code; the nominal pipeline is withheld`,
         );
       }
@@ -369,8 +352,7 @@ export function collectFromWarmblyPayload(
   }
 
   if (dealValueByCurrency.length > 1) {
-    currencyNotes.set(
-      "mixed_currencies",
+    currencyNotes.push(
       `open pipeline spans ${dealValueByCurrency.map((m) => m.currency).join(", ")}; totals stay separate because no explicit conversion rate with a source and a date is available`,
     );
   }
@@ -378,8 +360,7 @@ export function collectFromWarmblyPayload(
     (code) => code !== CATALOG_CURRENCY,
   );
   if (foreign.length > 0) {
-    currencyNotes.set(
-      "foreign_currency",
+    currencyNotes.push(
       `pipeline currency ${foreign.join(", ")} is not the contractual catalog currency ${CATALOG_CURRENCY}; reported as observed, never converted`,
     );
   }
@@ -392,16 +373,14 @@ export function collectFromWarmblyPayload(
 
   // A currency the Control Center cannot vouch for is an exception an operator
   // has to see, not something to render quietly.
-  const currencyExceptions: CommercialAttentionItem[] = [...currencyNotes.entries()].map(
-    ([key, note]) => ({
-      id: `warmbly:currency:pipeline:${key}`,
-      kind: "exception_state",
-      title: "Moeda do pipeline não confirmada",
-      why: note,
-      severity: "high",
-      provenance: provenance(now, "FRESH"),
-    }),
-  );
+  const currencyExceptions: CommercialAttentionItem[] = currencyNotes.map((note, index) => ({
+    id: `warmbly:currency:pipeline:${index}`,
+    kind: "exception_state",
+    title: "Moeda do pipeline não confirmada",
+    why: note,
+    severity: "high",
+    provenance: provenance(now, "FRESH"),
+  }));
   const allAttention =
     currencyExceptions.length > 0
       ? sortAttention(dedupeAttention([...attention, ...currencyExceptions]))

--- a/control-center/connectors/warmbly/src/mapper/normalize.ts
+++ b/control-center/connectors/warmbly/src/mapper/normalize.ts
@@ -1,8 +1,10 @@
 import {
   COMMERCIAL_SNAPSHOT_SCHEMA,
   SNAPSHOT_SOURCE,
+  type CommercialAttentionItem,
   type CommercialSnapshot,
   type FreshnessStatus,
+  type Money,
   type RequiredUpstreamContract,
   type SourceObservation,
 } from "../contracts/snapshot.ts";
@@ -32,7 +34,7 @@ import {
   type AttentionContext,
 } from "./attention.ts";
 import { provenance, rollupFreshness } from "./freshness.ts";
-import { majorUnitsToCents, sumOpenDealValue } from "./money.ts";
+import { CATALOG_CURRENCY, majorUnitsToCents, openDealTotals, resolveCurrency } from "./money.ts";
 
 const OPERATIONS_CAP = 50;
 
@@ -311,13 +313,68 @@ export function collectFromWarmblyPayload(
     return s !== "completed" && s !== "cancelled";
   }).length;
 
-  let dealValue = sumOpenDealValue(deals);
-  if (!dealValue && payload.deals_summary && payload.deals_summary.mixed_currency !== true) {
-    const currency = payload.deals_summary.currency || "BRL";
-    if (typeof payload.deals_summary.open_value === "number") {
-      dealValue = majorUnitsToCents(payload.deals_summary.open_value, currency);
-    }
+  // Currency is evidence, not a default. A total is only denominated in a code
+  // the payload actually justifies: the deals' own codes, or — when the payload
+  // says nothing at all — the contractual catalog currency. Totals in different
+  // codes are kept apart, never summed, because there is no rate source here.
+  const openTotals = openDealTotals(deals);
+  let dealValue: Money | undefined = openTotals.totals.length === 1 ? openTotals.totals[0] : undefined;
+  let dealValueByCurrency: Money[] = openTotals.totals;
+  const currencyNotes: string[] = [];
+  if (openTotals.unreadable_currency > 0) {
+    currencyNotes.push(
+      `${openTotals.unreadable_currency} open deal(s) carry a currency that is not an ISO-4217 code; they are excluded from the nominal pipeline rather than denominated in ${CATALOG_CURRENCY}`,
+    );
   }
+  if (openTotals.totals.length > 1) {
+    currencyNotes.push(
+      `open pipeline spans ${openTotals.totals.map((m) => m.currency).join(", ")}; totals stay separate because no explicit conversion rate with a source and a date is available`,
+    );
+  }
+  const summary = payload.deals_summary;
+  if (dealValueByCurrency.length === 0 && summary) {
+    if (summary.mixed_currency === true) {
+      currencyNotes.push(
+        "deals_summary reports mixed currencies without per-currency totals; the nominal pipeline is withheld rather than summed across currencies",
+      );
+    } else if (typeof summary.open_value === "number" && summary.open_value > 0) {
+      const currency = resolveCurrency(summary.currency);
+      if (currency) {
+        dealValue = majorUnitsToCents(summary.open_value, currency);
+        dealValueByCurrency = [dealValue];
+      } else {
+        currencyNotes.push(
+          `deals_summary.currency ${JSON.stringify(summary.currency)} is not an ISO-4217 code; the nominal pipeline is withheld`,
+        );
+      }
+    }
+    // open_value of 0 (or absent) with no open deal contributing a denominated
+    // amount is absence, not a zero: it carries no currency evidence, so it is
+    // omitted and surfaces as "sem dados" rather than as `<some currency> 0,00`.
+  }
+  const foreign = [...new Set(dealValueByCurrency.map((m) => m.currency))].filter(
+    (code) => code !== CATALOG_CURRENCY,
+  );
+  if (foreign.length > 0) {
+    currencyNotes.push(
+      `pipeline currency ${foreign.join(", ")} is not the contractual catalog currency ${CATALOG_CURRENCY}; reported as observed, never converted`,
+    );
+  }
+
+  // A currency the Control Center cannot vouch for is an exception an operator
+  // has to see, not something to render quietly.
+  const currencyExceptions: CommercialAttentionItem[] = currencyNotes.map((note, index) => ({
+    id: `warmbly:currency:pipeline:${index}`,
+    kind: "exception_state",
+    title: "Moeda do pipeline não confirmada",
+    why: note,
+    severity: "high",
+    provenance: provenance(now, "FRESH"),
+  }));
+  const allAttention =
+    currencyExceptions.length > 0
+      ? sortAttention(dedupeAttention([...attention, ...currencyExceptions]))
+      : attention;
 
   const snapshotFreshness = rollupFreshness(
     freshnessBySurface.length > 0 ? freshnessBySurface : [healthFresh],
@@ -357,14 +414,17 @@ export function collectFromWarmblyPayload(
         return s !== "done" && s !== "handled" && s !== "closed";
       }).length,
       confenge_attention: confengeAttention.length,
-      attention: attention.length,
+      attention: allAttention.length,
     },
-    attention,
+    attention: allAttention,
     observations,
     required_upstream_contract: [...uniqueContracts.values()],
   };
   if (dealValue) {
     snapshot.deal_value_open = dealValue;
+  }
+  if (dealValueByCurrency.length > 1) {
+    snapshot.deal_value_open_by_currency = dealValueByCurrency;
   }
 
   snapshot.operations = {

--- a/control-center/connectors/warmbly/src/mapper/normalize.ts
+++ b/control-center/connectors/warmbly/src/mapper/normalize.ts
@@ -10,6 +10,7 @@ import {
 } from "../contracts/snapshot.ts";
 import {
   contractForUnavailable,
+  DEALS_SUMMARY_CURRENCY_CONTRACT,
   LEADS_LIST_CONTRACT,
 } from "../contracts/required-upstream.ts";
 import {
@@ -34,7 +35,13 @@ import {
   type AttentionContext,
 } from "./attention.ts";
 import { provenance, rollupFreshness } from "./freshness.ts";
-import { CATALOG_CURRENCY, majorUnitsToCents, openDealTotals, resolveCurrency } from "./money.ts";
+import {
+  CATALOG_CURRENCY,
+  majorUnitsToCents,
+  openDealTotals,
+  resolveCurrency,
+  summaryTotalsByCurrency,
+} from "./money.ts";
 
 const OPERATIONS_CAP = 50;
 
@@ -318,32 +325,40 @@ export function collectFromWarmblyPayload(
   // says nothing at all — the contractual catalog currency. Totals in different
   // codes are kept apart, never summed, because there is no rate source here.
   const openTotals = openDealTotals(deals);
-  let dealValue: Money | undefined = openTotals.totals.length === 1 ? openTotals.totals[0] : undefined;
   let dealValueByCurrency: Money[] = openTotals.totals;
-  const currencyNotes: string[] = [];
+  // Keyed by anomaly, not by position: the same anomaly must keep the same id
+  // whichever siblings happen to fire alongside it, or dedupe and any operator
+  // acknowledgement keyed on the id both break.
+  const currencyNotes = new Map<string, string>();
   if (openTotals.unreadable_currency > 0) {
-    currencyNotes.push(
+    currencyNotes.set(
+      "unreadable_deal_currency",
       `${openTotals.unreadable_currency} open deal(s) carry a currency that is not an ISO-4217 code; they are excluded from the nominal pipeline rather than denominated in ${CATALOG_CURRENCY}`,
     );
   }
-  if (openTotals.totals.length > 1) {
-    currencyNotes.push(
-      `open pipeline spans ${openTotals.totals.map((m) => m.currency).join(", ")}; totals stay separate because no explicit conversion rate with a source and a date is available`,
-    );
-  }
+
   const summary = payload.deals_summary;
   if (dealValueByCurrency.length === 0 && summary) {
-    if (summary.mixed_currency === true) {
-      currencyNotes.push(
-        "deals_summary reports mixed currencies without per-currency totals; the nominal pipeline is withheld rather than summed across currencies",
+    const declared = summaryTotalsByCurrency(summary);
+    if (declared.length > 0) {
+      // The summary named its own per-currency totals: use them as given.
+      dealValueByCurrency = declared;
+    } else if (summary.mixed_currency === true) {
+      // The incident shape: summary-only, mixed, no breakdown. Nothing here can
+      // be separated by currency and nothing may be converted, so the gap is
+      // declared as an upstream contract rather than filled with a guess.
+      currencyNotes.set(
+        "summary_mixed_without_breakdown",
+        "deals_summary reports mixed currencies with no per-currency breakdown; the nominal pipeline is withheld rather than summed across currencies (see required upstream contract POST /v1/crm/deals/summary#open_value_by_currency)",
       );
+      contracts.push(DEALS_SUMMARY_CURRENCY_CONTRACT);
     } else if (typeof summary.open_value === "number" && summary.open_value > 0) {
       const currency = resolveCurrency(summary.currency);
       if (currency) {
-        dealValue = majorUnitsToCents(summary.open_value, currency);
-        dealValueByCurrency = [dealValue];
+        dealValueByCurrency = [majorUnitsToCents(summary.open_value, currency)];
       } else {
-        currencyNotes.push(
+        currencyNotes.set(
+          "summary_currency_unreadable",
           `deals_summary.currency ${JSON.stringify(summary.currency)} is not an ISO-4217 code; the nominal pipeline is withheld`,
         );
       }
@@ -352,25 +367,41 @@ export function collectFromWarmblyPayload(
     // amount is absence, not a zero: it carries no currency evidence, so it is
     // omitted and surfaces as "sem dados" rather than as `<some currency> 0,00`.
   }
+
+  if (dealValueByCurrency.length > 1) {
+    currencyNotes.set(
+      "mixed_currencies",
+      `open pipeline spans ${dealValueByCurrency.map((m) => m.currency).join(", ")}; totals stay separate because no explicit conversion rate with a source and a date is available`,
+    );
+  }
   const foreign = [...new Set(dealValueByCurrency.map((m) => m.currency))].filter(
     (code) => code !== CATALOG_CURRENCY,
   );
   if (foreign.length > 0) {
-    currencyNotes.push(
+    currencyNotes.set(
+      "foreign_currency",
       `pipeline currency ${foreign.join(", ")} is not the contractual catalog currency ${CATALOG_CURRENCY}; reported as observed, never converted`,
     );
   }
 
+  // A single currency is a total; more than one is a split that must not be
+  // merged. A scalar total of zero has no denominated contributor, so it is
+  // absence rather than a zero in a made-up currency.
+  const single = dealValueByCurrency.length === 1 ? dealValueByCurrency[0] : undefined;
+  const dealValue: Money | undefined = single && single.amount_cents !== 0 ? single : undefined;
+
   // A currency the Control Center cannot vouch for is an exception an operator
   // has to see, not something to render quietly.
-  const currencyExceptions: CommercialAttentionItem[] = currencyNotes.map((note, index) => ({
-    id: `warmbly:currency:pipeline:${index}`,
-    kind: "exception_state",
-    title: "Moeda do pipeline não confirmada",
-    why: note,
-    severity: "high",
-    provenance: provenance(now, "FRESH"),
-  }));
+  const currencyExceptions: CommercialAttentionItem[] = [...currencyNotes.entries()].map(
+    ([key, note]) => ({
+      id: `warmbly:currency:pipeline:${key}`,
+      kind: "exception_state",
+      title: "Moeda do pipeline não confirmada",
+      why: note,
+      severity: "high",
+      provenance: provenance(now, "FRESH"),
+    }),
+  );
   const allAttention =
     currencyExceptions.length > 0
       ? sortAttention(dedupeAttention([...attention, ...currencyExceptions]))

--- a/control-center/connectors/warmbly/tests/currency.test.ts
+++ b/control-center/connectors/warmbly/tests/currency.test.ts
@@ -156,8 +156,13 @@ describe("multi-currency pipeline", () => {
       { amount_cents: 5_000, currency: "USD" },
     ]);
     const raised = snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:"));
-    assert.ok(raised.length >= 1);
     assert.ok(raised.some((item) => /no explicit conversion rate/.test(item.why)));
+    // Ids are keyed by anomaly, not by position, so an operator acknowledgement
+    // survives a sibling note appearing or disappearing.
+    assert.deepEqual(raised.map((item) => item.id).sort(), [
+      "warmbly:currency:pipeline:foreign_currency",
+      "warmbly:currency:pipeline:mixed_currencies",
+    ]);
   });
 
   it("leaves a single-currency BRL pipeline as one total with no split", () => {
@@ -173,5 +178,113 @@ describe("multi-currency pipeline", () => {
       snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:")).length,
       0,
     );
+  });
+});
+
+describe("a summary-only mixed-currency pipeline (the incident shape)", () => {
+  it("separates the totals when the summary declares a per-currency breakdown", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({
+        deals: [],
+        deals_summary: {
+          open_count: 3,
+          open_value: 150,
+          mixed_currency: true,
+          open_value_by_currency: [
+            { currency: "USD", value: 50 },
+            { currency: "BRL", value: 100 },
+          ],
+        },
+      }),
+      { now: NOW },
+    );
+    assert.equal(snapshot.deal_value_open, undefined);
+    assert.deepEqual(snapshot.deal_value_open_by_currency, [
+      { amount_cents: 10_000, currency: "BRL" },
+      { amount_cents: 5_000, currency: "USD" },
+    ]);
+  });
+
+  it("declares the gap as an upstream contract when the summary gives no breakdown", () => {
+    // Empty deals[] plus a mixed summary is exactly the payload the incident
+    // arrived in. Nothing here can be separated and nothing may be converted,
+    // so the missing breakdown is named rather than guessed around.
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({
+        deals: [],
+        deals_summary: { open_count: 3, open_value: 150, currency: "BRL", mixed_currency: true },
+      }),
+      { now: NOW },
+    );
+    assert.equal(snapshot.deal_value_open, undefined);
+    assert.equal(snapshot.deal_value_open_by_currency, undefined);
+    assert.ok(
+      snapshot.required_upstream_contract.some(
+        (c) => c.id === "POST /v1/crm/deals/summary#open_value_by_currency",
+      ),
+    );
+    const raised = snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:"));
+    assert.deepEqual(raised.map((item) => item.id), [
+      "warmbly:currency:pipeline:summary_mixed_without_breakdown",
+    ]);
+  });
+
+  it("drops an unreadable code from the declared breakdown without losing the rest", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({
+        deals: [],
+        deals_summary: {
+          mixed_currency: true,
+          open_value_by_currency: [
+            { currency: "BRL", value: 100 },
+            { currency: "R$", value: 50 },
+          ],
+        },
+      }),
+      { now: NOW },
+    );
+    // One readable currency left is a total, not a split, and not absence.
+    assert.deepEqual(snapshot.deal_value_open, { amount_cents: 10_000, currency: "BRL" });
+    assert.equal(snapshot.deal_value_open_by_currency, undefined);
+  });
+});
+
+describe("a zero bucket does not take its siblings down with it", () => {
+  it("keeps a real BRL total alongside a zero USD one", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({
+        deals: [
+          deal({ id: "d1", value: 100, currency: "BRL" }),
+          deal({ id: "d2", value: 0, currency: "USD" }),
+        ],
+      }),
+      { now: NOW },
+    );
+    assert.deepEqual(snapshot.deal_value_open_by_currency, [
+      { amount_cents: 10_000, currency: "BRL" },
+      { amount_cents: 0, currency: "USD" },
+    ]);
+  });
+
+  it("promotes the readable total when the only sibling had an unreadable code", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({
+        deals: [
+          deal({ id: "d1", value: 100, currency: "BRL" }),
+          deal({ id: "d2", value: 5000, currency: "reais" }),
+        ],
+      }),
+      { now: NOW },
+    );
+    assert.deepEqual(snapshot.deal_value_open, { amount_cents: 10_000, currency: "BRL" });
+    assert.equal(snapshot.deal_value_open_by_currency, undefined);
+  });
+
+  it("still withholds a lone zero total, which has no denominated contributor", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({ deals: [deal({ id: "d1", value: 0, currency: "USD" })] }),
+      { now: NOW },
+    );
+    assert.equal(snapshot.deal_value_open, undefined);
   });
 });

--- a/control-center/connectors/warmbly/tests/currency.test.ts
+++ b/control-center/connectors/warmbly/tests/currency.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { collectFromWarmblyPayload } from "../src/mapper/normalize.ts";
+import {
+  CATALOG_CURRENCY,
+  majorUnitsToCents,
+  normalizeCurrency,
+  openDealTotals,
+  resolveCurrency,
+  sumOpenDealValue,
+} from "../src/mapper/money.ts";
+import type { WarmblyPayload } from "../src/contracts/warmbly-payload.ts";
+import { NOW } from "./helpers.ts";
+
+const deal = (over: Record<string, unknown>): Record<string, unknown> => ({
+  id: "d",
+  name: "Deal",
+  status: "open",
+  created_at: NOW.toISOString(),
+  updated_at: NOW.toISOString(),
+  ...over,
+});
+
+function payloadWith(over: Record<string, unknown>): WarmblyPayload {
+  return {
+    health: { status: "ok" },
+    api_version: "v1",
+    ...over,
+  } as unknown as WarmblyPayload;
+}
+
+describe("currency resolution", () => {
+  it("reads the CONFENGE catalog currency as BRL, never a foreign default", () => {
+    assert.equal(CATALOG_CURRENCY, "BRL");
+    assert.notEqual(CATALOG_CURRENCY, "USD");
+  });
+
+  it("denominates an amount that states no currency in the contractual catalog currency", () => {
+    assert.equal(resolveCurrency(undefined), "BRL");
+    assert.equal(resolveCurrency(null), "BRL");
+    assert.equal(resolveCurrency("   "), "BRL");
+    assert.equal(majorUnitsToCents(1500.5).currency, "BRL");
+    assert.equal(majorUnitsToCents(1500.5).amount_cents, 150_050);
+  });
+
+  it("fails closed on a currency that is present but not ISO-4217", () => {
+    assert.equal(normalizeCurrency("reais"), undefined);
+    assert.equal(normalizeCurrency("R$"), undefined);
+    assert.equal(normalizeCurrency(7), undefined);
+    assert.equal(resolveCurrency("reais"), undefined);
+    assert.throws(() => majorUnitsToCents(10, "reais"));
+  });
+
+  it("normalizes casing and padding without inventing a code", () => {
+    assert.equal(normalizeCurrency(" brl "), "BRL");
+    assert.equal(normalizeCurrency("usd"), "USD");
+  });
+});
+
+describe("open pipeline totals", () => {
+  it("totals a BRL catalog pipeline in integer cents", () => {
+    const total = sumOpenDealValue([
+      { status: "open", value: 1500.5, currency: "BRL" },
+      { status: "open", value: 2000 },
+      { status: "won", value: 9999, currency: "BRL" },
+    ]);
+    assert.deepEqual(total, { amount_cents: 350_050, currency: "BRL" });
+  });
+
+  it("keeps totals separate per currency instead of summing across them", () => {
+    const { totals, foreign_currencies } = openDealTotals([
+      { status: "open", value: 100, currency: "BRL" },
+      { status: "open", value: 50, currency: "USD" },
+      { status: "open", value: 25, currency: "usd" },
+    ]);
+    assert.deepEqual(totals, [
+      { amount_cents: 10_000, currency: "BRL" },
+      { amount_cents: 7_500, currency: "USD" },
+    ]);
+    assert.deepEqual(foreign_currencies, ["USD"]);
+    // No implicit conversion: there is no single total to hand to a caller.
+    assert.equal(sumOpenDealValue([
+      { status: "open", value: 100, currency: "BRL" },
+      { status: "open", value: 50, currency: "USD" },
+    ]), undefined);
+  });
+
+  it("excludes a deal whose currency cannot be read rather than calling it BRL", () => {
+    const { totals, unreadable_currency } = openDealTotals([
+      { status: "open", value: 100, currency: "BRL" },
+      { status: "open", value: 999, currency: "dólares" },
+    ]);
+    assert.equal(unreadable_currency, 1);
+    assert.deepEqual(totals, [{ amount_cents: 10_000, currency: "BRL" }]);
+  });
+});
+
+describe("deals_summary is not allowed to invent a pipeline currency", () => {
+  it("omits the nominal pipeline when the summary reports a zero open value", () => {
+    // Regression for the Comercial view showing "Pipeline nominal USD 0,00":
+    // Warmbly reported open_value 0 stamped with its own default currency, and
+    // the mapper denominated an empty pipeline in it.
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({ deals: [], deals_summary: { open_count: 0, open_value: 0, currency: "USD" } }),
+      { now: NOW },
+    );
+    assert.equal(snapshot.deal_value_open, undefined);
+    assert.equal(snapshot.deal_value_open_by_currency, undefined);
+  });
+
+  it("uses the catalog currency when the summary states none", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({ deals: [], deals_summary: { open_count: 1, open_value: 4800 } }),
+      { now: NOW },
+    );
+    assert.deepEqual(snapshot.deal_value_open, { amount_cents: 480_000, currency: "BRL" });
+  });
+
+  it("withholds the total and raises an exception when the summary currency is unreadable", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({ deals: [], deals_summary: { open_count: 1, open_value: 4800, currency: "reais" } }),
+      { now: NOW },
+    );
+    assert.equal(snapshot.deal_value_open, undefined);
+    const raised = snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:"));
+    assert.equal(raised.length, 1);
+    assert.match(raised[0]?.why ?? "", /ISO-4217/);
+  });
+
+  it("flags a foreign currency instead of rendering it as if it were contractual", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({ deals: [], deals_summary: { open_count: 1, open_value: 100, currency: "USD" } }),
+      { now: NOW },
+    );
+    assert.deepEqual(snapshot.deal_value_open, { amount_cents: 10_000, currency: "USD" });
+    const raised = snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:"));
+    assert.equal(raised.length, 1);
+    assert.match(raised[0]?.why ?? "", /never converted/);
+  });
+});
+
+describe("multi-currency pipeline", () => {
+  it("publishes per-currency totals and no merged nominal", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({
+        deals: [
+          deal({ id: "d1", value: 100, currency: "BRL" }),
+          deal({ id: "d2", value: 50, currency: "USD" }),
+        ],
+      }),
+      { now: NOW },
+    );
+    assert.equal(snapshot.deal_value_open, undefined);
+    assert.deepEqual(snapshot.deal_value_open_by_currency, [
+      { amount_cents: 10_000, currency: "BRL" },
+      { amount_cents: 5_000, currency: "USD" },
+    ]);
+    const raised = snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:"));
+    assert.ok(raised.length >= 1);
+    assert.ok(raised.some((item) => /no explicit conversion rate/.test(item.why)));
+  });
+
+  it("leaves a single-currency BRL pipeline as one total with no split", () => {
+    const snapshot = collectFromWarmblyPayload(
+      payloadWith({
+        deals: [deal({ id: "d1", value: 100 }), deal({ id: "d2", value: 50, currency: "BRL" })],
+      }),
+      { now: NOW },
+    );
+    assert.deepEqual(snapshot.deal_value_open, { amount_cents: 15_000, currency: "BRL" });
+    assert.equal(snapshot.deal_value_open_by_currency, undefined);
+    assert.equal(
+      snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:")).length,
+      0,
+    );
+  });
+});

--- a/control-center/connectors/warmbly/tests/currency.test.ts
+++ b/control-center/connectors/warmbly/tests/currency.test.ts
@@ -156,13 +156,8 @@ describe("multi-currency pipeline", () => {
       { amount_cents: 5_000, currency: "USD" },
     ]);
     const raised = snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:"));
+    assert.ok(raised.length >= 1);
     assert.ok(raised.some((item) => /no explicit conversion rate/.test(item.why)));
-    // Ids are keyed by anomaly, not by position, so an operator acknowledgement
-    // survives a sibling note appearing or disappearing.
-    assert.deepEqual(raised.map((item) => item.id).sort(), [
-      "warmbly:currency:pipeline:foreign_currency",
-      "warmbly:currency:pipeline:mixed_currencies",
-    ]);
   });
 
   it("leaves a single-currency BRL pipeline as one total with no split", () => {
@@ -178,74 +173,6 @@ describe("multi-currency pipeline", () => {
       snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:")).length,
       0,
     );
-  });
-});
-
-describe("a summary-only mixed-currency pipeline (the incident shape)", () => {
-  it("separates the totals when the summary declares a per-currency breakdown", () => {
-    const snapshot = collectFromWarmblyPayload(
-      payloadWith({
-        deals: [],
-        deals_summary: {
-          open_count: 3,
-          open_value: 150,
-          mixed_currency: true,
-          open_value_by_currency: [
-            { currency: "USD", value: 50 },
-            { currency: "BRL", value: 100 },
-          ],
-        },
-      }),
-      { now: NOW },
-    );
-    assert.equal(snapshot.deal_value_open, undefined);
-    assert.deepEqual(snapshot.deal_value_open_by_currency, [
-      { amount_cents: 10_000, currency: "BRL" },
-      { amount_cents: 5_000, currency: "USD" },
-    ]);
-  });
-
-  it("declares the gap as an upstream contract when the summary gives no breakdown", () => {
-    // Empty deals[] plus a mixed summary is exactly the payload the incident
-    // arrived in. Nothing here can be separated and nothing may be converted,
-    // so the missing breakdown is named rather than guessed around.
-    const snapshot = collectFromWarmblyPayload(
-      payloadWith({
-        deals: [],
-        deals_summary: { open_count: 3, open_value: 150, currency: "BRL", mixed_currency: true },
-      }),
-      { now: NOW },
-    );
-    assert.equal(snapshot.deal_value_open, undefined);
-    assert.equal(snapshot.deal_value_open_by_currency, undefined);
-    assert.ok(
-      snapshot.required_upstream_contract.some(
-        (c) => c.id === "POST /v1/crm/deals/summary#open_value_by_currency",
-      ),
-    );
-    const raised = snapshot.attention.filter((item) => item.id.startsWith("warmbly:currency:"));
-    assert.deepEqual(raised.map((item) => item.id), [
-      "warmbly:currency:pipeline:summary_mixed_without_breakdown",
-    ]);
-  });
-
-  it("drops an unreadable code from the declared breakdown without losing the rest", () => {
-    const snapshot = collectFromWarmblyPayload(
-      payloadWith({
-        deals: [],
-        deals_summary: {
-          mixed_currency: true,
-          open_value_by_currency: [
-            { currency: "BRL", value: 100 },
-            { currency: "R$", value: 50 },
-          ],
-        },
-      }),
-      { now: NOW },
-    );
-    // One readable currency left is a total, not a split, and not absence.
-    assert.deepEqual(snapshot.deal_value_open, { amount_cents: 10_000, currency: "BRL" });
-    assert.equal(snapshot.deal_value_open_by_currency, undefined);
   });
 });
 

--- a/control-center/contracts/schemas/commercial-snapshot.v1.schema.json
+++ b/control-center/contracts/schemas/commercial-snapshot.v1.schema.json
@@ -14,7 +14,6 @@
     "authority",
     "offer_pin",
     "funnel",
-    "pipeline_nominal",
     "aging_count",
     "stalled_count",
     "missing_next_action_count",
@@ -100,7 +99,17 @@
       }
     },
     "pipeline_nominal": {
+      "description": "Nominal open pipeline. Optional on purpose: a pipeline the runtime could not denominate is absent, never a zero stamped with a guessed currency. Absence renders as \"sem dados\"; a zero here would read as a measured amount.",
       "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+    },
+    "pipeline_nominal_by_currency": {
+      "type": "array",
+      "description": "Separate open-pipeline totals, one per observed currency, present only when the pipeline spans more than one. Totals are never added across currencies and never converted: conversion would require an explicit rate carrying a source and a date, which this read model does not have.",
+      "minItems": 2,
+      "maxItems": 8,
+      "items": {
+        "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/unsigned_money"
+      }
     },
     "pipeline_weighted": {
       "$ref": "https://github.com/tjsasakifln/Governance/control-center/contracts/schemas/primitives.v1.schema.json#/$defs/weighted_pipeline"

--- a/control-center/contracts/src/types.ts
+++ b/control-center/contracts/src/types.ts
@@ -219,7 +219,10 @@ export interface CommercialSnapshot {
   authority: CommercialAuthorityStamp;
   offer_pin: GovernanceOfferPin;
   funnel: CommercialFunnelCounts;
-  pipeline_nominal: Money;
+  /** Absent when the pipeline could not be denominated. Never a zero in a guessed currency. */
+  pipeline_nominal?: Money;
+  /** One total per currency, only when the pipeline spans more than one. Never summed, never converted. */
+  pipeline_nominal_by_currency?: Money[];
   pipeline_weighted?: WeightedPipeline;
   aging_count: number;
   stalled_count: number;

--- a/control-center/domains/commercial/src/normalize.ts
+++ b/control-center/domains/commercial/src/normalize.ts
@@ -184,11 +184,17 @@ function resolveAmount(record: WarmblyCommercialRecord): {
   amount_cents: number | null;
   currency: string | null;
 } {
+  // Absent currency is denominated in the contractual catalog currency.
+  // A currency that is present but unreadable is NOT relabelled as BRL: the
+  // amount loses its denomination and fails closed downstream.
+  const stated = record.currency;
+  const hasAmount = record.amount_cents != null || record.value != null;
   const currency =
-    normalizeCurrency(record.currency) ??
-    (record.amount_cents != null || record.value != null
-      ? DEFAULT_CURRENCY
-      : null);
+    stated === undefined || stated === null || (typeof stated === "string" && stated.trim() === "")
+      ? hasAmount
+        ? DEFAULT_CURRENCY
+        : null
+      : normalizeCurrency(stated);
   const fromCents = integerCents(record.amount_cents ?? null);
   if (fromCents !== null) {
     if (typeof record.value === "number" && Number.isFinite(record.value)) {

--- a/control-center/domains/commercial/src/project.ts
+++ b/control-center/domains/commercial/src/project.ts
@@ -156,10 +156,12 @@ function buildPipeline(
 
   if (open.length === 0) {
     return {
+      // No open record contributed a denominated amount, so there is nothing to
+      // state a currency in. A zero stamped with the catalog currency would read
+      // as a measured "BRL 0,00"; the honest answer is that there is no data.
       nominal: {
-        treatment: "present",
-        amount_cents: 0,
-        currency: DEFAULT_CURRENCY,
+        treatment: "insufficient_data",
+        reason: "no_open_pipeline",
         provenance: baseProv,
       },
       weighted: {
@@ -171,15 +173,24 @@ function buildPipeline(
   }
 
   const known = open.filter((r) => r.amount_cents !== null);
+  // An amount whose stated currency could not be read is undenominated. It is
+  // not folded into the catalog currency: that would hide a bad code inside a
+  // total that then looks like one clean BRL figure.
+  const undenominated = known.filter((r) => r.currency === null);
   const currencies = new Set(
-    known.map((r) => r.currency ?? DEFAULT_CURRENCY),
+    known.filter((r) => r.currency !== null).map((r) => r.currency as string),
   );
 
   let nominal: PipelineMoney;
-  if (known.length === 0 || currencies.size !== 1) {
+  if (known.length === 0 || undenominated.length > 0 || currencies.size !== 1) {
     nominal = {
       treatment: "insufficient_data",
-      reason: known.length === 0 ? "no_known_amounts" : "mixed_currency",
+      reason:
+        known.length === 0
+          ? "no_known_amounts"
+          : undenominated.length > 0
+            ? "unreadable_currency"
+            : "mixed_currency",
       provenance: baseProv,
     };
   } else {

--- a/control-center/domains/commercial/tests/money.test.ts
+++ b/control-center/domains/commercial/tests/money.test.ts
@@ -75,3 +75,86 @@ describe("weightedCentsExact", () => {
     assert.equal(weightedCentsExact(800000, -0.1), null);
   });
 });
+
+describe("pipeline currency is evidence, not a default", () => {
+  const base = {
+    schema_version: "control-center.commercial-observations.v1" as const,
+    observed_at: "2026-08-20T12:00:00Z",
+    freshness_status: "FRESH" as const,
+  };
+
+  it("does not report an empty pipeline as a zero in the catalog currency", () => {
+    // A pipeline with nothing open has no denominated contribution, so it has
+    // no currency to be stated in. "BRL 0,00" would read as a measured amount.
+    const summary = projectCommercialSummary({ ...base, records: [] }, { now: NOW });
+    assert.equal(summary.pipeline.nominal.treatment, "insufficient_data");
+    assert.equal(summary.pipeline.nominal.reason, "no_open_pipeline");
+    assert.equal(summary.pipeline.nominal.amount_cents, undefined);
+    assert.equal(summary.pipeline.nominal.currency, undefined);
+  });
+
+  it("denominates a deal that states no currency in the BRL catalog currency", () => {
+    const summary = projectCommercialSummary(
+      {
+        ...base,
+        records: [
+          {
+            id: "deal-no-currency",
+            entity: "deal",
+            status: "open",
+            funnel_stage: "propostas",
+            amount_cents: 800000,
+            next_action: "send",
+            next_action_at: "2026-08-21T00:00:00Z",
+            last_activity_at: "2026-08-19T00:00:00Z",
+            stage_entered_at: "2026-08-18T00:00:00Z",
+          },
+        ],
+      },
+      { now: NOW },
+    );
+    assert.equal(summary.pipeline.nominal.treatment, "present");
+    assert.equal(summary.pipeline.nominal.currency, "BRL");
+    assert.equal(summary.pipeline.nominal.amount_cents, 800000);
+  });
+
+  it("does not relabel an unreadable currency as BRL and fold it into the total", () => {
+    const summary = projectCommercialSummary(
+      {
+        ...base,
+        records: [
+          {
+            id: "deal-brl",
+            entity: "deal",
+            status: "open",
+            funnel_stage: "propostas",
+            amount_cents: 800000,
+            currency: "BRL",
+            next_action: "send",
+            next_action_at: "2026-08-21T00:00:00Z",
+            last_activity_at: "2026-08-19T00:00:00Z",
+            stage_entered_at: "2026-08-18T00:00:00Z",
+          },
+          {
+            id: "deal-bad-currency",
+            entity: "deal",
+            status: "open",
+            funnel_stage: "propostas",
+            amount_cents: 100000,
+            currency: "reais",
+            next_action: "send",
+            next_action_at: "2026-08-21T00:00:00Z",
+            last_activity_at: "2026-08-19T00:00:00Z",
+            stage_entered_at: "2026-08-18T00:00:00Z",
+          },
+        ],
+      },
+      { now: NOW },
+    );
+    // The two must not be summed into a single 900000 that looks like one
+    // clean BRL figure.
+    assert.equal(summary.pipeline.nominal.treatment, "insufficient_data");
+    assert.equal(summary.pipeline.nominal.reason, "unreadable_currency");
+    assert.equal(summary.pipeline.nominal.amount_cents, undefined);
+  });
+});

--- a/control-center/services/context/src/operational/assemble.ts
+++ b/control-center/services/context/src/operational/assemble.ts
@@ -138,7 +138,7 @@ function mapCommercial(payload: Record<string, unknown>, seed: ProvenanceSeed, i
   // stamped with whatever code the upstream summary reported is withheld here
   // too, not only at the moment it was collected.
   const nominal = nominalPipeline(payload.pipeline_nominal, seed);
-  const split = pipelineByCurrency(payload.pipeline_nominal_by_currency);
+  const split = pipelineByCurrency(payload.pipeline_nominal_by_currency, seed);
   if (nominal) {
     out.pipeline_nominal = nominal;
   } else if (split.length === 1) {

--- a/control-center/services/context/src/operational/assemble.ts
+++ b/control-center/services/context/src/operational/assemble.ts
@@ -8,7 +8,13 @@ import type { RepoDomainMap } from "../scope.ts";
 import type { FreshnessStatus, Scope } from "../types.ts";
 import { isOperationalUnavailableError } from "./errors.ts";
 import { demoteHealthStatus, looksHealthy, minConfidence, worstFreshness } from "./freshness.ts";
-import { financeStages, reliableWeightedPipeline, type ProvenanceSeed } from "./money.ts";
+import {
+  financeStages,
+  nominalPipeline,
+  pipelineByCurrency,
+  reliableWeightedPipeline,
+  type ProvenanceSeed,
+} from "./money.ts";
 import type { OperationalReadPort } from "./port.ts";
 import { stripForbiddenKeys } from "./sanitize.ts";
 import {
@@ -128,18 +134,16 @@ function mapCommercial(payload: Record<string, unknown>, seed: ProvenanceSeed, i
       out.funnel = derived;
     }
   }
-  const nominal = payload.pipeline_nominal;
-  if (nominal !== undefined) {
-    const money: Record<string, unknown> = {
-      ...asRecord(nominal),
-      source: seed.source,
-      observed_at: seed.observed_at,
-      freshness_status: seed.freshness_status,
-      confidence: seed.confidence,
-    };
-    if (typeof money.amount_cents === "number") {
-      out.pipeline_nominal = money;
-    }
+  // Read side, not just write side: snapshots persisted before the currency
+  // policy landed still carry a zero total stamped with whatever code the
+  // upstream summary happened to report. They are withheld here too.
+  const nominal = nominalPipeline(payload.pipeline_nominal, seed);
+  if (nominal) {
+    out.pipeline_nominal = nominal;
+  }
+  const nominalByCurrency = pipelineByCurrency(payload.pipeline_nominal_by_currency, seed);
+  if (nominalByCurrency.length > 1) {
+    out.pipeline_nominal_by_currency = nominalByCurrency;
   }
   const weighted = reliableWeightedPipeline(payload, seed);
   if (weighted) {

--- a/control-center/services/context/src/operational/assemble.ts
+++ b/control-center/services/context/src/operational/assemble.ts
@@ -134,16 +134,25 @@ function mapCommercial(payload: Record<string, unknown>, seed: ProvenanceSeed, i
       out.funnel = derived;
     }
   }
-  // Read side, not just write side: snapshots persisted before the currency
-  // policy landed still carry a zero total stamped with whatever code the
-  // upstream summary happened to report. They are withheld here too.
+  // Read side, not just write side: a snapshot persisted with a zero total
+  // stamped with whatever code the upstream summary reported is withheld here
+  // too, not only at the moment it was collected.
   const nominal = nominalPipeline(payload.pipeline_nominal, seed);
+  const split = pipelineByCurrency(payload.pipeline_nominal_by_currency);
   if (nominal) {
     out.pipeline_nominal = nominal;
+  } else if (split.length === 1) {
+    // A split that filtered down to a single readable currency is not a split
+    // any more, but it is not absence either: the surviving total is a real
+    // denominated figure. Promote it rather than dropping real money on the
+    // floor because its unreadable sibling was rejected.
+    const promoted = nominalPipeline(split[0], seed);
+    if (promoted) {
+      out.pipeline_nominal = promoted;
+    }
   }
-  const nominalByCurrency = pipelineByCurrency(payload.pipeline_nominal_by_currency, seed);
-  if (nominalByCurrency.length > 1) {
-    out.pipeline_nominal_by_currency = nominalByCurrency;
+  if (split.length > 1) {
+    out.pipeline_nominal_by_currency = split;
   }
   const weighted = reliableWeightedPipeline(payload, seed);
   if (weighted) {

--- a/control-center/services/context/src/operational/money.ts
+++ b/control-center/services/context/src/operational/money.ts
@@ -38,12 +38,6 @@ function integerCents(value: unknown): number | undefined {
 /**
  * Resolve the currency of one observed amount.
  *
- * This is a read boundary: values reaching it have already been through a
- * collector's normalizer, so a stated code must already be exact ISO-4217. It
- * is deliberately not lenient — no trimming, no case folding. Accepting "usd"
- * here would *widen* what this shared helper admits (it used to fall through
- * to BRL), and widening is the wrong direction for a fail-closed rule.
- *
  * Absent (or blank) resolves to the contractual catalog currency, which
  * Governance owns. Present-but-unreadable fails closed as `undefined` — the
  * caller then withholds the amount instead of relabelling a code it could not
@@ -56,8 +50,9 @@ function currencyOf(value: unknown, fallback?: string): string | undefined {
     if (typeof raw !== "string") {
       return undefined;
     }
-    if (raw.trim() !== "") {
-      return CURRENCY_RE.test(raw) ? raw : undefined;
+    const code = raw.trim().toUpperCase();
+    if (code !== "") {
+      return CURRENCY_RE.test(code) ? code : undefined;
     }
   }
   if (fallback && CURRENCY_RE.test(fallback)) {
@@ -213,12 +208,6 @@ export function financeStages(
   return out;
 }
 
-/** A per-currency bucket. Plain money: the snapshot already carries provenance. */
-export type CurrencyTotal = { amount_cents: number; currency: string };
-
-/** At most this many currency buckets, matching `unsigned_money` maxItems in the schema. */
-const MAX_CURRENCY_BUCKETS = 8;
-
 /**
  * Nominal pipeline total for the commercial read model.
  *
@@ -263,11 +252,11 @@ export function nominalPipeline(value: unknown, seed: ProvenanceSeed): Evidenced
  * because a split that filtered down to one entry was then discarded as "not a
  * split" — see the promotion in `assemble.ts`.
  */
-export function pipelineByCurrency(value: unknown): CurrencyTotal[] {
+export function pipelineByCurrency(value: unknown, seed: ProvenanceSeed): EvidencedMoney[] {
   if (!Array.isArray(value)) {
     return [];
   }
-  const out: CurrencyTotal[] = [];
+  const out: EvidencedMoney[] = [];
   const seen = new Set<string>();
   for (const item of value) {
     const cents = integerCents(item);
@@ -279,9 +268,16 @@ export function pipelineByCurrency(value: unknown): CurrencyTotal[] {
       continue;
     }
     seen.add(currency);
-    out.push({ amount_cents: cents, currency });
+    out.push({
+      amount_cents: cents,
+      currency,
+      source: seed.source,
+      observed_at: seed.observed_at,
+      freshness_status: seed.freshness_status,
+      confidence: seed.confidence,
+    });
   }
-  return out.sort((a, b) => a.currency.localeCompare(b.currency)).slice(0, MAX_CURRENCY_BUCKETS);
+  return out.sort((a, b) => a.currency.localeCompare(b.currency));
 }
 
 export function reliableWeightedPipeline(payload: Record<string, unknown>, seed: ProvenanceSeed): EvidencedMoney | undefined {
@@ -290,12 +286,6 @@ export function reliableWeightedPipeline(payload: Record<string, unknown>, seed:
     return undefined;
   }
   if (weighted.probability_reliable !== true) {
-    return undefined;
-  }
-  // Same scalar-aggregate rule as `nominalPipeline`: a weighted total of zero
-  // has no denominated contributor, so it must not sit under a nominal that
-  // reads "sem dados" claiming to be a measured "BRL 0,00".
-  if (integerCents(weighted) === 0) {
     return undefined;
   }
   return evidencedMoney(weighted, seed);

--- a/control-center/services/context/src/operational/money.ts
+++ b/control-center/services/context/src/operational/money.ts
@@ -3,6 +3,13 @@ import type { EvidencedMoney, SourceRef } from "./types.ts";
 
 const CURRENCY_RE = /^[A-Z]{3}$/;
 
+/**
+ * The CONFENGE catalog is contracted in BRL and Governance is its authority.
+ * It is the contractual currency for amounts that arrive undenominated — never
+ * a fallback applied over a currency the payload actually stated.
+ */
+export const CATALOG_CURRENCY = "BRL";
+
 export interface ProvenanceSeed {
   source: SourceRef;
   observed_at: string;
@@ -28,10 +35,25 @@ function integerCents(value: unknown): number | undefined {
   return undefined;
 }
 
+/**
+ * Resolve the currency of one observed amount.
+ *
+ * Absent (or blank) resolves to the contractual catalog currency, which
+ * Governance owns. Present-but-unreadable fails closed as `undefined` — the
+ * caller then withholds the amount instead of relabelling a code it could not
+ * parse, so a bad upstream code can never be laundered into BRL.
+ */
 function currencyOf(value: unknown, fallback?: string): string | undefined {
   const rec = asRecord(value);
-  if (rec && typeof rec.currency === "string" && CURRENCY_RE.test(rec.currency)) {
-    return rec.currency;
+  const raw = rec?.currency;
+  if (raw !== undefined && raw !== null) {
+    if (typeof raw !== "string") {
+      return undefined;
+    }
+    const code = raw.trim().toUpperCase();
+    if (code !== "") {
+      return CURRENCY_RE.test(code) ? code : undefined;
+    }
   }
   if (fallback && CURRENCY_RE.test(fallback)) {
     return fallback;
@@ -91,7 +113,7 @@ export function evidencedMoney(value: unknown, seed: ProvenanceSeed): EvidencedM
   if (cents === undefined) {
     return undefined;
   }
-  const currency = currencyOf(value, "BRL");
+  const currency = currencyOf(value, CATALOG_CURRENCY);
   if (!currency) {
     return undefined;
   }
@@ -184,6 +206,57 @@ export function financeStages(
     out.chargebacks = chargebacks;
   }
   return out;
+}
+
+/**
+ * Nominal pipeline total for the commercial read model.
+ *
+ * Two rules the plain `evidencedMoney` path cannot express:
+ *  - provenance always comes from the reading seed, not from whatever the
+ *    stored payload claims about itself;
+ *  - a total of exactly zero is absence, not a measured zero. Nothing
+ *    denominated contributed to it, so it has no currency to be stated in.
+ *    Rendering it would print `<currency> 0,00` where the honest answer is
+ *    "sem dados".
+ */
+export function nominalPipeline(value: unknown, seed: ProvenanceSeed): EvidencedMoney | undefined {
+  const cents = integerCents(value);
+  if (cents === undefined || cents === 0) {
+    return undefined;
+  }
+  const currency = currencyOf(value, CATALOG_CURRENCY);
+  if (!currency) {
+    return undefined;
+  }
+  return {
+    amount_cents: cents,
+    currency,
+    source: seed.source,
+    observed_at: seed.observed_at,
+    freshness_status: seed.freshness_status,
+    confidence: seed.confidence,
+  };
+}
+
+/**
+ * Per-currency pipeline totals. Kept apart rather than added: converting would
+ * need an explicit rate with a source and a date, and there is none here.
+ */
+export function pipelineByCurrency(value: unknown, seed: ProvenanceSeed): EvidencedMoney[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const out: EvidencedMoney[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    const money = nominalPipeline(item, seed);
+    if (!money || seen.has(money.currency)) {
+      continue;
+    }
+    seen.add(money.currency);
+    out.push(money);
+  }
+  return out.sort((a, b) => a.currency.localeCompare(b.currency));
 }
 
 export function reliableWeightedPipeline(payload: Record<string, unknown>, seed: ProvenanceSeed): EvidencedMoney | undefined {

--- a/control-center/services/context/src/operational/money.ts
+++ b/control-center/services/context/src/operational/money.ts
@@ -38,6 +38,12 @@ function integerCents(value: unknown): number | undefined {
 /**
  * Resolve the currency of one observed amount.
  *
+ * This is a read boundary: values reaching it have already been through a
+ * collector's normalizer, so a stated code must already be exact ISO-4217. It
+ * is deliberately not lenient — no trimming, no case folding. Accepting "usd"
+ * here would *widen* what this shared helper admits (it used to fall through
+ * to BRL), and widening is the wrong direction for a fail-closed rule.
+ *
  * Absent (or blank) resolves to the contractual catalog currency, which
  * Governance owns. Present-but-unreadable fails closed as `undefined` — the
  * caller then withholds the amount instead of relabelling a code it could not
@@ -50,9 +56,8 @@ function currencyOf(value: unknown, fallback?: string): string | undefined {
     if (typeof raw !== "string") {
       return undefined;
     }
-    const code = raw.trim().toUpperCase();
-    if (code !== "") {
-      return CURRENCY_RE.test(code) ? code : undefined;
+    if (raw.trim() !== "") {
+      return CURRENCY_RE.test(raw) ? raw : undefined;
     }
   }
   if (fallback && CURRENCY_RE.test(fallback)) {
@@ -208,16 +213,26 @@ export function financeStages(
   return out;
 }
 
+/** A per-currency bucket. Plain money: the snapshot already carries provenance. */
+export type CurrencyTotal = { amount_cents: number; currency: string };
+
+/** At most this many currency buckets, matching `unsigned_money` maxItems in the schema. */
+const MAX_CURRENCY_BUCKETS = 8;
+
 /**
  * Nominal pipeline total for the commercial read model.
  *
  * Two rules the plain `evidencedMoney` path cannot express:
  *  - provenance always comes from the reading seed, not from whatever the
  *    stored payload claims about itself;
- *  - a total of exactly zero is absence, not a measured zero. Nothing
- *    denominated contributed to it, so it has no currency to be stated in.
- *    Rendering it would print `<currency> 0,00` where the honest answer is
- *    "sem dados".
+ *  - a *scalar aggregate* of exactly zero is absence. Nothing denominated
+ *    contributed to it, so it has no currency to be stated in; rendering it
+ *    would print `<currency> 0,00` where the honest answer is "sem dados".
+ *
+ * The zero rule is scoped to scalar aggregates on purpose. A per-currency
+ * bucket exists only because some denominated amount created it, and a
+ * per-deal amount carries the currency stated on that deal — in both of those
+ * a zero is evidence, not a gap, so `pipelineByCurrency` does not apply it.
  */
 export function nominalPipeline(value: unknown, seed: ProvenanceSeed): EvidencedMoney | undefined {
   const cents = integerCents(value);
@@ -241,22 +256,32 @@ export function nominalPipeline(value: unknown, seed: ProvenanceSeed): Evidenced
 /**
  * Per-currency pipeline totals. Kept apart rather than added: converting would
  * need an explicit rate with a source and a date, and there is none here.
+ *
+ * A zero bucket is kept. The bucket exists because a deal denominated in that
+ * currency contributed to it, so unlike a scalar aggregate it has real currency
+ * evidence behind it. Dropping it here once destroyed the *sibling* totals too,
+ * because a split that filtered down to one entry was then discarded as "not a
+ * split" — see the promotion in `assemble.ts`.
  */
-export function pipelineByCurrency(value: unknown, seed: ProvenanceSeed): EvidencedMoney[] {
+export function pipelineByCurrency(value: unknown): CurrencyTotal[] {
   if (!Array.isArray(value)) {
     return [];
   }
-  const out: EvidencedMoney[] = [];
+  const out: CurrencyTotal[] = [];
   const seen = new Set<string>();
   for (const item of value) {
-    const money = nominalPipeline(item, seed);
-    if (!money || seen.has(money.currency)) {
+    const cents = integerCents(item);
+    if (cents === undefined) {
       continue;
     }
-    seen.add(money.currency);
-    out.push(money);
+    const currency = currencyOf(item, CATALOG_CURRENCY);
+    if (!currency || seen.has(currency)) {
+      continue;
+    }
+    seen.add(currency);
+    out.push({ amount_cents: cents, currency });
   }
-  return out.sort((a, b) => a.currency.localeCompare(b.currency));
+  return out.sort((a, b) => a.currency.localeCompare(b.currency)).slice(0, MAX_CURRENCY_BUCKETS);
 }
 
 export function reliableWeightedPipeline(payload: Record<string, unknown>, seed: ProvenanceSeed): EvidencedMoney | undefined {
@@ -265,6 +290,12 @@ export function reliableWeightedPipeline(payload: Record<string, unknown>, seed:
     return undefined;
   }
   if (weighted.probability_reliable !== true) {
+    return undefined;
+  }
+  // Same scalar-aggregate rule as `nominalPipeline`: a weighted total of zero
+  // has no denominated contributor, so it must not sit under a nominal that
+  // reads "sem dados" claiming to be a measured "BRL 0,00".
+  if (integerCents(weighted) === 0) {
     return undefined;
   }
   return evidencedMoney(weighted, seed);

--- a/control-center/services/context/test/operational-money.test.ts
+++ b/control-center/services/context/test/operational-money.test.ts
@@ -5,6 +5,7 @@ import {
   evidencedMoney,
   nominalPipeline,
   pipelineByCurrency,
+  reliableWeightedPipeline,
   type ProvenanceSeed,
 } from "../src/operational/money.ts";
 
@@ -75,46 +76,87 @@ describe("nominalPipeline", () => {
 });
 
 describe("pipelineByCurrency", () => {
-  it("keeps one total per currency, sorted, and never sums across them", () => {
-    const split = pipelineByCurrency(
-      [
+  it("keeps one total per currency, sorted, as plain money", () => {
+    // Plain money on purpose: the snapshot already carries provenance, and the
+    // contract types these buckets as `unsigned_money`, which forbids extras.
+    assert.deepEqual(
+      pipelineByCurrency([
         { amount_cents: 5_000, currency: "USD" },
         { amount_cents: 10_000, currency: "BRL" },
-      ],
-      SEED,
-    );
-    assert.deepEqual(
-      split.map((m) => [m.currency, m.amount_cents]),
+      ]),
       [
-        ["BRL", 10_000],
-        ["USD", 5_000],
+        { amount_cents: 10_000, currency: "BRL" },
+        { amount_cents: 5_000, currency: "USD" },
       ],
     );
   });
 
-  it("drops unreadable and zero entries rather than denominating them in BRL", () => {
-    const split = pipelineByCurrency(
+  it("keeps a zero bucket: a denominated deal created it", () => {
+    // The zero rule is for scalar aggregates. Dropping a zero bucket here once
+    // collapsed the split to one entry, and the caller then discarded the
+    // surviving BRL total as "not a split" — real money lost to a USD 0.
+    assert.deepEqual(
+      pipelineByCurrency([
+        { amount_cents: 10_000, currency: "BRL" },
+        { amount_cents: 0, currency: "USD" },
+      ]),
       [
         { amount_cents: 10_000, currency: "BRL" },
-        { amount_cents: 999, currency: "reais" },
         { amount_cents: 0, currency: "USD" },
       ],
-      SEED,
     );
-    assert.deepEqual(split, [
-      {
-        amount_cents: 10_000,
-        currency: "BRL",
-        source: SEED.source,
-        observed_at: SEED.observed_at,
-        freshness_status: SEED.freshness_status,
-        confidence: SEED.confidence,
-      },
-    ]);
+  });
+
+  it("drops an unreadable entry without taking its readable siblings with it", () => {
+    assert.deepEqual(
+      pipelineByCurrency([
+        { amount_cents: 10_000, currency: "BRL" },
+        { amount_cents: 999, currency: "reais" },
+      ]),
+      [{ amount_cents: 10_000, currency: "BRL" }],
+    );
+  });
+
+  it("caps the buckets at the schema maximum", () => {
+    const many = ["AED", "BRL", "CAD", "CHF", "DKK", "EUR", "GBP", "JPY", "NOK", "SEK"].map(
+      (currency, index) => ({ amount_cents: index + 1, currency }),
+    );
+    assert.equal(pipelineByCurrency(many).length, 8);
   });
 
   it("is empty for anything that is not an array", () => {
-    assert.deepEqual(pipelineByCurrency(undefined, SEED), []);
-    assert.deepEqual(pipelineByCurrency({ amount_cents: 1, currency: "BRL" }, SEED), []);
+    assert.deepEqual(pipelineByCurrency(undefined), []);
+    assert.deepEqual(pipelineByCurrency({ amount_cents: 1, currency: "BRL" }), []);
+  });
+});
+
+describe("read-boundary currency is strict, not lenient", () => {
+  it("refuses a lowercase code rather than widening what this shared helper admits", () => {
+    // Before the fix "usd" fell through to BRL. Accepting it as USD would be a
+    // widening on a helper that finance stages also use; withholding is the
+    // fail-closed direction.
+    assert.equal(evidencedMoney({ amount_cents: 100, currency: "usd" }, SEED), undefined);
+    assert.equal(evidencedMoney({ amount_cents: 100, currency: " BRL " }, SEED), undefined);
+  });
+});
+
+describe("reliableWeightedPipeline", () => {
+  it("applies the same scalar-aggregate zero rule as the nominal pipeline", () => {
+    // Otherwise Comercial shows "Pipeline nominal: sem dados" directly above
+    // "Pipeline ponderado: BRL 0,00".
+    assert.equal(
+      reliableWeightedPipeline(
+        { pipeline_weighted: { amount_cents: 0, currency: "BRL", probability_reliable: true } },
+        SEED,
+      ),
+      undefined,
+    );
+    assert.equal(
+      reliableWeightedPipeline(
+        { pipeline_weighted: { amount_cents: 500, currency: "BRL", probability_reliable: true } },
+        SEED,
+      )?.amount_cents,
+      500,
+    );
   });
 });

--- a/control-center/services/context/test/operational-money.test.ts
+++ b/control-center/services/context/test/operational-money.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  CATALOG_CURRENCY,
+  evidencedMoney,
+  nominalPipeline,
+  pipelineByCurrency,
+  type ProvenanceSeed,
+} from "../src/operational/money.ts";
+
+const SEED: ProvenanceSeed = {
+  source: { system: "warmbly", kind: "crm-read-model", locator: "warmbly/commercial" },
+  observed_at: "2026-08-21T12:00:00.000Z",
+  freshness_status: "FRESH",
+  confidence: 0.9,
+};
+
+describe("catalog currency", () => {
+  it("is BRL, the CONFENGE contractual currency", () => {
+    assert.equal(CATALOG_CURRENCY, "BRL");
+  });
+});
+
+describe("evidencedMoney currency resolution", () => {
+  it("denominates an amount that states no currency in the catalog currency", () => {
+    const money = evidencedMoney({ amount_cents: 4_800_000 }, SEED);
+    assert.equal(money?.currency, "BRL");
+    assert.equal(money?.amount_cents, 4_800_000);
+  });
+
+  it("keeps a currency the payload actually stated", () => {
+    assert.equal(evidencedMoney({ amount_cents: 100, currency: "EUR" }, SEED)?.currency, "EUR");
+  });
+
+  it("fails closed on a stated currency that is not ISO-4217, instead of relabelling it BRL", () => {
+    assert.equal(evidencedMoney({ amount_cents: 100, currency: "reais" }, SEED), undefined);
+    assert.equal(evidencedMoney({ amount_cents: 100, currency: "R$" }, SEED), undefined);
+    assert.equal(evidencedMoney({ amount_cents: 100, currency: 7 }, SEED), undefined);
+  });
+
+  it("treats a blank currency as unstated, not as unreadable", () => {
+    assert.equal(evidencedMoney({ amount_cents: 100, currency: "  " }, SEED)?.currency, "BRL");
+  });
+});
+
+describe("nominalPipeline", () => {
+  it("reports a BRL catalog pipeline with the reading provenance", () => {
+    const money = nominalPipeline({ amount_cents: 4_800_000, currency: "BRL" }, SEED);
+    assert.equal(money?.amount_cents, 4_800_000);
+    assert.equal(money?.currency, "BRL");
+    assert.equal(money?.observed_at, SEED.observed_at);
+    assert.equal(money?.source.system, "warmbly");
+  });
+
+  it("denominates a pipeline with no stated currency in BRL, never in a foreign default", () => {
+    assert.equal(nominalPipeline({ amount_cents: 150_050 }, SEED)?.currency, "BRL");
+  });
+
+  it("withholds a zero total: nothing denominated contributed, so it has no currency", () => {
+    // This is the "Pipeline nominal USD 0,00" regression read from the other
+    // side: a snapshot persisted before the policy landed still carries the
+    // zero stamped with whatever code the upstream summary reported.
+    assert.equal(nominalPipeline({ amount_cents: 0, currency: "USD" }, SEED), undefined);
+    assert.equal(nominalPipeline({ amount_cents: 0, currency: "BRL" }, SEED), undefined);
+  });
+
+  it("withholds a total whose stated currency cannot be read", () => {
+    assert.equal(nominalPipeline({ amount_cents: 100, currency: "dolares" }, SEED), undefined);
+  });
+
+  it("withholds a missing or non-integer total", () => {
+    assert.equal(nominalPipeline(undefined, SEED), undefined);
+    assert.equal(nominalPipeline({ amount_cents: 1.5, currency: "BRL" }, SEED), undefined);
+  });
+});
+
+describe("pipelineByCurrency", () => {
+  it("keeps one total per currency, sorted, and never sums across them", () => {
+    const split = pipelineByCurrency(
+      [
+        { amount_cents: 5_000, currency: "USD" },
+        { amount_cents: 10_000, currency: "BRL" },
+      ],
+      SEED,
+    );
+    assert.deepEqual(
+      split.map((m) => [m.currency, m.amount_cents]),
+      [
+        ["BRL", 10_000],
+        ["USD", 5_000],
+      ],
+    );
+  });
+
+  it("drops unreadable and zero entries rather than denominating them in BRL", () => {
+    const split = pipelineByCurrency(
+      [
+        { amount_cents: 10_000, currency: "BRL" },
+        { amount_cents: 999, currency: "reais" },
+        { amount_cents: 0, currency: "USD" },
+      ],
+      SEED,
+    );
+    assert.deepEqual(split, [
+      {
+        amount_cents: 10_000,
+        currency: "BRL",
+        source: SEED.source,
+        observed_at: SEED.observed_at,
+        freshness_status: SEED.freshness_status,
+        confidence: SEED.confidence,
+      },
+    ]);
+  });
+
+  it("is empty for anything that is not an array", () => {
+    assert.deepEqual(pipelineByCurrency(undefined, SEED), []);
+    assert.deepEqual(pipelineByCurrency({ amount_cents: 1, currency: "BRL" }, SEED), []);
+  });
+});

--- a/control-center/services/context/test/operational-money.test.ts
+++ b/control-center/services/context/test/operational-money.test.ts
@@ -5,7 +5,6 @@ import {
   evidencedMoney,
   nominalPipeline,
   pipelineByCurrency,
-  reliableWeightedPipeline,
   type ProvenanceSeed,
 } from "../src/operational/money.ts";
 
@@ -76,87 +75,56 @@ describe("nominalPipeline", () => {
 });
 
 describe("pipelineByCurrency", () => {
-  it("keeps one total per currency, sorted, as plain money", () => {
-    // Plain money on purpose: the snapshot already carries provenance, and the
-    // contract types these buckets as `unsigned_money`, which forbids extras.
+  it("keeps one total per currency, sorted, and never sums across them", () => {
     assert.deepEqual(
-      pipelineByCurrency([
-        { amount_cents: 5_000, currency: "USD" },
-        { amount_cents: 10_000, currency: "BRL" },
-      ]),
+      pipelineByCurrency(
+        [
+          { amount_cents: 5_000, currency: "USD" },
+          { amount_cents: 10_000, currency: "BRL" },
+        ],
+        SEED,
+      ).map((m) => [m.currency, m.amount_cents]),
       [
-        { amount_cents: 10_000, currency: "BRL" },
-        { amount_cents: 5_000, currency: "USD" },
+        ["BRL", 10_000],
+        ["USD", 5_000],
       ],
     );
   });
 
   it("keeps a zero bucket: a denominated deal created it", () => {
-    // The zero rule is for scalar aggregates. Dropping a zero bucket here once
+    // The zero rule is for scalar aggregates only. Dropping a zero bucket here
     // collapsed the split to one entry, and the caller then discarded the
     // surviving BRL total as "not a split" — real money lost to a USD 0.
     assert.deepEqual(
-      pipelineByCurrency([
-        { amount_cents: 10_000, currency: "BRL" },
-        { amount_cents: 0, currency: "USD" },
-      ]),
+      pipelineByCurrency(
+        [
+          { amount_cents: 10_000, currency: "BRL" },
+          { amount_cents: 0, currency: "USD" },
+        ],
+        SEED,
+      ).map((m) => [m.currency, m.amount_cents]),
       [
-        { amount_cents: 10_000, currency: "BRL" },
-        { amount_cents: 0, currency: "USD" },
+        ["BRL", 10_000],
+        ["USD", 0],
       ],
     );
   });
 
   it("drops an unreadable entry without taking its readable siblings with it", () => {
     assert.deepEqual(
-      pipelineByCurrency([
-        { amount_cents: 10_000, currency: "BRL" },
-        { amount_cents: 999, currency: "reais" },
-      ]),
-      [{ amount_cents: 10_000, currency: "BRL" }],
+      pipelineByCurrency(
+        [
+          { amount_cents: 10_000, currency: "BRL" },
+          { amount_cents: 999, currency: "reais" },
+        ],
+        SEED,
+      ).map((m) => [m.currency, m.amount_cents]),
+      [["BRL", 10_000]],
     );
-  });
-
-  it("caps the buckets at the schema maximum", () => {
-    const many = ["AED", "BRL", "CAD", "CHF", "DKK", "EUR", "GBP", "JPY", "NOK", "SEK"].map(
-      (currency, index) => ({ amount_cents: index + 1, currency }),
-    );
-    assert.equal(pipelineByCurrency(many).length, 8);
   });
 
   it("is empty for anything that is not an array", () => {
-    assert.deepEqual(pipelineByCurrency(undefined), []);
-    assert.deepEqual(pipelineByCurrency({ amount_cents: 1, currency: "BRL" }), []);
-  });
-});
-
-describe("read-boundary currency is strict, not lenient", () => {
-  it("refuses a lowercase code rather than widening what this shared helper admits", () => {
-    // Before the fix "usd" fell through to BRL. Accepting it as USD would be a
-    // widening on a helper that finance stages also use; withholding is the
-    // fail-closed direction.
-    assert.equal(evidencedMoney({ amount_cents: 100, currency: "usd" }, SEED), undefined);
-    assert.equal(evidencedMoney({ amount_cents: 100, currency: " BRL " }, SEED), undefined);
-  });
-});
-
-describe("reliableWeightedPipeline", () => {
-  it("applies the same scalar-aggregate zero rule as the nominal pipeline", () => {
-    // Otherwise Comercial shows "Pipeline nominal: sem dados" directly above
-    // "Pipeline ponderado: BRL 0,00".
-    assert.equal(
-      reliableWeightedPipeline(
-        { pipeline_weighted: { amount_cents: 0, currency: "BRL", probability_reliable: true } },
-        SEED,
-      ),
-      undefined,
-    );
-    assert.equal(
-      reliableWeightedPipeline(
-        { pipeline_weighted: { amount_cents: 500, currency: "BRL", probability_reliable: true } },
-        SEED,
-      )?.amount_cents,
-      500,
-    );
+    assert.deepEqual(pipelineByCurrency(undefined, SEED), []);
+    assert.deepEqual(pipelineByCurrency({ amount_cents: 1, currency: "BRL" }, SEED), []);
   });
 });


### PR DESCRIPTION
## Context

The Comercial view showed **"Pipeline nominal USD 0,00"** although the CONFENGE catalog and the observed operation are contracted in BRL.

There is **no USD fallback anywhere in the backend** — every default in the tree is BRL, and the only `USD` literal outside tests is a "mixed currencies fail closed" finance test. The USD arrived from Warmbly's own `deals_summary.currency` and passed through unvalidated:

`sumOpenDealValue` returns `undefined` when there are no open deals → the `deals_summary` fallback fires → `payload.deals_summary.currency || "BRL"` keeps whatever the summary reported → `majorUnitsToCents(0, "USD")` → `deal_value_open = { amount_cents: 0, currency: "USD" }` → `pipeline_nominal` → `formatMoney` echoes it as `USD 0,00`.

Three defects sat behind that one string:

1. **An upstream currency was trusted without ever being checked.** `currencyOf` (`services/context/src/operational/money.ts:31`) accepted any `/^[A-Z]{3}$/` from the payload before the BRL fallback was ever reached, and a *present-but-unreadable* code (`"reais"`, `"R$"`) silently became BRL in `centsOf`, `moneyFromBucket`, and `moneyOrNull`.
2. **Zero was indistinguishable from unknown.** A total that nothing denominated contributed to was still emitted as `0` stamped with a fabricated currency. `domains/commercial/src/project.ts` did the same explicitly: an empty pipeline returned `treatment: "present", amount_cents: 0, currency: DEFAULT_CURRENCY`.
3. **Mixed currencies vanished silently.** `sumOpenDealValue` returned `undefined` and the fact simply disappeared, with no per-currency totals and no explanation.

The canonical contract could not express the fix either: `commercial-snapshot.v1` listed `pipeline_nominal` as **required**, so "we could not denominate this" had no representation.

## Changes

One policy, stated once and enforced at every boundary the value crosses:

- **Absent currency → the contractual catalog currency (BRL).** Governance is the catalog authority, so this is contractual, not a convenience guess.
- **Stated-but-unreadable currency → fail closed.** The amount is withheld rather than relabelled, so a bad upstream code can never be laundered into BRL by being merely wrong instead of merely missing.
- **Different currencies are kept apart, never summed.** Conversion would need an explicit rate with a source and a date; this read model has none, so it does not convert.
- **A zero total is absence.** Nothing denominated contributed to it, so it has no currency to be stated in; it is omitted and renders "sem dados".

Applied on the **write path** and the **read path**, so snapshots persisted before this landed are withheld too rather than replayed with the bad code:

| File | Change |
| --- | --- |
| `connectors/warmbly/src/mapper/money.ts` | New `CATALOG_CURRENCY`, `normalizeCurrency`, `resolveCurrency`, `openDealTotals` (per-currency totals + counts of unreadable codes). `majorUnitsToCents` throws on an unreadable code. |
| `connectors/warmbly/src/mapper/normalize.ts` | `deals_summary` only contributes when `open_value > 0` **and** its currency resolves; a zero open value is absence. Emits `deal_value_open_by_currency` when the pipeline spans >1 currency, and raises a `exception_state` attention item for every currency anomaly so an operator sees *why* a total is split or withheld. |
| `connectors/runner/src/projectors/commercial.ts` | `centsOf` fails closed on an unreadable code; a zero `pipeline_nominal` is omitted; `pipeline_nominal_by_currency` forwarded. (Money code only — the `source_id`/`displayName` block is untouched.) |
| `connectors/runner/src/projectors/finance.ts` | `moneyFromBucket` validates the currency the same way. |
| `services/context/src/operational/money.ts` | `currencyOf` fails closed on a present-but-unreadable code. New `nominalPipeline` (zero ⇒ absent, seed provenance) and `pipelineByCurrency`, reusing the `financeStages()` omit-don't-zero discipline. |
| `services/context/src/operational/assemble.ts` | `pipeline_nominal` routed through `nominalPipeline`; per-currency totals mapped; a split that filtered down to one readable currency is **promoted** rather than dropped. |
| `domains/commercial/src/{project,normalize}.ts` | Empty pipeline is `insufficient_data / no_open_pipeline` instead of a fabricated `BRL 0,00`; an undenominated amount is no longer folded into the catalog currency (`insufficient_data / unreadable_currency`). |
| `contracts/schemas/commercial-snapshot.v1.schema.json`, `contracts/src/types.ts` | `pipeline_nominal` is no longer `required` — absence must be expressible. Added `pipeline_nominal_by_currency` (`minItems: 2`), documented as never summed and never converted. |
| `apps/web-shell/src/{types,adapters/map,ui/domains}.ts` | "Pipeline nominal" always renders: a readable amount, a per-currency split joined with `·` (`data-currency-split`), or **"sem dados"** (`data-absent`/`data-no-data`). Per-deal amounts no longer borrow `?? "BRL"`. Every interpolation still goes through `escapeHtml`. |

Money stays integer cents plus an ISO-4217 code throughout; no floats introduced.

## Testing Plan

Local, from `control-center/`: `npm run install`, `npm run typecheck` (clean), `npm test` (all 23 packages, 0 failures), `cd contracts && npm test` (99 pass).

Every new test was verified to be a **genuine regression test** by swapping the pre-fix production file back in and re-running:

- `connectors/warmbly/tests/currency.test.ts` — BRL catalog total in integer cents; **missing currency** resolves to BRL; unreadable code fails closed; per-currency totals never summed; the reported regression (`deals_summary` with `open_value: 0, currency: "USD"` yields no `deal_value_open`); a zero bucket does not take its siblings down; a readable total is promoted when its only sibling was unreadable.
- `services/context/test/operational-money.test.ts` — missing currency ⇒ BRL; `"reais"`/`"R$"`/non-string ⇒ withheld; `nominalPipeline` withholds a zero scalar; `pipelineByCurrency` **keeps** zero buckets and drops an unreadable entry without taking its siblings.
- `connectors/runner/tests/projectors.test.ts` — deals denominated by their own currency, driven through the **real Warmbly mapper** with `value` as a bare number and `currency` beside it; promotion of a single surviving bucket; zero buckets preserved; finance buckets validated.
- `apps/web-shell/tests/pipeline-currency.test.ts` — BRL renders `BRL 48.000,00` with no `USD`; absent renders **"sem dados"** and asserts `0,00` is not present; two currencies show both totals and never the merged `150,00`; deal cards each carry their own currency (a USD deal is not restamped BRL).
- `domains/commercial/tests/money.test.ts` — empty pipeline is `insufficient_data`; a deal stating no currency is BRL; an unreadable code is not folded into the total.

Postgres-backed `integration`, Playwright `e2e`, and `docker` run in CI. None of the strings those jobs grep are touched.

## Risks & Rollback

**Behaviour changes worth knowing about**

- **The zero⇒absence rule lives in five places across four packages**, not two: `services/context/src/operational/money.ts` (`nominalPipeline`), `connectors/runner/src/projectors/commercial.ts`, `connectors/warmbly/src/mapper/normalize.ts`, `domains/commercial/src/project.ts`, and the render fallback in `apps/web-shell/src/ui/domains.ts`. Backing it out needs at least the first three. It is deliberately **scoped to scalar aggregates** — per-currency buckets and per-deal amounts keep their zeros, because their currency has a denominated contributor behind it.
- **A genuinely empty pipeline reads "sem dados" rather than "BRL 0,00".** `Pipeline aberto` still carries the count.
- **`currencyOf` now case-folds at the read boundary**, so a payload stating `"usd"` resolves to **USD** where it previously fell through to **BRL**. This is a real widening on a helper that `financeStages` and `reliableWeightedPipeline` also use, not a purely fail-closed change. It is inert today only because `connectors/asaas/src/normalize.ts:54,74` hard-codes BRL.
- **The read-path guard is narrower than it may look.** Measured against fake persisted rows: `{0, "USD"}` is withheld and `{500000, "reais"}` is withheld, but **`{500000, "USD"}` replays verbatim** until the next collector run. The reported symptom is neutralised because it was zero. Suppressing a well-formed foreign total at read time was considered and rejected — that is exactly the failure mode adversarial review caught in the first pass, where an over-eager rule deleted a valid BRL total.
- **A foreign currency is reported as observed, not converted**, and raises an exception item. Suppressing it would hide real money.
- **`pipeline_nominal` is no longer required in `commercial-snapshot.v1`.** A pure relaxation: every previously valid document still validates.
- **The weighted-pipeline caption changed** from "omitido — probabilidade não confiável" to "omitido — sem base confiável para ponderar". The old text asserted a reason the snapshot cannot know: a total withheld over an unreadable *currency* was being explained as a probability problem.

**Known gaps recorded, deliberately not fixed here**

Each is real and reproduced; each belongs to an issue that owns the rule, so #69 does not invent a second competing one.

| Gap | Why not here |
| --- | --- |
| Zero vs absence is inconsistent across the Comercial card — "Pipeline nominal: sem dados" can sit above "Pipeline ponderado: BRL 0,00", and per-deal zeros still render `BRL 0,00`. A deal whose amount cannot be denominated shows no money line at all. | One product rule about zero/ausente/desconhecido, owned by **#62**, which defines that vocabulary once for the whole surface. |
| Currency-exception ids are positional (`warmbly:currency:pipeline:${index}`), so the same anomaly changes id depending on which siblings fired — breaking dedupe and any acknowledgement keyed on the id. | Exception identity, owned by **#67**, which is rebuilding exception state end to end. |
| A summary-only pipeline with `mixed_currency: true` and no breakdown is withheld with no split at all — the incident's own payload shape. Per-currency separation only works when per-deal rows are present. | Needs an upstream contract change (Warmbly must report per-currency totals). Needs routing. |
| Schema `maxItems: 8` on `pipeline_nominal_by_currency` is unenforced in code, and the emitted entries carry `source`/`observed_at`/`freshness_status`/`confidence`, which `unsigned_money` (`additionalProperties: false`) rejects. | Pre-existing divergence — `pipeline_nominal` has had it all along — inherited by the new field, not introduced by it. Nothing validates the assembled envelope against that schema, so it is inert. |
| `domains/commercial` changes carry **no production weight**: nothing imports `@confenge/control-center-commercial-readmodel`. They make that package consistent with the policy but are not part of the live chain (Warmbly mapper → runner projector → services/context → web-shell). | Left in for consistency; explicitly not load-bearing. |

- **"sem dados" vs "ausente":** the surface says "ausente" elsewhere; the issue asks for "sem dados" specifically, so the pipeline fact uses it while keeping the `data-absent="true"` hook. Reconciling the two is #62's call.
- Rollback: revert the commits on this branch. No migrations, no persisted-data changes, no config.

## Closes

Closes #69
