### PR TITLE
fix(control-center): feed the live gate the rendered health status, not freshness twice

### DIFF
--- a/.github/workflows/control-center.yml
+++ b/.github/workflows/control-center.yml
@@ -60,6 +60,9 @@ jobs:
           CONTROL_CENTER_TEST_DATABASE_URL: postgres://control_center:control_center@127.0.0.1:5432/control_center
           CONTROL_CENTER_DATABASE_URL: postgres://control_center:control_center@127.0.0.1:5432/control_center
         run: npm run test:integration
+      - name: Stale-data detector capability proof
+        working-directory: control-center
+        run: npx tsx --test tests/convergence/live-runtime/presented-freshness.test.ts
       - name: Live runtime QA gate
         working-directory: control-center
         env:
@@ -67,9 +70,9 @@ jobs:
           CONTROL_CENTER_DATABASE_URL: postgres://control_center:control_center@127.0.0.1:5432/control_center
         run: |
           set -o pipefail
-          npm run qa:live | tee /tmp/cc-live-qa.log
+          npm run qa:live -- /tmp/cc-live-qa.json | tee /tmp/cc-live-qa.log
           grep -F "stale data mostrado como saudável" /tmp/cc-live-qa.log
-          grep -F "READY_FOR_INTERNAL_PRODUCTION" /tmp/cc-live-qa.log
+          node tests/convergence/live-runtime/assert-ready.mjs /tmp/cc-live-qa.json
 
   e2e:
     runs-on: ubuntu-latest

--- a/control-center/tests/convergence/dockerfiles.test.ts
+++ b/control-center/tests/convergence/dockerfiles.test.ts
@@ -79,6 +79,22 @@ test("CI installs Playwright OS deps including libnspr4 without Ubuntu 22 libaso
   assert.match(workflow, /launch-probe ok/);
 });
 
