### PR TITLE
fix(control-center): consume Warmbly report schema

### DIFF
--- a/control-center/connectors/runner/tests/projectors.test.ts
+++ b/control-center/connectors/runner/tests/projectors.test.ts
@@ -99,7 +99,7 @@ test("real Warmbly mapping selects controlled-email telemetry by cohort and poli
       },
     },
     confenge_intel_report: {
-      schema_version: "confenge.observability_report.v1",
+      schema_version: "confenge.inbound_learning_report.v1",
       month: "2026-08",
       include_synthetic: false,
       real_empty: false,
@@ -167,7 +167,7 @@ test("controlled-email aggregation fails closed without a proven policy version"
       },
     },
     confenge_intel_report: {
-      schema_version: "confenge.observability_report.v1",
+      schema_version: "confenge.inbound_learning_report.v1",
       include_synthetic: false,
       real_empty: false,
       controlled_email: [
@@ -218,7 +218,7 @@ test("synthetic or unproven reports never publish real controlled-email outcomes
         },
       },
       confenge_intel_report: {
-        schema_version: "confenge.observability_report.v1",
+        schema_version: "confenge.inbound_learning_report.v1",
         include_synthetic: includeSynthetic,
         real_empty: false,
         controlled_email: [{
@@ -267,7 +267,7 @@ test("controlled-email grant integrity flags expose unsafe observed states witho
       },
     },
     confenge_intel_report: {
-      schema_version: "confenge.observability_report.v1",
+      schema_version: "confenge.inbound_learning_report.v1",
       include_synthetic: false,
       real_empty: true,
       controlled_email: [],

--- a/control-center/connectors/warmbly/src/collector/envelope.ts
+++ b/control-center/connectors/warmbly/src/collector/envelope.ts
@@ -36,7 +36,9 @@ const EXECUTIVE_KEYS = [
   "generated_at",
 ] as const;
 const REPORT_KEYS = ["schema_version", "month", "controlled_email", "real_empty"] as const;
-const REAL_REPORT_SCHEMA = "confenge.observability_report.v1";
+// Producer-owned contract: Warmbly's report type exposes this exact schema.
+// Keep the consumer strict, but never validate against a consumer-invented name.
+const REAL_REPORT_SCHEMA = "confenge.inbound_learning_report.v1";
 const ORGANIC_KEYS = ["schema_version", "windows", "sources", "recommendation", "generated_at"] as const;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/control-center/connectors/warmbly/tests/envelope.test.ts
+++ b/control-center/connectors/warmbly/tests/envelope.test.ts
@@ -21,7 +21,7 @@ const EXECUTIVE = {
 };
 
 const REPORT = {
-  schema_version: "confenge.observability_report.v1",
+  schema_version: "confenge.inbound_learning_report.v1",
   month: "2026-08",
   include_synthetic: false,
   real_empty: false,


### PR DESCRIPTION
## Production finding

The deployed Warmbly producer identifies `/v1/confenge/intel/report` as `confenge.inbound_learning_report.v1`. The Control Center consumer introduced in #86 validated a consumer-invented `confenge.observability_report.v1`, so a valid real report was discarded as contract drift and controlled-outbound availability stayed UNKNOWN.

## Fix

Keep fail-closed validation, but pin it to the producer-owned schema. Update the envelope/projector fixtures to the exact production contract.

## Evidence

- direct production report: HTTP 200, include_synthetic=false, controlled_email=[], schema=confenge.inbound_learning_report.v1
- 58 focused envelope/projector/persistence tests PASS
- both affected workspace typechecks PASS

No external mutation or email send.