### PR TITLE
fix(control-center): one content column, one scroll context on desktop (#58)

### DIFF
--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -75,12 +75,32 @@ const extraHashes = [
   "clientes/acme",
 ];
 
+/**
+ * `matrixShots: false` keeps the per-hash overflow/layout assertions but stops
+ * writing a full-page screenshot per hash, so the three desktop resolutions
+ * required by the layout acceptance criteria do not triple the artifact size.
+ */
 const viewports = [
-  { name: "360", width: 360, height: 800 },
-  { name: "390", width: 390, height: 844 },
-  { name: "430", width: 430, height: 932 },
-  { name: "desktop", width: 1280, height: 800 },
+  { name: "360", width: 360, height: 800, matrixShots: true },
+  { name: "390", width: 390, height: 844, matrixShots: true },
+  { name: "430", width: 430, height: 932, matrixShots: true },
+  { name: "desktop", width: 1280, height: 800, matrixShots: true },
+  { name: "desktop-1366", width: 1366, height: 768, matrixShots: false },
+  { name: "desktop-1440", width: 1440, height: 900, matrixShots: false },
+  { name: "desktop-1920", width: 1920, height: 1080, matrixShots: false },
 ];
+
+/** Matches the `--main-gutter` of the >=880px branch in src/styles.css. */
+const DESKTOP_GUTTER_REM = 1.6;
+/** Below this the shell is the single-column mobile layout: nav is a bottom bar. */
+const DESKTOP_MIN_WIDTH = 880;
+/**
+ * Floor for "the main content actually uses the desktop width". The regression
+ * this guards is `main { max-width: 52rem }` with no centering, which parked the
+ * content on the left of a 1fr column and left ~47% of a 1920px viewport empty
+ * (measured content ratio 0.41; the centred column measures 0.63).
+ */
+const MIN_CONTENT_RATIO = 0.55;
 
 const viewStates = ["loading", "error", "stale", "empty"];
 
@@ -103,6 +123,100 @@ const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
 const errors = [];
 page.on("pageerror", (err) => errors.push(String(err)));
 page.on("crash", () => errors.push("page crashed"));
+
+/**
+ * Geometry of the content column plus every element that currently owns a
+ * vertical scrollbar. `documentScrollRange` is probed by actually scrolling the
+ * window: absolutely positioned descendants of a scroll container whose
+ * containing block is the initial containing block escape that container and
+ * inflate the document scrolling area without changing any element's box, so
+ * box measurements alone do not see the second scrollbar.
+ */
+async function layoutMetrics(page) {
+  return page.evaluate(() => {
+    const de = document.documentElement;
+    const main = document.querySelector("main");
+    if (!main) throw new Error("no <main> rendered");
+    const cs = getComputedStyle(main);
+    const rect = main.getBoundingClientRect();
+    const padLeft = parseFloat(cs.paddingLeft);
+    const padRight = parseFloat(cs.paddingRight);
+    const remPx = parseFloat(getComputedStyle(de).fontSize);
+    const contentMax = getComputedStyle(de).getPropertyValue("--content-max").trim();
+    const owners = [];
+    for (const el of document.querySelectorAll("html, body, *")) {
+      const style = getComputedStyle(el);
+      if (style.overflowY !== "auto" && style.overflowY !== "scroll") continue;
+      if (el.scrollHeight - el.clientHeight <= 1) continue;
+      const tag = el.tagName.toLowerCase();
+      const label = tag + (el.id ? `#${el.id}` : "") + (el.className ? `.${String(el.className).trim().split(/\s+/).join(".")}` : "");
+      owners.push({ label, insideMain: main.contains(el) && el !== main, isMain: el === main, isDocument: tag === "html" || tag === "body" });
+    }
+    const restore = window.scrollY;
+    window.scrollTo(0, 1_000_000);
+    const documentScrollRange = window.scrollY;
+    window.scrollTo(0, restore);
+    return {
+      viewportWidth: window.innerWidth,
+      remPx,
+      contentMaxPx: contentMax.endsWith("rem") ? parseFloat(contentMax) * remPx : parseFloat(contentMax),
+      mainWidth: Math.round(rect.width),
+      contentWidth: Math.round(rect.width - padLeft - padRight),
+      padLeft: Math.round(padLeft),
+      padRight: Math.round(padRight),
+      deadRight: Math.round(window.innerWidth - (rect.right - padRight)),
+      mainOverflowX: main.scrollWidth - main.clientWidth,
+      documentScrollRange,
+      documentScrollHeightRange: de.scrollHeight - de.clientHeight,
+      owners,
+    };
+  });
+}
+
+/**
+ * Acceptance criteria of the desktop layout issue, asserted as geometry:
+ * a single vertical scroll context, no dead right-hand panel, nothing clipped
+ * horizontally inside the content column.
+ */
+function assertSingleScrollContext(m, where) {
+  if (m.documentScrollRange > 1 || m.documentScrollHeightRange > 1) {
+    throw new Error(
+      `${where}: the page itself scrolls ${m.documentScrollRange}px (scrollHeight range ${m.documentScrollHeightRange}px) alongside the content scroller`,
+    );
+  }
+  const stray = m.owners.filter((o) => o.isDocument || o.insideMain);
+  if (stray.length > 0) {
+    throw new Error(`${where}: competing vertical scroll owners ${stray.map((o) => o.label).join(", ")}`);
+  }
+  if (m.mainOverflowX > 1) {
+    throw new Error(`${where}: content column clips ${m.mainOverflowX}px horizontally`);
+  }
+}
+
+function assertContentColumn(m, where) {
+  if (m.viewportWidth < DESKTOP_MIN_WIDTH) return;
+  if (Math.abs(m.padLeft - m.padRight) > 1) {
+    throw new Error(`${where}: content column is not centred (padding ${m.padLeft}/${m.padRight})`);
+  }
+  if (m.deadRight > m.padRight + 1) {
+    throw new Error(
+      `${where}: ${m.deadRight}px of empty panel to the right of the content, but the column gutter is only ${m.padRight}px -- the content column does not reach the right edge of the grid`,
+    );
+  }
+  const cappedByDesign = m.contentWidth >= m.contentMaxPx - 1;
+  const fullBleed = m.padLeft <= DESKTOP_GUTTER_REM * m.remPx + 1;
+  if (!cappedByDesign && !fullBleed) {
+    throw new Error(
+      `${where}: content column neither reaches --content-max (${Math.round(m.contentMaxPx)}px) nor fills the grid column: width ${m.contentWidth}px, gutters ${m.padLeft}px`,
+    );
+  }
+  const ratio = m.contentWidth / m.viewportWidth;
+  if (ratio < MIN_CONTENT_RATIO) {
+    throw new Error(
+      `${where}: content uses only ${(ratio * 100).toFixed(1)}% of the viewport (${m.contentWidth}px of ${m.viewportWidth}px); dead space on the right is ${m.deadRight}px`,
+    );
+  }
+}
 
 async function assertFilled(page, minChars = 80) {
   const box = await page.locator("#root").boundingBox();
@@ -209,9 +323,15 @@ try {
     if (overflow > 1) {
       throw new Error(`viewport ${vp.name} accidental horizontal overflow ${overflow}px`);
     }
+    const metrics = await layoutMetrics(page);
+    assertSingleScrollContext(metrics, `viewport ${vp.name}`);
+    assertContentColumn(metrics, `viewport ${vp.name}`);
     const shot = screenshotPath.replace(/(\.[a-z]+)$/i, `-${vp.name}$1`);
     await page.screenshot({ path: shot, fullPage: true });
     console.log(`viewport=${vp.name} screenshot=${shot} surface=${Math.round(vpFilled.box.width)}x${Math.round(vpFilled.box.height)} overflow=${overflow}`);
+    console.log(
+      `layout viewport=${vp.name} content_width=${metrics.contentWidth} gutters=${metrics.padLeft}/${metrics.padRight} dead_right=${metrics.deadRight} doc_scroll_range=${metrics.documentScrollRange} scroll_owners=${metrics.owners.map((o) => o.label).join("|") || "none"}`,
+    );
     for (const hash of matrixHashes) {
       await page.goto(`${baseUrl}#/${hash}`, { waitUntil: "networkidle" });
       const surface = hash.includes("/") ? hash.split("/")[1] : null;
@@ -225,9 +345,17 @@ try {
       if (pageOverflow > 1) {
         throw new Error(`viewport ${vp.name} hash ${hash} accidental horizontal overflow ${pageOverflow}px`);
       }
-      const hashShot = screenshotPath.replace(/(\.[a-z]+)$/i, `-${vp.name}-${hash.replaceAll("/", "-")}$1`);
-      await page.screenshot({ path: hashShot, fullPage: true });
-      console.log(`matrix viewport=${vp.name} hash=${hash} overflow=${pageOverflow} screenshot=${hashShot}`);
+      const hashMetrics = await layoutMetrics(page);
+      assertSingleScrollContext(hashMetrics, `viewport ${vp.name} hash ${hash}`);
+      assertContentColumn(hashMetrics, `viewport ${vp.name} hash ${hash}`);
+      let hashShot = "skipped";
+      if (vp.matrixShots) {
+        hashShot = screenshotPath.replace(/(\.[a-z]+)$/i, `-${vp.name}-${hash.replaceAll("/", "-")}$1`);
+        await page.screenshot({ path: hashShot, fullPage: true });
+      }
+      console.log(
+        `matrix viewport=${vp.name} hash=${hash} overflow=${pageOverflow} content_width=${hashMetrics.contentWidth} dead_right=${hashMetrics.deadRight} doc_scroll_range=${hashMetrics.documentScrollRange} screenshot=${hashShot}`,
+      );
     }
   }
 

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -14,6 +14,9 @@
   --low: #b7c4d4;
   --ok: #b5c9b0;
   --space: 0.85rem;
+  /* Design-system maximum measure for the main content column. Content wider
+     than this is centred inside the column instead of hugging its left edge. */
+  --content-max: 76rem;
   --font: "Segoe UI", system-ui, -apple-system, sans-serif;
   --mono: ui-monospace, "SFMono-Regular", "Cascadia Code", Menlo, monospace;
 }
@@ -67,6 +70,7 @@ a {
   min-height: 100dvh;
   height: 100dvh;
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr) auto;
   grid-template-areas:
     "top"
@@ -192,11 +196,23 @@ a {
 
 main {
   grid-area: main;
+  /* Positioned ancestor for the .sr-only absolutes the page body renders.
+     Without it their containing block is the initial containing block, so they
+     escape this scroll container and inflate the document scrolling area with
+     thousands of invisible pixels -- the second, competing scrollbar. */
+  position: relative;
   min-height: 0;
+  min-width: 0;
   overflow-y: auto;
+  /* main is the only vertical scroll context; never chain to the document. */
+  overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
-  padding: 0.9rem 0.9rem 1.4rem;
-  max-width: 52rem;
+  --main-gutter: 0.9rem;
+  padding-block: 0.9rem 1.4rem;
+  /* Full-bleed scroll container, centred content column capped at
+     --content-max. Replaces a bare max-width, which pinned the content to the
+     left edge of the desktop grid column and left the right half empty. */
+  padding-inline: max(var(--main-gutter), calc((100% - var(--content-max)) / 2));
 }
 
 .page-head h1 {
@@ -566,8 +582,8 @@ h2 {
 
 @media (min-width: 880px) {
   .shell {
-    grid-template-columns: 13.5rem 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-columns: 13.5rem minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
     grid-template-areas:
       "top top"
       "nav main";
@@ -575,14 +591,15 @@ h2 {
 
   .nav {
     flex-direction: column;
-    overflow: visible;
+    overflow-x: hidden;
+    /* Stretches to its grid row instead of a hardcoded calc(100dvh - 3rem)
+       that never matched the real topbar height and pushed the shell past the
+       viewport. Scrolls internally when the link list is taller than the row. */
+    overflow-y: auto;
     border-top: 0;
     border-right: 1px solid var(--line);
     padding: 0.8rem 0.55rem;
-    position: sticky;
-    top: 0;
-    align-self: start;
-    height: calc(100dvh - 3rem);
+    min-height: 0;
   }
 
   .nav a {
@@ -591,7 +608,8 @@ h2 {
   }
 
   main {
-    padding: 1.2rem 1.6rem 2rem;
+    --main-gutter: 1.6rem;
+    padding-block: 1.2rem 2rem;
   }
 
   .page-head h1 {
@@ -605,6 +623,7 @@ h2 {
   }
 
   main {
-    padding: 0.75rem 0.75rem 1.1rem;
+    --main-gutter: 0.75rem;
+    padding-block: 0.75rem 1.1rem;
   }
 }

--- a/control-center/apps/web-shell/tests/ux.test.ts
+++ b/control-center/apps/web-shell/tests/ux.test.ts
@@ -118,6 +118,40 @@ test("viewport overflow is confined to nav/subnav; html/body clip accidental hor
   assert.match(css, /min-height:\s*44px/);
 });
 
+/**
+ * Static guards for the desktop layout contract. They pin the declarations, not
+ * the rendered geometry -- the behavioural proof lives in
+ * scripts/launch-probe.mjs, which measures the real build in Chromium at
+ * 1366x768, 1440x900 and 1920x1080 and fails on a dead right-hand panel or a
+ * second vertical scroll context.
+ */
+test("main is a single full-bleed scroll context with a centred, capped content column", () => {
+  const css = readFileSync(join(rootDir, "src/styles.css"), "utf8");
+  const mainBlock = /\nmain\s*\{([^}]*)\}/.exec(css)?.[1];
+  assert.ok(mainBlock, "top-level main rule not found");
+
+  // The design system, not a magic number in one rule, owns the measure.
+  assert.match(css, /:root\s*\{[^}]*--content-max:\s*[\d.]+rem/s);
+  assert.match(mainBlock, /padding-inline:\s*max\(\s*var\(--main-gutter\)/);
+  assert.match(mainBlock, /--content-max/);
+  // A bare max-width on the scroll container is the regression being fixed: it
+  // pins the content to the left edge of the desktop grid column.
+  assert.doesNotMatch(mainBlock, /^\s*max-width\s*:/m);
+
+  // main owns the only vertical scroll context.
+  assert.match(mainBlock, /overflow-y:\s*auto/);
+  assert.match(mainBlock, /overscroll-behavior-y:\s*contain/);
+  // Without a positioned ancestor the .sr-only absolutes inside the page body
+  // resolve against the initial containing block, escape this scroll container
+  // and inflate the document scrolling area into a second scrollbar.
+  assert.match(mainBlock, /position:\s*relative/);
+
+  // The desktop sidebar stretches to its grid row; a guessed topbar height
+  // pushes the shell past the viewport and adds a third scroll context.
+  assert.doesNotMatch(css, /height:\s*calc\(100dvh\s*-/);
+  assert.match(css, /grid-template-columns:\s*13\.5rem\s+minmax\(0,\s*1fr\)/);
+});
+
 test("keyboard-focusable nav exists and skip link is present", () => {
   const root = { innerHTML: "" };
   const handle = mount(root, createMockAdapter(), createMemoryRuntime("#/hoje"));


### PR DESCRIPTION
## Context

Issue #58: on desktop production the Control Center paints its content in roughly half the width, the right half is empty, and there are competing scrollbars.

Both symptoms were reproduced against the real production build (`npm run build` + the shipped `styles.css`) in Chromium before anything was changed, and each cause was confirmed by reverting it and watching the symptom come back.

Measured at 1920×1080 on `#/hoje`, before:

| metric | before |
| --- | --- |
| content column width | **781px** (41% of the viewport) |
| dead background right of the content | **898px** |
| document (page) scroll range | **3507px** |
| `main` scroll range | 5058px |

Scrolling the page 2000px produced a **completely blank screen**: the whole shell translated out of view while the content stayed inside `main`. A wheel event over the empty right half scrolled the page, not the content.

Two independent causes:

1. **Dead right panel** — `main { max-width: 52rem }` with no `margin-inline: auto` inside the desktop `13.5rem 1fr` grid column. On 1920px the column is 1704px and `main` sat flush left at 832px.
2. **Second scroll context** — the `.sr-only` spans the page body renders are `position: absolute` with **no positioned ancestor**, so their containing block is the initial containing block. They escape `main`'s scroll container and inflate the *document's* scrolling area by thousands of invisible pixels. This is why no amount of `overflow` on `#root`/`.shell`/`main` suppressed it: an absolute positioned against the ICB is not clipped by boxes that are not its containing block. Injecting `main { position: relative }` at runtime drove the document scroll range to 0 at every viewport; injecting `.sr-only { position: static }` did the same. A minimal page with the identical grid/overflow structure but no `.sr-only` never reproduced it.

   The hardcoded `.nav { height: calc(100dvh - 3rem) }` was a latent **third** scroll context on the same shell: 3rem does not match the real topbar height (measured 47px), so any growth of the topbar (e.g. the logo landing in #57) pushes the sidebar past its grid row and out of the 100dvh shell.

## Changes

`apps/web-shell/src/styles.css` (layout rules only — no brand or operator element touched, and `src/ui/render.ts` is untouched):

* `:root` gains `--content-max: 76rem`, the design-system measure for the content column.
* `main` becomes a **full-bleed scroll container with a centred content column**: `padding-inline: max(var(--main-gutter), calc((100% - var(--content-max)) / 2))` replaces `max-width: 52rem`. The scrollbar stays at the edge of the grid column; the content is centred and capped. `--main-gutter` carries the per-breakpoint gutter (0.75rem / 0.9rem / 1.6rem) that the three `padding` shorthands used to hold.
* `main { position: relative }` — contains the `.sr-only` absolutes so they can no longer inflate the document scrolling area. Plus `overscroll-behavior-y: contain` so a wheel inside the content never chains to the page, and `min-width: 0` so wide content cannot blow the column out.
* Desktop `.nav` drops `position: sticky` / `align-self: start` / `height: calc(100dvh - 3rem)` and instead stretches to its grid row with `overflow-y: auto` (`overflow-x: hidden`), so the sidebar is exactly as tall as the row whatever the topbar measures, and scrolls internally if the link list ever outgrows it.
* `grid-template-columns`/`grid-template-rows` use `minmax(0, 1fr)` on both breakpoints so a wide card, table or `<pre>` cannot force the track wider than the viewport.

`apps/web-shell/scripts/launch-probe.mjs`:

* Adds the three required viewports — **1366×768, 1440×900, 1920×1080** — alongside the existing 360/390/430/1280×800. New desktop viewports run the full per-hash assertion matrix but skip the per-hash full-page screenshot (`matrixShots: false`), so the artifact does not triple in size. Total probe runtime measured at **20s**.
* New `layoutMetrics()` + `assertSingleScrollContext()` + `assertContentColumn()`, run on every viewport and every hash in the matrix. They assert the acceptance criteria as geometry:
  * the page itself must not scroll (`window.scrollTo` probe **and** `documentElement.scrollHeight`) and no element inside `main`, nor `html`/`body`, may own a vertical scrollbar;
  * no empty panel right of the content: `deadRight <= padRight + 1`;
  * the content column is centred (`padLeft === padRight`) and either reaches `--content-max` or fills the grid column;
  * content uses at least 55% of the viewport width on desktop;
  * `main` clips nothing horizontally.
* New `layout viewport=… content_width=… dead_right=… doc_scroll_range=… scroll_owners=…` log line per viewport. **No string the e2e job greps was changed** — `launch-probe ok`, `nav_changed_to=comercial`, `view_state_driven=empty` and `context_risks=[1-9]` are all still emitted and were verified in a local probe run.

`apps/web-shell/tests/ux.test.ts`:

* The existing `viewport overflow is confined to nav/subnav` test at :113 is **unchanged**. It did not need to change: `overflow-x: hidden` on `html, body`, `overflow-x: auto` in the base `.nav` and `.subnav` rules, and `min-height: 44px` are all still there. The touch-target assertion is untouched and unweakened.
* Adds one new test, `main is a single full-bleed scroll context with a centred, capped content column`, pinning the four declarations the fix depends on: `--content-max` defined on `:root`, `padding-inline: max(var(--main-gutter), …)` with no bare `max-width` on `main`, `position: relative` + `overscroll-behavior-y: contain` on `main`, and the absence of `height: calc(100dvh - …)` anywhere. Its docblock states plainly that it guards declarations, not geometry — the behavioural proof is the launch probe against the real build.

## Testing Plan

**Measured against the real production build in Chromium**, `#/hoje`, `#/comercial`, `#/clientes`, `#/financeiro`, `#/engenharia`, `#/infra`, `#/crescimento`, `#/memoria`, `#/agentes` and the five sub-surfaces:

| viewport | content width before → after | dead space right before → after | document scroll range before → after | scroll owners after |
| --- | --- | --- | --- | --- |
| 1366×768 | 781px → **1099px** | 344px → **26px** | 3819px → **0** | `main#conteudo` |
| 1440×900 | 781px → **1173px** | 418px → **26px** | 3687px → **0** | `main#conteudo` |
| 1920×1080 | 781px → **1216px** (centred, 244px symmetric gutters) | 898px → **244px** | 3507px → **0** | `main#conteudo` |

`main.scrollWidth - main.clientWidth = 0` on every route at every viewport — nothing clipped horizontally. A wheel over the previously dead right area now scrolls the content (`main.scrollTop` advances, `window.scrollY` stays 0); before the fix it scrolled the page into blank background.

**Mutation checks (every new assertion fails with the production code reverted):**

* Full CSS revert → probe fails: `viewport 360: the page itself scrolls 5187px (scrollHeight range 5187px) alongside the content scroller`.
* Partial revert restoring only `max-width: 52rem` (keeping the scroll fix) → probe fails at the first desktop viewport: `viewport desktop: 258px of empty panel to the right of the content, but the column gutter is only 26px`.
* Full CSS revert → the new `ux.test.ts` test fails; the other 86 keep passing.

**Suites:** `npm test` in `apps/web-shell` → 87/87. `npm run typecheck` → clean. `npx tsx --test tests/convergence/dockerfiles.test.ts tests/convergence/web-prod-hardening.test.ts` → 15/15. `tests/playwright-env.test.ts`, which greps the probe for `360`/`390`/`430`/`desktop`/`view_state_driven`, still passes. Full `scripts/launch-probe.mjs` run: `launch-probe ok` in 20s.

Mobile (360/390/430) re-checked visually: the bottom tab bar, the sticky sub-nav and the internal content scroll are unchanged.

## Risks & Rollback

* **Scope of `main { position: relative }`.** It changes the containing block for any absolutely positioned descendant of `main`. Today that is only `.sr-only` (1×1px, `clip: rect(0,0,0,0)`, auto offsets → static position, so it does not move) and `.subnav`, which is `position: sticky` and unaffected. Anyone adding an absolutely positioned overlay inside the page body now positions against `main` rather than the viewport — which is the correct behaviour for a scrolled content pane.
* **`--content-max: 76rem` is a judgement call.** No design-system max width existed; 52rem was the only prior number and it was the bug. 76rem keeps a readable measure while roughly halving the dead space at 1920. Changing it is a one-token edit; the probe's `MIN_CONTENT_RATIO = 0.55` will fail if it is lowered far enough to bring the empty half back.
* **`.nav` no longer sticky on desktop.** Safe only because the shell is now exactly 100dvh with a non-scrolling document — verified at all three resolutions (`navHeight === viewportHeight - topbarHeight`). If a future change makes the document scroll again, the sidebar would scroll with it; the probe's single-scroll-context assertion fails first.
* **File collision.** #57 owns the brand CSS and the topbar brand element; #59 owns the operator element. Neither is touched here, and `src/ui/render.ts` is not in the diff. The `.nav` change specifically *removes* the dependency on the topbar's height, so #57 growing the topbar with a logo can no longer produce a third scrollbar.
* **Rollback:** revert the single commit. The change is three files, CSS + test + probe, with no runtime, contract, schema or API surface touched.

## Closes #58