+test("live QA gate asserts READY_FOR_INTERNAL_PRODUCTION structurally, not by grepping the log", () => {
+  const workflow = readFileSync(join(root, "../.github/workflows/control-center.yml"), "utf8");
+  // A bare `grep -F READY_FOR_INTERNAL_PRODUCTION` matched `false` as happily as `true`.
+  assert.doesNotMatch(workflow, /grep -F "READY_FOR_INTERNAL_PRODUCTION"/);
+  assert.match(workflow, /npm run qa:live -- \/tmp\/cc-live-qa\.json/);
+  assert.match(workflow, /node tests\/convergence\/live-runtime\/assert-ready\.mjs \/tmp\/cc-live-qa\.json/);
+  // The exit-code path stays: run-gate.ts exits 2 when not ready and the step is piped under pipefail.
+  assert.match(workflow, /set -o pipefail/);
+  assert.match(workflow, /grep -F "stale data mostrado como saudável"/);
+  // The stale-data detector must be proven capable of failing on every run.
+  assert.match(
+    workflow,
+    /npx tsx --test tests\/convergence\/live-runtime\/presented-freshness\.test\.ts/,
+  );
+});
+
 test("web-shell Vite aliases exact-match contract subpaths, not index.ts prefix", () => {
   const vite = readFileSync(join(root, "apps/web-shell/vite.config.ts"), "utf8");
   assert.match(vite, /find:\s*\/\^@confenge\\\/control-center-contracts\\\/taxonomy\$\//);

--- a/control-center/tests/convergence/live-runtime/assert-ready.mjs
+++ b/control-center/tests/convergence/live-runtime/assert-ready.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Structured assertion over the live gate's JSON report.
+ *
+ * `run-gate.ts` already exits 2 when the gate is not ready, and CI runs it under
+ * `set -o pipefail`, so a not-ready gate fails the step on its own. This adds a
+ * second, non-scrapeable check: `grep -F READY_FOR_INTERNAL_PRODUCTION` matched
+ * `"READY_FOR_INTERNAL_PRODUCTION": false` just as happily as `true`.
+ */
+import { readFileSync } from "node:fs";
+
+const path = process.argv[2];
+if (!path) {
+  console.error("usage: assert-ready.mjs <live-gate-report.json>");
+  process.exit(1);
+}
+
+const report = JSON.parse(readFileSync(path, "utf8"));
+
+const failures = [];
+if (report.READY_FOR_INTERNAL_PRODUCTION !== true) {
+  failures.push(
+    `READY_FOR_INTERNAL_PRODUCTION is ${JSON.stringify(report.READY_FOR_INTERNAL_PRODUCTION)}, expected true`,
+  );
+}
+if (!Array.isArray(report.attacks) || report.attacks.length === 0) {
+  failures.push("report carries no attacks[]");
+} else {
+  const notPass = report.attacks.filter((row) => row.state !== "pass");
+  for (const row of notPass) {
+    failures.push(`${row.attack_id}: ${row.state} — ${row.reason} ${JSON.stringify(row.evidence ?? {})}`);
+  }
+  const stale = report.attacks.find((row) => row.attack_id === "stale data mostrado como saudável");
+  if (!stale) {
+    failures.push("the stale-data-shown-as-healthy check did not run");
+  }
+}
+
+if (failures.length > 0) {
+  console.error("live QA gate is not ready:");
+  for (const line of failures) console.error(`  - ${line}`);
+  process.exit(1);
+}
+
+console.log(`READY_FOR_INTERNAL_PRODUCTION=true (${report.attacks.length} checks, all pass)`);

--- a/control-center/tests/convergence/live-runtime/presented-freshness.test.ts
+++ b/control-center/tests/convergence/live-runtime/presented-freshness.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Capability proof for the `stale data mostrado como saudável` evaluator as it
+ * is wired by the live-runtime snapshot.
+ *
+ * The evaluator is only an oracle if the payload the live snapshot builds can
+ * actually make it say `fail`. These tests drive the real collector over real
+ * cockpit view models and assert both directions: a stale-but-healthy page
+ * fails, an honestly-labelled page passes.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { evaluateStaleDataShownAsHealthy } from "../../../qa/src/index.ts";
+import type { DestinationPage } from "../../../apps/web-shell/src/adapters/contract.ts";
+import type { HojeViewModel } from "../../../apps/web-shell/src/hoje-compose.ts";
+import type { Provenance, ServiceHealth, SourceRef } from "../../../apps/web-shell/src/types.ts";
+import { collectPresentedFreshness } from "./presented-freshness.ts";
+
+const AS_OF = "2026-08-20T15:00:00.000Z";
+const SOURCE: SourceRef = { system: "collector", kind: "host-health", locator: "infrastructure/hosts" };
+
+function provenance(freshness: Provenance["freshness_status"], observedAt: string): Provenance {
+  return { source: SOURCE, observed_at: observedAt, freshness_status: freshness, confidence: 0.9 };
+}
+
+function serviceHealth(
+  status: ServiceHealth["status"],
+  prov: Provenance,
+  extra: Partial<ServiceHealth> = {},
+): ServiceHealth {
+  return {
+    schema_version: "control-center.service-health.v1",
+    id: "cc:service-health:edge",
+    scope: "infrastructure",
+    service_name: "edge",
+    status,
+    provenance: prov,
+    checked_at: prov.observed_at,
+    ...extra,
+  };
+}
+
+function page(overrides: Partial<DestinationPage>): DestinationPage {
+  return {
+    id: "infra",
+    label: "Infra",
+    scope: "infrastructure",
+    generated_at: AS_OF,
+    operator: { kind: "human", id: "founder-local" },
+    headline: "infra",
+    attention: [],
+    priorities: [],
+    ...overrides,
+  };
+}
+
+function evaluate(pages: DestinationPage[]) {
+  const records = pages.flatMap((item) => collectPresentedFreshness(item));
+  return { records, verdict: evaluateStaleDataShownAsHealthy({ as_of: AS_OF, records }) };
+}
+
+test("a STALE service still painted 'healthy' makes the live gate check fail", () => {
+  const { records, verdict } = evaluate([
+    page({ health: [serviceHealth("healthy", provenance("STALE", "2026-08-18T12:00:00.000Z"))] }),
+  ]);
+  const row = records.find((r) => r.id.endsWith(":health:cc:service-health:edge"));
+  assert.ok(row, "collector must emit a record for the rendered health card");
+  assert.equal(row.freshness_status, "STALE");
+  assert.equal(row.health_status, "healthy", "health card renders its status pill verbatim");
+  assert.notEqual(
+    row.presented_as,
+    row.health_status,
+    "presented_as and health_status must carry independent signals",
+  );
+  assert.equal(verdict.state, "fail", verdict.reason);
+  assert.deepEqual(verdict.evidence.offender_ids, [row.id]);
+});
+
+test("an UNKNOWN-freshness service reported 'ok' on a sub-check fails too", () => {
+  const { verdict } = evaluate([
+    page({
+      health: [
+        serviceHealth("degraded", provenance("UNKNOWN", "2026-08-20T14:50:00.000Z"), {
+          http: { status: "ok", detail: "200" },
+        }),
+      ],
+    }),
+  ]);
+  assert.equal(verdict.state, "fail", verdict.reason);
+  assert.deepEqual(verdict.evidence.offender_ids, ["ui:infra:health-http:cc:service-health:edge"]);
+});
+
+test("a FRESH observation older than its window and painted healthy fails", () => {
+  const stale: Provenance = {
+    ...provenance("FRESH", "2026-08-20T10:00:00.000Z"),
+    freshness_window_seconds: 1800,
+  };
+  const { verdict } = evaluate([page({ health: [serviceHealth("healthy", stale)] })]);
+  assert.equal(verdict.state, "fail", verdict.reason);
+});
+
+test("a Hoje row painted green while not FRESH fails", () => {
+  const hoje: HojeViewModel = {
+    schema_version: "control-center.hoje-view.v1",
+    generated_at: AS_OF,
+    headline: "hoje",
+    sections: [
+      {
+        id: "incidents",
+        title: "Incidentes, blockers e riscos.",
+        compressed: false,
+        compressed_summary: null,
+        shortcuts: [],
+        rows: [
+          {
+            id: "cc:attention-item:edge-down",
+            title: "edge",
+            summary: "edge",
+            source: SOURCE,
+            observed_at: "2026-08-18T12:00:00.000Z",
+            observed_at_local: "18/08/2026 09:00",
+            freshness_status: "STALE",
+            // the bug this guards: an untrusted row wearing the healthy tone
+            freshness_tone: "green",
+            confidence: 0.9,
+          },
+        ],
+      },
+    ],
+    charts_emitted: false,
+  };
+  const { verdict } = evaluate([page({ id: "hoje", hoje })]);
+  assert.equal(verdict.state, "fail", verdict.reason);
+  assert.deepEqual(verdict.evidence.offender_ids, ["ui:hoje:hoje-incidents:cc:attention-item:edge-down"]);
+});
+
+test("honest labelling passes: stale is shown as degraded, fresh is shown as healthy", () => {
+  const { records, verdict } = evaluate([
+    page({ health: [serviceHealth("degraded", provenance("STALE", "2026-08-18T12:00:00.000Z"))] }),
+    page({
+      id: "financeiro",
+      health: [serviceHealth("healthy", provenance("FRESH", "2026-08-20T14:50:00.000Z"))],
+    }),
+  ]);
+  assert.equal(verdict.state, "pass", verdict.reason);
+  assert.equal(verdict.evidence.inspected, records.length);
+});
+
+test("the previous wiring — freshness echoed into both fields — could not fail", () => {
+  // Regression guard. This is the payload shape the snapshot used to build; it
+  // is kept here only to show why the detector was blind.
+  const blind = [
+    {
+      id: "ui:infrastructure/hosts",
+      freshness_status: "STALE",
+      observed_at: "2026-08-18T12:00:00.000Z",
+      freshness_window_seconds: 86400,
+      presented_as: "STALE",
+      health_status: "STALE",
+    },
+  ];
+  assert.equal(evaluateStaleDataShownAsHealthy({ as_of: AS_OF, records: blind }).state, "pass");
+
+  const wired = collectPresentedFreshness(
+    page({ health: [serviceHealth("healthy", provenance("STALE", "2026-08-18T12:00:00.000Z"))] }),
+  );
+  assert.equal(evaluateStaleDataShownAsHealthy({ as_of: AS_OF, records: wired }).state, "fail");
+});

--- a/control-center/tests/convergence/live-runtime/presented-freshness.test.ts
+++ b/control-center/tests/convergence/live-runtime/presented-freshness.test.ts
@@ -8,12 +8,17 @@
  * fails, an honestly-labelled page passes.
  */
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import { evaluateStaleDataShownAsHealthy } from "../../../qa/src/index.ts";
 import type { DestinationPage } from "../../../apps/web-shell/src/adapters/contract.ts";
 import type { HojeViewModel } from "../../../apps/web-shell/src/hoje-compose.ts";
 import type { Provenance, ServiceHealth, SourceRef } from "../../../apps/web-shell/src/types.ts";
 import { collectPresentedFreshness } from "./presented-freshness.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
 
 const AS_OF = "2026-08-20T15:00:00.000Z";
 const SOURCE: SourceRef = { system: "collector", kind: "host-health", locator: "infrastructure/hosts" };
@@ -164,4 +169,15 @@ test("the previous wiring — freshness echoed into both fields — could not fa
     page({ health: [serviceHealth("healthy", provenance("STALE", "2026-08-18T12:00:00.000Z"))] }),
   );
   assert.equal(evaluateStaleDataShownAsHealthy({ as_of: AS_OF, records: wired }).state, "fail");
+});
+
+test("the live snapshot is actually wired to the collector, not to the self-echo", () => {
+  // Everything above proves the collector can make the evaluator fail. It does
+  // not prove the live gate USES the collector: reverting snapshot.ts to
+  // `health_status: prov.freshness_status` would leave all of those green while
+  // the gate went blind again. Pin the wiring itself.
+  const snapshot = readFileSync(join(here, "snapshot.ts"), "utf8");
+  assert.match(snapshot, /collectPresentedFreshness\(pageResult\.page\)/);
+  assert.doesNotMatch(snapshot, /collectProvenance/);
+  assert.doesNotMatch(snapshot, /health_status:\s*prov\.freshness_status/);
 });

--- a/control-center/tests/convergence/live-runtime/presented-freshness.ts
+++ b/control-center/tests/convergence/live-runtime/presented-freshness.ts
@@ -1,0 +1,135 @@
+/**
+ * What the cockpit actually paints, in the shape the
+ * `stale data mostrado como saudável` evaluator inspects.
+ *
+ * The evaluator fails a record when `presented_as` OR `health_status` reads as
+ * healthy while the observation is not FRESH (or is outside its window). That
+ * only has teeth if the two fields carry *different* signals:
+ *
+ *   presented_as  -> the freshness pill the provenance block renders verbatim
+ *                    (`FRESH` / `STALE` / `UNKNOWN` / `ERROR`).
+ *   health_status -> the health word the card renders on its own: the service
+ *                    health pill, a client's "Saúde" fact, a Hoje row's health,
+ *                    or — for records that carry no health of their own — the
+ *                    health colour the row is painted with.
+ *
+ * Feeding freshness into both fields makes the check compare freshness to
+ * itself, which can never fail. This module keeps them independent.
+ */
+import type { DestinationPage } from "../../../apps/web-shell/src/adapters/contract.ts";
+import { freshnessTone, type FreshnessTone } from "../../../apps/web-shell/src/freshness-tone.ts";
+import type { Provenance } from "../../../apps/web-shell/src/types.ts";
+
+/** Same default the live snapshot has always used for records without a declared window. */
+export const DEFAULT_FRESHNESS_WINDOW_SECONDS = 86400;
+
+/** The health word a rendered tone communicates. `green` is the only healthy one. */
+const TONE_AS_HEALTH: Record<FreshnessTone, string> = {
+  green: "healthy",
+  amber: "stale",
+  slate: "unknown",
+  red: "error",
+};
+
+export interface PresentedFreshnessRecord {
+  id: string;
+  freshness_status: string;
+  observed_at: string;
+  freshness_window_seconds: number;
+  presented_as: string;
+  health_status: string;
+}
+
+function utcZ(value: string): string {
+  return value.endsWith("Z") ? value : `${value}Z`;
+}
+
+function toneHealth(provenance: Provenance): string {
+  return TONE_AS_HEALTH[freshnessTone(provenance.freshness_status)];
+}
+
+/**
+ * Walk one rendered destination page and emit one record per painted element.
+ * `page` must be a page the adapter returned as ok and not loading.
+ */
+export function collectPresentedFreshness(page: DestinationPage): PresentedFreshnessRecord[] {
+  const rows: PresentedFreshnessRecord[] = [];
+
+  const push = (kind: string, id: string, provenance: Provenance, health: string): void => {
+    rows.push({
+      id: `ui:${page.id}:${kind}:${id}`,
+      freshness_status: provenance.freshness_status,
+      observed_at: utcZ(provenance.observed_at),
+      freshness_window_seconds:
+        provenance.freshness_window_seconds ?? DEFAULT_FRESHNESS_WINDOW_SECONDS,
+      presented_as: provenance.freshness_status,
+      health_status: health,
+    });
+  };
+
+  for (const item of page.attention) {
+    push("attention", item.id, item.provenance, toneHealth(item.provenance));
+  }
+  for (const item of page.priorities) {
+    push("priority", item.id, item.provenance, toneHealth(item.provenance));
+  }
+  if (page.commercial) {
+    push("commercial", page.commercial.id, page.commercial.provenance, toneHealth(page.commercial.provenance));
+  }
+  if (page.finance) {
+    push("finance", page.finance.id, page.finance.provenance, toneHealth(page.finance.provenance));
+  }
+  if (page.engineering) {
+    push(
+      "engineering",
+      page.engineering.id,
+      page.engineering.provenance,
+      toneHealth(page.engineering.provenance),
+    );
+  }
+  for (const item of page.clients ?? []) {
+    // clientCard renders `Saúde` as item.health, falling back to the lifecycle.
+    push("client", item.id, item.provenance, item.health ?? item.lifecycle);
+  }
+  for (const item of page.health ?? []) {
+    // healthCard renders item.status verbatim in its pill, whatever the freshness is.
+    push("health", item.id, item.provenance, item.status);
+    const checks: ReadonlyArray<readonly [string, { status?: string } | undefined]> = [
+      ["http", item.http],
+      ["tls", item.tls],
+      ["docker", item.docker],
+      ["backup", item.backup],
+    ];
+    for (const [name, check] of checks) {
+      const status = check?.status;
+      if (typeof status === "string" && status.length > 0) {
+        push(`health-${name}`, item.id, item.provenance, status);
+      }
+    }
+  }
+  for (const item of page.activities ?? []) {
+    push("activity", item.id, item.provenance, toneHealth(item.provenance));
+  }
+  if (page.hoje) {
+    for (const section of page.hoje.sections) {
+      for (const row of section.rows) {
+        const provenance: Provenance = {
+          source: row.source,
+          observed_at: row.observed_at,
+          freshness_status: row.freshness_status,
+          confidence: row.confidence ?? 0,
+        };
+        // HojeRow.health is the domain health the row carries; otherwise the row
+        // is judged by the tone it is actually painted with.
+        push(
+          `hoje-${section.id}`,
+          row.id,
+          provenance,
+          row.health ?? TONE_AS_HEALTH[row.freshness_tone],
+        );
+      }
+    }
+  }
+
+  return rows;
+}

--- a/control-center/tests/convergence/live-runtime/snapshot.ts
+++ b/control-center/tests/convergence/live-runtime/snapshot.ts
@@ -24,7 +24,7 @@ import { parseForwardAuthIdentity, defaultTrustedHopPolicy } from "../../../secu
 import { COOKIE_POLICY, CORS_POLICY, CSRF_STRATEGY } from "../../../security/src/constants.ts";
 import { analyzeCaddyfile } from "../../../security/src/caddy.ts";
 import { createHttpAdapter } from "../../../apps/web-shell/src/adapters/http.ts";
-import { collectProvenance } from "../../../apps/web-shell/src/page.ts";
+import { collectPresentedFreshness } from "./presented-freshness.ts";
 import { FOUNDER, LIVE_AS_OF, LIVE_NOW } from "./seed.ts";
 import {
   bootLiveRuntime,
@@ -430,15 +430,11 @@ export async function collectLiveSnapshot(runtime: LiveRuntime): Promise<LiveSna
     if (!pageResult.ok || pageResult.loading) {
       continue;
     }
-    for (const prov of collectProvenance(pageResult.page)) {
-      freshnessRecords.push({
-        id: `ui:${prov.source.locator}`,
-        freshness_status: prov.freshness_status,
-        observed_at: observedAt(prov.observed_at),
-        freshness_window_seconds: 86400,
-        presented_as: prov.freshness_status,
-        health_status: prov.freshness_status,
-      });
+    // The rendered health word and the rendered freshness pill are separate
+    // signals. Echoing freshness into both made the evaluator compare freshness
+    // to itself, so it could never fail.
+    for (const presented of collectPresentedFreshness(pageResult.page)) {
+      freshnessRecords.push({ ...presented, observed_at: observedAt(presented.observed_at) });
     }
   }
 


### PR DESCRIPTION
## Context

`control-center/qa/src/evaluators.ts` ships `evaluateStaleDataShownAsHealthy`, the
check named `stale data mostrado como saudável`. It fails a record when
`presented_as` **or** `health_status` reads as healthy (`healthy` / `FRESH` /
`fresh` / `ok` / `saudável`) while the observation is not FRESH, or while
`observed_at` is outside its freshness window.

The live-runtime snapshot fed it a payload where both fields were set to the same
freshness string:

```ts
presented_as: prov.freshness_status,
health_status: prov.freshness_status,   // freshness, not health
```

So the evaluator that exists to catch "something stale is painted as healthy"
never inspected a health status at all — it compared freshness to itself. Every
non-FRESH record was skipped before any comparison ran, and every FRESH record
trivially satisfied `freshness === "FRESH"`. The detector was structurally
incapable of failing on the UI corpus.

Separately, the CI step greped `grep -F "READY_FOR_INTERNAL_PRODUCTION"`, which
matches `"READY_FOR_INTERNAL_PRODUCTION": false` exactly as happily as `true`.

## Changes

**Defect 1 — the detector can now fire.**
New `control-center/tests/convergence/live-runtime/presented-freshness.ts` walks a
rendered `DestinationPage` and emits one record per painted element, with the two
signals kept independent:

- `presented_as` — the freshness pill the provenance block renders verbatim
  (`FRESH` / `STALE` / `UNKNOWN` / `ERROR`). Unchanged behaviour, so the existing
  assertion in `live-runtime-qa.test.ts` ("STALE and ERROR observed as those
  statuses, not healthy") still holds.
- `health_status` — the health word the cockpit actually paints:
  - `healthCard` renders `item.status` verbatim in its pill regardless of
    freshness, so the service-health record carries the real `HealthStatus`;
  - its `checkLine` rows (HTTP / TLS / Docker / Backup) render their `status`
    string, so each becomes its own record (`ok` is a healthy presentation);
  - `clientCard` renders `Saúde` as `item.health ?? item.lifecycle`;
  - a Hoje row carries `row.health`, or the tone it is actually painted with
    (`green -> healthy`, `amber -> stale`, `slate -> unknown`, `red -> error`);
  - elements with no health of their own fall back to their rendered tone.

`freshness_window_seconds` now honours a provenance-declared window when present,
defaulting to the same 86400 as before.

`snapshot.ts` consumes the new collector in place of `collectProvenance`. The
scoped-directive loop above it is deliberately untouched: its `presented_as`
values are asserted by `tests/convergence/live-runtime-qa.test.ts`, which is
outside this change's blast radius.

**Defect 2 — the toothless grep.** `npm run qa:live` now writes its JSON report
via the output-path argument `run-gate.ts` already accepted, and
`tests/convergence/live-runtime/assert-ready.mjs` asserts structurally that
`READY_FOR_INTERNAL_PRODUCTION === true`, that every attack state is `pass`, and
that the stale-data check actually ran. **The exit-code path is untouched** —
`run-gate.ts` still ends with `process.exitCode = ready ? 0 : 2` and the step
still runs under `set -o pipefail`, which remains the primary teeth. The grep was
redundant, not load-bearing. The `grep -F "stale data mostrado como saudável"`
trap and every `e2e` string trap are left alone.

`tests/convergence/dockerfiles.test.ts` gains a test asserting the workflow's new
content and the absence of the old grep.

Nothing in `control-center/qa/` was weakened, deleted, or bypassed; no evaluator,
threshold, or fixture changed.

## Testing Plan

From `control-center/`:

- `npm run typecheck` — pass
- `npm test` — pass (all workspaces)
- `npm run test:hardening` — 23/23 pass
- `npx tsx --test --test-concurrency=1 tests/convergence/live-runtime-qa.test.ts` — 4/4 pass
- `npm run qa:live -- report.json` — exit 0, `READY_FOR_INTERNAL_PRODUCTION: true`
- `npx tsx --test tests/convergence/live-runtime/presented-freshness.test.ts` — 6/6 pass
- `node tests/convergence/live-runtime/assert-ready.mjs report.json` — exit 0;
  with `READY_FOR_INTERNAL_PRODUCTION` flipped to `false` in the JSON, exit 1

The new `presented-freshness.test.ts` runs in CI as its own `integration` step so
the detector's capability to fail is re-proven on every run.

## Outcome

**Green — and the detector is now genuinely capable of failing.**

The fix did not turn `integration` red on `origin/main`. That is not the detector
staying blind: every provenance the live corpus renders is `FRESH`, and the one
`ServiceHealth` card the infra page paints reports `status: "down"` on a `FRESH`
observation — honest labelling, correctly passed. The two non-FRESH rows in the
corpus (`STALE`, `ERROR`) are context directives, not UI health cards.

Before the fix, the record for that health card read
`presented_as=FRESH, health_status=FRESH`. After it reads
`presented_as=FRESH, health_status=down` — the real rendered status. The
evaluator now has a health signal to inspect where it previously had a copy of
the freshness string.

Because CI went green, per the brief the capability is proven by test rather than
asserted. `presented-freshness.test.ts` drives the **real collector** over real
cockpit view models and asserts `fail` in four independent directions:

1. a `STALE` service still painted `healthy` -> `fail`, offender is that record;
2. an `UNKNOWN`-freshness service whose HTTP sub-check reads `ok` -> `fail`;
3. a `FRESH` observation older than its declared window, painted healthy -> `fail`;
4. a Hoje row wearing the green tone while `STALE` -> `fail`;

plus a control case (stale shown as `degraded`, fresh shown as `healthy`) that
must `pass`, and a regression guard that feeds the **old** self-echoed shape to
the same evaluator and shows it returns `pass` — the blindness, pinned in a test.

A seventh case closes the gap those six leave open. They exercise the
*collector*; they say nothing about whether the gate *uses* it. I verified this
by reverting `snapshot.ts` to the self-echo and re-running: **all six stayed
green while the gate went blind again.** So the suite now also asserts
`snapshot.ts` calls `collectPresentedFreshness` and no longer carries
`health_status: prov.freshness_status`. That case fails on the revert; the other
six do not.

Assessment: yes, the check is now genuinely capable of failing, and the gate is
pinned to the wiring that makes it so.

But be clear about what green on current `main` proves, because it is less than
it looks. It proves the one health card the live corpus renders is labelled
honestly (`down` on a `FRESH` observation). It does **not** prove the system is
honest. The live corpus paints exactly one health card and every UI provenance
in it is `FRESH`, so the corpus contains no stale-and-healthy shape for the
detector to catch. The detector's eyes are open; there is currently almost
nothing in front of them.

So the honest answer to "honest system or blind instrumentation?" is: neither,
yet. The instrumentation is no longer blind — it now reads the real rendered
health word instead of a copy of the freshness string — but its field of view is
one card wide. Capability is fixed here; coverage is a separate piece of work,
and it belongs in the seed corpus (`live-runtime/seed.ts`), which is outside this
change's permitted blast radius. I would treat "make the live corpus render a
non-FRESH health card" as the natural follow-up, and I did not manufacture one
here because seeding a fake defect to force a red build would be theatre, not
evidence.

## Risks & Rollback

- **Risk: a real finding surfaces on another branch and reads as a regression.**
  That is the intended behaviour. The evidence is in the verdict's
  `offender_ids`, which now name the specific rendered element.
- **Risk: a connector emits a free-form sub-check status like `ok` on a stale
  observation.** This would newly fail. It is a true positive by the evaluator's
  own contract, but it is the most likely source of an unexpected red.
- **Risk: false positives from the tone fallback.** Bounded — for elements
  rendered through `provenanceBlock`, `freshnessTone` is green iff `FRESH`, so
  the fallback can only fire where the UI genuinely paints green on non-FRESH
  data, which `assertNoGreenForUntrusted` already forbids.
- **Rollback:** revert the commit. `snapshot.ts` returns to `collectProvenance`,
  the workflow returns to the bare grep, and the new files are unreferenced. No
  migration, no state, no runtime surface touched — this is test and CI
  instrumentation only.
