### PR TITLE
fix(control-center): make gate secret runtime-readable

### DIFF
--- a/control-center/deploy/PRODUCTION-RUNBOOK.md
+++ b/control-center/deploy/PRODUCTION-RUNBOOK.md
@@ -93,11 +93,15 @@ environment:
 ```bash
 /opt/confenge-control-center/control-center/security/production/secrets/install-warmbly-operator-token.sh \
   /root/.confenge/control-center/warmbly-human-gate.one-time \
-  /etc/confenge/control-center/secrets
+  /etc/confenge/control-center/secrets \
+  1000:1000
 ```
 
-The installer is atomic, does not print the value and does not touch any other
-secret. Remove the one-time source after `/v1/me` proves `permissions=196` and
+The numeric owner is the `node` runtime UID/GID declared by the Context image;
+without it a local Compose secret remains a root-owned bind mount and the service
+must fail closed. The installer is atomic, keeps mode `0600`, does not print the
+value and does not touch any other secret. Remove the one-time source after
+the Context container can read the mount and `/v1/me` proves `permissions=196` and
 the absence of `send_campaigns`. Never reuse the collector's broader read key.
 
 On an upgraded installation, preserve the current password hash and add `admins`

--- a/control-center/docs/WARMBLY-HUMAN-GATE-EVIDENCE.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-EVIDENCE.md
@@ -30,8 +30,11 @@ Evidência executada em 2026-08-23:
   existentes de pause/resume.
 - Context Service: 93/93 — PASS, incluindo token file-backed e fail-closed em
   credential ausente, vazia ou ilegível.
-- Deploy: 22/22; security: 40/40 — PASS, incluindo compose canônico, rede
-  explícita, secret 0600, rotação atômica e ausência de token em output.
+- Deploy: 22/22; security: 40/40 — PASS na entrega inicial, incluindo compose
+  canônico, rede explícita, secret 0600, rotação atômica e ausência de token em
+  output. O smoke pós-deploy encontrou e corrigiu o ownership do bind mount:
+  `0600` agora pertence ao UID/GID 1000 do runtime `node`, e o Context continua
+  falhando fechado quando a credencial é ausente, vazia ou ilegível.
 - Go targeted human gate + handler compile — PASS.
 - PostgreSQL 16 integration — PASS: duas escritas concorrentes são serializadas,
   produzem um único receipt, payload divergente conflita e todos os receipts

--- a/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
@@ -59,7 +59,9 @@ denominadores, ou qualquer indício de auto-send/green autorun habilitado.
 3. Crie pelo endpoint auditado `/v1/api-keys` uma credencial separada com máscara
    decimal exata `196` (`read_contacts|write_contacts|write_campaigns`), prazo de
    rotação e sem `send_campaigns`. Instale-a atomicamente com
-   `install-warmbly-operator-token.sh`; não altere a chave do collector.
+   `install-warmbly-operator-token.sh SOURCE CC_SECRET_DIR 1000:1000`; o owner
+   numérico corresponde ao usuário `node` do Context e mantém o bind mount
+   legível com modo `0600`. Não altere a chave do collector.
 4. Aplique `docker-compose.warmbly-human-gate.override.yml` e faça apenas smoke
    GET em produção.
    Valide POST exclusivamente no sandbox. Auto-send e GREEN autorun permanecem

--- a/control-center/security/production/secrets/install-warmbly-operator-token.sh
+++ b/control-center/security/production/secrets/install-warmbly-operator-token.sh
@@ -10,14 +10,16 @@ refuse() {
   exit 1
 }
 
-if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
-  refuse "usage: install-warmbly-operator-token.sh SOURCE_FILE [CC_SECRET_DIR]"
+if [[ "$#" -lt 1 || "$#" -gt 3 ]]; then
+  refuse "usage: install-warmbly-operator-token.sh SOURCE_FILE [CC_SECRET_DIR] [RUNTIME_UID:RUNTIME_GID]"
 fi
 
 SOURCE_FILE="$1"
 DEST_DIR="${2:-/etc/confenge/control-center/secrets}"
+RUNTIME_OWNER="${3:-}"
 [[ -f "$SOURCE_FILE" && -r "$SOURCE_FILE" ]] || refuse "source credential file is not readable"
 [[ "$DEST_DIR" != *"CHANGE_ME"* && "$DEST_DIR" != *"placeholder"* ]] || refuse "refusing placeholder destination"
+[[ -z "$RUNTIME_OWNER" || "$RUNTIME_OWNER" =~ ^[0-9]+:[0-9]+$ ]] || refuse "runtime owner must be numeric UID:GID"
 
 credential="$(tr -d '\r\n' < "$SOURCE_FILE")"
 [[ "$credential" =~ ^wmbly_[A-Za-z0-9_-]{16,}$ ]] || refuse "source is not a Warmbly API credential"
@@ -31,7 +33,10 @@ trap cleanup EXIT
 umask 077
 printf '%s' "$credential" > "$tmp"
 chmod 600 "$tmp"
+if [[ -n "$RUNTIME_OWNER" ]]; then
+  chown "$RUNTIME_OWNER" "$tmp"
+fi
 mv -f "$tmp" "$DEST_DIR/CC_WARMBLY_OPERATOR_TOKEN"
 trap - EXIT
 unset credential
-printf 'installed Warmbly operator credential (mode 0600); value not printed\n'
+printf 'installed Warmbly operator credential (mode 0600, runtime-readable); value not printed\n'

--- a/control-center/security/tests/production-edge.test.ts
+++ b/control-center/security/tests/production-edge.test.ts
@@ -343,13 +343,16 @@ describe("production-edge security bundle", () => {
     const source = path.join(sourceDir, "credential");
     const value = "wmbly_fixture_human_gate_123456789";
     writeFileSync(source, `${value}\n`, { mode: 0o600 });
-    const result = spawnSync("bash", [WARMBLY_INSTALLER, source, dest], { encoding: "utf8" });
+    const owner = `${process.getuid?.() ?? 0}:${process.getgid?.() ?? 0}`;
+    const result = spawnSync("bash", [WARMBLY_INSTALLER, source, dest, owner], { encoding: "utf8" });
     assert.equal(result.status, 0, result.stderr);
     assert.doesNotMatch(result.stdout, new RegExp(value));
     assert.doesNotMatch(result.stderr, new RegExp(value));
     const installed = path.join(dest, "CC_WARMBLY_OPERATOR_TOKEN");
     assert.equal(readFileSync(installed, "utf8"), value);
     assert.equal(statSync(installed).mode & 0o777, 0o600);
+    assert.equal(statSync(installed).uid, process.getuid?.() ?? 0);
+    assert.equal(statSync(installed).gid, process.getgid?.() ?? 0);
     assert.deepEqual(readdirSync(dest), ["CC_WARMBLY_OPERATOR_TOKEN"]);
 
     const bad = path.join(sourceDir, "bad");
@@ -357,6 +360,12 @@ describe("production-edge security bundle", () => {
     const refused = spawnSync("bash", [WARMBLY_INSTALLER, bad, dest], { encoding: "utf8" });
     assert.notEqual(refused.status, 0);
     assert.equal(readFileSync(installed, "utf8"), value, "a rejected rotation must preserve the old credential");
+
+    const invalidOwner = spawnSync("bash", [WARMBLY_INSTALLER, source, dest, "node:node"], {
+      encoding: "utf8",
+    });
+    assert.notEqual(invalidOwner.status, 0);
+    assert.equal(readFileSync(installed, "utf8"), value, "an invalid owner must preserve the old credential");
   });
 
   it("generator writes 0600 files, prints no values, and refuses placeholders and CI", () => {


### PR DESCRIPTION
## Outcome

Fixes the production Compose bind-mounted Warmbly human-gate credential so the non-root Context runtime (UID/GID 1000) can read it while the file remains mode 0600. The module continues to fail closed when the credential is absent, empty, or unreadable.

## Evidence

- security: 40/40 pass
- deploy: 22/22 pass
- no token value is printed
- installer validates numeric UID:GID and preserves the previous credential on refusal

## Rollout

Reinstall the already-provisioned credential with owner 1000:1000, restart only Context, then repeat authenticated read-only GET smoke. No cohort write or email send.