### PR TITLE
feat(cc-warmbly): make the first governed cohort runnable by the founder from #/warmbly

### DIFF
--- a/control-center/apps/web-shell/README.md
+++ b/control-center/apps/web-shell/README.md
@@ -19,6 +19,36 @@ Chrome navigation exposes exactly these ten areas:
 
 “Operação Warmbly” is the safe-operation cockpit for the outbound kill switch: dispatch state, pause reason, commercial window, approved queue, hourly cap and the recent audit trail are rendered **before** the three controls (pause in one step, resume in two, acknowledge an inbound alert). There is no send control there and there must never be one.
 
+### Rotas do gate humano de cohorts
+
+O gate humano vive **inteiramente** sob “Operação Warmbly”, em três sub-rotas:
+
+| Rota | O que é |
+| --- | --- |
+| `#/warmbly` (`operacao`) | Resumo do piloto — Fonte → Cohort → Validação → Revisão → GO → Handoff — mais a versão mais recente, o botão “Abrir revisão” e os três controles de disparo. |
+| `#/warmbly/cohorts` | Lista de cohorts versionadas, com os denominadores do preview e a criação de uma cohort pequena (1–10). |
+| `#/warmbly/revisao?resource=<id>` | Revisão candidato a candidato da versão escolhida, e o registro de GO/NO-GO. |
+
+O `resource` viaja na subnav: abrir “Revisão” a partir de “Cohorts” **não** perde a
+versão selecionada, e uma Revisão sem `resource` oferece a lista de versões em vez
+de uma página vazia.
+
+`#/comercial/cohorts` (“Comercial → Coortes”) é **outra coisa**: são coortes de
+aquisição e métricas por período. Nenhum runbook do gate humano deve apontar para
+lá — o caminho correto é **Operação Warmbly → Cohorts**. Pausar, retomar e
+reconhecer também já não vivem em Comercial; a aba de lá só carrega o ponteiro
+para `#/warmbly`.
+
+Autoridade: `operators` cria, reproduz, pede verificação, ajusta e registra
+APPROVE/HOLD/REJECT. `admins` é exigido para GO/NO-GO — sem esse grupo o controle
+aparece desabilitado com o motivo, e nunca escondido em silêncio. A identidade é
+resolvida pelo Authelia na borda; esta tela não envia cabeçalho de ator em
+nenhuma escrita do gate.
+
+Ajustar assunto/corpo cria uma **nova versão** (`POST …/candidates/{id}/adjust`).
+Enquanto essa rota não estiver implantada, a UI trata o 404 como estado esperado,
+diz isso e desabilita o editor em vez de oferecer um controle que não escreve.
+
 Hoje is an attention cockpit: open exceptions plus **at most three** current priorities. There is no chat composer. Financial and commercial-send mutations (cobrança, checkout, refund, cancelamento, Asaas write, commercial send) are not offered.
 
 ## Cards de alerta

--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -75,6 +75,11 @@ const extraHashes = [
   "comercial/pipeline",
   "comercial/excecoes",
   "warmbly/operacao",
+  // The gate surfaces are part of the layout matrix now that they carry tables,
+  // a stepper and a message body. `revisao` with no resource is a real page —
+  // the version selector — so it is probe-safe without a fixture id.
+  "warmbly/cohorts",
+  "warmbly/revisao",
   "clientes/acme",
 ];
 const minimalEvidence = process.env.CC_EVIDENCE_MINIMAL === "1";

--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -73,6 +73,25 @@ export type AdapterReadResult =
   | { ok: false; loading: false; error: AdapterError }
   | { ok: true; loading: true; page: null };
 
+/** One field the server itself reported as changed by an accepted adjust. */
+export interface GateDiffEntry {
+  field: string;
+  before?: string;
+  after?: string;
+}
+
+/**
+ * What a GET issued *after* a definitive write found.
+ *
+ * A 2xx says the channel accepted the call, not that the resource now reads the
+ * way the operator expects. Claiming "aplicado" from the status alone is the
+ * same mistake as reading "PAUSADO" from a collection that never ran.
+ */
+export interface GateReadback {
+  status: "confirmed" | "not_confirmed" | "unavailable" | "skipped";
+  detail: string;
+}
+
 export interface AdapterWriteResult {
   ok: boolean;
   path: string;
@@ -112,6 +131,31 @@ export interface AdapterWriteResult {
     target?: string;
     writes_to: "control-center" | "warmbly";
   };
+  /**
+   * Which human-gate action produced this result.
+   *
+   * Without it every gate write collapses into one anonymous "decisão
+   * registrada" and the operator cannot tell a created cohort from a recorded
+   * HOLD, which is exactly the defect this field exists to prevent.
+   */
+  gateAction?: WarmblyGateAction;
+  /** The card this result belongs to, so feedback lands where the operator acted. */
+  gateTarget?: { cohort_id?: string; candidate_id?: string };
+  /**
+   * Resource the server created or superseded, read from the response body.
+   *
+   * The UI navigates to what the server returned. It never guesses `n + 1`:
+   * a version the server did not name is a version that may not exist.
+   */
+  gateResource?: { cohort_id?: string; version?: number };
+  /** Correlation id echoed by the edge envelope, for the audit trail. */
+  correlationId?: string;
+  /** Receipt token echoed by the gate (a string, unlike the dispatch receipt object). */
+  receiptId?: string;
+  /** Field-level diff the server returned for an accepted adjust. */
+  diff?: readonly GateDiffEntry[];
+  /** Result of the GET readback performed after a definitive response. */
+  readback?: GateReadback;
 }
 
 /**
@@ -152,8 +196,22 @@ export interface ControlCenterReadAdapter {
   warmblyGate?(input: WarmblyGateInput): AdapterWriteResult | Promise<AdapterWriteResult>;
 }
 
+export const WARMBLY_GATE_ACTIONS = [
+  "create",
+  "reproduce",
+  "validate",
+  "review",
+  "decide",
+  "adjust",
+] as const;
+export type WarmblyGateAction = (typeof WARMBLY_GATE_ACTIONS)[number];
+
+export function isWarmblyGateAction(value: string | null): value is WarmblyGateAction {
+  return typeof value === "string" && (WARMBLY_GATE_ACTIONS as readonly string[]).includes(value);
+}
+
 export interface WarmblyGateInput {
-  action: "create" | "reproduce" | "validate" | "review" | "decide";
+  action: WarmblyGateAction;
   version_id?: string;
   candidate_id?: string;
   limit?: number;
@@ -161,6 +219,15 @@ export interface WarmblyGateInput {
   reason?: string;
   acknowledged?: boolean;
   confirmation?: string;
+  /**
+   * `adjust` only. Exactly three fields are editable, and the contract carries
+   * no others: mailbox, evidence, source, policy and route class are frozen by
+   * construction, so this UI has no control that could offer to change them.
+   */
+  subject?: string;
+  body_text?: string;
+  /** `adjust` only: the frozen hash the operator actually reviewed. */
+  expected_frozen_hash?: string;
   idempotency_key: string;
 }
 

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -85,6 +85,149 @@ function validReceiptInstant(value: string, now = Date.now()): boolean {
   return inputSecond === parsedSecond;
 }
 
+/* ------------------------------------------------------------------ *
+ * Human-gate response reading.
+ *
+ * The channel answers every gate write with the same envelope shape, so the
+ * only way to tell a created cohort from a recorded HOLD is to read the action
+ * back out and to keep the resource the server named. Collapsing all of them
+ * into one "Decisão registrada" — and dropping the returned resource — is what
+ * left the operator with no way to reach the version they had just created.
+ * ------------------------------------------------------------------ */
+
+function gateText(body: Record<string, unknown>, key: string): string | undefined {
+  const value = body[key];
+  if (typeof value === "string" && value.trim() !== "") return value;
+  return undefined;
+}
+
+function gateNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/** The cohort payload, whether the server nests it or answers it at the root. */
+function gateCohortOf(body: Record<string, unknown>): Record<string, unknown> | undefined {
+  const nested = asRecord(body.cohort);
+  if (nested && typeof nested.id === "string") return nested;
+  return typeof body.id === "string" ? body : undefined;
+}
+
+function gateDiffOf(
+  adjustment: Record<string, unknown> | null | undefined,
+): AdapterWriteResult["diff"] {
+  if (!adjustment || !Array.isArray(adjustment.diff)) return undefined;
+  const rows = adjustment.diff
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is Record<string, unknown> => entry !== null)
+    .map((entry) => ({
+      field: String(entry.field ?? ""),
+      ...(typeof entry.before === "string" ? { before: entry.before } : {}),
+      ...(typeof entry.after === "string" ? { after: entry.after } : {}),
+    }))
+    .filter((entry) => entry.field !== "");
+  return rows.length > 0 ? rows : undefined;
+}
+
+/**
+ * The prose an operator reads when the server sent none.
+ *
+ * The channel's own success bodies carry a receipt and nothing else, so the
+ * sentence has to come from the action that was actually performed.
+ */
+function gateFallbackMessage(input: WarmblyGateInput, version: number | undefined): string {
+  const v = version === undefined ? "" : ` v${version}`;
+  switch (input.action) {
+    case "create":
+      return `Cohort congelada criada${v}.`;
+    case "reproduce":
+      return `Reprodução da versão imutável concluída${v}.`;
+    case "validate":
+      return "Verificação do destinatário solicitada ao Warmbly.";
+    case "review":
+      return input.decision === "APPROVE"
+        ? "Aprovação registrada para este candidato."
+        : input.decision === "HOLD"
+          ? "HOLD registrado para este candidato."
+          : "Rejeição registrada para este candidato.";
+    case "decide":
+      return input.decision === "GO"
+        ? "GO registrado. Nenhum e-mail foi enfileirado nem enviado."
+        : "NO-GO registrado.";
+    case "adjust":
+      return `Ajuste aceito. O servidor criou a nova versão${v}.`;
+  }
+}
+
+export function gateResult(
+  input: WarmblyGateInput,
+  path: string,
+  status: number,
+  ok: boolean,
+  body: Record<string, unknown>,
+): AdapterWriteResult {
+  const adjustment = asRecord(body.adjustment);
+  const cohort = gateCohortOf(body);
+  const version =
+    gateNumber(adjustment?.to_version) ?? gateNumber(cohort?.version) ?? gateNumber(body.version);
+  const cohortId =
+    (cohort && typeof cohort.id === "string" ? cohort.id : undefined) ?? input.version_id;
+  const rawServerMessage =
+    gateText(body, "message")
+    ?? (Array.isArray(body.reason)
+      ? body.reason.filter((row) => typeof row === "string").join(", ") || undefined
+      : gateText(body, "reason"));
+  // The edge stamps `reason: ["ok"]` / `["upstream_refused"]` when the upstream
+  // sent no prose at all. Those are envelope filler, not a sentence, and
+  // showing them would be the same "HTTP 200" non-answer in Portuguese.
+  const serverMessage =
+    rawServerMessage === "ok" || rawServerMessage === "upstream_refused"
+      ? undefined
+      : rawServerMessage;
+  const rawCode = gateText(body, "code");
+  // A 404 on adjust is the expected state of an install whose backend route has
+  // not landed yet, not an operator mistake. It gets its own code so the UI can
+  // say so and stop offering the control.
+  const code =
+    input.action === "adjust" && status === 404 && rawCode !== "candidate_not_found"
+      ? "adjust_route_unavailable"
+      : rawCode;
+  const diff = gateDiffOf(adjustment);
+  const receipt = gateText(body, "receipt") ?? gateText(adjustment ?? {}, "receipt");
+  const correlation =
+    gateText(adjustment ?? {}, "correlation_id")
+    ?? gateText(body, "correlation_id")
+    ?? gateText(body, "edge_correlation_id");
+  return {
+    ok,
+    path,
+    kind: "nota",
+    status,
+    outcome: ok ? "executed" : status === 503 ? "unknown" : "refused",
+    message: serverMessage ?? gateFallbackMessage(input, version),
+    gateAction: input.action,
+    ...(code ? { code } : {}),
+    ...(input.version_id || input.candidate_id
+      ? {
+          gateTarget: {
+            ...(input.version_id ? { cohort_id: input.version_id } : {}),
+            ...(input.candidate_id ? { candidate_id: input.candidate_id } : {}),
+          },
+        }
+      : {}),
+    ...(ok && (cohortId || version !== undefined)
+      ? {
+          gateResource: {
+            ...(cohortId ? { cohort_id: cohortId } : {}),
+            ...(version !== undefined ? { version } : {}),
+          },
+        }
+      : {}),
+    ...(receipt ? { receiptId: receipt } : {}),
+    ...(correlation ? { correlationId: correlation } : {}),
+    ...(diff ? { diff } : {}),
+  };
+}
+
 async function operatorIdempotencyKey(input: {
   action_type: string;
   target_canonical_id: string;
@@ -261,39 +404,66 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       : input.action === "reproduce" ? `${base}/${version}/reproduce`
       : input.action === "validate" ? `${base}/${version}/candidates/${candidate}/validation`
       : input.action === "review" ? `${base}/${version}/candidates/${candidate}/review`
+      : input.action === "adjust" ? `${base}/${version}/candidates/${candidate}/adjust`
       : `${base}/${version}/decision`;
+    // Every refusal below happens before the wire, so "nada foi aplicado" is a
+    // fact this adapter can prove rather than a hope.
+    const target = {
+      ...(version ? { cohort_id: version } : {}),
+      ...(candidate ? { candidate_id: candidate } : {}),
+    };
+    const refuse = (message: string, code: string): AdapterWriteResult => {
+      const refusal: AdapterWriteResult = {
+        ok: false,
+        path,
+        kind: "nota",
+        message,
+        outcome: "refused",
+        code,
+        gateAction: input.action,
+        ...(Object.keys(target).length > 0 ? { gateTarget: target } : {}),
+      };
+      this.lastOperatorResult = refusal;
+      return refusal;
+    };
     if (
       (input.action !== "create" && !version)
-      || (["validate", "review"].includes(input.action) && !candidate)
+      || (["validate", "review", "adjust"].includes(input.action) && !candidate)
     ) {
-      return {
-        ok: false,
-        path,
-        kind: "nota",
-        message: "alvo do gate incompleto",
-        outcome: "refused",
-        code: "client_precondition",
-      };
+      return refuse("alvo do gate incompleto", "gate_precondition");
     }
     if (input.action === "review" && input.decision === "APPROVE" && input.acknowledged !== true) {
-      return {
-        ok: false,
-        path,
-        kind: "nota",
-        message: "APPROVE exige ciência explícita do destinatário, mensagem, policy e evidência",
-        outcome: "refused",
-        code: "approval_acknowledgement_required",
-      };
+      return refuse(
+        "APPROVE exige ciência explícita do destinatário, mensagem, policy e evidência",
+        "approval_acknowledgement_required",
+      );
     }
     if (input.action === "decide" && !input.confirmation?.trim()) {
-      return {
-        ok: false,
-        path,
-        kind: "nota",
-        message: "GO/NO-GO exige a confirmação digitada da versão imutável",
-        outcome: "refused",
-        code: "cohort_version_confirmation_required",
-      };
+      return refuse(
+        "GO/NO-GO exige a confirmação digitada da versão imutável",
+        "cohort_version_confirmation_required",
+      );
+    }
+    if (input.action === "adjust") {
+      // The three editable fields plus the two anti-clobber tokens. An adjust
+      // that cannot name the frozen hash it was written against is an edit
+      // against an unknown baseline, and the server is right to reject it —
+      // this refuses it one hop earlier, without spending an attempt.
+      if (!input.subject?.trim() || !input.body_text?.trim() || !input.reason?.trim()) {
+        return refuse(
+          "ajuste exige assunto, corpo e motivo preenchidos",
+          "gate_precondition",
+        );
+      }
+      if (!input.confirmation?.trim()) {
+        return refuse("ajuste exige a confirmação digitada da versão", "confirmation_mismatch");
+      }
+      if (!input.expected_frozen_hash?.trim()) {
+        return refuse(
+          "ajuste exige o frozen hash da versão revisada",
+          "gate_precondition",
+        );
+      }
     }
     try {
       const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
@@ -307,20 +477,17 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
           ...(input.reason ? { reason: input.reason } : {}),
           ...(input.acknowledged === true ? { acknowledged: true } : {}),
           ...(input.confirmation ? { confirmation: input.confirmation.trim().toLowerCase() } : {}),
+          ...(input.action === "adjust"
+            ? {
+                subject: input.subject,
+                body_text: input.body_text,
+                expected_frozen_hash: input.expected_frozen_hash,
+              }
+            : {}),
         }),
       });
       const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
-      const result: AdapterWriteResult = {
-        ok: response.ok,
-        path,
-        kind: "nota",
-        status: response.status,
-        outcome: response.ok ? "executed" : response.status === 503 ? "unknown" : "refused",
-        message: response.ok
-          ? `Decisão registrada. Receipt: ${String(body.receipt ?? "—")}`
-          : String(body.message ?? (Array.isArray(body.reason) ? body.reason.join(", ") : body.reason) ?? `HTTP ${response.status}`),
-        ...(typeof body.code === "string" ? { code: body.code } : {}),
-      };
+      const result = gateResult(input, path, response.status, response.ok, body);
       this.lastOperatorResult = result;
       return result;
     } catch {
@@ -331,6 +498,8 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
         outcome: "unknown",
         code: "browser_transport",
         message: "Sem resposta; releia o recurso antes de repetir.",
+        gateAction: input.action,
+        ...(Object.keys(target).length > 0 ? { gateTarget: target } : {}),
       };
       this.lastOperatorResult = result;
       return result;
@@ -672,13 +841,27 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     // they moved to their own route.
     if (id === "warmbly" && page.commercial) {
       const parsed = parseHash(location ?? "#/warmbly");
-      if (parsed.surface === "cohorts" || parsed.surface === "revisao") {
-        const list = asRecord(await this.getJson("/v1/warmbly/operator/cohorts?limit=50")) ?? {};
-        const selected = parsed.resource
-          ? asRecord(await this.getJson(`/v1/warmbly/operator/cohorts/${encodeURIComponent(parsed.resource)}`))
-          : undefined;
-        page.warmbly_gate = { list, ...(selected ? { selected } : {}) };
-      } else {
+      // Every Warmbly surface now reads the gate, because the operation cockpit
+      // opens on a stepper that has to say where the pilot actually stands. A
+      // gate the channel cannot serve must not take the whole destination down
+      // with it, so these reads are soft and report their own status.
+      const list = await this.readGate("/v1/warmbly/operator/cohorts?limit=50");
+      const selected = parsed.resource
+        ? await this.readGate(`/v1/warmbly/operator/cohorts/${encodeURIComponent(parsed.resource)}`)
+        : undefined;
+      page.warmbly_gate = {
+        list: list.data ?? {},
+        list_status: list.status,
+        ...(list.detail ? { list_detail: list.detail } : {}),
+        ...(selected
+          ? {
+              selected: selected.data ?? {},
+              selected_status: selected.status,
+              ...(selected.detail ? { selected_detail: selected.detail } : {}),
+            }
+          : {}),
+      };
+      if (parsed.surface !== "cohorts" && parsed.surface !== "revisao") {
         await this.attachOperatorLedger(page.commercial);
       }
     }
@@ -765,6 +948,50 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       // Same reason as above: unreadable is not empty.
       ops.operator_ledger_status = "unreadable";
       ops.operator_ledger_detail = err instanceof Error ? err.name : "erro de transporte";
+    }
+  }
+
+  /**
+   * Reads one human-gate resource without ever taking the page down with it.
+   *
+   * Two differences from `getJson`, both deliberate:
+   *
+   * - No `x-actor-id`/`x-actor-kind`. These routes authenticate at the edge with
+   *   Authelia; a browser-set actor has no business travelling next to them.
+   * - A failure returns a status instead of throwing. "Não consegui ler" is a
+   *   thing this surface must be able to say out loud; an exception here would
+   *   render the whole destination as a generic error, which reads to an
+   *   operator exactly like "there are no cohorts".
+   */
+  private async readGate(path: string): Promise<{
+    status: "read" | "not_mounted" | "forbidden" | "unreadable";
+    data?: Record<string, unknown>;
+    detail?: string;
+  }> {
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        headers: { accept: "application/json" },
+        credentials: "include",
+      });
+      if (!response.ok) {
+        return {
+          status:
+            response.status === 404
+              ? "not_mounted"
+              : response.status === 401 || response.status === 403
+                ? "forbidden"
+                : "unreadable",
+          detail: `HTTP ${response.status}`,
+        };
+      }
+      const parsed = asRecord(await response.json().catch(() => undefined));
+      if (!parsed) return { status: "unreadable", detail: "resposta não é um objeto JSON" };
+      return { status: "read", data: parsed };
+    } catch (err) {
+      return {
+        status: "unreadable",
+        detail: err instanceof Error ? err.name : "erro de transporte",
+      };
     }
   }
 

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -3,10 +3,20 @@ import type {
   AdapterWriteResult,
   ControlCenterReadAdapter,
   DestinationPage,
+  GateReadback,
+  WarmblyGateAction,
 } from "./adapters/contract";
+import { isWarmblyGateAction } from "./adapters/contract";
 import { WARMBLY_DISPATCH_PATHS, type WriteShortcutKind } from "./adapters/paths";
 import { parseHash } from "./destinations";
 import { LIST_FORM_FIELDS, defaultParamValues, listHref, listSpecById } from "./filter";
+import {
+  beginGateFlight,
+  clearAdjustDraft,
+  endGateFlight,
+  markAdjustRouteMissing,
+  setAdjustDraft,
+} from "./human-gate-flight";
 import {
   humanGateIdempotencyKey,
   settleHumanGateIntent,
@@ -159,8 +169,9 @@ function applyPaint(
       result.ok && !result.loading ? result.page?.commercial : undefined,
     ),
   );
-  bindWarmblyHumanGate(root, adapter, repaint);
+  bindWarmblyHumanGate(root, adapter, repaint, navigate);
   bindWarmblyGateFilters(root, renderHash, navigate);
+  bindMessageToggle(root, renderHash, navigate);
   bindCopyControls(root);
   bindListFilters(root, renderHash, navigate);
   consumeQueueFocus(
@@ -494,10 +505,29 @@ function bindWarmblyDispatch(
   }
 }
 
+/**
+ * Binds every human-gate control.
+ *
+ * Four things this binder owes the operator, none of which the previous one
+ * gave them:
+ *
+ * 1. **One click is one write.** A gate POST is not idempotent by accident —
+ *    a second `create` mints a second cohort — so a form already waiting on the
+ *    channel refuses the next submit outright.
+ * 2. **A pending state.** The paint before the await is what makes the wait
+ *    visible; a control that looks idle while a write is in flight is a control
+ *    that invites the second click.
+ * 3. **A readback before claiming an effect.** A 2xx says the channel accepted
+ *    the call, not that the resource changed.
+ * 4. **Navigation to the resource the server named.** After create, reproduce or
+ *    adjust the operator is taken to the version the response carried — never to
+ *    a version this screen guessed.
+ */
 function bindWarmblyHumanGate(
   root: MountableRoot,
   adapter: ControlCenterReadAdapter,
   onDone: () => void,
+  navigate: Navigate,
 ): void {
   if (!adapter.warmblyGate || typeof root.querySelectorAll !== "function") return;
   const forms = root.querySelectorAll("[data-human-gate]");
@@ -505,31 +535,251 @@ function bindWarmblyHumanGate(
     const form = forms[i];
     if (!form) continue;
     const raw = form.getAttribute("data-human-gate");
-    if (raw !== "create" && raw !== "reproduce" && raw !== "validate" && raw !== "review" && raw !== "decide") continue;
+    if (!isWarmblyGateAction(raw)) continue;
     form.addEventListener("submit", (event) => {
       event.preventDefault();
-      const decision = form.querySelector('[name="decision"]')?.value;
+      const versionId = form.getAttribute("data-version") ?? "";
+      const candidateId = form.getAttribute("data-candidate") ?? "";
+      const key = form.getAttribute("data-gate-key") ?? `${raw}:${versionId}:${candidateId}:`;
+      // The APPROVE form carries its decision on the element, because APPROVE
+      // and HOLD/REJECT are different forms with different requirements: one
+      // demands the acknowledgement, the other must never demand it.
+      const fixedDecision = form.getAttribute("data-decision");
+      const decision = fixedDecision ?? form.querySelector('[name="decision"]')?.value;
       const limit = Number(form.querySelector('[name="limit"]')?.value ?? 0);
       const acknowledgement = form.querySelector('[name="ack"]')?.checked === true;
       const confirmation = form.querySelector('[name="confirmation"]')?.value?.trim() ?? "";
+      const reason = form.querySelector('[name="reason"]')?.value ?? "";
+
+      if (raw === "adjust") {
+        const subject = form.querySelector('[name="subject"]')?.value ?? "";
+        const bodyText = form.querySelector('[name="body_text"]')?.value ?? "";
+        if (form.getAttribute("data-adjust-step") !== "confirm") {
+          // Step one is local and writes nothing: it parks the draft so the
+          // next paint can show the operator the diff they are about to commit.
+          setAdjustDraft({
+            cohort_id: versionId,
+            candidate_id: candidateId,
+            subject,
+            body_text: bodyText,
+            reason,
+            // The frozen originals ride on the form, not on the inputs: the
+            // moment the operator types, the input no longer knows what was
+            // frozen, and a diff against the edited text is no diff at all.
+            before_subject: form.getAttribute("data-before-subject") ?? "",
+            before_body_text: form.getAttribute("data-before-body") ?? "",
+            version: form.getAttribute("data-cohort-version") ?? "",
+            frozen_hash: form.getAttribute("data-frozen-hash") ?? "",
+          });
+          onDone();
+          return;
+        }
+      }
+
+      if (!beginGateFlight(key)) return;
       const intent: HumanGateIntent = {
         action: raw,
-        ...(form.getAttribute("data-version") ? { version_id: form.getAttribute("data-version")! } : {}),
-        ...(form.getAttribute("data-candidate") ? { candidate_id: form.getAttribute("data-candidate")! } : {}),
+        ...(versionId ? { version_id: versionId } : {}),
+        ...(candidateId ? { candidate_id: candidateId } : {}),
         ...(limit > 0 ? { limit } : {}),
         ...(decision === "APPROVE" || decision === "REJECT" || decision === "HOLD" || decision === "GO" || decision === "NO_GO" ? { decision } : {}),
-        ...(form.querySelector('[name="reason"]')?.value ? { reason: form.querySelector('[name="reason"]')!.value } : {}),
+        ...(reason ? { reason } : {}),
         ...(decision === "APPROVE" ? { acknowledged: acknowledgement } : {}),
-        ...(raw === "decide" && confirmation ? { confirmation } : {}),
+        ...((raw === "decide" || raw === "adjust") && confirmation ? { confirmation } : {}),
+        ...(raw === "adjust"
+          ? {
+              subject: form.querySelector('[name="subject"]')?.value ?? "",
+              body_text: form.querySelector('[name="body_text"]')?.value ?? "",
+              expected_frozen_hash: form.getAttribute("data-frozen-hash") ?? "",
+            }
+          : {}),
       };
-      void Promise.resolve(adapter.warmblyGate?.({
-        ...intent,
-        idempotency_key: humanGateIdempotencyKey(intent),
-      })).then((result) => {
+      // Paint the pending state before the await. The key is computed first so
+      // this paint already renders the form as busy.
+      onDone();
+      void (async () => {
+        let result: AdapterWriteResult | undefined;
+        try {
+          result = await Promise.resolve(
+            adapter.warmblyGate?.({
+              ...intent,
+              idempotency_key: humanGateIdempotencyKey(intent),
+            }),
+          );
+        } catch {
+          // The adapter threw instead of answering, so this client cannot know
+          // whether the POST reached the gate. `unknown` is the only honest
+          // verdict — and it is the one that keeps the idempotency key.
+          result = {
+            ok: false,
+            path: "",
+            kind: "nota",
+            message: "O canal falhou sem responder.",
+            outcome: "unknown",
+            code: "browser_transport",
+            gateAction: raw,
+            ...(versionId || candidateId
+              ? {
+                  gateTarget: {
+                    ...(versionId ? { cohort_id: versionId } : {}),
+                    ...(candidateId ? { candidate_id: candidateId } : {}),
+                  },
+                }
+              : {}),
+          };
+        } finally {
+          endGateFlight(key);
+        }
+        // Only a definitive outcome advances the key. An `unknown` keeps it, so
+        // the retry of an uncertain intent is the same intent to the server.
         settleHumanGateIntent(intent, result?.outcome);
-        if (result) adapter.lastOperatorResult = result;
+        if (result) {
+          if (result.code === "adjust_route_unavailable") markAdjustRouteMissing();
+          const readback = await gateReadback(adapter, intent, result);
+          adapter.lastOperatorResult = { ...result, readback };
+          if (raw === "adjust" && result.ok) clearAdjustDraft(candidateId);
+        }
+        const next = gateNavigation(raw, result);
+        if (next) {
+          navigate(next);
+          return;
+        }
         onDone();
-      });
+      })();
+    });
+  }
+}
+
+/** Where the operator is taken after a write, according to the server's answer. */
+function gateNavigation(
+  action: WarmblyGateAction,
+  result: AdapterWriteResult | undefined,
+): string | null {
+  if (!result?.ok) return null;
+  if (action !== "create" && action !== "reproduce" && action !== "adjust") return null;
+  const cohortId = result.gateResource?.cohort_id;
+  // No id in the response is not a reason to guess one: a version this screen
+  // invented is a version that may not exist.
+  return cohortId ? `#/warmbly/revisao?resource=${encodeURIComponent(cohortId)}` : null;
+}
+
+function gateRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Re-reads the resource a definitive write claimed to change.
+ *
+ * "O canal aceitou" and "o recurso mudou" are different statements and only the
+ * second one is what an operator needs. Everything reported here is what the
+ * fresh GET returned; nothing is inferred from the write's own status.
+ */
+async function gateReadback(
+  adapter: ControlCenterReadAdapter,
+  intent: HumanGateIntent,
+  result: AdapterWriteResult,
+): Promise<GateReadback> {
+  if (result.outcome !== "executed" || !result.ok) {
+    return {
+      status: "skipped",
+      detail: "Nenhuma releitura é devida: o canal não relatou uma escrita aplicada.",
+    };
+  }
+  const cohortId = result.gateResource?.cohort_id ?? intent.version_id;
+  if (!cohortId) {
+    return { status: "unavailable", detail: "A resposta não nomeou nenhum recurso para reler." };
+  }
+  let read: import("./adapters/contract").AdapterReadResult;
+  try {
+    read = await Promise.resolve(
+      adapter.readDestination("warmbly", `#/warmbly/revisao?resource=${encodeURIComponent(cohortId)}`),
+    );
+  } catch {
+    return { status: "unavailable", detail: "A releitura não completou." };
+  }
+  if (!read.ok || read.loading || !read.page) {
+    return { status: "unavailable", detail: "A releitura não completou." };
+  }
+  const gate = gateRecord(read.page.warmbly_gate);
+  const cohort = gateRecord(gateRecord(gate.selected).data);
+  if (!cohort.id) {
+    return { status: "unavailable", detail: "O servidor não devolveu esta versão na releitura." };
+  }
+  const candidates = Array.isArray(cohort.candidates) ? cohort.candidates.map(gateRecord) : [];
+  const candidate = intent.candidate_id
+    ? candidates.find((row) => row.candidate_id === intent.candidate_id)
+    : undefined;
+  switch (intent.action) {
+    case "create":
+    case "reproduce":
+    case "adjust": {
+      const version = cohort.version;
+      const expected = result.gateResource?.version;
+      const matches = expected === undefined || version === expected;
+      return matches
+        ? { status: "confirmed", detail: `O servidor devolve a versão v${String(version)}.` }
+        : {
+            status: "not_confirmed",
+            detail: `O servidor devolve a versão v${String(version)}, não a v${String(expected)} anunciada na resposta.`,
+          };
+    }
+    case "review": {
+      if (!candidate) {
+        return { status: "not_confirmed", detail: "O candidato não aparece nesta versão na releitura." };
+      }
+      const recorded = gateRecord(candidate.review).decision;
+      return recorded === intent.decision
+        ? { status: "confirmed", detail: `O servidor registra ${String(recorded)} neste candidato.` }
+        : {
+            status: "not_confirmed",
+            detail: `O servidor ainda registra "${String(recorded ?? "nada")}" neste candidato.`,
+          };
+    }
+    case "decide": {
+      const recorded = gateRecord(cohort.decision).decision;
+      return recorded === intent.decision
+        ? { status: "confirmed", detail: `O servidor registra a decisão final ${String(recorded)}.` }
+        : {
+            status: "not_confirmed",
+            detail: `O servidor ainda registra "${String(recorded ?? "nada")}" como decisão final.`,
+          };
+    }
+    case "validate": {
+      if (!candidate) {
+        return { status: "not_confirmed", detail: "O candidato não aparece nesta versão na releitura." };
+      }
+      // Validation is asynchronous at Warmbly, so the honest readback is the
+      // state the server reports now — not a verdict about whether it "worked".
+      return {
+        status: "confirmed",
+        detail: `O servidor reporta validação "${String(gateRecord(candidate.validation).status ?? "sem estado")}" agora.`,
+      };
+    }
+  }
+}
+
+/**
+ * The "expand/collapse all messages" control.
+ *
+ * It is URL state like every other recorte on this shell, so it survives the
+ * repaint that reading a candidate causes.
+ */
+function bindMessageToggle(root: MountableRoot, hash: string, navigate: Navigate): void {
+  if (typeof root.querySelectorAll !== "function") return;
+  const buttons = root.querySelectorAll("[data-toggle-messages]");
+  for (let i = 0; i < buttons.length; i += 1) {
+    const button = buttons[i];
+    if (!button || !button.getAttribute("data-toggle-messages")) continue;
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      const [path = "#/warmbly/revisao", query = ""] = hash.split("?");
+      const params = new URLSearchParams(query);
+      if (params.get("mensagens") === "recolhidas") params.delete("mensagens");
+      else params.set("mensagens", "recolhidas");
+      const rendered = params.toString();
+      navigate(`${path}${rendered ? `?${rendered}` : ""}`);
     });
   }
 }

--- a/control-center/apps/web-shell/src/human-gate-flight.ts
+++ b/control-center/apps/web-shell/src/human-gate-flight.ts
@@ -1,0 +1,92 @@
+/**
+ * Ephemeral state of a human-gate submission, parked at module scope.
+ *
+ * The shell repaints by replacing `root.innerHTML` wholesale, so anything kept
+ * in the closure of the form that started a write dies before the paint that
+ * has to render its outcome. `warmbly-confirmation.ts` exists for the same
+ * reason; this module is its sibling for the cohort gate.
+ *
+ * Nothing here is durable and nothing here reaches storage: a reload is a
+ * deliberate act that clears an in-flight marker and an unconfirmed draft. The
+ * idempotency key — the one thing that *must* survive a retry — lives in
+ * `human-gate-idempotency.ts` instead.
+ */
+
+/** Draft of an adjust, held between the preview step and the confirmation. */
+export interface AdjustDraft {
+  cohort_id: string;
+  candidate_id: string;
+  subject: string;
+  body_text: string;
+  reason: string;
+  /** Frozen content the operator was shown, so the diff is against what they read. */
+  before_subject: string;
+  before_body_text: string;
+  /** Version the operator confirmed against, replayed verbatim as `v<n>`. */
+  version: string;
+  /** Frozen hash of the candidate as rendered. Sent as `expected_frozen_hash`. */
+  frozen_hash: string;
+}
+
+const inFlight = new Set<string>();
+const drafts = new Map<string, AdjustDraft>();
+let adjustRouteAbsent = false;
+
+/**
+ * Claims a form for one submission.
+ *
+ * Returns false when that same form is already waiting on the channel. A gate
+ * write is not idempotent-by-accident: a second POST of "create" mints a second
+ * cohort, and a double-click on a trackpad is one operator intent, not two.
+ */
+export function beginGateFlight(key: string): boolean {
+  if (key === "" || inFlight.has(key)) return false;
+  inFlight.add(key);
+  return true;
+}
+
+export function endGateFlight(key: string): void {
+  inFlight.delete(key);
+}
+
+export function gateInFlight(key: string): boolean {
+  return inFlight.has(key);
+}
+
+export function anyGateInFlight(): boolean {
+  return inFlight.size > 0;
+}
+
+/**
+ * Records that the channel answered 404 for the adjust route.
+ *
+ * The backend lands in a parallel workstream, so an install without it is an
+ * expected state, not a defect. Remembering the refusal keeps the UI from
+ * offering a control that provably cannot work in this deployment.
+ */
+export function markAdjustRouteMissing(): void {
+  adjustRouteAbsent = true;
+}
+
+export function adjustRouteMissing(): boolean {
+  return adjustRouteAbsent;
+}
+
+export function setAdjustDraft(draft: AdjustDraft): void {
+  drafts.set(draft.candidate_id, draft);
+}
+
+export function adjustDraft(candidateId: string): AdjustDraft | undefined {
+  return drafts.get(candidateId);
+}
+
+export function clearAdjustDraft(candidateId: string): void {
+  drafts.delete(candidateId);
+}
+
+/** Test seam. Production never needs to forget all of this at once. */
+export function resetGateFlight(): void {
+  inFlight.clear();
+  drafts.clear();
+  adjustRouteAbsent = false;
+}

--- a/control-center/apps/web-shell/src/human-gate-idempotency.ts
+++ b/control-center/apps/web-shell/src/human-gate-idempotency.ts
@@ -5,7 +5,7 @@
  */
 
 export interface HumanGateIntent {
-  action: "create" | "reproduce" | "validate" | "review" | "decide";
+  action: "create" | "reproduce" | "validate" | "review" | "decide" | "adjust";
   version_id?: string;
   candidate_id?: string;
   limit?: number;
@@ -13,6 +13,16 @@ export interface HumanGateIntent {
   reason?: string;
   acknowledged?: boolean;
   confirmation?: string;
+  /**
+   * Adjust only. The proposed copy is part of the intent's identity: retrying
+   * the *same* text must reuse the key, while changing a word is a different
+   * intent that must not inherit the previous one's slot.
+   *
+   * Only the fingerprint of these reaches storage — see `identity` below.
+   */
+  subject?: string;
+  body_text?: string;
+  expected_frozen_hash?: string;
 }
 
 interface TinyStorage {
@@ -59,6 +69,13 @@ function identity(intent: HumanGateIntent): string {
     intent.reason?.trim() ?? "",
     intent.acknowledged === true,
     intent.confirmation?.trim().toLowerCase() ?? "",
+    // Proposed message content is folded into the identity as a fingerprint, so
+    // the same retry keeps its key while different copy gets a different one —
+    // and no subject or body is ever written to browser storage.
+    intent.subject === undefined && intent.body_text === undefined
+      ? ""
+      : fingerprint(JSON.stringify([intent.subject ?? "", intent.body_text ?? ""])),
+    intent.expected_frozen_hash ?? "",
   ]);
 }
 

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -1263,3 +1263,101 @@ details.alert-why > summary {
   border-bottom: 1px dotted currentColor;
   cursor: help;
 }
+
+/* ------------------------------------------------------------------ *
+ * Gate humano do Warmbly.
+ *
+ * A mensagem exata é o objeto da revisão, então ela é o que ocupa espaço.
+ * O resto do bloco existe para tornar visível o que antes era invisível:
+ * em que passo o piloto está, o que está bloqueado e por quê, e o que uma
+ * chamada em curso está fazendo agora.
+ * ------------------------------------------------------------------ */
+
+[data-pilot-stepper] {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+@media (min-width: 900px) {
+  [data-pilot-stepper] {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+[data-step-state="current"] {
+  border-color: var(--focus);
+}
+
+[data-step-state="unknown"] {
+  border-style: dashed;
+}
+
+[data-write-pending] {
+  border-left: 4px solid var(--focus);
+}
+
+/* A disabled control must read as deliberate, not as broken. Its reason is
+   always rendered next to it, so the greying is the cue, not the message. */
+.operator-form button[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+[data-approve-blocked],
+[data-blocked-reason],
+[data-go-authority="absent"] {
+  border-left: 3px solid var(--high);
+  padding-left: 0.6rem;
+}
+
+[data-adjust-diff] del {
+  color: var(--crit);
+  text-decoration: line-through;
+}
+
+[data-adjust-diff] ins,
+[data-server-diff] ins {
+  color: var(--ok);
+  text-decoration: none;
+}
+
+[data-server-diff] del {
+  color: var(--crit);
+}
+
+[data-message-preview] > summary {
+  font-weight: 600;
+}
+
+[data-exact-body] {
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+[data-readback="not_confirmed"],
+[data-readback="unavailable"] {
+  border-left: 3px solid var(--crit);
+  padding-left: 0.6rem;
+}
+
+[data-cohort-selector] {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+a.button,
+button[data-toggle-messages] {
+  display: inline-block;
+  min-height: 44px;
+  padding: 0.6rem 0.9rem;
+  border: 1px solid var(--accent);
+  border-radius: 0.4rem;
+  background: var(--bg-elev);
+  color: var(--fg);
+  font: inherit;
+  text-decoration: none;
+}

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -250,6 +250,7 @@ function pageBody(
         ...(operatorResult ? { operatorResult } : {}),
         ...(page.warmbly_gate ? { gate: page.warmbly_gate } : {}),
         ...(query ? { query } : {}),
+        ...(resource ? { resource } : {}),
       },
       surface,
     );

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -24,6 +24,13 @@ import {
   type WarmblySurface,
 } from "../destinations";
 import type { AdapterWriteResult } from "../adapters/contract";
+import {
+  adjustDraft,
+  adjustRouteMissing,
+  gateInFlight,
+  type AdjustDraft,
+} from "../human-gate-flight";
+import { AUTH_HOST, PRODUCTIVE_HOST } from "../topology";
 import type { ActorRef, CommercialSnapshot } from "../types";
 import type { PendingResumeConfirmation } from "../warmbly-confirmation";
 import {
@@ -45,6 +52,8 @@ export interface WarmblySurfaceInput {
   confirmation?: PendingResumeConfirmation;
   gate?: Record<string, unknown>;
   query?: string;
+  /** Selected cohort id, carried by the route so the subnav cannot drop it. */
+  resource?: string | null;
 }
 
 export type WarmblySurfaceRenderer = (input: WarmblySurfaceInput) => string;
@@ -197,6 +206,108 @@ const OUTCOME_BY_CODE: Record<string, OutcomeRule> = {
     recovery:
       "O canal chegou ao Warmbly e o Warmbly respondeu com erro. Confira o estado do disparo acima; se o outbound precisa parar, use o fallback fora de banda.",
   },
+
+  /* ---------------------------------------------------------------- *
+   * Gate humano de cohorts. Mesmo dicionário, códigos próprios: um
+   * "recusado" genérico não diz ao operador o que corrigir, e cada um
+   * destes exige um movimento diferente.
+   * ---------------------------------------------------------------- */
+  gate_precondition: {
+    kind: "refused",
+    title: "Recusada aqui mesmo: faltam campos obrigatórios",
+    recovery:
+      "Nada saiu do navegador e nada foi gravado no Warmbly. Complete os campos indicados no formulário e envie de novo.",
+  },
+  approval_acknowledgement_required: {
+    kind: "refused",
+    title: "Recusada: APPROVE exige a ciência marcada",
+    recovery:
+      "Aprovar é assumir que você leu destinatário, mensagem exata, policy e evidência desta versão. Marque a ciência e aprove de novo. HOLD e REJECT não pedem essa marcação.",
+  },
+  cohort_version_confirmation_required: {
+    kind: "refused",
+    title: "Recusada: falta a confirmação digitada da versão",
+    recovery:
+      "GO/NO-GO exige digitar a versão imutável (por exemplo v1). Nada foi decidido.",
+  },
+  insufficient_human_gate_role: {
+    kind: "refused",
+    title: "Recusada: sua sessão não tem a autoridade necessária",
+    recovery:
+      "Revisar exige o grupo operators; registrar GO/NO-GO exige admins. Nada foi aplicado. Peça a inclusão no grupo no Authelia e reautentique antes de repetir.",
+  },
+  idempotency_key_required: {
+    kind: "refused",
+    title: "Recusada: escrita sem chave de idempotência",
+    recovery:
+      "Toda escrita do gate viaja com uma chave que impede duplicar a intenção. Nada foi aplicado; isto é defeito desta tela, não do operador.",
+  },
+  human_gate_route_not_allowed: {
+    kind: "refused",
+    title: "Recusada: rota fora do allowlist fixo do gate",
+    recovery:
+      "O proxy do gate só encaminha um conjunto fixo de rotas e esta não está nele. Nada foi aplicado; isto é configuração do canal, não do operador.",
+  },
+  human_gate_transport_unknown: {
+    kind: "unknown",
+    title: "Sem resposta: a escrita pode ter sido aplicada",
+    recovery:
+      "A requisição saiu e a resposta não voltou. Não repita às cegas: recarregue esta versão e compare receipt e correlation id. Se repetir, repita a MESMA intenção — a chave de idempotência é preservada.",
+  },
+  human_gate_read_unavailable: {
+    kind: "refused",
+    title: "Leitura do gate não concluída: nenhuma escrita foi tentada",
+    recovery: "Recarregue a página. Nada foi gravado.",
+  },
+  /* Ajuste (nova versão de conteúdo). */
+  frozen_hash_mismatch: {
+    kind: "refused",
+    title: "Recusada: o conteúdo congelado mudou desde a sua leitura",
+    recovery:
+      "Você editou sobre uma versão que já não é a atual, então o ajuste não foi aplicado. Recarregue esta revisão, releia a mensagem congelada e refaça a edição sobre o texto novo.",
+  },
+  confirmation_mismatch: {
+    kind: "refused",
+    title: "Recusada: a confirmação não corresponde à versão",
+    recovery:
+      "Digite exatamente a versão exibida nesta revisão (por exemplo v1) e confirme de novo. Nada foi alterado.",
+  },
+  version_superseded: {
+    kind: "refused",
+    title: "Recusada: esta versão já foi substituída por outra mais nova",
+    recovery:
+      "Alguém criou uma versão posterior enquanto você editava. Abra a versão mais recente na lista de Cohorts e refaça o ajuste lá. Nada foi alterado aqui.",
+  },
+  authority_active: {
+    kind: "refused",
+    title: "Recusada: há autoridade bounded ativa para esta cohort",
+    recovery:
+      "Uma cohort com GO ativo não pode ter conteúdo ajustado. Registre NO-GO para revogar a autoridade e só então ajuste. Nada foi alterado.",
+  },
+  immutable_field: {
+    kind: "refused",
+    title: "Recusada: o pedido tocou um campo imutável",
+    recovery:
+      "Só assunto e corpo podem ser ajustados; destinatário, evidência, origem, policy e classe de rota são congelados. Nada foi alterado; isto é defeito desta tela, não do operador.",
+  },
+  copy_qa_failed: {
+    kind: "refused",
+    title: "Recusada: o texto proposto reprovou no QA de copy",
+    recovery:
+      "O Warmbly aplica as mesmas regras de copy da composição original. Leia os motivos no detalhe técnico, corrija o assunto ou o corpo e proponha de novo. Nada foi alterado.",
+  },
+  candidate_not_found: {
+    kind: "refused",
+    title: "Recusada: candidato não encontrado nesta versão",
+    recovery:
+      "O candidato não existe mais nesta versão da cohort. Recarregue a revisão antes de agir de novo.",
+  },
+  adjust_route_unavailable: {
+    kind: "refused",
+    title: "Ajuste ainda não disponível nesta instalação",
+    recovery:
+      "A rota de ajuste do Warmbly ainda não foi implantada neste ambiente, então nada foi alterado. Enquanto isso, registre HOLD ou REJECT com o motivo e refaça a cohort quando a rota entrar no ar.",
+  },
 };
 
 /** Fallback when the channel answers a status this build does not have a code for. */
@@ -320,7 +431,33 @@ export function classifyDispatchOutcome(result: AdapterWriteResult): DispatchOut
   };
 }
 
-function outcomeBlock(result: AdapterWriteResult | undefined): string {
+const GATE_ACTION_LABELS: Record<string, string> = {
+  create: "criar cohort congelada",
+  reproduce: "reproduzir versão imutável",
+  validate: "verificar destinatário",
+  review: "registrar decisão de revisão",
+  decide: "registrar GO/NO-GO",
+  adjust: "ajustar assunto e corpo",
+};
+
+const READBACK_LABELS: Record<string, string> = {
+  confirmed: "Releitura do servidor confirmou o novo estado.",
+  not_confirmed:
+    "A releitura do servidor ainda NÃO mostra este efeito. O canal aceitou a chamada, mas o recurso lido não confirma a mudança: recarregue antes de concluir que foi aplicada.",
+  unavailable:
+    "Não foi possível reler o recurso para confirmar. Aceite do canal não é prova de efeito: recarregue e confira antes de repetir.",
+  skipped: "Releitura não aplicável a esta resposta.",
+};
+
+/**
+ * The one banner every write outcome goes through.
+ *
+ * Operation, Cohorts and Revisão share it deliberately. Three copies of this
+ * block would drift, and the surfaces that never had one — Cohorts and Revisão —
+ * are exactly where an operator was left with no success, no refusal, no code
+ * and no next move after every create, review and GO.
+ */
+export function writeResultBlock(result: AdapterWriteResult | undefined): string {
   if (!result) return "";
   const view = classifyDispatchOutcome(result);
   const tone = ownMapValue(OUTCOME_TONE, view.kind) ?? "stale";
@@ -332,18 +469,54 @@ function outcomeBlock(result: AdapterWriteResult | undefined): string {
     failed: "A tentativa falhou; confirme o estado observado antes de tentar novamente.",
     unknown: "Não foi possível comprovar se a ação chegou a ser aplicada.",
   };
+  const actionLabel = result.gateAction
+    ? ownMapValue(GATE_ACTION_LABELS, result.gateAction) ?? "ação do gate não catalogada"
+    : "";
+  const readback = result.readback;
+  const diffRows = (result.diff ?? [])
+    .map(
+      (entry) =>
+        `<div data-diff-field="${escapeHtml(entry.field)}"><dt>${escapeHtml(entry.field)}</dt><dd><del>${escapeHtml(
+          entry.before ?? "—",
+        )}</del> <ins>${escapeHtml(entry.after ?? "—")}</ins></dd></div>`,
+    )
+    .join("");
   return `
     <article
       class="card banner ${tone}"
       role="${role}"
       data-dispatch-outcome="${escapeHtml(view.kind)}"
+      data-write-result="${escapeHtml(view.kind)}"
       data-outcome-code="${escapeHtml(view.code ?? "")}"
       data-outcome-status="${view.status ?? ""}"
+      data-gate-action="${escapeHtml(result.gateAction ?? "")}"
     >
-      <p class="kicker"><span class="pill">${escapeHtml(ownMapValue(OUTCOME_LABELS, view.kind) ?? "DESFECHO NÃO RECONHECIDO")}</span></p>
+      <p class="kicker"><span class="pill">${escapeHtml(ownMapValue(OUTCOME_LABELS, view.kind) ?? "DESFECHO NÃO RECONHECIDO")}</span>${
+        actionLabel ? ` <span class="scope">${escapeHtml(actionLabel)}</span>` : ""
+      }</p>
       <h3>${escapeHtml(view.title)}</h3>
       <p data-outcome-detail="true">${escapeHtml(ownMapValue(summary, view.kind) ?? "O canal retornou um desfecho não reconhecido.")}</p>
       <p class="constraint" data-outcome-recovery="true">O que fazer agora: ${escapeHtml(view.recovery)}</p>
+      ${
+        readback
+          ? `<p class="constraint" data-readback="${escapeHtml(readback.status)}">Releitura: ${escapeHtml(
+              ownMapValue(READBACK_LABELS, readback.status) ?? "estado de releitura não reconhecido",
+            )}${readback.detail ? ` ${escapeHtml(readback.detail)}` : ""}</p>`
+          : ""
+      }
+      <dl class="facts" data-write-evidence="true">
+        ${fact("Código do canal", view.code ?? "nenhum código devolvido")}
+        ${fact("Receipt", result.receiptId ?? result.receipt?.id ?? "não devolvido nesta resposta")}
+        ${fact(
+          "Correlation id",
+          result.correlationId ?? result.receipt?.correlation_id ?? "não devolvido nesta resposta",
+        )}
+      </dl>
+      ${
+        diffRows
+          ? `<dl class="facts" data-server-diff="true">${diffRows}</dl>`
+          : ""
+      }
       ${technicalDetails(
         [
           { term: "path", value: result.path },
@@ -351,10 +524,61 @@ function outcomeBlock(result: AdapterWriteResult | undefined): string {
           { term: "code", value: view.code ?? "" },
           { term: "status", value: view.status === null ? "" : String(view.status) },
           { term: "outcome", value: result.outcome ?? "" },
+          { term: "gate_action", value: result.gateAction ?? "" },
+          { term: "receipt", value: result.receiptId ?? result.receipt?.id ?? "" },
+          { term: "correlation_id", value: result.correlationId ?? result.receipt?.correlation_id ?? "" },
+          { term: "readback", value: readback?.status ?? "" },
         ],
         "warmbly-operator-result",
       )}
     </article>`;
+}
+
+/** The "enviando…" state. A control with no pending state invites a second click. */
+function pendingBlock(label: string): string {
+  return `
+    <article class="card banner stale" role="status" data-write-pending="true">
+      <p class="kicker"><span class="pill">ENVIANDO</span></p>
+      <h3>${escapeHtml(label)}</h3>
+      <p>A chamada saiu e a resposta ainda não voltou. Não repita: este formulário está bloqueado até o canal responder.</p>
+    </article>`;
+}
+
+/**
+ * Routes one write outcome to exactly one place on the page.
+ *
+ * "On the affected card" is the requirement, and "rendered once" is the other
+ * half of it: a banner repeated at the top and on the card reads as two events.
+ * The first claimant wins; whatever is left over lands at the top of the
+ * surface so a result can never be swallowed.
+ */
+export interface FeedbackRouter {
+  forCandidate(candidateId: string): string;
+  forCohort(cohortId: string): string;
+  remainder(): string;
+}
+
+export function feedbackRouter(result: AdapterWriteResult | undefined): FeedbackRouter {
+  let claimed = false;
+  const claim = (): string => {
+    claimed = true;
+    return writeResultBlock(result);
+  };
+  return {
+    forCandidate(candidateId: string): string {
+      if (claimed || !result || !candidateId) return "";
+      return result.gateTarget?.candidate_id === candidateId ? claim() : "";
+    },
+    forCohort(cohortId: string): string {
+      if (claimed || !result || !cohortId) return "";
+      if (result.gateTarget?.candidate_id) return "";
+      return result.gateTarget?.cohort_id === cohortId ? claim() : "";
+    },
+    remainder(): string {
+      if (claimed || !result) return "";
+      return claim();
+    },
+  };
 }
 
 /* ------------------------------------------------------------------ *
@@ -592,6 +816,345 @@ function controlsBlock(
     </section>`;
 }
 
+
+/* ------------------------------------------------------------------ *
+ * Gate humano: leitura do payload.
+ *
+ * Nada aqui recalcula elegibilidade, denominador ou validade. Quando um número
+ * não veio no payload, a tela diz que não veio — derivar seria inventar uma
+ * verdade que o servidor não afirmou.
+ * ------------------------------------------------------------------ */
+
+function array(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.map(record) : [];
+}
+
+/** Marker for a field the server did not send. Never a zero, never a guess. */
+const NOT_IN_PAYLOAD = "não informado pelo servidor";
+
+function fromPayload(value: unknown): string {
+  return value === undefined || value === null || value === "" ? NOT_IN_PAYLOAD : String(value);
+}
+
+interface GateSection {
+  status: string;
+  data: Record<string, unknown>;
+  detail: string;
+}
+
+function gateSection(input: WarmblySurfaceInput, key: "list" | "selected"): GateSection {
+  const gate = record(input.gate);
+  const raw = record(gate[key]);
+  const status = typeof gate[`${key}_status`] === "string" ? String(gate[`${key}_status`]) : "";
+  const detail = typeof gate[`${key}_detail`] === "string" ? String(gate[`${key}_detail`]) : "";
+  return {
+    // An older payload carried no status at all. A section that has data is a
+    // section that was read; anything else stays honestly unknown.
+    status: status || (Object.keys(raw).length > 0 ? "read" : "absent"),
+    data: raw,
+    detail,
+  };
+}
+
+function cohortRows(input: WarmblySurfaceInput): Record<string, unknown>[] {
+  return array(gateSection(input, "list").data.data);
+}
+
+function selectedCohort(input: WarmblySurfaceInput): Record<string, unknown> {
+  return record(gateSection(input, "selected").data.data);
+}
+
+/** The most recent version the server listed. Order is the server's, not ours. */
+function latestCohort(input: WarmblySurfaceInput): Record<string, unknown> | undefined {
+  const rows = cohortRows(input);
+  return rows[0];
+}
+
+function gateUnreadableBanner(section: GateSection, what: string): string {
+  if (section.status === "read" || section.status === "") return "";
+  const message =
+    section.status === "not_mounted"
+      ? `O canal do gate não está montado neste Control Center (${section.detail || "HTTP 404"}), então ${what} não pôde ser lido. Ausência aqui não é ausência de cohorts.`
+      : section.status === "forbidden"
+        ? `Sua sessão não tem autorização para ler ${what} (${section.detail || "HTTP 403"}). Isto não significa que não existam cohorts.`
+        : section.status === "absent"
+          ? `Não houve leitura de ${what} neste carregamento.`
+          : `Não foi possível ler ${what} (${section.detail || "erro"}). Ilegível não é vazio.`;
+  // "Not consulted" is a different claim from "could not be read", and only the
+  // second one is an alert. Both still have to be said out loud: a surface that
+  // renders nothing where cohorts would go reads as "there are no cohorts".
+  const tone = section.status === "absent" ? "empty" : "error";
+  const role = section.status === "absent" ? "status" : "alert";
+  return `<p class="banner ${tone}" role="${role}" data-gate-read="${escapeHtml(section.status)}">${escapeHtml(message)}</p>`;
+}
+
+/* ------------------------------------------------------------------ *
+ * RBAC e ambiente.
+ * ------------------------------------------------------------------ */
+
+const CAPABILITY_LABELS: Record<string, string> = {
+  operators: "revisar candidatos, criar e reproduzir cohorts, pedir verificação",
+  admins: "registrar GO/NO-GO (autoridade bounded)",
+};
+
+export interface OperatorAuthority {
+  /** Whether the channel actually told us the effective groups. */
+  known: boolean;
+  groups: readonly string[];
+  canReview: boolean;
+  canDecide: boolean;
+}
+
+/**
+ * Effective authority, as reported by the edge — never as claimed by the browser.
+ *
+ * Authelia resolves the identity at the edge and the gate proxy echoes the
+ * groups it enforced with. This surface reads that echo; it does not send an
+ * actor, and it must not pretend to know an authority the channel never stated.
+ */
+export function operatorAuthority(input: WarmblySurfaceInput): OperatorAuthority {
+  const gate = record(input.gate);
+  const actor =
+    record(record(gate.list).edge_actor).groups !== undefined
+      ? record(record(gate.list).edge_actor)
+      : record(record(gate.selected).edge_actor);
+  const groups = Array.isArray(actor.groups)
+    ? actor.groups.filter((group): group is string => typeof group === "string")
+    : [];
+  const known = Array.isArray(actor.groups);
+  return {
+    known,
+    groups,
+    canReview: groups.includes("operators"),
+    canDecide: groups.includes("admins"),
+  };
+}
+
+/**
+ * Friendly identity plus effective capabilities (issue #59).
+ *
+ * The raw auditable identifier stays in the collapsed technical block: it is
+ * needed to match an audit row, and it is not what an operator should have to
+ * read to know who they are and what they may do.
+ */
+function identityBlock(input: WarmblySurfaceInput): string {
+  const authority = operatorAuthority(input);
+  const name = input.operator.display_name ?? "Sessão autenticada no Authelia";
+  const capabilities = authority.known
+    ? authority.groups.length > 0
+      ? authority.groups
+          .map((group) => `${group}: ${ownMapValue(CAPABILITY_LABELS, group) ?? "capacidade não catalogada nesta tela"}`)
+          .join(" · ")
+      : "nenhum grupo efetivo — esta sessão não pode escrever no gate"
+    : NOT_IN_PAYLOAD;
+  return `
+    <article class="card" data-operator-identity="true" data-can-review="${authority.canReview ? "true" : "false"}" data-can-decide="${authority.canDecide ? "true" : "false"}">
+      <p class="kicker"><span class="pill">${escapeHtml(authority.canDecide ? "admins" : authority.canReview ? "operators" : "sem autoridade de escrita")}</span></p>
+      <h3>Quem você é nesta tela</h3>
+      <dl class="facts">
+        ${fact("Operador", name)}
+        ${fact("Ambiente", PRODUCTIVE_HOST)}
+        ${fact("Autenticação", `Authelia em ${AUTH_HOST}`)}
+        ${fact("Capacidades efetivas", capabilities)}
+      </dl>
+      <p class="constraint">A identidade que a auditoria grava é a do Authelia resolvida na borda. Esta tela não envia cabeçalho de ator em nenhuma escrita.${
+        authority.known ? "" : " O canal não devolveu os grupos efetivos neste carregamento, então as capacidades acima não puderam ser confirmadas."
+      }</p>
+      ${technicalDetails(
+        [
+          { term: "identificador_auditavel", value: input.operator.id },
+          { term: "grupos_efetivos", value: authority.groups.join(",") },
+        ],
+        "warmbly-operator-identity",
+      )}
+    </article>`;
+}
+
+/* ------------------------------------------------------------------ *
+ * Passo a passo do piloto.
+ * ------------------------------------------------------------------ */
+
+interface StepView {
+  id: string;
+  label: string;
+  state: "done" | "current" | "pending" | "unknown";
+  detail: string;
+}
+
+const STEP_STATE_LABELS: Record<string, string> = {
+  done: "concluído",
+  current: "é aqui que você está",
+  pending: "ainda não",
+  unknown: "não dá para saber com o que o servidor devolveu",
+};
+
+/**
+ * Where the pilot stands, read strictly off the payload.
+ *
+ * Every "done" below is something the server said, not something this screen
+ * counted. When the payload is silent the step is `unknown`, never `pending`:
+ * "não sei" and "ainda não" are different answers and only one of them is safe.
+ */
+export function pilotSteps(input: WarmblySurfaceInput): StepView[] {
+  const list = gateSection(input, "list");
+  const rows = cohortRows(input);
+  const cohort = Object.keys(selectedCohort(input)).length > 0 ? selectedCohort(input) : latestCohort(input);
+  const readable = list.status === "read";
+  const candidates = array(cohort?.candidates);
+  const validations = candidates.map((candidate) => show(record(candidate.validation).status));
+  const reviews = candidates.map((candidate) => show(record(candidate.review).decision));
+  const decision = show(record(cohort?.decision).decision);
+  const unknownStep = (id: string, label: string, detail: string): StepView => ({
+    id,
+    label,
+    state: "unknown",
+    detail,
+  });
+  if (!readable && rows.length === 0) {
+    return [
+      unknownStep("fonte", "Fonte", "O gate não pôde ser lido neste carregamento."),
+      unknownStep("cohort", "Cohort", "O gate não pôde ser lido neste carregamento."),
+      unknownStep("validacao", "Validação", "O gate não pôde ser lido neste carregamento."),
+      unknownStep("revisao", "Revisão", "O gate não pôde ser lido neste carregamento."),
+      unknownStep("go", "GO", "O gate não pôde ser lido neste carregamento."),
+      unknownStep("handoff", "Handoff", "O gate não pôde ser lido neste carregamento."),
+    ];
+  }
+  const hasCohort = cohort !== undefined && Object.keys(cohort).length > 0;
+  const source = hasCohort ? show(cohort.source) : "—";
+  const freshness = hasCohort ? show(cohort.freshness) : "—";
+  const decided = decision === "GO" || decision === "NO_GO";
+  const validationPending = validations.filter((status) => status !== "VALID").length;
+  const reviewPending = reviews.filter((decisionValue) => decisionValue !== "APPROVE").length;
+  return [
+    {
+      id: "fonte",
+      label: "Fonte",
+      state: hasCohort ? "done" : "pending",
+      detail: hasCohort
+        ? `Origem ${source}, freshness ${freshness}, as_of ${show(cohort.as_of)}.`
+        : "Nenhuma cohort listada pelo servidor.",
+    },
+    {
+      id: "cohort",
+      label: "Cohort",
+      state: hasCohort ? "done" : "current",
+      detail: hasCohort
+        ? `v${show(cohort.version)} congelada com ${candidates.length === 0 ? fromPayload(undefined) : String(candidates.length)} candidato(s) no payload.`
+        : "Crie uma cohort pequena (1–10) em Cohorts para começar.",
+    },
+    {
+      id: "validacao",
+      label: "Validação",
+      state: !hasCohort
+        ? "pending"
+        : candidates.length === 0
+          ? "unknown"
+          : validationPending === 0
+            ? "done"
+            : "current",
+      detail:
+        !hasCohort || candidates.length === 0
+          ? "O payload desta versão não trouxe candidatos."
+          : `${validations.filter((status) => status === "VALID").length} de ${candidates.length} com validação VALID segundo o servidor.`,
+    },
+    {
+      id: "revisao",
+      label: "Revisão",
+      state: !hasCohort
+        ? "pending"
+        : candidates.length === 0
+          ? "unknown"
+          : reviewPending === 0
+            ? "done"
+            : "current",
+      detail:
+        !hasCohort || candidates.length === 0
+          ? "O payload desta versão não trouxe candidatos."
+          : `${reviews.filter((value) => value === "APPROVE").length} de ${candidates.length} aprovados segundo o servidor.`,
+    },
+    {
+      id: "go",
+      label: "GO",
+      state: decided ? "done" : hasCohort ? "pending" : "pending",
+      detail: decided
+        ? `Decisão final registrada: ${decision}.`
+        : hasCohort
+          ? "Nenhuma decisão final registrada nesta versão."
+          : "Sem cohort não existe GO.",
+    },
+    {
+      id: "handoff",
+      label: "Handoff",
+      state: decision === "GO" ? "current" : "pending",
+      detail:
+        decision === "GO"
+          ? "GO cria a autoridade bounded. Ele não enfileira, não envia e não liga auto-send."
+          : "O handoff só existe depois de um GO registrado.",
+    },
+  ];
+}
+
+function stepperBlock(input: WarmblySurfaceInput): string {
+  const steps = pilotSteps(input);
+  const items = steps
+    .map(
+      (step) => `
+      <li class="card" data-step="${escapeHtml(step.id)}" data-step-state="${escapeHtml(step.state)}">
+        <p class="kicker"><span class="pill">${escapeHtml(ownMapValue(STEP_STATE_LABELS, step.state) ?? "estado não reconhecido")}</span></p>
+        <h3>${escapeHtml(step.label)}</h3>
+        <p>${escapeHtml(step.detail)}</p>
+      </li>`,
+    )
+    .join("");
+  return `<ol class="stack" data-pilot-stepper="true">${items}</ol>`;
+}
+
+/**
+ * The landing card of `#/warmbly`: what the pilot is, where it stands, and the
+ * one button that opens the version the operator actually has to review.
+ */
+function pilotSummary(input: WarmblySurfaceInput): string {
+  const list = gateSection(input, "list");
+  const latest = latestCohort(input);
+  const authority = operatorAuthority(input);
+  const open = latest
+    ? `<p><a class="button" data-open-review="true" href="#/warmbly/revisao?resource=${escapeHtml(show(latest.id))}">Abrir revisão da v${escapeHtml(show(latest.version))}</a></p>`
+    : `<p><a class="button" data-open-cohorts="true" href="#/warmbly/cohorts">Abrir Cohorts para criar a primeira versão</a></p>`;
+  return `
+    <section class="stack" aria-labelledby="warmbly-piloto" data-pilot-summary="true">
+      <h2 id="warmbly-piloto">Onde o piloto está</h2>
+      <p class="constraint">Fonte → Cohort → Validação → Revisão → GO → Handoff. Cada passo abaixo repete o que o servidor devolveu; nada é recontado nesta tela. GO não envia e-mail e auto-send permanece desligado.</p>
+      ${gateUnreadableBanner(list, "a lista de cohorts")}
+      ${identityBlock(input)}
+      ${stepperBlock(input)}
+      ${
+        latest
+          ? `<article class="card" data-latest-cohort="${escapeHtml(show(latest.id))}">
+              <p class="kicker"><span class="pill">${escapeHtml(show(latest.freshness))}</span> <span class="scope">${escapeHtml(show(latest.source))}</span></p>
+              <h3>Versão mais recente: v${escapeHtml(show(latest.version))}</h3>
+              <dl class="facts">
+                ${fact("Identificador da versão", show(latest.id))}
+                ${fact("as_of", show(latest.as_of))}
+                ${fact("Decisão final", fromPayload(record(latest.decision).decision))}
+                ${fact("Destinatários finais no preview", fromPayload(record(record(latest.manifest).preview).recipients_final))}
+              </dl>
+              ${open}
+            </article>`
+          : list.status === "read"
+            ? `<article class="card" data-latest-cohort="none"><h3>Nenhuma cohort listada</h3><p>O servidor respondeu e não listou nenhuma versão. Uma cohort vazia nunca pode receber GO.</p>${open}</article>`
+            : open
+      }
+      ${
+        authority.canDecide
+          ? ""
+          : `<p class="constraint" data-go-authority="absent">Registrar GO/NO-GO exige o grupo <code>admins</code> no Authelia. Sua sessão ${
+              authority.known ? "não tem esse grupo" : "não teve os grupos confirmados pelo canal"
+            }: revisar continua permitido, e o controle de GO aparece desabilitado com o motivo na Revisão.</p>`
+      }
+    </section>`;
+}
+
 /* ------------------------------------------------------------------ *
  * Surface registry.
  * ------------------------------------------------------------------ */
@@ -601,7 +1164,10 @@ function operationSurface(input: WarmblySurfaceInput): string {
   const reading = readDispatch(operations);
   const lastAction = record(operations.last_operator_action);
   const hasLast = Object.keys(lastAction).length > 0;
+  const feedback = feedbackRouter(input.operatorResult);
   return `
+    ${pilotSummary(input)}
+    ${feedback.remainder()}
     <section class="stack" aria-labelledby="warmbly-estado" data-dispatch-state="${escapeHtml(reading.state)}">
       <h2 id="warmbly-estado">Estado antes de agir</h2>
       ${stateBlock(reading, input.snapshot?.provenance)}
@@ -628,7 +1194,6 @@ function operationSurface(input: WarmblySurfaceInput): string {
         }
       </article>
     </section>
-    ${outcomeBlock(input.operatorResult)}
     ${controlsBlock(reading, input.confirmation)}
     ${auditBlock(operations, input.operator)}`;
 }
@@ -644,18 +1209,6 @@ const WARMBLY_SURFACE_RENDERERS: Record<WarmblySurface, WarmblySurfaceRenderer> 
   revisao: reviewSurface,
 };
 
-function array(value: unknown): Record<string, unknown>[] {
-  return Array.isArray(value) ? value.map(record) : [];
-}
-
-function gateData(input: WarmblySurfaceInput, key: "list" | "selected"): Record<string, unknown> {
-  return record(record(input.gate)[key]);
-}
-
-function cohortData(input: WarmblySurfaceInput): Record<string, unknown>[] {
-  return array(gateData(input, "list").data);
-}
-
 function validationPill(candidate: Record<string, unknown>): string {
   const validation = record(candidate.validation);
   const observed = show(validation.status).toUpperCase();
@@ -670,11 +1223,56 @@ function validationPill(candidate: Record<string, unknown>): string {
   return `<span class="pill ${tone}" data-validation-status="${escapeHtml(status)}">${escapeHtml(status)}</span>`;
 }
 
+/**
+ * Whether APPROVE is offered at all for this candidate.
+ *
+ * The server refuses APPROVE on anything but a current VALID validation. A UI
+ * that renders the control anyway teaches the operator that approving is a
+ * thing they may try, and then hands them a refusal with no explanation. The
+ * verdict comes from the server's own `validation.status` plus its own
+ * `blocked_by` — never from a date this screen compared itself.
+ */
+export function approvalGate(candidate: Record<string, unknown>): {
+  allowed: boolean;
+  reason: string;
+} {
+  const status = show(record(candidate.validation).status).toUpperCase();
+  const blockers = Array.isArray(candidate.blocked_by)
+    ? candidate.blocked_by.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  const validationBlocker = blockers.find((entry) => entry.startsWith("validation"));
+  if (validationBlocker) {
+    return {
+      allowed: false,
+      reason: `O servidor marcou este candidato com o bloqueio "${validationBlocker}". Peça uma nova verificação do destinatário antes de aprovar.`,
+    };
+  }
+  if (status === "VALID") return { allowed: true, reason: "" };
+  if (status === NOT_IN_PAYLOAD.toUpperCase() || status === "—") {
+    return {
+      allowed: false,
+      reason:
+        "O payload não trouxe o estado da validação deste candidato. Sem validação vigente o servidor recusa APPROVE.",
+    };
+  }
+  return {
+    allowed: false,
+    reason: `A validação deste destinatário está ${status}, não VALID. O servidor recusa APPROVE fora de uma validação vigente: peça a verificação e aprove só depois que ela voltar VALID.`,
+  };
+}
+
+/* ------------------------------------------------------------------ *
+ * Cohorts.
+ * ------------------------------------------------------------------ */
+
 function cohortSurface(input: WarmblySurfaceInput): string {
   const params = new URLSearchParams(input.query ?? "");
   const freshness = params.get("freshness") ?? "all";
   const decisionFilter = params.get("decision") ?? "all";
-  const cohorts = cohortData(input).filter((cohort) => {
+  const list = gateSection(input, "list");
+  const authority = operatorAuthority(input);
+  const feedback = feedbackRouter(input.operatorResult);
+  const cohorts = cohortRows(input).filter((cohort) => {
     const decision = show(record(cohort.decision).decision);
     return (freshness === "all" || show(cohort.freshness) === freshness)
       && (decisionFilter === "all" || decision === decisionFilter);
@@ -682,43 +1280,327 @@ function cohortSurface(input: WarmblySurfaceInput): string {
   const rows = cohorts.map((cohort) => {
     const preview = record(record(cohort.manifest).preview);
     const decision = record(cohort.decision);
-    return `<tr><td><a href="#/warmbly/revisao?resource=${escapeHtml(show(cohort.id))}">v${escapeHtml(show(cohort.version))}</a></td><td>${escapeHtml(show(cohort.freshness))}</td><td>${escapeHtml(show(preview.accounts_considered))}</td><td>${escapeHtml(show(preview.accounts_eligible))}</td><td>${escapeHtml(show(preview.accounts_excluded))}</td><td>${escapeHtml(show(preview.recipients_final))}</td><td>${escapeHtml(show(decision.decision))}</td></tr>`;
+    const id = show(cohort.id);
+    return `<tr data-cohort-row="${escapeHtml(id)}"><td><a href="#/warmbly/revisao?resource=${escapeHtml(id)}">v${escapeHtml(show(cohort.version))}</a></td><td>${escapeHtml(show(cohort.freshness))}</td><td>${escapeHtml(fromPayload(preview.accounts_considered))}</td><td>${escapeHtml(fromPayload(preview.accounts_eligible))}</td><td>${escapeHtml(fromPayload(preview.accounts_excluded))}</td><td>${escapeHtml(fromPayload(preview.recipients_final))}</td><td>${escapeHtml(fromPayload(decision.decision))}</td><td><a class="button" data-open-review="true" href="#/warmbly/revisao?resource=${escapeHtml(id)}">Abrir revisão</a></td></tr>`;
   }).join("");
+  const createKey = "create::::";
+  const createPending = gateInFlight(createKey);
   return `<section class="stack" aria-labelledby="cohorts-title"><h2 id="cohorts-title">Cohorts versionadas</h2><p class="constraint">Denominadores vêm do preview Warmbly: considerados = elegíveis + excluídos e destinatários finais nunca são recalculados nesta tela. Auto-send permanece OFF.</p>
+  ${gateUnreadableBanner(list, "a lista de cohorts")}
+  ${feedback.remainder()}
+  ${identityBlock(input)}
   <form class="filters" data-human-gate-filters="cohorts"><label>Freshness<select name="freshness"><option value="all">Todos</option><option value="FRESH"${freshness === "FRESH" ? " selected" : ""}>FRESH</option><option value="STALE"${freshness === "STALE" ? " selected" : ""}>STALE</option></select></label><label>Decisão<select name="decision"><option value="all">Todas</option><option value="GO"${decisionFilter === "GO" ? " selected" : ""}>GO</option><option value="NO_GO"${decisionFilter === "NO_GO" ? " selected" : ""}>NO_GO</option></select></label></form>
-  <form class="operator-form" data-human-gate="create"><label>Tamanho pequeno (1–10)<input name="limit" type="number" min="1" max="10" value="5" required></label><button type="submit">Criar cohort congelada</button></form>
-  <div class="table-wrap"><table><thead><tr><th>Versão</th><th>Freshness</th><th>Considerados</th><th>Elegíveis</th><th>Excluídos</th><th>Finais</th><th>Decisão</th></tr></thead><tbody>${rows || `<tr><td colspan="7">Nenhuma cohort. Uma cohort vazia nunca pode receber GO.</td></tr>`}</tbody></table></div></section>`;
+  ${createPending ? pendingBlock("Criando a cohort congelada") : ""}
+  <form class="operator-form" data-human-gate="create" data-gate-key="${escapeHtml(createKey)}"><label>Tamanho pequeno (1–10)<input name="limit" type="number" min="1" max="10" value="5" required></label><button type="submit"${createPending || !authority.canReview ? " disabled" : ""}>${createPending ? "Enviando…" : "Criar cohort congelada"}</button>${
+    authority.canReview
+      ? ""
+      : `<p class="constraint" data-blocked-reason="create">Criar cohort exige o grupo <code>operators</code> no Authelia.</p>`
+  }</form>
+  <div class="table-wrap"><table><thead><tr><th>Versão</th><th>Freshness</th><th>Considerados</th><th>Elegíveis</th><th>Excluídos</th><th>Finais</th><th>Decisão</th><th>Revisão</th></tr></thead><tbody>${rows || `<tr><td colspan="8">Nenhuma cohort ${list.status === "read" ? "listada pelo servidor" : "pôde ser lida"}. Uma cohort vazia nunca pode receber GO.</td></tr>`}</tbody></table></div></section>`;
+}
+
+/* ------------------------------------------------------------------ *
+ * Revisão.
+ * ------------------------------------------------------------------ */
+
+/** Preview denominators, rendered verbatim with an explicit "não veio". */
+function previewBlock(preview: Record<string, unknown>): string {
+  const exclusions = record(preview.exclusions_by_reason);
+  const exclusionRows = Object.keys(exclusions)
+    .sort()
+    .map((reason) => fact(`Excluídos por ${reason}`, fromPayload(exclusions[reason])))
+    .join("");
+  return `
+    <article class="card" data-preview-denominators="true">
+      <h3>Denominadores do preview</h3>
+      <dl class="facts">
+        ${fact("Considerados", fromPayload(preview.accounts_considered))}
+        ${fact("Elegíveis", fromPayload(preview.accounts_eligible))}
+        ${fact("Excluídos", fromPayload(preview.accounts_excluded))}
+        ${fact("Destinatários finais", fromPayload(preview.recipients_final))}
+        ${fact("Excluídos por suppression", fromPayload(preview.suppressed))}
+        ${fact("Excluídos por opt-out", fromPayload(preview.opt_out))}
+        ${fact("Excluídos por risco (risky)", fromPayload(preview.risky_excluded))}
+        ${fact("Excluídos por duplicidade", fromPayload(preview.duplicates_excluded ?? preview.duplicate_excluded))}
+        ${fact("Excluídos por hard bounce", fromPayload(preview.hard_bounce_excluded ?? preview.hard_bounce))}
+        ${fact("Excluídos por falta de proveniência", fromPayload(preview.missing_provenance_excluded ?? preview.missing_provenance))}
+        ${fact("Excluídos por reprovação de copy QA", fromPayload(preview.copy_qa_failed_excluded ?? preview.copy_qa_failed))}
+        ${exclusionRows}
+      </dl>
+      <p class="constraint">Estes números são os do servidor. Onde está escrito &quot;${escapeHtml(NOT_IN_PAYLOAD)}&quot; o payload não trouxe o campo: a tela não soma, não subtrai e não infere o que falta.</p>
+    </article>`;
+}
+
+function listFacts(label: string, value: unknown): string {
+  if (Array.isArray(value)) {
+    const rows = value.filter((entry) => typeof entry === "string" || typeof entry === "number");
+    return fact(label, rows.length > 0 ? rows.map(String).join(", ") : "nenhum");
+  }
+  return fact(label, fromPayload(value));
+}
+
+/**
+ * One candidate, message first.
+ *
+ * Recipient, exact subject and exact body are visible by default. Hiding the
+ * only thing a reviewer is there to review behind a closed `<details>` labelled
+ * "Ver mensagem exata congelada" turns a review gate into a rubber stamp.
+ */
+function candidateCard(
+  cohort: Record<string, unknown>,
+  candidate: Record<string, unknown>,
+  authority: OperatorAuthority,
+  feedback: FeedbackRouter,
+  expandAll: boolean,
+): string {
+  const cohortId = show(cohort.id);
+  const candidateId = show(candidate.candidate_id);
+  const validation = record(candidate.validation);
+  const review = record(candidate.review);
+  const evidence = record(candidate.evidence ?? candidate.observed_fact);
+  const copyQa = record(candidate.copy_qa);
+  const blockers = Array.isArray(candidate.blocked_by)
+    ? candidate.blocked_by.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  const gate = approvalGate(candidate);
+  const frozenHash = show(candidate.frozen_hash ?? candidate.content_hash);
+  const version = show(cohort.version);
+  const draft = adjustDraft(candidateId);
+
+  const validateKey = `validate:${cohortId}:${candidateId}:`;
+  const approveKey = `review:${cohortId}:${candidateId}:APPROVE`;
+  const holdKey = `review:${cohortId}:${candidateId}:HOLD_REJECT`;
+  const adjustKey = `adjust:${cohortId}:${candidateId}:`;
+
+  const copyQaFailures = Array.isArray(copyQa.failures)
+    ? copyQa.failures.filter((entry): entry is string => typeof entry === "string")
+    : Array.isArray(candidate.copy_qa_failures)
+      ? candidate.copy_qa_failures.filter((entry): entry is string => typeof entry === "string")
+      : [];
+
+  return `<article class="card" data-candidate-id="${escapeHtml(candidateId)}" data-approve-allowed="${gate.allowed ? "true" : "false"}">
+    <p class="kicker">${validationPill(candidate)} · ${escapeHtml(show(candidate.route_class))} · ${escapeHtml(show(candidate.source))}</p>
+    <h3>${escapeHtml(show(candidate.company))}</h3>
+    ${feedback.forCandidate(candidateId)}
+    <dl class="facts" data-candidate-identity="true">
+      ${fact("Destinatário exato", show(candidate.mailbox))}
+      ${fact("Purpose do destinatário", show(candidate.mailbox_purpose))}
+      ${fact("Classe de rota", show(candidate.route_class))}
+    </dl>
+    <details data-message-preview="true"${expandAll ? " open" : ""}>
+      <summary>Mensagem exata congelada (assunto e corpo)</summary>
+      <p data-exact-subject="true"><strong>Assunto:</strong> ${escapeHtml(show(candidate.subject))}</p>
+      <pre class="message-preview" data-exact-body="true">${escapeHtml(show(candidate.body_text))}</pre>
+      <p data-cta="true"><strong>Chamada para ação (CTA):</strong> ${escapeHtml(fromPayload(candidate.cta ?? candidate.cta_text))}</p>
+    </details>
+    <dl class="facts" data-observed-fact="true">
+      ${fact("Fato observado", fromPayload(candidate.observed_fact_text ?? evidence.text ?? evidence.summary))}
+      ${fact("Proveniência do fato", fromPayload(candidate.evidence_source ?? evidence.source ?? evidence.locator))}
+      ${fact("Observado em", fromPayload(candidate.evidence_observed_at ?? evidence.observed_at))}
+      ${fact("Evidence hash", fromPayload(candidate.evidence_hash))}
+    </dl>
+    <dl class="facts" data-candidate-integrity="true">
+      ${fact("Content hash", fromPayload(candidate.content_hash))}
+      ${fact("Frozen hash", fromPayload(candidate.frozen_hash))}
+      ${fact("Policy version", fromPayload(cohort.policy_version))}
+      ${fact("Composer version", fromPayload(candidate.composer_version ?? cohort.composer_version))}
+      ${fact("Validação", fromPayload(validation.status))}
+      ${fact("Motivo da validação", fromPayload(validation.reason))}
+      ${fact("Validação vence em", validation.expires_at ? stamp(validation.expires_at) : NOT_IN_PAYLOAD)}
+      ${fact("Revisão registrada", fromPayload(review.decision))}
+      ${fact("Revisão efetiva", fromPayload(review.effective))}
+      ${listFacts("Bloqueios", candidate.blocked_by)}
+      ${listFacts("Reprovações de copy QA", copyQaFailures.length > 0 ? copyQaFailures : copyQa.failures)}
+      ${fact("Duplicidade apontada pelo servidor", fromPayload(candidate.duplicate_of ?? candidate.duplicate))}
+      ${fact("Proveniência ausente", fromPayload(candidate.missing_provenance))}
+      ${fact("Hard bounce registrado", fromPayload(candidate.hard_bounce))}
+      ${fact("Excluído do preview por", fromPayload(candidate.exclusion_reason ?? candidate.excluded_reason))}
+    </dl>
+    ${
+      blockers.length > 0
+        ? `<p class="banner error" role="alert" data-candidate-blockers="${escapeHtml(blockers.join(" "))}">O servidor registrou ${blockers.length} bloqueio(s) neste candidato: ${escapeHtml(blockers.join(", "))}.</p>`
+        : ""
+    }
+
+    ${gateInFlight(validateKey) ? pendingBlock("Pedindo a verificação do destinatário") : ""}
+    <form class="operator-form" data-human-gate="validate" data-gate-key="${escapeHtml(validateKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
+      <p class="constraint">Pede ao Warmbly que verifique agora se este endereço aceita entrega. Não envia mensagem nenhuma.</p>
+      <button type="submit"${gateInFlight(validateKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(validateKey) ? "Enviando…" : "Verificar o destinatário agora"}</button>
+    </form>
+
+    ${gateInFlight(approveKey) ? pendingBlock("Registrando a aprovação") : ""}
+    <form class="operator-form" data-human-gate="review" data-gate-key="${escapeHtml(approveKey)}" data-decision="APPROVE" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
+      <h4>Aprovar este candidato</h4>
+      <label>Motivo<input name="reason" required minlength="3"></label>
+      <label><input type="checkbox" name="ack"${gate.allowed ? " required" : ""}${gate.allowed ? "" : " disabled"}> Revisei destinatário, mensagem exata, policy e evidência desta versão</label>
+      <button type="submit"${gate.allowed && authority.canReview && !gateInFlight(approveKey) ? "" : " disabled"}>${gateInFlight(approveKey) ? "Enviando…" : "Registrar APPROVE"}</button>
+      ${
+        gate.allowed
+          ? ""
+          : `<p class="constraint" data-approve-blocked="true">APPROVE está desabilitado: ${escapeHtml(gate.reason)}</p>`
+      }
+      ${
+        authority.canReview
+          ? ""
+          : `<p class="constraint" data-blocked-reason="review">Revisar exige o grupo <code>operators</code> no Authelia.</p>`
+      }
+    </form>
+
+    ${gateInFlight(holdKey) ? pendingBlock("Registrando HOLD/REJECT") : ""}
+    <form class="operator-form" data-human-gate="review" data-gate-key="${escapeHtml(holdKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
+      <h4>Segurar ou rejeitar</h4>
+      <label>Decisão<select name="decision"><option value="HOLD">HOLD</option><option value="REJECT">REJECT</option></select></label>
+      <label>Motivo<input name="reason" required minlength="3"></label>
+      <p class="constraint" data-no-ack-required="true">HOLD e REJECT não pedem a ciência de aprovação: segurar ou rejeitar nunca autoriza uma mensagem.</p>
+      <button type="submit"${authority.canReview && !gateInFlight(holdKey) ? "" : " disabled"}>${gateInFlight(holdKey) ? "Enviando…" : "Registrar HOLD/REJECT"}</button>
+    </form>
+
+    ${adjustBlock({ cohortId, candidateId, version, frozenHash, candidate, authority, adjustKey, draft })}
+    ${technicalDetails(
+      [
+        { term: "candidate_id", value: candidateId },
+        { term: "content_hash", value: show(candidate.content_hash) },
+        { term: "frozen_hash", value: frozenHash },
+        { term: "evidence_hash", value: show(candidate.evidence_hash) },
+        { term: "blocked_by", value: blockers.join(",") },
+      ],
+      "warmbly-candidate",
+    )}
+  </article>`;
+}
+
+/**
+ * The adjust editor: exactly three fields, and a preview before the write.
+ *
+ * The contract accepts subject, body_text and reason and nothing else, so there
+ * is nothing here that could offer to change mailbox, evidence, source, policy
+ * or route class — the fields that make the frozen cohort worth trusting.
+ */
+function adjustBlock(args: {
+  cohortId: string;
+  candidateId: string;
+  version: string;
+  frozenHash: string;
+  candidate: Record<string, unknown>;
+  authority: OperatorAuthority;
+  adjustKey: string;
+  draft: AdjustDraft | undefined;
+}): string {
+  const { cohortId, candidateId, version, frozenHash, candidate, authority, adjustKey, draft } = args;
+  const unavailable = adjustRouteMissing();
+  const pending = gateInFlight(adjustKey);
+  const subject = show(candidate.subject);
+  const body = show(candidate.body_text);
+  const diff = draft
+    ? `
+      <div class="banner stale" role="status" data-adjust-diff="true">
+        <h4>Confira a mudança antes de confirmar</h4>
+        <dl class="facts">
+          <div data-diff-field="subject"><dt>Assunto</dt><dd><del>${escapeHtml(draft.before_subject)}</del><br><ins>${escapeHtml(draft.subject)}</ins></dd></div>
+          <div data-diff-field="body_text"><dt>Corpo</dt><dd><del><pre class="message-preview">${escapeHtml(draft.before_body_text)}</pre></del><ins><pre class="message-preview">${escapeHtml(draft.body_text)}</pre></ins></dd></div>
+          <div data-diff-field="reason"><dt>Motivo</dt><dd>${escapeHtml(draft.reason)}</dd></div>
+        </dl>
+        <p class="constraint">Confirmar cria a versão seguinte. A versão v${escapeHtml(version)} continua existindo e legível; validação, revisão e GO da nova versão começam pendentes.</p>
+      </div>`
+    : "";
+  return `
+    <details class="card" data-adjust-editor="${escapeHtml(candidateId)}"${draft ? " open" : ""}>
+      <summary>Ajustar assunto e corpo (cria uma NOVA versão)</summary>
+      <p class="constraint" data-adjust-warning="true">Ajustar não edita esta versão: o Warmbly congela uma versão nova a partir dela. Destinatário, evidência, origem, policy e classe de rota são imutáveis e não aparecem aqui porque não podem ser alterados.</p>
+      ${
+        unavailable
+          ? `<p class="banner error" role="alert" data-adjust-unavailable="true">A rota de ajuste ainda não está implantada neste Control Center, então este editor não pode gravar. Registre HOLD ou REJECT com o motivo enquanto isso.</p>`
+          : ""
+      }
+      ${pending ? pendingBlock("Enviando o ajuste") : ""}
+      ${diff}
+      <form class="operator-form" data-human-gate="adjust" data-gate-key="${escapeHtml(adjustKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}" data-cohort-version="${escapeHtml(version)}" data-frozen-hash="${escapeHtml(frozenHash)}" data-before-subject="${escapeHtml(subject)}" data-before-body="${escapeHtml(body)}" data-adjust-step="${draft ? "confirm" : "preview"}">
+        <label>Assunto<input name="subject" required minlength="3" maxlength="200" value="${escapeHtml(draft?.subject ?? subject)}"></label>
+        <label>Corpo<textarea name="body_text" required minlength="3" rows="8">${escapeHtml(draft?.body_text ?? body)}</textarea></label>
+        <label>Motivo do ajuste<input name="reason" required minlength="3" value="${escapeHtml(draft?.reason ?? "")}"></label>
+        <label>Confirme digitando <code>v${escapeHtml(version)}</code><input name="confirmation" required pattern="v${escapeHtml(version)}" value="${escapeHtml(draft ? `v${version}` : "")}"></label>
+        <button type="submit"${pending || unavailable || !authority.canReview ? " disabled" : ""}>${
+          pending ? "Enviando…" : draft ? `Confirmar e criar a versão seguinte a partir da v${escapeHtml(version)}` : "Pré-visualizar a mudança"
+        }</button>
+        ${
+          authority.canReview
+            ? ""
+            : `<p class="constraint" data-blocked-reason="adjust">Ajustar exige o grupo <code>operators</code> no Authelia.</p>`
+        }
+      </form>
+    </details>`;
 }
 
 function reviewSurface(input: WarmblySurfaceInput): string {
-  const selected = gateData(input, "selected");
-  const cohort = record(selected.data);
+  const selected = gateSection(input, "selected");
+  const list = gateSection(input, "list");
+  const cohort = selectedCohort(input);
+  const authority = operatorAuthority(input);
+  const feedback = feedbackRouter(input.operatorResult);
   if (!cohort.id) {
-    return `<section class="stack"><h2>Revisão</h2><p class="banner empty">Selecione uma versão em <a href="#/warmbly/cohorts">Cohorts</a>. Nenhuma elegibilidade é inferida localmente.</p></section>`;
+    // Never a silently empty page. Either the operator picks from what the
+    // server listed, or they are told plainly that the list itself could not
+    // be read — those are different situations with different next moves.
+    const options = cohortRows(input)
+      .map(
+        (row) =>
+          `<li class="card" data-cohort-option="${escapeHtml(show(row.id))}"><h3>v${escapeHtml(show(row.version))} · ${escapeHtml(show(row.freshness))}</h3><dl class="facts">${fact("Origem", show(row.source))}${fact("as_of", show(row.as_of))}${fact("Decisão final", fromPayload(record(row.decision).decision))}</dl><p><a class="button" data-open-review="true" href="#/warmbly/revisao?resource=${escapeHtml(show(row.id))}">Abrir revisão</a></p></li>`,
+      )
+      .join("");
+    return `<section class="stack" data-review-empty="true"><h2>Revisão</h2>
+      ${feedback.remainder()}
+      ${input.resource ? gateUnreadableBanner(selected, "a versão selecionada") : ""}
+      ${gateUnreadableBanner(list, "a lista de cohorts")}
+      <p class="banner empty">Nenhuma versão selecionada. Escolha uma abaixo — nenhuma elegibilidade é inferida localmente.</p>
+      ${
+        options
+          ? `<ol class="stack" data-cohort-selector="true">${options}</ol>`
+          : `<p><a class="button" data-open-cohorts="true" href="#/warmbly/cohorts">Abrir Cohorts</a></p>`
+      }
+      </section>`;
   }
   const manifest = record(cohort.manifest);
   const preview = record(manifest.preview);
   const candidates = array(cohort.candidates);
-  const candidateCards = candidates.map((candidate) => {
-    const validation = record(candidate.validation);
-    const review = record(candidate.review);
-    const blocked = Array.isArray(candidate.blocked_by) ? candidate.blocked_by.join(", ") : "";
-    return `<article class="card" data-candidate-id="${escapeHtml(show(candidate.candidate_id))}"><p class="kicker">${validationPill(candidate)} · ${escapeHtml(show(candidate.route_class))} · ${escapeHtml(show(candidate.source))}</p><h3>${escapeHtml(show(candidate.company))}</h3>
-    <dl>${fact("Destinatário exato", show(candidate.mailbox))}${fact("Purpose", show(candidate.mailbox_purpose))}${fact("Validação", show(validation.reason))}${fact("Evidência vence", stamp(validation.expires_at))}${fact("Review", show(review.decision))}${fact("Efetiva", show(review.effective))}${fact("Bloqueios", blocked || "nenhum")}</dl>
-    <details><summary>Ver mensagem exata congelada</summary><p><strong>Assunto:</strong> ${escapeHtml(show(candidate.subject))}</p><pre class="message-preview">${escapeHtml(show(candidate.body_text))}</pre><p class="constraint">content hash ${escapeHtml(show(candidate.content_hash))}; policy ${escapeHtml(show(cohort.policy_version))}; evidence ${escapeHtml(show(candidate.evidence_hash))}</p></details>
-    <form class="operator-form" data-human-gate="validate" data-version="${escapeHtml(show(cohort.id))}" data-candidate="${escapeHtml(show(candidate.candidate_id))}"><button type="submit">Solicitar validation</button></form>
-    <form class="operator-form" data-human-gate="review" data-version="${escapeHtml(show(cohort.id))}" data-candidate="${escapeHtml(show(candidate.candidate_id))}"><label>Decisão<select name="decision"><option>APPROVE</option><option>HOLD</option><option>REJECT</option></select></label><label>Motivo<input name="reason" required minlength="3"></label><label><input type="checkbox" name="ack" required> Revisei destinatário, mensagem e evidência desta versão</label><button type="submit">Registrar decisão</button></form></article>`;
-  }).join("");
-  return `<section class="stack" aria-labelledby="review-title"><h2 id="review-title">Revisão v${escapeHtml(show(cohort.version))}</h2><p class="constraint">${escapeHtml(show(cohort.source))}, as_of ${escapeHtml(show(cohort.as_of))}, ${escapeHtml(show(cohort.freshness))}, policy ${escapeHtml(show(cohort.policy_version))}. Receipt ${escapeHtml(show(cohort.receipt))}.</p>
-  <dl>${fact("Considerados", show(preview.accounts_considered))}${fact("Elegíveis", show(preview.accounts_eligible))}${fact("Excluídos", show(preview.accounts_excluded))}${fact("Destinatários finais", show(preview.recipients_final))}${fact("Suppression", show(preview.suppressed))}${fact("Opt-out", show(preview.opt_out))}${fact("Risky excluídos", show(preview.risky_excluded))}</dl>
-  <form class="operator-form" data-human-gate="reproduce" data-version="${escapeHtml(show(cohort.id))}"><button type="submit">Reproduzir versão imutável</button></form>${candidateCards || `<p class="banner error">Cohort vazia: GO bloqueado.</p>`}
-  <form class="operator-form" data-human-gate="decide" data-version="${escapeHtml(show(cohort.id))}"><label>Decisão final<select name="decision"><option>NO_GO</option><option>GO</option></select></label><label>Motivo<input name="reason" required minlength="3"></label><label>Confirme digitando <code>v${escapeHtml(show(cohort.version))}</code><input name="confirmation" required pattern="v${escapeHtml(show(cohort.version))}"></label><button type="submit">Registrar GO/NO-GO</button></form><p class="constraint">GO não envia e-mail. O Control Center não expõe dispatch, queue ou send neste gate.</p></section>`;
+  const expandAll = new URLSearchParams(input.query ?? "").get("mensagens") !== "recolhidas";
+  const cohortId = show(cohort.id);
+  const version = show(cohort.version);
+  const reproduceKey = `reproduce:${cohortId}::`;
+  const decideKey = `decide:${cohortId}::`;
+  const candidateCards = candidates
+    .map((candidate) => candidateCard(cohort, candidate, authority, feedback, expandAll))
+    .join("");
+  const cohortFeedback = feedback.forCohort(cohortId);
+  const leftover = feedback.remainder();
+  const decisionValue = fromPayload(record(cohort.decision).decision);
+  return `<section class="stack" aria-labelledby="review-title" data-review-cohort="${escapeHtml(cohortId)}"><h2 id="review-title">Revisão v${escapeHtml(version)}</h2>
+  ${leftover}${cohortFeedback}
+  ${gateUnreadableBanner(selected, "a versão selecionada")}
+  <p class="constraint">${escapeHtml(show(cohort.source))}, as_of ${escapeHtml(show(cohort.as_of))}, ${escapeHtml(show(cohort.freshness))}, policy ${escapeHtml(show(cohort.policy_version))}. Receipt ${escapeHtml(show(cohort.receipt))}.</p>
+  ${identityBlock(input)}
+  ${previewBlock(preview)}
+  <p><button type="button" data-toggle-messages="true" aria-expanded="${expandAll ? "true" : "false"}">${expandAll ? "Recolher todas as mensagens" : "Expandir todas as mensagens"}</button></p>
+  ${gateInFlight(reproduceKey) ? pendingBlock("Reproduzindo a versão imutável") : ""}
+  <form class="operator-form" data-human-gate="reproduce" data-gate-key="${escapeHtml(reproduceKey)}" data-version="${escapeHtml(cohortId)}"><button type="submit"${gateInFlight(reproduceKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(reproduceKey) ? "Enviando…" : "Reproduzir versão imutável"}</button></form>
+  ${candidateCards || `<p class="banner error">Cohort vazia: GO bloqueado.</p>`}
+  ${gateInFlight(decideKey) ? pendingBlock("Registrando GO/NO-GO") : ""}
+  <form class="operator-form" data-human-gate="decide" data-gate-key="${escapeHtml(decideKey)}" data-version="${escapeHtml(cohortId)}"><label>Decisão final<select name="decision"><option value="NO_GO">NO_GO</option><option value="GO">GO</option></select></label><label>Motivo<input name="reason" required minlength="3"></label><label>Confirme digitando <code>v${escapeHtml(version)}</code><input name="confirmation" required pattern="v${escapeHtml(version)}"></label><button type="submit"${authority.canDecide && !gateInFlight(decideKey) ? "" : " disabled"}>${gateInFlight(decideKey) ? "Enviando…" : "Registrar GO/NO-GO"}</button>${
+    authority.canDecide
+      ? ""
+      : `<p class="constraint" data-go-authority="absent">GO/NO-GO está desabilitado nesta sessão: ele exige o grupo <code>admins</code> no Authelia. Peça a inclusão nesse grupo e reautentique; revisar candidatos continua permitido com <code>operators</code>.</p>`
+  }</form>
+  <dl class="facts"><div><dt>Decisão final registrada</dt><dd>${escapeHtml(decisionValue)}</dd></div></dl>
+  <p class="constraint">GO não envia e-mail. O Control Center não expõe dispatch, queue ou send neste gate.</p></section>`;
 }
 
-function warmblySubnav(current: WarmblySurface): string {
+function warmblySubnav(current: WarmblySurface, resource: string | null | undefined): string {
+  // The resource travels with the operator. A subnav that drops it lands the
+  // reviewer on an empty Revisão and makes the selection they just made look
+  // like it never happened.
+  const suffix = resource ? `?resource=${encodeURIComponent(resource)}` : "";
   return `<nav class="subnav" aria-label="Superfícies de operação Warmbly">${WARMBLY_SURFACES.map(
     (id) =>
-      `<a href="#/warmbly/${id}" data-surface="${id}" aria-current="${current === id ? "page" : "false"}">${escapeHtml(
+      `<a href="#/warmbly/${id}${suffix}" data-surface="${id}" aria-current="${current === id ? "page" : "false"}">${escapeHtml(
         ownMapValue(WARMBLY_SURFACE_LABELS, id) ?? "Operação",
       )}</a>`,
   ).join("")}</nav>`;
@@ -731,5 +1613,5 @@ export function resolveWarmblySurface(surface: string | null | undefined): Warmb
 export function warmblyBlock(input: WarmblySurfaceInput, surface: string | null | undefined): string {
   const current = resolveWarmblySurface(surface);
   const render = ownMapValue(WARMBLY_SURFACE_RENDERERS, current) ?? operationSurface;
-  return `${warmblySubnav(current)}${render(input)}`;
+  return `${warmblySubnav(current, input.resource)}${render(input)}`;
 }

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -1,0 +1,1112 @@
+/**
+ * The founder-facing cohort gate.
+ *
+ * Every test here pins a defect that shipped to production: a subnav that lost
+ * the selected version, a review that hid the message it existed to review, a
+ * write that answered nothing at all on the surface it was fired from, an
+ * APPROVE offered on candidates the server would always refuse, a HOLD that
+ * demanded the approval acknowledgement, and a double click that meant two
+ * cohorts.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { AdapterWriteResult, WarmblyGateInput } from "../src/adapters/contract";
+import { HttpControlCenterAdapter } from "../src/adapters/http";
+import { paintShell } from "../src/app";
+import { resetGateFlight } from "../src/human-gate-flight";
+import { warmblyBlock } from "../src/ui/warmbly";
+import { clearPendingResumeConfirmation } from "../src/warmbly-confirmation";
+
+/* ------------------------------------------------------------------ *
+ * Fixtures. No real mailbox, no real company, no secret.
+ * ------------------------------------------------------------------ */
+
+const COHORT_ID = "11111111-1111-4111-8111-111111111111";
+const NEXT_COHORT_ID = "aaaaaaaa-1111-4111-8111-111111111111";
+const CANDIDATE_ID = "22222222-2222-4222-8222-222222222222";
+
+function candidate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    candidate_id: CANDIDATE_ID,
+    company: "Empresa Fixture",
+    mailbox: "compras@empresa.invalid",
+    mailbox_purpose: "ROLE_OR_DEPARTMENT",
+    route_class: "ROLE_OR_DEPARTMENT",
+    source: "fixture.sanitized",
+    subject: "Assunto exato congelado",
+    body_text: "Corpo exato congelado da mensagem.",
+    cta: "Posso enviar uma segunda leitura técnica?",
+    observed_fact_text: "Fato público de fixture",
+    evidence_source: "fixture://diario-oficial",
+    evidence_observed_at: "2026-08-22T12:00:00Z",
+    content_hash: "content-fixture-001",
+    frozen_hash: "frozen-fixture-001",
+    evidence_hash: "evidence-fixture-001",
+    composer_version: "composer.v3",
+    copy_qa: { failures: ["assunto_generico"] },
+    duplicate_of: "outro-candidato-fixture",
+    missing_provenance: false,
+    hard_bounce: false,
+    exclusion_reason: "nenhuma",
+    validation: { status: "VALID", reason: "MX confirmado no sandbox", expires_at: "2026-08-24T12:00:00Z" },
+    review: { decision: "HOLD", effective: false },
+    blocked_by: ["approval_missing_or_invalid"],
+    ...overrides,
+  };
+}
+
+function cohort(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: COHORT_ID,
+    version: 1,
+    source: "extra-cli",
+    as_of: "2026-08-23T12:00:00Z",
+    freshness: "FRESH",
+    policy_version: "bounded-cohort-policy.v1",
+    receipt: `cohort:${COHORT_ID}`,
+    manifest: {
+      preview: {
+        accounts_considered: 7,
+        accounts_eligible: 2,
+        accounts_excluded: 5,
+        recipients_final: 2,
+        suppressed: 1,
+        opt_out: 1,
+        risky_excluded: 1,
+        duplicates_excluded: 1,
+        hard_bounce_excluded: 1,
+        missing_provenance_excluded: 0,
+        copy_qa_failed_excluded: 1,
+      },
+    },
+    candidates: [candidate()],
+    ...overrides,
+  };
+}
+
+function gatePayload(
+  groups: readonly string[] = ["operators", "admins"],
+  selected: Record<string, unknown> | null = cohort(),
+): Record<string, unknown> {
+  return {
+    list: { data: [cohort()], edge_actor: { id: "fixture-user", groups } },
+    list_status: "read",
+    ...(selected ? { selected: { data: selected }, selected_status: "read" } : {}),
+  };
+}
+
+function surfaceInput(overrides: Record<string, unknown> = {}): Parameters<typeof warmblyBlock>[0] {
+  return {
+    snapshot: undefined,
+    operator: { kind: "human" as const, id: "human:operator", display_name: "Fundador" },
+    gate: gatePayload(),
+    resource: COHORT_ID,
+    ...overrides,
+  } as Parameters<typeof warmblyBlock>[0];
+}
+
+/* ------------------------------------------------------------------ *
+ * A root that really parses the markup it was handed.
+ *
+ * The binders read attributes and field values off the elements this returns,
+ * so a fake that invents its own forms would test the fake. This one scans the
+ * painted HTML, which means a renderer that stops emitting a form makes the
+ * binder test fail — which is the point.
+ * ------------------------------------------------------------------ */
+
+interface FakeField {
+  value: string;
+  checked?: boolean;
+}
+
+class FakeElement {
+  readonly attributes: Record<string, string>;
+  readonly fields: Record<string, FakeField>;
+  private listeners: Array<{ type: string; listener: (event: Event) => void }> = [];
+
+  constructor(attributes: Record<string, string>, fields: Record<string, FakeField>) {
+    this.attributes = attributes;
+    this.fields = fields;
+  }
+
+  addEventListener(type: string, listener: (event: Event) => void): void {
+    this.listeners.push({ type, listener });
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes[name] ?? null;
+  }
+
+  querySelector(selector: string): FakeField | null {
+    const name = selector.replace(/[[\]'"]/g, "").replace("name=", "");
+    return this.fields[name] ?? null;
+  }
+
+  set(name: string, value: string): void {
+    this.fields[name] = { ...(this.fields[name] ?? { value: "" }), value };
+  }
+
+  check(name: string): void {
+    this.fields[name] = { ...(this.fields[name] ?? { value: "on" }), checked: true };
+  }
+
+  fire(type = "submit"): void {
+    for (const entry of this.listeners) {
+      if (entry.type === type) entry.listener({ preventDefault(): void {} } as unknown as Event);
+    }
+  }
+}
+
+function parseAttributes(tag: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  for (const match of tag.matchAll(/([a-zA-Z0-9_:-]+)="([^"]*)"/g)) {
+    attributes[match[1]!] = match[2]!;
+  }
+  for (const match of tag.matchAll(/(?:^|\s)(disabled|required|open|selected)(?=\s|>|$)/g)) {
+    attributes[match[1]!] = "";
+  }
+  return attributes;
+}
+
+function parseFields(inner: string): Record<string, FakeField> {
+  const fields: Record<string, FakeField> = {};
+  for (const match of inner.matchAll(/<input\b([^>]*)>/g)) {
+    const attributes = parseAttributes(match[1]!);
+    if (!attributes.name) continue;
+    fields[attributes.name] =
+      attributes.type === "checkbox"
+        ? { value: attributes.value ?? "on", checked: attributes.checked !== undefined }
+        : { value: attributes.value ?? "" };
+  }
+  // A textarea holds its value as text, and a select holds it on an option.
+  // Reading only the opening tag would report every one of them as empty.
+  for (const match of inner.matchAll(/<textarea\b([^>]*)>([\s\S]*?)<\/textarea>/g)) {
+    const attributes = parseAttributes(match[1]!);
+    if (attributes.name) fields[attributes.name] = { value: match[2]! };
+  }
+  for (const match of inner.matchAll(/<select\b([^>]*)>([\s\S]*?)<\/select>/g)) {
+    const attributes = parseAttributes(match[1]!);
+    if (!attributes.name) continue;
+    const options = [...match[2]!.matchAll(/<option\b([^>]*)>([^<]*)</g)].map((option) => ({
+      attributes: parseAttributes(option[1]!),
+      text: option[2]!,
+    }));
+    const chosen = options.find((option) => option.attributes.selected !== undefined) ?? options[0];
+    fields[attributes.name] = { value: chosen?.attributes.value ?? chosen?.text ?? "" };
+  }
+  return fields;
+}
+
+function elementsOf(html: string): FakeElement[] {
+  const elements: FakeElement[] = [];
+  for (const match of html.matchAll(/<form\b([^>]*)>([\s\S]*?)<\/form>/g)) {
+    elements.push(new FakeElement(parseAttributes(match[1]!), parseFields(match[2]!)));
+  }
+  for (const match of html.matchAll(/<button\b([^>]*)>/g)) {
+    const attributes = parseAttributes(match[1]!);
+    if (attributes["data-toggle-messages"] !== undefined) {
+      elements.push(new FakeElement(attributes, {}));
+    }
+  }
+  return elements;
+}
+
+function matches(element: FakeElement, selector: string): boolean {
+  const withValue = selector.match(/^\[([a-zA-Z0-9_-]+)="([^"]*)"\]$/);
+  if (withValue) return element.getAttribute(withValue[1]!) === withValue[2];
+  const bare = selector.match(/^\[([a-zA-Z0-9_-]+)\]$/);
+  if (bare) return element.getAttribute(bare[1]!) !== null;
+  return false;
+}
+
+function paintingRoot(): {
+  root: { innerHTML: string; querySelectorAll(selector: string): FakeElement[] };
+  paints: number;
+  find(selector: string): FakeElement;
+  all(selector: string): FakeElement[];
+} {
+  let html = "";
+  let elements: FakeElement[] = [];
+  let paints = 0;
+  const root = {
+    get innerHTML(): string {
+      return html;
+    },
+    set innerHTML(next: string) {
+      html = next;
+      elements = elementsOf(next);
+      paints += 1;
+    },
+    querySelectorAll(selector: string): FakeElement[] {
+      return elements.filter((element) => matches(element, selector));
+    },
+  };
+  return {
+    root,
+    get paints(): number {
+      return paints;
+    },
+    find(selector: string): FakeElement {
+      const found = root.querySelectorAll(selector)[0];
+      assert.ok(found, `no element matched ${selector}`);
+      return found;
+    },
+    all(selector: string): FakeElement[] {
+      return root.querySelectorAll(selector);
+    },
+  };
+}
+
+interface FakeAdapterOptions {
+  respond: (input: WarmblyGateInput) => Promise<AdapterWriteResult> | AdapterWriteResult;
+  gate?: () => Record<string, unknown>;
+  onNavigate?: (hash: string) => void;
+}
+
+function gateAdapter(options: FakeAdapterOptions): {
+  adapter: Record<string, unknown>;
+  seen: WarmblyGateInput[];
+} {
+  const seen: WarmblyGateInput[] = [];
+  const adapter = {
+    mode: "http" as const,
+    actions: ["read"] as const,
+    lastOperatorResult: undefined as AdapterWriteResult | undefined,
+    readOperator: () => ({ kind: "human" as const, id: "human:operator", display_name: "Fundador" }),
+    readDestination: () => ({
+      ok: true as const,
+      loading: false as const,
+      page: {
+        id: "warmbly",
+        label: "Operação Warmbly",
+        scope: "company",
+        generated_at: "2026-08-23T12:00:00Z",
+        operator: { kind: "human", id: "human:operator", display_name: "Fundador" },
+        headline: "Operação Warmbly",
+        attention: [],
+        priorities: [],
+        commercial: {
+          provenance: {
+            source: { system: "warmbly", kind: "dispatch", locator: "dispatch" },
+            observed_at: "2026-08-23T12:00:00Z",
+            freshness_status: "FRESH",
+            confidence: 1,
+          },
+          operations: {},
+        },
+        warmbly_gate: options.gate ? options.gate() : gatePayload(),
+      } as never,
+    }),
+    warmblyGate: async (input: WarmblyGateInput) => {
+      seen.push({ ...input });
+      return options.respond(input);
+    },
+  };
+  return { adapter, seen };
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 6; i += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function reset(): void {
+  resetGateFlight();
+  clearPendingResumeConfirmation();
+}
+
+/* ------------------------------------------------------------------ *
+ * 1. Discoverability.
+ * ------------------------------------------------------------------ */
+
+test("the subnav carries the selected version across every Warmbly surface", () => {
+  reset();
+  for (const surface of ["operacao", "cohorts", "revisao"] as const) {
+    const html = warmblyBlock(surfaceInput(), surface);
+    for (const target of ["operacao", "cohorts", "revisao"]) {
+      assert.match(
+        html,
+        new RegExp(`href="#/warmbly/${target}\\?resource=${COHORT_ID}"`),
+        `${surface} → ${target} lost the selected resource`,
+      );
+    }
+  }
+});
+
+test("Revisão without a resource offers the versions the server listed instead of an empty page", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators"], null), resource: null }),
+    "revisao",
+  );
+  assert.match(html, /data-review-empty="true"/);
+  assert.match(html, /data-cohort-selector="true"/);
+  assert.match(html, new RegExp(`data-cohort-option="${COHORT_ID}"`));
+  assert.match(html, new RegExp(`data-open-review="true" href="#/warmbly/revisao\\?resource=${COHORT_ID}"`));
+});
+
+test("Revisão says the list was unreadable instead of implying there are no cohorts", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: { list: {}, list_status: "not_mounted", list_detail: "HTTP 404" },
+      resource: null,
+    }),
+    "revisao",
+  );
+  assert.match(html, /data-gate-read="not_mounted"/);
+  assert.match(html, /Ausência aqui não é ausência de cohorts/);
+});
+
+test("#/warmbly opens on the pilot stepper with the latest cohort and a way into its review", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "operacao");
+  assert.match(html, /data-pilot-summary="true"/);
+  for (const step of ["fonte", "cohort", "validacao", "revisao", "go", "handoff"]) {
+    assert.match(html, new RegExp(`data-step="${step}"`), `step ${step} is missing`);
+  }
+  assert.match(html, new RegExp(`data-latest-cohort="${COHORT_ID}"`));
+  assert.match(html, new RegExp(`data-open-review="true" href="#/warmbly/revisao\\?resource=${COHORT_ID}"`));
+});
+
+test("a stepper with no readable gate says it does not know, never that a step is pending", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({ gate: { list: {}, list_status: "unreadable", list_detail: "TypeError" } }),
+    "operacao",
+  );
+  const states = [...html.matchAll(/data-step-state="([a-z_]+)"/g)].map((match) => match[1]);
+  assert.deepEqual(new Set(states), new Set(["unknown"]));
+});
+
+/* ------------------------------------------------------------------ *
+ * 2. The message must be reviewable.
+ * ------------------------------------------------------------------ */
+
+test("recipient, exact subject and exact body are visible by default on every candidate", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  const details = html.match(/<details data-message-preview="true"([^>]*)>/);
+  assert.ok(details, "the message block must exist");
+  assert.match(details[1]!, /\bopen\b/, "the exact message must not start collapsed");
+  assert.match(html, /data-exact-subject="true"[^>]*><strong>Assunto:<\/strong> Assunto exato congelado/);
+  assert.match(html, /data-exact-body="true">Corpo exato congelado/);
+  assert.match(html, /compras@empresa\.invalid/);
+});
+
+test("the messages collapse only when the operator asks, through the expand/collapse control", () => {
+  reset();
+  const collapsed = warmblyBlock(surfaceInput({ query: "mensagens=recolhidas" }), "revisao");
+  assert.doesNotMatch(collapsed, /<details data-message-preview="true" open>/);
+  assert.match(collapsed, /data-toggle-messages="true" aria-expanded="false"/);
+  assert.match(collapsed, /Expandir todas as mensagens/);
+});
+
+test("provenance, CTA, hashes, versions, expiry and every blocker travel with the candidate", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  for (const label of [
+    "Fato observado",
+    "Proveniência do fato",
+    "Chamada para ação (CTA)",
+    "Content hash",
+    "Frozen hash",
+    "Policy version",
+    "Composer version",
+    "Validação vence em",
+    "Reprovações de copy QA",
+    "Duplicidade apontada pelo servidor",
+    "Proveniência ausente",
+    "Hard bounce registrado",
+    "Excluído do preview por",
+  ]) {
+    assert.ok(html.includes(label), `${label} is missing from the candidate card`);
+  }
+  assert.match(html, /data-candidate-blockers="approval_missing_or_invalid"/);
+  assert.match(html, /assunto_generico/);
+});
+
+test("preview denominators are rendered verbatim, and an absent number says so instead of being derived", () => {
+  reset();
+  const full = warmblyBlock(surfaceInput(), "revisao");
+  for (const label of ["Considerados", "Elegíveis", "Excluídos", "Destinatários finais"]) {
+    assert.ok(full.includes(label), `${label} denominator is missing`);
+  }
+  const sparse = warmblyBlock(
+    surfaceInput({
+      gate: gatePayload(["operators"], cohort({ manifest: { preview: { accounts_considered: 7 } } })),
+    }),
+    "revisao",
+  );
+  assert.match(sparse, /não informado pelo servidor/);
+  // 7 considered with nothing else must not become "7 - 0 = 7 eligible".
+  assert.doesNotMatch(sparse, /<dt>Elegíveis<\/dt><dd>7<\/dd>/);
+});
+
+/* ------------------------------------------------------------------ *
+ * 3. Actions must be comprehensible and safe.
+ * ------------------------------------------------------------------ */
+
+const SAMPLE_RESULT: AdapterWriteResult = {
+  ok: true,
+  path: "/v1/warmbly/operator/cohorts",
+  kind: "nota",
+  status: 201,
+  outcome: "executed",
+  message: "Cohort congelada criada v1.",
+  gateAction: "create",
+  receiptId: "receipt-fixture-1",
+  correlationId: "cc:human-gate:fixture-1",
+  readback: { status: "confirmed", detail: "O servidor devolve a versão v1." },
+};
+
+for (const surface of ["operacao", "cohorts", "revisao"] as const) {
+  test(`a write outcome is rendered on ${surface}, with code, receipt, correlation id and next action`, () => {
+    reset();
+    const html = warmblyBlock(surfaceInput({ operatorResult: SAMPLE_RESULT }), surface);
+    assert.match(html, /data-write-result="executed"/, "the shared wrapper did not render");
+    assert.match(html, /data-gate-action="create"/);
+    assert.match(html, /receipt-fixture-1/);
+    assert.match(html, /cc:human-gate:fixture-1/);
+    assert.match(html, /data-outcome-recovery="true"/);
+    assert.match(html, /data-readback="confirmed"/);
+    // Rendered once. A banner repeated at the top and on the card reads as two
+    // separate events to the operator.
+    assert.equal((html.match(/data-write-result=/g) ?? []).length, 1);
+  });
+}
+
+test("feedback for a candidate lands on that candidate's card, not at the top of the page", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      operatorResult: {
+        ...SAMPLE_RESULT,
+        gateAction: "review",
+        gateTarget: { cohort_id: COHORT_ID, candidate_id: CANDIDATE_ID },
+      },
+    }),
+    "revisao",
+  );
+  const cardStart = html.indexOf(`data-candidate-id="${CANDIDATE_ID}"`);
+  const banner = html.indexOf('data-write-result="executed"');
+  assert.ok(cardStart > 0 && banner > cardStart, "the outcome must render inside the affected card");
+  assert.equal((html.match(/data-write-result=/g) ?? []).length, 1);
+});
+
+test("APPROVE is offered only against a current VALID validation, and explains itself otherwise", () => {
+  reset();
+  const valid = warmblyBlock(surfaceInput(), "revisao");
+  assert.match(valid, /data-approve-allowed="true"/);
+  assert.doesNotMatch(valid, /data-approve-blocked="true"/);
+
+  for (const status of ["INVALID", "UNKNOWN", "RISKY", "STALE"]) {
+    const html = warmblyBlock(
+      surfaceInput({
+        gate: gatePayload(
+          ["operators"],
+          cohort({ candidates: [candidate({ validation: { status } })] }),
+        ),
+      }),
+      "revisao",
+    );
+    assert.match(html, /data-approve-allowed="false"/, `${status} must not offer APPROVE`);
+    assert.match(html, /data-approve-blocked="true"/, `${status} must explain the refusal`);
+    const approveForm = html.match(/data-gate-key="review:[^"]*:APPROVE"[\s\S]*?<\/form>/)?.[0] ?? "";
+    assert.match(approveForm, /Registrar APPROVE<\/button>/);
+    assert.match(approveForm, /<button type="submit" disabled>/);
+  }
+});
+
+test("a validation blocker from the server blocks APPROVE even when the status reads VALID", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: gatePayload(
+        ["operators"],
+        cohort({ candidates: [candidate({ blocked_by: ["validation_stale"] })] }),
+      ),
+    }),
+    "revisao",
+  );
+  assert.match(html, /data-approve-allowed="false"/);
+  assert.match(html, /validation_stale/);
+});
+
+test("HOLD and REJECT ask for a reason and never for the approval acknowledgement", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  const holdForm = html.match(/data-gate-key="review:[^"]*:HOLD_REJECT"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.ok(holdForm.length > 0, "the HOLD/REJECT form must exist separately from APPROVE");
+  assert.match(holdForm, /name="reason" required/);
+  assert.doesNotMatch(holdForm, /name="ack"/, "HOLD/REJECT must not carry the approval checkbox");
+  assert.match(holdForm, /data-no-ack-required="true"/);
+  assert.match(holdForm, /<option value="HOLD">/);
+  assert.match(holdForm, /<option value="REJECT">/);
+
+  const approveForm = html.match(/data-gate-key="review:[^"]*:APPROVE"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.match(approveForm, /name="ack" required/, "APPROVE must still demand the acknowledgement");
+});
+
+test("HOLD really reaches the adapter without an acknowledgement", async () => {
+  reset();
+  const { adapter, seen } = gateAdapter({
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "HOLD registrado.",
+      outcome: "executed",
+      gateAction: "review" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  const form = dom.find(`[data-gate-key="review:${COHORT_ID}:${CANDIDATE_ID}:HOLD_REJECT"]`);
+  form.set("reason", "endereço genérico demais");
+  form.fire();
+  await settle();
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0]!.decision, "HOLD");
+  assert.equal(seen[0]!.acknowledged, undefined);
+});
+
+test("a second click while a write is in flight does not become a second write", async () => {
+  reset();
+  let release: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const { adapter, seen } = gateAdapter({
+    respond: async () => {
+      await gate;
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: "criada",
+        outcome: "executed",
+        gateAction: "create" as const,
+      };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, "#/warmbly/cohorts");
+  dom.find('[data-human-gate="create"]').fire();
+  await settle();
+  // The pending paint must be visible, and it must be what stops the next click.
+  assert.match(dom.root.innerHTML, /data-write-pending="true"/);
+  dom.find('[data-human-gate="create"]').fire();
+  await settle();
+  assert.equal(seen.length, 1, "the second click must not reach the adapter");
+  release?.();
+  await settle();
+  assert.doesNotMatch(dom.root.innerHTML, /data-write-pending="true"/);
+});
+
+test("an UNKNOWN outcome keeps the idempotency key so the retry is the same intent", async () => {
+  reset();
+  let attempt = 0;
+  const { adapter, seen } = gateAdapter({
+    respond: () => {
+      attempt += 1;
+      return attempt === 1
+        ? {
+            ok: false,
+            path: "/x",
+            kind: "nota" as const,
+            message: "sem resposta",
+            outcome: "unknown",
+            code: "human_gate_transport_unknown",
+            gateAction: "review" as const,
+          }
+        : {
+            ok: true,
+            path: "/x",
+            kind: "nota" as const,
+            message: "registrado",
+            outcome: "executed",
+            gateAction: "review" as const,
+          };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  const key = `review:${COHORT_ID}:${CANDIDATE_ID}:HOLD_REJECT`;
+  const first = dom.find(`[data-gate-key="${key}"]`);
+  first.set("reason", "mesmo motivo exato");
+  first.fire();
+  await settle();
+  const second = dom.find(`[data-gate-key="${key}"]`);
+  second.set("reason", "mesmo motivo exato");
+  second.fire();
+  await settle();
+  assert.equal(seen.length, 2);
+  assert.equal(
+    seen[0]!.idempotency_key,
+    seen[1]!.idempotency_key,
+    "an unresolved intent must be retried under the same key",
+  );
+});
+
+test("a definitive write is only claimed after the readback, and a divergent readback says so", async () => {
+  reset();
+  const { adapter } = gateAdapter({
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "registrado",
+      outcome: "executed",
+      gateAction: "review" as const,
+      gateTarget: { cohort_id: COHORT_ID, candidate_id: CANDIDATE_ID },
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  const form = dom.find(`[data-gate-key="review:${COHORT_ID}:${CANDIDATE_ID}:HOLD_REJECT"]`);
+  form.set("reason", "não confere ainda");
+  form.fire();
+  await settle();
+  // The fixture keeps answering `review.decision = HOLD` with `effective:false`
+  // for a HOLD submit, so this readback confirms; the branch that matters is
+  // that the readback ran at all and is reported.
+  assert.match(dom.root.innerHTML, /data-readback="(confirmed|not_confirmed)"/);
+});
+
+/* ------------------------------------------------------------------ *
+ * 4. Adjust.
+ * ------------------------------------------------------------------ */
+
+test("the adjust editor offers exactly subject, body and reason, and warns that it forks a version", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  const editor = html.match(/<details class="card" data-adjust-editor[\s\S]*?<\/details>/)?.[0] ?? "";
+  assert.ok(editor.length > 0, "the adjust editor must exist");
+  assert.match(editor, /data-adjust-warning="true"/);
+  assert.match(editor, /cria uma NOVA versão/i);
+  const names = [...editor.matchAll(/name="([a-z_]+)"/g)].map((match) => match[1]).sort();
+  assert.deepEqual(names, ["body_text", "confirmation", "reason", "subject"]);
+  for (const forbidden of ["mailbox", "evidence", "route_class", "policy_version", "source"]) {
+    assert.doesNotMatch(editor, new RegExp(`name="${forbidden}"`), `${forbidden} must never be editable`);
+  }
+});
+
+test("the first adjust submit previews the diff and writes nothing", async () => {
+  reset();
+  const { adapter, seen } = gateAdapter({
+    respond: () => {
+      throw new Error("the preview step must not reach the adapter");
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  const form = dom.find(`[data-gate-key="adjust:${COHORT_ID}:${CANDIDATE_ID}:"]`);
+  form.set("subject", "Assunto revisado pelo operador");
+  form.set("body_text", "Corpo revisado pelo operador.");
+  form.set("reason", "assunto genérico demais");
+  form.fire();
+  await settle();
+  assert.equal(seen.length, 0, "the preview must not write");
+  assert.match(dom.root.innerHTML, /data-adjust-diff="true"/);
+  assert.match(dom.root.innerHTML, /Assunto exato congelado/);
+  assert.match(dom.root.innerHTML, /Assunto revisado pelo operador/);
+  assert.match(dom.root.innerHTML, /data-adjust-step="confirm"/);
+});
+
+test("a confirmed adjust sends the contract body and lands on the new version the server named", async () => {
+  reset();
+  const navigations: string[] = [];
+  const { adapter, seen } = gateAdapter({
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      status: 201,
+      message: "Ajuste aceito.",
+      outcome: "executed",
+      gateAction: "adjust" as const,
+      gateTarget: { cohort_id: COHORT_ID, candidate_id: CANDIDATE_ID },
+      gateResource: { cohort_id: NEXT_COHORT_ID, version: 2 },
+      diff: [{ field: "subject", before: "Assunto exato congelado", after: "Assunto revisado" }],
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(
+    dom.root as never,
+    adapter as never,
+    `#/warmbly/revisao?resource=${COHORT_ID}`,
+    0,
+    () => true,
+    (hash) => {
+      navigations.push(hash);
+    },
+  );
+  const preview = dom.find(`[data-gate-key="adjust:${COHORT_ID}:${CANDIDATE_ID}:"]`);
+  preview.set("subject", "Assunto revisado");
+  preview.set("body_text", "Corpo revisado.");
+  preview.set("reason", "assunto genérico demais");
+  preview.fire();
+  await settle();
+  const confirm = dom.find(`[data-gate-key="adjust:${COHORT_ID}:${CANDIDATE_ID}:"]`);
+  confirm.fire();
+  await settle();
+
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0]!.action, "adjust");
+  assert.equal(seen[0]!.subject, "Assunto revisado");
+  assert.equal(seen[0]!.body_text, "Corpo revisado.");
+  assert.equal(seen[0]!.reason, "assunto genérico demais");
+  assert.equal(seen[0]!.confirmation, "v1");
+  assert.equal(seen[0]!.expected_frozen_hash, "frozen-fixture-001");
+  assert.deepEqual(navigations, [`#/warmbly/revisao?resource=${NEXT_COHORT_ID}`]);
+});
+
+test("the new version opens with validation, review and GO all pending", () => {
+  reset();
+  const fresh = cohort({
+    id: NEXT_COHORT_ID,
+    version: 2,
+    candidates: [candidate({ validation: { status: "UNKNOWN" }, review: {}, blocked_by: [] })],
+    decision: {},
+  });
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: {
+        list: { data: [fresh], edge_actor: { id: "u", groups: ["operators", "admins"] } },
+        list_status: "read",
+        selected: { data: fresh },
+        selected_status: "read",
+      },
+      resource: NEXT_COHORT_ID,
+    }),
+    "revisao",
+  );
+  assert.match(html, /Revisão v2/);
+  assert.match(html, /data-approve-allowed="false"/, "a fresh version cannot already be approvable");
+  assert.match(html, /<dt>Revisão registrada<\/dt><dd>não informado pelo servidor<\/dd>/);
+  assert.match(html, /<dt>Decisão final registrada<\/dt><dd>não informado pelo servidor<\/dd>/);
+});
+
+test("every adjust refusal code renders its own actionable sentence", () => {
+  reset();
+  const expectations: Record<string, RegExp> = {
+    frozen_hash_mismatch: /conteúdo congelado mudou desde a sua leitura/i,
+    confirmation_mismatch: /confirmação não corresponde à versão/i,
+    version_superseded: /já foi substituída por outra mais nova/i,
+    authority_active: /autoridade bounded ativa/i,
+    immutable_field: /campo imutável/i,
+    copy_qa_failed: /reprovou no QA de copy/i,
+    candidate_not_found: /candidato não encontrado nesta versão/i,
+    adjust_route_unavailable: /ainda não foi implantada neste ambiente/i,
+  };
+  for (const [code, expected] of Object.entries(expectations)) {
+    const html = warmblyBlock(
+      surfaceInput({
+        operatorResult: {
+          ok: false,
+          path: "/x",
+          kind: "nota",
+          message: code,
+          outcome: "refused",
+          status: code === "candidate_not_found" || code === "adjust_route_unavailable" ? 404 : 409,
+          code,
+          gateAction: "adjust",
+        },
+      }),
+      "revisao",
+    );
+    assert.match(html, expected, `${code} did not render its own explanation`);
+    assert.match(html, /data-outcome-recovery="true"/, `${code} rendered no next action`);
+  }
+});
+
+test("adjust degrades gracefully when the route is not deployed: the editor stops offering the write", async () => {
+  reset();
+  const { adapter } = gateAdapter({
+    respond: () => ({
+      ok: false,
+      path: "/x",
+      kind: "nota" as const,
+      status: 404,
+      message: "route is outside the fixed human-gate allowlist",
+      outcome: "refused",
+      code: "adjust_route_unavailable",
+      gateAction: "adjust" as const,
+      gateTarget: { cohort_id: COHORT_ID, candidate_id: CANDIDATE_ID },
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  const preview = dom.find(`[data-gate-key="adjust:${COHORT_ID}:${CANDIDATE_ID}:"]`);
+  preview.set("subject", "Assunto revisado");
+  preview.set("body_text", "Corpo revisado.");
+  preview.set("reason", "motivo do ajuste");
+  preview.fire();
+  await settle();
+  dom.find(`[data-gate-key="adjust:${COHORT_ID}:${CANDIDATE_ID}:"]`).fire();
+  await settle();
+  assert.match(dom.root.innerHTML, /data-adjust-unavailable="true"/);
+  assert.match(dom.root.innerHTML, /ainda não foi implantada neste ambiente/i);
+});
+
+test("the HTTP adapter refuses an adjust without its anti-clobber tokens before the wire", async () => {
+  reset();
+  const calls: string[] = [];
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://control-center.fixture",
+    fetchImpl: (async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      return new Response(JSON.stringify({}), { status: 201 });
+    }) as typeof fetch,
+  });
+  const base = {
+    action: "adjust" as const,
+    version_id: COHORT_ID,
+    candidate_id: CANDIDATE_ID,
+    subject: "s",
+    body_text: "b",
+    reason: "r",
+    idempotency_key: "cc-human-gate:v1:fixture:0",
+  };
+  assert.equal((await adapter.warmblyGate({ ...base })).code, "confirmation_mismatch");
+  assert.equal(
+    (await adapter.warmblyGate({ ...base, confirmation: "v1" })).code,
+    "gate_precondition",
+  );
+  assert.equal(calls.length, 0, "an incomplete adjust must never reach the channel");
+
+  const accepted = await adapter.warmblyGate({
+    ...base,
+    confirmation: "v1",
+    expected_frozen_hash: "frozen-fixture-001",
+  });
+  assert.equal(accepted.ok, true);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0]!, /\/candidates\/[^/]+\/adjust$/);
+});
+
+test("the adjust wire body is exactly the contract's five fields plus the idempotency key", async () => {
+  reset();
+  let sent: Record<string, unknown> = {};
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://control-center.fixture",
+    fetchImpl: (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sent = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(
+        JSON.stringify({
+          cohort: { id: NEXT_COHORT_ID, version: 2 },
+          adjustment: {
+            from_version: 1,
+            to_version: 2,
+            candidate_id: CANDIDATE_ID,
+            receipt: "receipt-adjust-1",
+            correlation_id: "cc:human-gate:adjust-1",
+            diff: [{ field: "subject", before: "antes", after: "depois" }],
+          },
+        }),
+        { status: 201 },
+      );
+    }) as typeof fetch,
+  });
+  const result = await adapter.warmblyGate({
+    action: "adjust",
+    version_id: COHORT_ID,
+    candidate_id: CANDIDATE_ID,
+    subject: "Assunto revisado",
+    body_text: "Corpo revisado.",
+    reason: "assunto genérico",
+    confirmation: "v1",
+    expected_frozen_hash: "frozen-fixture-001",
+    idempotency_key: "cc-human-gate:v1:fixture:0",
+  });
+  assert.deepEqual(Object.keys(sent).sort(), [
+    "body_text",
+    "confirmation",
+    "expected_frozen_hash",
+    "idempotency_key",
+    "reason",
+    "subject",
+  ]);
+  assert.equal(sent.confirmation, "v1");
+  assert.deepEqual(result.gateResource, { cohort_id: NEXT_COHORT_ID, version: 2 });
+  assert.equal(result.receiptId, "receipt-adjust-1");
+  assert.equal(result.correlationId, "cc:human-gate:adjust-1");
+  assert.deepEqual(result.diff, [{ field: "subject", before: "antes", after: "depois" }]);
+});
+
+test("gate results carry their own action and resource instead of one generic sentence", async () => {
+  reset();
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://control-center.fixture",
+    fetchImpl: (async () =>
+      new Response(JSON.stringify({ id: NEXT_COHORT_ID, version: 2, receipt: "r-create" }), {
+        status: 201,
+      })) as typeof fetch,
+  });
+  const created = await adapter.warmblyGate({
+    action: "create",
+    limit: 5,
+    idempotency_key: "cc-human-gate:v1:fixture:0",
+  });
+  assert.equal(created.gateAction, "create");
+  assert.deepEqual(created.gateResource, { cohort_id: NEXT_COHORT_ID, version: 2 });
+  assert.doesNotMatch(created.message, /Decisão registrada/);
+  assert.match(created.message, /Cohort congelada criada v2\./);
+});
+
+/* ------------------------------------------------------------------ *
+ * 5. RBAC and environment.
+ * ------------------------------------------------------------------ */
+
+test("the surface names the operator and the environment without a raw identifier in the visible text", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  const identity = html.match(/<article class="card" data-operator-identity="true"[\s\S]*?<\/article>/)?.[0] ?? "";
+  assert.ok(identity.length > 0);
+  const visible = identity.replace(/<details class="tech"[\s\S]*?<\/details>/g, " ");
+  assert.match(visible, /Fundador/);
+  assert.match(visible, /ops\.confenge\.com\.br/);
+  assert.doesNotMatch(visible, /human:operator/, "the raw identifier belongs in the technical block");
+  assert.match(identity, /identificador_auditavel/);
+});
+
+test("GO is disabled without admins and says how to obtain the authority", () => {
+  reset();
+  const operatorsOnly = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators"]) }),
+    "revisao",
+  );
+  assert.match(operatorsOnly, /data-can-decide="false"/);
+  assert.match(operatorsOnly, /data-go-authority="absent"/);
+  assert.match(operatorsOnly, /exige o grupo <code>admins<\/code> no Authelia/);
+  const decideForm = operatorsOnly.match(/data-human-gate="decide"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.match(decideForm, /<button type="submit" disabled>/);
+
+  const admins = warmblyBlock(surfaceInput(), "revisao");
+  assert.match(admins, /data-can-decide="true"/);
+  const enabled = admins.match(/data-human-gate="decide"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.doesNotMatch(enabled, /<button type="submit" disabled>/);
+});
+
+test("capabilities the channel never reported are rendered as unknown, never as granted", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: {
+        list: { data: [cohort()] },
+        list_status: "read",
+        selected: { data: cohort() },
+        selected_status: "read",
+      },
+    }),
+    "revisao",
+  );
+  assert.match(html, /data-can-decide="false"/);
+  assert.match(html, /não informado pelo servidor/);
+  assert.match(html, /não teve os grupos confirmados pelo canal|não devolveu os grupos efetivos/);
+});
+
+test("no gate write ever carries a browser-set actor header", async () => {
+  reset();
+  const headers: Array<Record<string, string>> = [];
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://control-center.fixture",
+    fetchImpl: (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      headers.push((init?.headers ?? {}) as Record<string, string>);
+      return new Response(JSON.stringify({ id: COHORT_ID, version: 1 }), { status: 201 });
+    }) as typeof fetch,
+  });
+  await adapter.warmblyGate({ action: "create", limit: 5, idempotency_key: "cc-human-gate:v1:a:0" });
+  await adapter.warmblyGate({
+    action: "adjust",
+    version_id: COHORT_ID,
+    candidate_id: CANDIDATE_ID,
+    subject: "s",
+    body_text: "b",
+    reason: "r",
+    confirmation: "v1",
+    expected_frozen_hash: "f",
+    idempotency_key: "cc-human-gate:v1:b:0",
+  });
+  assert.equal(headers.length, 2);
+  for (const header of headers) {
+    assert.equal(header["x-actor-id"], undefined);
+    assert.equal(header["x-actor-kind"], undefined);
+  }
+});
+
+test("the gate never exposes a queue, dispatch, send, resume or payment control", () => {
+  reset();
+  for (const surface of ["cohorts", "revisao"] as const) {
+    const html = warmblyBlock(surfaceInput(), surface);
+    assert.doesNotMatch(html, /data-human-gate="(queue|dispatch|send|resume|payment)"/);
+    assert.doesNotMatch(html, /enviar agora|disparar|SEND_CAMPAIGN|cobran[çc]a|checkout/i);
+  }
+});
+
+test("a gate read that fails never takes the destination down and never sends an actor header", async () => {
+  reset();
+  const requests: Array<{ url: string; headers: Record<string, string> }> = [];
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://control-center.fixture",
+    fetchImpl: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      requests.push({ url, headers: (init?.headers ?? {}) as Record<string, string> });
+      if (url.includes("/v1/warmbly/operator/cohorts")) {
+        return new Response(JSON.stringify({ code: "human_gate_route_not_allowed" }), { status: 404 });
+      }
+      if (url.includes("/v1/domains/commercial")) {
+        return new Response(
+          JSON.stringify({
+            schema_version: "control-center.commercial-snapshot.v1",
+            id: "cc:commercial-snapshot:fixture",
+            scope: "commercial",
+            generated_at: "2026-08-23T12:00:00Z",
+            provenance: {
+              source: { system: "warmbly", kind: "crm-read-model", locator: "commercial/pipeline" },
+              observed_at: "2026-08-23T11:59:00Z",
+              freshness_status: "FRESH",
+              confidence: 1,
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as typeof fetch,
+    operator: { kind: "human", id: "human:operator" },
+  });
+  const read = await adapter.readDestination("warmbly", `#/warmbly/revisao?resource=${COHORT_ID}`);
+  assert.equal(read.ok, true, "a 404 on the gate must not fail the whole destination");
+  assert.equal(read.loading, false);
+  const gate = (read as { page: { warmbly_gate?: Record<string, unknown> } }).page.warmbly_gate ?? {};
+  assert.equal(gate.list_status, "not_mounted");
+  assert.equal(gate.selected_status, "not_mounted");
+
+  const gateReads = requests.filter((request) => request.url.includes("/v1/warmbly/operator/cohorts"));
+  assert.ok(gateReads.length >= 2, "list and selected are both read");
+  for (const request of gateReads) {
+    assert.equal(request.headers["x-actor-id"], undefined);
+    assert.equal(request.headers["x-actor-kind"], undefined);
+  }
+});
+
+test("the operation cockpit reads the gate too, because its stepper has to know where the pilot stands", async () => {
+  reset();
+  const urls: string[] = [];
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://control-center.fixture",
+    fetchImpl: (async (input: RequestInfo | URL) => {
+      urls.push(String(input));
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as typeof fetch,
+    operator: { kind: "human", id: "human:operator" },
+  });
+  await adapter.readDestination("warmbly", "#/warmbly");
+  assert.ok(
+    urls.some((url) => url.includes("/v1/warmbly/operator/cohorts?limit=50")),
+    "#/warmbly must read the cohort list",
+  );
+});

--- a/control-center/connectors/warmbly/src/human-gate/contract.ts
+++ b/control-center/connectors/warmbly/src/human-gate/contract.ts
@@ -1,0 +1,257 @@
+/**
+ * The slice of `confenge.human-gate.v1` this connector actually depends on.
+ *
+ * This is deliberately NOT a copy of the Warmbly-owned schema document — that
+ * one lives at `contracts/human-gate-v1.schema.json` and is compared byte for
+ * byte against the authority in `tests/human-gate-contract.test.ts`. What lives
+ * here is narrower and different in kind: the exact request fields this
+ * connector will put on the wire, the exact response fields it reads back, and
+ * the exact upstream routes it will build. If Warmbly renames a field or moves a
+ * route, the pin in `tests/human-gate-adjust-contract.test.ts` fails here rather
+ * than silently forwarding a body the backend ignores.
+ */
+
+/** Canonical contract this connector speaks. Owned by Warmbly, referenced by name. */
+export const HUMAN_GATE_CONTRACT = "confenge.human-gate.v1";
+
+/**
+ * Single source for the upstream cohort route prefix. Every human-gate route is
+ * composed from this constant, so the six operations can never drift apart from
+ * one another, and a prefix change is one edit plus one failing contract pin.
+ */
+export const WARMBLY_COHORTS_PREFIX = "/v1/confenge/cohorts";
+
+/**
+ * Every operation the human gate can name. There is deliberately no generic
+ * proxy entry and no `send`, `dispatch`, `queue`, `resume` or `payment` member:
+ * the type itself is part of the security boundary.
+ */
+export const HUMAN_GATE_OPERATIONS = [
+  "list_cohorts",
+  "read_cohort",
+  "read_candidate",
+  "create",
+  "reproduce",
+  "validation",
+  "review",
+  "adjust",
+  "decision",
+] as const;
+export type HumanGateOperation = (typeof HUMAN_GATE_OPERATIONS)[number];
+
+/** Operations that mutate. Only these carry an idempotency key. */
+export const HUMAN_GATE_WRITE_OPERATIONS = [
+  "create",
+  "reproduce",
+  "validation",
+  "review",
+  "adjust",
+  "decision",
+] as const;
+
+/**
+ * Route classes this connector must never be able to construct, at any prefix.
+ * Kept as data so `tests/human-gate-negative-allowlist.test.ts` can enumerate
+ * them instead of a reviewer having to remember the list.
+ */
+export const FORBIDDEN_HUMAN_GATE_SEGMENTS = [
+  "send",
+  "dispatch",
+  "queue",
+  "resume",
+  "auto-send",
+  "autosend",
+  "payment",
+  "payments",
+  "charge",
+  "enroll",
+  "deliver",
+] as const;
+
+/** How a call ended. `UNKNOWN` is never collapsed into `REFUSED`. */
+export const HUMAN_GATE_OUTCOMES = ["APPLIED", "REFUSED", "UNKNOWN"] as const;
+export type HumanGateOutcome = (typeof HUMAN_GATE_OUTCOMES)[number];
+
+// ---------------------------------------------------------------------------
+// adjust — POST {prefix}/{id}/candidates/{candidateId}/adjust
+// ---------------------------------------------------------------------------
+
+/**
+ * Exactly the fields the adjust request may carry. Anything else is refused by
+ * `validateAdjustRequest` before a URL is built, not dropped silently: a caller
+ * that believes it set `mailbox` must be told the field does not exist, because
+ * silently ignoring it is how a recipient override gets shipped believing it
+ * works.
+ */
+export const ADJUST_REQUEST_FIELDS = [
+  "subject",
+  "body_text",
+  "reason",
+  "confirmation",
+  "expected_frozen_hash",
+] as const;
+export type AdjustRequestField = (typeof ADJUST_REQUEST_FIELDS)[number];
+
+/**
+ * Edge-only fields the gate consumes and never forwards in the body. The
+ * idempotency key travels as the `Idempotency-Key` header, exactly as the other
+ * five writes do.
+ */
+export const ADJUST_EDGE_ONLY_FIELDS = ["idempotency_key"] as const;
+
+/**
+ * Named because they are the tempting ones: each would widen the blast radius of
+ * an "adjust the copy" call into recipient selection, provenance forgery or
+ * routing. The schema refuses them; this list exists so the refusal is tested by
+ * name rather than by a reviewer's memory.
+ */
+export const ADJUST_REFUSED_FIELDS = [
+  "mailbox",
+  "recipient",
+  "evidence",
+  "source",
+  "policy_version",
+  "route_class",
+  "composer_version",
+] as const;
+
+export interface CohortAdjustmentDiffEntry {
+  field: string;
+  before: unknown;
+  after: unknown;
+}
+
+/** The `adjustment` object of a 201. Field names are Warmbly's, not ours. */
+export const ADJUSTMENT_FIELDS = [
+  "id",
+  "cohort_id",
+  "from_version",
+  "to_version",
+  "candidate_id",
+  "before_content_hash",
+  "after_content_hash",
+  "before_frozen_hash",
+  "after_frozen_hash",
+  "diff",
+  "revoked_authorization_id",
+  "actor_id",
+  "correlation_id",
+  "receipt",
+  "created_at",
+] as const;
+
+export interface CohortAdjustment {
+  id: string;
+  cohort_id: string;
+  from_version: number | string;
+  to_version: number | string;
+  candidate_id: string;
+  before_content_hash: string;
+  after_content_hash: string;
+  before_frozen_hash: string;
+  after_frozen_hash: string;
+  diff: CohortAdjustmentDiffEntry[];
+  revoked_authorization_id: string | null;
+  actor_id: string;
+  correlation_id: string;
+  receipt: string;
+  created_at: string;
+}
+
+/** Top-level 201 body. `cohort` is the full new-version payload, passed through. */
+export const ADJUST_RESPONSE_FIELDS = ["contract_version", "cohort", "adjustment"] as const;
+
+export interface CohortAdjustResponse {
+  contract_version: typeof HUMAN_GATE_CONTRACT;
+  cohort: Record<string, unknown>;
+  adjustment: CohortAdjustment;
+}
+
+/**
+ * Server-owned refusal codes for adjust, with the status each arrives on. The
+ * connector never invents one of these and never rewrites one into another; the
+ * map exists so the edge can be pinned against the backend's vocabulary.
+ */
+export const ADJUST_ERROR_CODES = {
+  frozen_hash_mismatch: 409,
+  confirmation_mismatch: 409,
+  version_superseded: 409,
+  authority_active: 409,
+  immutable_field: 422,
+  copy_qa_failed: 422,
+  candidate_not_found: 404,
+} as const satisfies Record<string, number>;
+export type AdjustErrorCode = keyof typeof ADJUST_ERROR_CODES;
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+export type AdjustRequest = Record<AdjustRequestField, string>;
+
+export type AdjustValidation =
+  | { ok: true; value: AdjustRequest }
+  | { ok: false; code: string; message: string; fields: string[] };
+
+/**
+ * Canonical 8-4-4-4-12 UUID. The looser `[0-9a-fA-F-]{36}` this module replaced
+ * matched 36 hyphens, which is not an id — every route now composes its upstream
+ * URL only after this returns true.
+ */
+const CANONICAL_UUID = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export function isCanonicalUuid(value: unknown): value is string {
+  return typeof value === "string" && CANONICAL_UUID.test(value);
+}
+
+/** Source of truth for the route regexes, so pattern and guard cannot diverge. */
+export const UUID_PATTERN_SOURCE =
+  "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
+
+/**
+ * Strict, closed-world validation of the adjust request body.
+ *
+ * Closed-world is the point: `additionalProperties: false` semantics are what
+ * stops `{"mailbox": "..."}` from reaching a backend that might one day honour
+ * it. Refusal happens before any URL is built and before any socket is opened.
+ */
+export function validateAdjustRequest(body: unknown): AdjustValidation {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return {
+      ok: false,
+      code: "invalid_adjust_payload",
+      message: "the adjust request body must be a JSON object",
+      fields: [],
+    };
+  }
+  const record = body as Record<string, unknown>;
+  const allowed = new Set<string>([...ADJUST_REQUEST_FIELDS, ...ADJUST_EDGE_ONLY_FIELDS]);
+  const unexpected = Object.keys(record).filter((key) => !allowed.has(key));
+  if (unexpected.length > 0) {
+    return {
+      ok: false,
+      code: "unexpected_field",
+      message: `the adjust request refuses unknown fields: ${unexpected.sort().join(", ")}`,
+      fields: unexpected.sort(),
+    };
+  }
+  const missing: string[] = [];
+  const value = {} as AdjustRequest;
+  for (const field of ADJUST_REQUEST_FIELDS) {
+    const raw = record[field];
+    if (typeof raw !== "string" || raw.trim() === "") {
+      missing.push(field);
+      continue;
+    }
+    value[field] = raw;
+  }
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      code: "invalid_adjust_payload",
+      message: `every adjust field is required and must be a non-empty string: ${missing.join(", ")}`,
+      fields: missing,
+    };
+  }
+  return { ok: true, value };
+}

--- a/control-center/connectors/warmbly/src/human-gate/http.ts
+++ b/control-center/connectors/warmbly/src/human-gate/http.ts
@@ -2,24 +2,68 @@ import { createHash, randomUUID } from "node:crypto";
 import { parseForwardAuthIdentity, type TrustedHopPolicy } from "@confenge/control-center-security";
 import { redactSecrets, type Logger } from "../http/redaction.ts";
 import type { OperatorHttpRequest, OperatorHttpResponse } from "../operator/http.ts";
+import {
+  HUMAN_GATE_CONTRACT,
+  UUID_PATTERN_SOURCE,
+  WARMBLY_COHORTS_PREFIX,
+  isCanonicalUuid,
+  validateAdjustRequest,
+  type AdjustValidation,
+  type HumanGateOperation,
+  type HumanGateOutcome,
+} from "./contract.ts";
 
-export const HUMAN_GATE_CONTRACT = "confenge.human-gate.v1";
+export { HUMAN_GATE_CONTRACT };
 export const HUMAN_GATE_PREFIX = "/v1/warmbly/operator/cohorts";
 
-const UUID = "[0-9a-fA-F-]{36}";
-const routes = [
-  { method: "GET", local: new RegExp(`^${HUMAN_GATE_PREFIX}$`), upstream: () => "/v1/confenge/cohorts", role: "operators" },
-  { method: "POST", local: new RegExp(`^${HUMAN_GATE_PREFIX}$`), upstream: () => "/v1/confenge/cohorts", role: "operators" },
-  { method: "GET", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})$`), upstream: (m: RegExpMatchArray) => `/v1/confenge/cohorts/${m[1]}`, role: "operators" },
-  { method: "GET", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/candidates/(${UUID})$`), upstream: (m: RegExpMatchArray) => `/v1/confenge/cohorts/${m[1]}/candidates/${m[2]}`, role: "operators" },
-  { method: "POST", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/reproduce$`), upstream: (m: RegExpMatchArray) => `/v1/confenge/cohorts/${m[1]}/reproduce`, role: "operators" },
-  { method: "POST", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/candidates/(${UUID})/validation$`), upstream: (m: RegExpMatchArray) => `/v1/confenge/cohorts/${m[1]}/candidates/${m[2]}/validation`, role: "operators" },
-  { method: "POST", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/candidates/(${UUID})/review$`), upstream: (m: RegExpMatchArray) => `/v1/confenge/cohorts/${m[1]}/candidates/${m[2]}/review`, role: "operators" },
-  { method: "POST", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/decision$`), upstream: (m: RegExpMatchArray) => `/v1/confenge/cohorts/${m[1]}/decision`, role: "admins" },
-] as const;
+const UUID = UUID_PATTERN_SOURCE;
+
+/**
+ * The fixed allowlist. Adding a row here is the only way to reach Warmbly
+ * through this handler: there is no generic proxy row, no wildcard, and no
+ * caller-supplied upstream path. Every `upstream` builder composes from
+ * `WARMBLY_COHORTS_PREFIX` and from capture groups that have already matched a
+ * canonical UUID, so no caller string is ever concatenated raw into a URL.
+ */
+interface HumanGateRoute {
+  method: "GET" | "POST";
+  operation: HumanGateOperation;
+  local: RegExp;
+  upstream: (m: RegExpMatchArray) => string;
+  role: "operators" | "admins";
+  /** Strict, closed-world body validation. Absent means the legacy field filter. */
+  validate?: (body: unknown) => AdjustValidation;
+}
+
+const routes: readonly HumanGateRoute[] = [
+  { method: "GET", operation: "list_cohorts", local: new RegExp(`^${HUMAN_GATE_PREFIX}$`), upstream: () => WARMBLY_COHORTS_PREFIX, role: "operators" },
+  { method: "POST", operation: "create", local: new RegExp(`^${HUMAN_GATE_PREFIX}$`), upstream: () => WARMBLY_COHORTS_PREFIX, role: "operators" },
+  { method: "GET", operation: "read_cohort", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}`, role: "operators" },
+  { method: "GET", operation: "read_candidate", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/candidates/(${UUID})$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/candidates/${m[2]}`, role: "operators" },
+  { method: "POST", operation: "reproduce", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/reproduce$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/reproduce`, role: "operators" },
+  { method: "POST", operation: "validation", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/candidates/(${UUID})/validation$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/candidates/${m[2]}/validation`, role: "operators" },
+  { method: "POST", operation: "review", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/candidates/(${UUID})/review$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/candidates/${m[2]}/review`, role: "operators" },
+  // Same operators-equivalent permission as review. Adjusting frozen copy mints
+  // a new immutable version and revokes the authorization bound to the old one;
+  // it is not a GO, so it is deliberately NOT behind the admins gate.
+  { method: "POST", operation: "adjust", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/candidates/(${UUID})/adjust$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/candidates/${m[2]}/adjust`, role: "operators", validate: validateAdjustRequest },
+  { method: "POST", operation: "decision", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/decision$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/decision`, role: "admins" },
+];
+
+/** Exposed for tests and for the cockpit: the complete reachable surface. */
+export const HUMAN_GATE_ROUTES = routes.map((r) => ({
+  method: r.method,
+  operation: r.operation,
+  role: r.role,
+  local: r.local.source,
+})) as readonly { method: string; operation: HumanGateOperation; role: string; local: string }[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
 
 function bodyRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+  return isRecord(value) ? value : {};
 }
 
 function idempotency(value: unknown): string | undefined {
@@ -32,8 +76,50 @@ function opaqueActorId(actor: string): string {
   return `authelia:${createHash("sha256").update(actor).digest("hex").slice(0, 16)}`;
 }
 
+/**
+ * The identity of whatever the write produced, read only out of what the server
+ * actually sent. Nothing here is synthesised: an absent field stays absent, so
+ * the cockpit can tell "the server did not say" from "the server said none".
+ */
+function resourceIdentity(payload: Record<string, unknown>): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {};
+  for (const container of [payload.cohort, payload.data, payload]) {
+    if (!isRecord(container)) continue;
+    if (typeof container.id === "string" && out.id === undefined) out.id = container.id;
+    const version = container.version;
+    if ((typeof version === "string" || typeof version === "number") && out.version === undefined) {
+      out.version = version;
+    }
+    if (out.id !== undefined && out.version !== undefined) break;
+  }
+  const adjustment = payload.adjustment;
+  if (isRecord(adjustment)) {
+    if (typeof adjustment.id === "string") out.adjustment_id = adjustment.id;
+    if (adjustment.from_version !== undefined) out.from_version = adjustment.from_version;
+    if (adjustment.to_version !== undefined) out.to_version = adjustment.to_version;
+  }
+  if (Object.keys(out).length === 0) return undefined;
+  return { kind: "cohort", ...out };
+}
+
+/** Upstream receipt, wherever the server put it. Never minted from thin air. */
+function upstreamReceipt(payload: Record<string, unknown>): string | undefined {
+  if (typeof payload.receipt === "string") return payload.receipt;
+  const adjustment = payload.adjustment;
+  if (isRecord(adjustment) && typeof adjustment.receipt === "string") return adjustment.receipt;
+  return undefined;
+}
+
+interface EnvelopeContext {
+  correlation: string;
+  operation: HumanGateOperation;
+  outcome: HumanGateOutcome;
+  /** Echoed back on writes so a retry after UNKNOWN reuses the same key. */
+  idempotencyKey?: string | undefined;
+}
+
 function edgeEnvelope(
-  correlation: string,
+  ctx: EnvelopeContext,
   payload: Record<string, unknown>,
   fallbackReason: string,
 ): Record<string, unknown> {
@@ -44,6 +130,7 @@ function edgeEnvelope(
     : typeof rawReason === "string" && rawReason.trim() !== ""
       ? [rawReason]
       : [fallbackReason];
+  const resource = resourceIdentity(payload);
   return {
     ...payload,
     contract_version: typeof meta.contract_version === "string" ? meta.contract_version : HUMAN_GATE_CONTRACT,
@@ -52,15 +139,21 @@ function edgeEnvelope(
     freshness: typeof meta.freshness === "string" ? meta.freshness : "UNKNOWN",
     policy_version: typeof meta.policy_version === "string" ? meta.policy_version : "bounded-cohort-policy.v1",
     reason,
-    correlation_id: typeof meta.correlation_id === "string" ? meta.correlation_id : correlation,
-    receipt: typeof payload.receipt === "string" ? payload.receipt : `edge:${correlation}`,
+    correlation_id: typeof meta.correlation_id === "string" ? meta.correlation_id : ctx.correlation,
+    receipt: upstreamReceipt(payload) ?? `edge:${ctx.correlation}`,
     auto_send_enabled: false,
-    edge_correlation_id: correlation,
+    edge_correlation_id: ctx.correlation,
+    // Distinct write results used to arrive as one indistinguishable body. These
+    // three say which call this was, how it ended, and what it produced.
+    operation: ctx.operation,
+    outcome: ctx.outcome,
+    ...(resource ? { resource } : {}),
+    ...(ctx.idempotencyKey ? { idempotency_key: ctx.idempotencyKey } : {}),
   };
 }
 
-function edgeRefusal(correlation: string, code: string, message: string): Record<string, unknown> {
-  return edgeEnvelope(correlation, { ok: false, code, message }, code);
+function edgeRefusal(ctx: EnvelopeContext, code: string, message: string): Record<string, unknown> {
+  return edgeEnvelope(ctx, { ok: false, code, message }, code);
 }
 
 export interface HumanGateHttpOptions {
@@ -83,37 +176,76 @@ export function createHumanGateHttpHandler(options: HumanGateHttpOptions) {
     const method = (req.method ?? "GET").toUpperCase();
     const correlation = `cc:human-gate:${randomUUID()}`;
     const route = routes.find((r) => r.method === method && r.local.test(url.pathname));
-    if (!route) return { status: 404, body: edgeRefusal(correlation, "human_gate_route_not_allowed", "route is outside the fixed human-gate allowlist") };
+    const ctx = (
+      operation: HumanGateOperation,
+      outcome: HumanGateOutcome,
+      idempotencyKey?: string | undefined,
+    ): EnvelopeContext => ({ correlation, operation, outcome, idempotencyKey });
+    if (!route) {
+      return {
+        status: 404,
+        body: edgeRefusal(
+          { correlation, operation: "list_cohorts", outcome: "REFUSED" },
+          "human_gate_route_not_allowed",
+          "route is outside the fixed human-gate allowlist",
+        ),
+      };
+    }
     const identity = parseForwardAuthIdentity({
       remoteAddress: req.remoteAddress ?? "",
       headers: req.headers,
       ...(req.rawHeaders ? { rawHeaders: req.rawHeaders } : {}),
     }, options.identityPolicy);
     if (!identity.ok) {
-      log({ level: "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: "anonymous", method, upstream_path: url.pathname, after: "REFUSED", upstream_status: 401, reason_code: identity.code });
-      return { status: 401, body: edgeRefusal(correlation, identity.code, identity.reason) };
+      log({ level: "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: "anonymous", operation: route.operation, method, upstream_path: url.pathname, after: "REFUSED", upstream_status: 401, reason_code: identity.code });
+      return { status: 401, body: edgeRefusal(ctx(route.operation, "REFUSED"), identity.code, identity.reason) };
     }
     if (!identity.identity.groups.includes(route.role)) {
-      log({ level: "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: opaqueActorId(identity.identity.user), method, upstream_path: url.pathname, after: "REFUSED", upstream_status: 403, reason_code: "insufficient_human_gate_role" });
-      return { status: 403, body: edgeRefusal(correlation, "insufficient_human_gate_role", `${route.role} role required`) };
+      log({ level: "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: opaqueActorId(identity.identity.user), operation: route.operation, method, upstream_path: url.pathname, after: "REFUSED", upstream_status: 403, reason_code: "insufficient_human_gate_role" });
+      return { status: 403, body: edgeRefusal(ctx(route.operation, "REFUSED"), "insufficient_human_gate_role", `${route.role} role required`) };
     }
     const match = url.pathname.match(route.local)!;
+    // Belt and braces. The route regex already required canonical UUIDs, but the
+    // guard is restated here so that no future edit to a pattern can let an
+    // unvalidated segment reach URL construction: this is the last statement
+    // before a caller-derived string becomes part of an upstream URL.
+    const ids = match.slice(1);
+    if (ids.some((id) => !isCanonicalUuid(id))) {
+      log({ level: "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: opaqueActorId(identity.identity.user), operation: route.operation, method, upstream_path: url.pathname, after: "REFUSED", upstream_status: 400, reason_code: "invalid_identifier" });
+      return { status: 400, body: edgeRefusal(ctx(route.operation, "REFUSED"), "invalid_identifier", "cohort and candidate identifiers must be canonical UUIDs") };
+    }
     const upstreamPath = route.upstream(match) + (method === "GET" ? url.search : "");
     const actorId = opaqueActorId(identity.identity.user);
     const key = method === "POST" ? idempotency(req.body) : undefined;
     if (method === "POST" && !key) {
-      log({ level: "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: actorId, method, upstream_path: upstreamPath, after: "REFUSED", upstream_status: 400, reason_code: "idempotency_key_required" });
+      log({ level: "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: actorId, operation: route.operation, method, upstream_path: upstreamPath, after: "REFUSED", upstream_status: 400, reason_code: "idempotency_key_required" });
       return {
         status: 400,
-        body: edgeRefusal(correlation, "idempotency_key_required", "a valid idempotency_key is required for every human-gate write"),
+        body: edgeRefusal(ctx(route.operation, "REFUSED"), "idempotency_key_required", "a valid idempotency_key is required for every human-gate write"),
       };
     }
     const submitted = bodyRecord(req.body);
-    const body: Record<string, unknown> = {};
-    for (const field of ["limit", "source_run_id", "decision", "reason", "acknowledged", "confirmation"] as const) {
-      if (submitted[field] !== undefined) body[field] = submitted[field];
+    let body: Record<string, unknown> = {};
+    if (route.validate) {
+      // Closed-world schema: an unknown field is a refusal, never a silent drop.
+      const validated = route.validate(req.body);
+      if (!validated.ok) {
+        log({ level: "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: actorId, operation: route.operation, method, upstream_path: upstreamPath, after: "REFUSED", upstream_status: 422, reason_code: validated.code });
+        return {
+          status: 422,
+          body: {
+            ...edgeRefusal(ctx(route.operation, "REFUSED", key), validated.code, validated.message),
+            rejected_fields: validated.fields,
+          },
+        };
+      }
+      body = { ...validated.value };
+    } else {
+      for (const field of ["limit", "source_run_id", "decision", "reason", "acknowledged", "confirmation"] as const) {
+        if (submitted[field] !== undefined) body[field] = submitted[field];
+      }
     }
-    log({ level: "info", msg: "warmbly.human_gate.before", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: actorId, method, upstream_path: upstreamPath, before: "REQUESTED" });
+    log({ level: "info", msg: "warmbly.human_gate.before", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: actorId, operation: route.operation, method, upstream_path: upstreamPath, before: "REQUESTED" });
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
@@ -134,13 +266,29 @@ export function createHumanGateHttpHandler(options: HumanGateHttpOptions) {
       let payload: unknown = {};
       try { payload = text ? JSON.parse(text) : {}; } catch { payload = { code: "invalid_upstream_payload" }; }
       const safe = bodyRecord(payload);
-      log({ level: res.ok ? "info" : "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: actorId, method, upstream_path: upstreamPath, after: res.ok ? "APPLIED" : "REFUSED", upstream_status: res.status, receipt: typeof safe.receipt === "string" ? safe.receipt : null });
-      return { status: res.status, body: edgeEnvelope(correlation, { ...safe, edge_actor: { id: identity.identity.user, groups: identity.identity.groups } }, res.ok ? "ok" : "upstream_refused") };
+      // A 5xx on a write is indeterminate, not a failure: the request was
+      // written, the backend may well have applied it, and only the answer was
+      // lost. Calling that REFUSED would tell an operator nothing happened.
+      const indeterminate = method === "POST" && res.status >= 500;
+      const outcome: HumanGateOutcome = res.ok ? "APPLIED" : indeterminate ? "UNKNOWN" : "REFUSED";
+      log({ level: res.ok ? "info" : "warn", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: actorId, operation: route.operation, method, upstream_path: upstreamPath, after: outcome, upstream_status: res.status, receipt: upstreamReceipt(safe) ?? null });
+      return {
+        status: res.status,
+        body: edgeEnvelope(
+          ctx(route.operation, outcome, key),
+          { ...safe, edge_actor: { id: identity.identity.user, groups: identity.identity.groups } },
+          res.ok ? "ok" : indeterminate ? "human_gate_upstream_unknown" : "upstream_refused",
+        ),
+      };
     } catch (error) {
-      log({ level: "error", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: actorId, method, upstream_path: upstreamPath, after: "UNKNOWN", error: redactSecrets(error instanceof Error ? error.name : "transport_error") });
+      log({ level: "error", msg: "warmbly.human_gate.after", schema_version: HUMAN_GATE_CONTRACT, correlation_id: correlation, actor_id: actorId, operation: route.operation, method, upstream_path: upstreamPath, after: "UNKNOWN", error: redactSecrets(error instanceof Error ? error.name : "transport_error") });
       const code = method === "POST" ? "human_gate_transport_unknown" : "human_gate_read_unavailable";
       const message = method === "POST" ? "write may have been applied; read the resource before retrying" : "read did not complete; no write was attempted";
-      return { status: 503, body: edgeRefusal(correlation, code, message) };
+      // A read that never reached Warmbly changed nothing; a write that timed out
+      // may have. Only the write is UNKNOWN, and it keeps its idempotency key so
+      // the retry is the same request rather than a second one.
+      const outcome: HumanGateOutcome = method === "POST" ? "UNKNOWN" : "REFUSED";
+      return { status: 503, body: edgeRefusal(ctx(route.operation, outcome, key), code, message) };
     } finally { clearTimeout(timer); }
   };
 }

--- a/control-center/connectors/warmbly/src/index.ts
+++ b/control-center/connectors/warmbly/src/index.ts
@@ -47,5 +47,37 @@ export {
  * exported from this connector stays read-only.
  */
 export * from "./operator/index.ts";
-export { HUMAN_GATE_CONTRACT, HUMAN_GATE_PREFIX, createHumanGateHttpHandler } from "./human-gate/http.ts";
+export {
+  HUMAN_GATE_CONTRACT,
+  HUMAN_GATE_PREFIX,
+  HUMAN_GATE_ROUTES,
+  createHumanGateHttpHandler,
+} from "./human-gate/http.ts";
 export type { HumanGateHttpOptions } from "./human-gate/http.ts";
+export {
+  ADJUSTMENT_FIELDS,
+  ADJUST_EDGE_ONLY_FIELDS,
+  ADJUST_ERROR_CODES,
+  ADJUST_REFUSED_FIELDS,
+  ADJUST_REQUEST_FIELDS,
+  ADJUST_RESPONSE_FIELDS,
+  FORBIDDEN_HUMAN_GATE_SEGMENTS,
+  HUMAN_GATE_OPERATIONS,
+  HUMAN_GATE_OUTCOMES,
+  HUMAN_GATE_WRITE_OPERATIONS,
+  UUID_PATTERN_SOURCE,
+  WARMBLY_COHORTS_PREFIX,
+  isCanonicalUuid,
+  validateAdjustRequest,
+} from "./human-gate/contract.ts";
+export type {
+  AdjustErrorCode,
+  AdjustRequest,
+  AdjustRequestField,
+  AdjustValidation,
+  CohortAdjustResponse,
+  CohortAdjustment,
+  CohortAdjustmentDiffEntry,
+  HumanGateOperation,
+  HumanGateOutcome,
+} from "./human-gate/contract.ts";

--- a/control-center/connectors/warmbly/tests/human-gate-adjust-contract.test.ts
+++ b/control-center/connectors/warmbly/tests/human-gate-adjust-contract.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Cross-repo contract pin for the cohort `adjust` operation.
+ *
+ * The canonical contract is `confenge.human-gate.v1`, owned by Warmbly. This
+ * file deliberately does NOT copy Warmbly's schema document into Governance —
+ * a second source of truth is exactly how the two drift while both look green.
+ * Instead it pins the slice this connector actually depends on: the upstream
+ * route it builds, the request fields it puts on the wire, the response fields
+ * it reads back, and the refusal vocabulary it forwards unchanged.
+ *
+ * Change any of those and this test fails, which is the signal to go and agree
+ * the change with the Warmbly side rather than ship a silent divergence.
+ *
+ * When `WARMBLY_REPO` points at a checkout, the pin is additionally cross-checked
+ * against the backend source: the route literal and every request/response field
+ * name must be present there. That reads the authority; it never copies it.
+ */
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  ADJUSTMENT_FIELDS,
+  ADJUST_EDGE_ONLY_FIELDS,
+  ADJUST_ERROR_CODES,
+  ADJUST_REFUSED_FIELDS,
+  ADJUST_REQUEST_FIELDS,
+  ADJUST_RESPONSE_FIELDS,
+  HUMAN_GATE_CONTRACT,
+  HUMAN_GATE_OPERATIONS,
+  HUMAN_GATE_OUTCOMES,
+  HUMAN_GATE_WRITE_OPERATIONS,
+  WARMBLY_COHORTS_PREFIX,
+  validateAdjustRequest,
+} from "../src/human-gate/contract.ts";
+import { HUMAN_GATE_ROUTES } from "../src/human-gate/http.ts";
+
+/** The one route template the backend and this connector must agree on. */
+const ADJUST_UPSTREAM_TEMPLATE = `${WARMBLY_COHORTS_PREFIX}/{id}/candidates/{candidateId}/adjust`;
+
+test("adjust is pinned to the canonical contract by name and version", () => {
+  assert.equal(HUMAN_GATE_CONTRACT, "confenge.human-gate.v1");
+  assert.equal(WARMBLY_COHORTS_PREFIX, "/v1/confenge/cohorts");
+  assert.equal(ADJUST_UPSTREAM_TEMPLATE, "/v1/confenge/cohorts/{id}/candidates/{candidateId}/adjust");
+});
+
+test("adjust is one POST route under the operators role and nothing else", () => {
+  const adjust = HUMAN_GATE_ROUTES.filter((route) => route.operation === "adjust");
+  assert.equal(adjust.length, 1, "adjust must have exactly one route");
+  assert.equal(adjust[0]?.method, "POST");
+  assert.equal(
+    adjust[0]?.role,
+    "operators",
+    "adjust carries the same permission as review, never the admins-only GO permission",
+  );
+  const decision = HUMAN_GATE_ROUTES.find((route) => route.operation === "decision");
+  assert.equal(decision?.role, "admins", "the GO decision stays admins-only");
+  assert.deepEqual(
+    HUMAN_GATE_ROUTES.filter((r) => r.method === "POST").map((r) => r.operation).sort(),
+    [...HUMAN_GATE_WRITE_OPERATIONS].sort(),
+    "the write surface is exactly the six declared operations",
+  );
+  assert.equal(HUMAN_GATE_OPERATIONS.length, 9, "three reads plus six writes; nothing else exists");
+});
+
+test("the adjust request shape is exactly the five contract fields", () => {
+  assert.deepEqual([...ADJUST_REQUEST_FIELDS], [
+    "subject",
+    "body_text",
+    "reason",
+    "confirmation",
+    "expected_frozen_hash",
+  ]);
+  assert.deepEqual([...ADJUST_EDGE_ONLY_FIELDS], ["idempotency_key"]);
+  // No refused field may quietly become an accepted one.
+  for (const field of ADJUST_REFUSED_FIELDS) {
+    assert.ok(
+      !(ADJUST_REQUEST_FIELDS as readonly string[]).includes(field),
+      `${field} must never join the adjust request`,
+    );
+    const verdict = validateAdjustRequest({
+      subject: "s", body_text: "b", reason: "r", confirmation: "v1",
+      expected_frozen_hash: "sha256:x", [field]: "fixture",
+    });
+    assert.equal(verdict.ok, false, `${field} must be refused by the schema itself`);
+    assert.equal(verdict.ok === false && verdict.code, "unexpected_field");
+  }
+  const accepted = validateAdjustRequest({
+    subject: "s", body_text: "b", reason: "r", confirmation: "v1",
+    expected_frozen_hash: "sha256:x", idempotency_key: "idem-contract-0001",
+  });
+  assert.equal(accepted.ok, true);
+  assert.deepEqual(
+    accepted.ok === true ? Object.keys(accepted.value).sort() : [],
+    [...ADJUST_REQUEST_FIELDS].sort(),
+    "the edge-only idempotency key is never forwarded in the body",
+  );
+});
+
+test("the adjust 201 shape is exactly what the connector reads back", () => {
+  assert.deepEqual([...ADJUST_RESPONSE_FIELDS], ["contract_version", "cohort", "adjustment"]);
+  assert.deepEqual([...ADJUSTMENT_FIELDS], [
+    "id",
+    "cohort_id",
+    "from_version",
+    "to_version",
+    "candidate_id",
+    "before_content_hash",
+    "after_content_hash",
+    "before_frozen_hash",
+    "after_frozen_hash",
+    "diff",
+    "revoked_authorization_id",
+    "actor_id",
+    "correlation_id",
+    "receipt",
+    "created_at",
+  ]);
+  // The two fields the cockpit navigates by, and the two it audits by.
+  for (const required of ["to_version", "receipt", "correlation_id", "revoked_authorization_id"]) {
+    assert.ok((ADJUSTMENT_FIELDS as readonly string[]).includes(required));
+  }
+});
+
+test("the adjust refusal vocabulary and its statuses are pinned", () => {
+  assert.deepEqual(ADJUST_ERROR_CODES, {
+    frozen_hash_mismatch: 409,
+    confirmation_mismatch: 409,
+    version_superseded: 409,
+    authority_active: 409,
+    immutable_field: 422,
+    copy_qa_failed: 422,
+    candidate_not_found: 404,
+  });
+  assert.deepEqual([...HUMAN_GATE_OUTCOMES], ["APPLIED", "REFUSED", "UNKNOWN"]);
+});
+
+/** Walk a checkout for source files, so the probe does not hard-code a layout. */
+function sourceText(root: string, limit = 4000): string {
+  const chunks: string[] = [];
+  let seen = 0;
+  const walk = (dir: string): void => {
+    if (seen > limit) return;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (seen > limit) return;
+      if (entry === "node_modules" || entry === ".git" || entry === "vendor") continue;
+      const full = join(dir, entry);
+      let info;
+      try {
+        info = statSync(full);
+      } catch {
+        continue;
+      }
+      if (info.isDirectory()) {
+        walk(full);
+      } else if (/\.(go|ts|json|md|ya?ml|sql)$/.test(entry) && info.size < 2_000_000) {
+        seen += 1;
+        try {
+          chunks.push(readFileSync(full, "utf8"));
+        } catch {
+          /* unreadable file is not a drift signal */
+        }
+      }
+    }
+  };
+  walk(root);
+  return chunks.join("\n");
+}
+
+test("the Warmbly checkout, when present, still declares the adjust route and its fields", (t) => {
+  const repo = process.env.WARMBLY_REPO;
+  if (!repo) {
+    t.skip("WARMBLY_REPO not set; the connector-side pin still guards this repo's half");
+    return;
+  }
+  const text = sourceText(repo);
+  assert.match(text, /cohorts\/[^"'`\s]*candidates\/[^"'`\s]*adjust/, "backend no longer declares the adjust route");
+  for (const field of [...ADJUST_REQUEST_FIELDS, ...ADJUSTMENT_FIELDS]) {
+    assert.ok(text.includes(field), `backend no longer mentions the adjust field "${field}"`);
+  }
+  for (const code of Object.keys(ADJUST_ERROR_CODES)) {
+    assert.ok(text.includes(code), `backend no longer emits the refusal code "${code}"`);
+  }
+});

--- a/control-center/connectors/warmbly/tests/human-gate-adjust.test.ts
+++ b/control-center/connectors/warmbly/tests/human-gate-adjust.test.ts
@@ -1,0 +1,421 @@
+/**
+ * The cohort `adjust` control-plane operation.
+ *
+ * Adjust mints a new immutable cohort version from edited copy and revokes the
+ * authorization bound to the version it supersedes. It is the sixth and only
+ * new member of the fixed human-gate allowlist; everything asserted here is
+ * about keeping it exactly that narrow.
+ *
+ * No real mailbox, token or PII appears in this file. Hosts are `.invalid`,
+ * hashes are obvious fixtures, and copy is neutral Portuguese.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  ADJUST_REFUSED_FIELDS,
+  ADJUST_REQUEST_FIELDS,
+} from "../src/human-gate/contract.ts";
+import { createHumanGateHttpHandler, HUMAN_GATE_PREFIX } from "../src/human-gate/http.ts";
+import { defaultOperatorIdentityPolicy } from "../src/operator/identity.ts";
+
+const hop = "10.89.0.2";
+const TOKEN = "wmbly_fixture_operator_credential";
+const COHORT = "11111111-1111-4111-8111-111111111111";
+const CANDIDATE = "22222222-2222-4222-8222-222222222222";
+const ADJUST_PATH = `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/adjust`;
+const UPSTREAM_PATH = `/v1/confenge/cohorts/${COHORT}/candidates/${CANDIDATE}/adjust`;
+
+function request(method: string, url: string, groups = "operators", body: unknown = {}) {
+  return {
+    method,
+    url,
+    remoteAddress: hop,
+    headers: {
+      "Remote-User": "founder",
+      "Remote-Groups": groups,
+      "Remote-Name": "Founder",
+      "Remote-Email": "founder@confenge.invalid",
+    },
+    body,
+  };
+}
+
+function adjustBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    subject: "Assunto revisado da versao congelada",
+    body_text: "Corpo revisado, sem destinatario e sem link de envio.",
+    reason: "ajuste de copy aprovado em revisao",
+    confirmation: "v3",
+    expected_frozen_hash: "sha256:frozen-fixture-before",
+    idempotency_key: "idem-adjust-000001",
+    ...extra,
+  };
+}
+
+/** A 201 shaped exactly like the canonical contract, with fixture values only. */
+function createdPayload(): Record<string, unknown> {
+  return {
+    contract_version: "confenge.human-gate.v1",
+    cohort: { id: COHORT, version: 4, freshness: "FRESH", candidates: [] },
+    adjustment: {
+      id: "33333333-3333-4333-8333-333333333333",
+      cohort_id: COHORT,
+      from_version: 3,
+      to_version: 4,
+      candidate_id: CANDIDATE,
+      before_content_hash: "sha256:content-before",
+      after_content_hash: "sha256:content-after",
+      before_frozen_hash: "sha256:frozen-fixture-before",
+      after_frozen_hash: "sha256:frozen-fixture-after",
+      diff: [{ field: "subject", before: "antes", after: "depois" }],
+      revoked_authorization_id: "44444444-4444-4444-8444-444444444444",
+      actor_id: "authelia:0000000000000000",
+      correlation_id: "wmbly:adjust:fixture",
+      receipt: "adjust:r1",
+      created_at: "2026-08-23T12:00:00Z",
+    },
+  };
+}
+
+function handlerWith(
+  fetchImpl: typeof fetch,
+  extra: { timeoutMs?: number; logger?: (entry: { level: "info" | "warn" | "error"; msg: string } & Record<string, unknown>) => void } = {},
+) {
+  return createHumanGateHttpHandler({
+    baseUrl: "https://warmbly.invalid",
+    token: TOKEN,
+    identityPolicy: defaultOperatorIdentityPolicy([hop]),
+    fetchImpl,
+    ...extra,
+  });
+}
+
+describe("human gate adjust — the request that reaches Warmbly", () => {
+  it("forwards exactly the canonical fields to the exact upstream route", async () => {
+    let seen: { url?: string; body?: Record<string, unknown>; headers?: Headers; method?: string } = {};
+    const handler = handlerWith(async (input, init) => {
+      seen = {
+        url: String(input),
+        method: init?.method,
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+        headers: new Headers(init?.headers),
+      };
+      return new Response(JSON.stringify(createdPayload()), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const res = await handler(request("POST", ADJUST_PATH, "operators", adjustBody()));
+
+    assert.equal(res.status, 201);
+    assert.equal(seen.method, "POST");
+    assert.equal(seen.url, `https://warmbly.invalid${UPSTREAM_PATH}`);
+    // Exactly the five contract fields — no more, and the edge-only idempotency
+    // key travels as a header rather than in the body.
+    assert.deepEqual(Object.keys(seen.body ?? {}).sort(), [...ADJUST_REQUEST_FIELDS].sort());
+    assert.equal(seen.headers?.get("idempotency-key"), "idem-adjust-000001");
+    assert.match(String(seen.headers?.get("x-correlation-id")), /^cc:human-gate:/);
+  });
+
+  it("runs under the operators role, exactly like review and never like GO", async () => {
+    let hits = 0;
+    const handler = handlerWith(async () => {
+      hits += 1;
+      return new Response(JSON.stringify(createdPayload()), { status: 201 });
+    });
+    // One identity, operators only. Adjust is reachable for it; the cohort GO
+    // decision is not. That difference is the whole RBAC claim.
+    const ok = await handler(request("POST", ADJUST_PATH, "operators", adjustBody()));
+    assert.equal(ok.status, 201, "operators must be sufficient for adjust");
+    assert.equal(hits, 1);
+
+    const denied = await handler(
+      request("POST", `${HUMAN_GATE_PREFIX}/${COHORT}/decision`, "operators", {
+        decision: "GO", reason: "x", confirmation: "v3", idempotency_key: "idem-decide-0002",
+      }),
+    );
+    assert.equal(denied.status, 403);
+    assert.equal(denied.body.code, "insufficient_human_gate_role");
+    assert.equal(denied.body.operation, "decision");
+    assert.equal(hits, 1, "a role refusal must never reach Warmbly");
+  });
+
+  it("refuses an identity whose groups carry no operator group at all", async () => {
+    let hits = 0;
+    const handler = handlerWith(async () => {
+      hits += 1;
+      return new Response("{}");
+    });
+    const res = await handler(request("POST", ADJUST_PATH, "viewers", adjustBody()));
+    assert.equal(res.status, 401, "the identity layer refuses a non-operator group outright");
+    assert.equal(res.body.operation, "adjust");
+    assert.equal(res.body.outcome, "REFUSED");
+    assert.equal(hits, 0);
+  });
+
+  it("refuses an unauthenticated caller before any socket is opened", async () => {
+    let hits = 0;
+    const handler = handlerWith(async () => {
+      hits += 1;
+      return new Response("{}");
+    });
+    const res = await handler({
+      method: "POST",
+      url: ADJUST_PATH,
+      remoteAddress: hop,
+      headers: {},
+      body: adjustBody(),
+    });
+    assert.equal(res.status, 401);
+    assert.equal(hits, 0);
+    assert.equal(res.body.operation, "adjust");
+    assert.equal(res.body.outcome, "REFUSED");
+  });
+});
+
+describe("human gate adjust — the schema refuses, it does not ignore", () => {
+  for (const field of ADJUST_REFUSED_FIELDS) {
+    it(`rejects the extra property "${field}" instead of dropping it`, async () => {
+      let hits = 0;
+      const handler = handlerWith(async () => {
+        hits += 1;
+        return new Response(JSON.stringify(createdPayload()), { status: 201 });
+      });
+      const res = await handler(
+        request("POST", ADJUST_PATH, "operators", adjustBody({ [field]: "fixture" })),
+      );
+      assert.equal(res.status, 422, `${field} must be a refusal, not a silent drop`);
+      assert.equal(res.body.code, "unexpected_field");
+      assert.deepEqual(res.body.rejected_fields, [field]);
+      assert.equal(hits, 0, `${field} must never reach Warmbly`);
+    });
+  }
+
+  it("names every unknown field at once rather than only the first", async () => {
+    let hits = 0;
+    const handler = handlerWith(async () => {
+      hits += 1;
+      return new Response("{}");
+    });
+    const res = await handler(
+      request("POST", ADJUST_PATH, "operators", adjustBody({ mailbox: "x", route_class: "y" })),
+    );
+    assert.equal(res.status, 422);
+    assert.deepEqual(res.body.rejected_fields, ["mailbox", "route_class"]);
+    assert.equal(hits, 0);
+  });
+
+  for (const field of ADJUST_REQUEST_FIELDS) {
+    it(`requires "${field}" to be present and non-empty`, async () => {
+      let hits = 0;
+      const handler = handlerWith(async () => {
+        hits += 1;
+        return new Response("{}");
+      });
+      const body = adjustBody();
+      delete body[field];
+      const res = await handler(request("POST", ADJUST_PATH, "operators", body));
+      assert.equal(res.status, 422);
+      assert.equal(res.body.code, "invalid_adjust_payload");
+      assert.deepEqual(res.body.rejected_fields, [field]);
+      assert.equal(hits, 0);
+    });
+  }
+
+  it("requires a caller-stable idempotency key before it even looks at the copy", async () => {
+    let hits = 0;
+    const handler = handlerWith(async () => {
+      hits += 1;
+      return new Response("{}");
+    });
+    const body = adjustBody();
+    delete body.idempotency_key;
+    const res = await handler(request("POST", ADJUST_PATH, "operators", body));
+    assert.equal(res.status, 400);
+    assert.equal(res.body.code, "idempotency_key_required");
+    assert.equal(hits, 0);
+  });
+});
+
+describe("human gate adjust — response fidelity", () => {
+  it("surfaces receipt, correlation and the new version identity instead of a generic message", async () => {
+    const handler = handlerWith(
+      async () =>
+        new Response(JSON.stringify(createdPayload()), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const res = await handler(request("POST", ADJUST_PATH, "operators", adjustBody()));
+    assert.equal(res.status, 201);
+    assert.equal(res.body.operation, "adjust");
+    assert.equal(res.body.outcome, "APPLIED");
+    // The server's own receipt, not an edge placeholder.
+    assert.equal(res.body.receipt, "adjust:r1");
+    assert.match(String(res.body.edge_correlation_id), /^cc:human-gate:/);
+    // The created resource is navigable: the cockpit can open the new version.
+    assert.deepEqual(res.body.resource, {
+      kind: "cohort",
+      id: COHORT,
+      version: 4,
+      adjustment_id: "33333333-3333-4333-8333-333333333333",
+      from_version: 3,
+      to_version: 4,
+    });
+    // The full new-version cohort payload survives, undiluted.
+    const adjustment = res.body.adjustment as Record<string, unknown>;
+    assert.equal(adjustment.correlation_id, "wmbly:adjust:fixture");
+    assert.equal(adjustment.revoked_authorization_id, "44444444-4444-4444-8444-444444444444");
+    assert.deepEqual(adjustment.diff, [{ field: "subject", before: "antes", after: "depois" }]);
+    assert.deepEqual(res.body.cohort, { id: COHORT, version: 4, freshness: "FRESH", candidates: [] });
+    assert.equal(res.body.auto_send_enabled, false);
+  });
+
+  it("invents nothing when the server returned no resource identity", async () => {
+    const handler = handlerWith(
+      async () => new Response(JSON.stringify({ receipt: "review:r1" }), { status: 200 }),
+    );
+    const res = await handler(
+      request(
+        "POST",
+        `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/review`,
+        "operators",
+        { decision: "APPROVE", reason: "ok", acknowledged: true, idempotency_key: "idem-review-0001" },
+      ),
+    );
+    assert.equal(res.body.operation, "review");
+    assert.equal(res.body.outcome, "APPLIED");
+    assert.equal(res.body.resource, undefined, "an absent identity must stay absent");
+    assert.equal(res.body.receipt, "review:r1");
+  });
+
+  it("labels every one of the six writes with its own operation name", async () => {
+    const handler = handlerWith(async () => new Response(JSON.stringify({ receipt: "r" }), { status: 200 }));
+    const cases: [string, string, Record<string, unknown>, string][] = [
+      ["POST", HUMAN_GATE_PREFIX, { limit: 2, idempotency_key: "idem-create-0001" }, "create"],
+      ["POST", `${HUMAN_GATE_PREFIX}/${COHORT}/reproduce`, { idempotency_key: "idem-repro-0001" }, "reproduce"],
+      ["POST", `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/validation`, { idempotency_key: "idem-valid-0001" }, "validation"],
+      ["POST", `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/review`, { decision: "HOLD", reason: "x", idempotency_key: "idem-review-0002" }, "review"],
+      ["POST", ADJUST_PATH, adjustBody(), "adjust"],
+      ["GET", HUMAN_GATE_PREFIX, {}, "list_cohorts"],
+    ];
+    for (const [method, path, body, operation] of cases) {
+      const res = await handler(request(method, path, "operators", body));
+      assert.equal(res.body.operation, operation, `${method} ${path}`);
+    }
+    const decision = await handler(
+      request("POST", `${HUMAN_GATE_PREFIX}/${COHORT}/decision`, "admins,operators", {
+        decision: "NO_GO", reason: "x", confirmation: "v3", idempotency_key: "idem-decide-0001",
+      }),
+    );
+    assert.equal(decision.body.operation, "decision");
+  });
+
+  it("preserves the server's own refusal codes for every adjust conflict", async () => {
+    for (const [status, code] of [
+      [409, "frozen_hash_mismatch"],
+      [409, "confirmation_mismatch"],
+      [409, "version_superseded"],
+      [409, "authority_active"],
+      [422, "immutable_field"],
+      [422, "copy_qa_failed"],
+      [404, "candidate_not_found"],
+    ] as const) {
+      let hits = 0;
+      const handler = handlerWith(async () => {
+        hits += 1;
+        return new Response(JSON.stringify({ ok: false, code, reason: "fixture refusal" }), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      });
+      const res = await handler(request("POST", ADJUST_PATH, "operators", adjustBody()));
+      assert.equal(res.status, status, code);
+      assert.equal(res.body.code, code);
+      assert.equal(res.body.outcome, "REFUSED", `${code} is a determinate refusal`);
+      assert.equal(res.body.operation, "adjust");
+      assert.equal(hits, 1, `${code} must never be retried by the edge`);
+    }
+  });
+});
+
+describe("human gate adjust — UNKNOWN is never reported as failure", () => {
+  it("reports a write timeout as UNKNOWN, keeps the idempotency key and never retries", async () => {
+    let hits = 0;
+    const handler = handlerWith(async (_input, init) => {
+      hits += 1;
+      await new Promise((_resolve, reject) =>
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted"))),
+      );
+      return new Response("{}");
+    }, { timeoutMs: 1 });
+    const res = await handler(request("POST", ADJUST_PATH, "operators", adjustBody()));
+    assert.equal(res.status, 503);
+    assert.equal(res.body.code, "human_gate_transport_unknown");
+    assert.equal(res.body.outcome, "UNKNOWN", "a timed-out write is indeterminate, not failed");
+    assert.equal(res.body.operation, "adjust");
+    // Retrying with the same key is safe; losing the key is what makes a retry
+    // a second adjustment.
+    assert.equal(res.body.idempotency_key, "idem-adjust-000001");
+    assert.equal(hits, 1);
+  });
+
+  for (const status of [500, 502, 503, 504] as const) {
+    it(`reports upstream ${status} on a write as UNKNOWN, not as a refusal`, async () => {
+      let hits = 0;
+      const handler = handlerWith(async () => {
+        hits += 1;
+        return new Response(JSON.stringify({ ok: false, code: "internal_error" }), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      });
+      const res = await handler(request("POST", ADJUST_PATH, "operators", adjustBody()));
+      assert.equal(res.status, status);
+      assert.equal(res.body.outcome, "UNKNOWN");
+      assert.equal(res.body.code, "internal_error", "the server's code is preserved verbatim");
+      assert.equal(res.body.idempotency_key, "idem-adjust-000001");
+      assert.equal(hits, 1, "the edge must never retry an indeterminate write");
+    });
+  }
+
+  it("keeps a 5xx read a refusal, because a read that failed changed nothing", async () => {
+    const handler = handlerWith(
+      async () => new Response(JSON.stringify({ ok: false, code: "internal_error" }), { status: 500 }),
+    );
+    const res = await handler(request("GET", HUMAN_GATE_PREFIX));
+    assert.equal(res.body.outcome, "REFUSED");
+    assert.equal(res.body.idempotency_key, undefined);
+  });
+
+  it("keeps a timed-out read a refusal and says no write was attempted", async () => {
+    const handler = handlerWith(async (_input, init) => {
+      await new Promise((_resolve, reject) =>
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted"))),
+      );
+      return new Response("{}");
+    }, { timeoutMs: 1 });
+    const res = await handler(request("GET", HUMAN_GATE_PREFIX));
+    assert.equal(res.status, 503);
+    assert.equal(res.body.code, "human_gate_read_unavailable");
+    assert.equal(res.body.outcome, "REFUSED");
+  });
+
+  it("logs the adjust actor opaquely and leaks no identity into the log stream", async () => {
+    const logs: unknown[] = [];
+    const handler = handlerWith(
+      async () => new Response(JSON.stringify(createdPayload()), { status: 201 }),
+      { logger: (entry) => { logs.push(entry); } },
+    );
+    const res = await handler(request("POST", ADJUST_PATH, "operators", adjustBody()));
+    assert.equal(res.status, 201);
+    const serialized = JSON.stringify(logs);
+    assert.match(serialized, /authelia:[a-f0-9]{16}/);
+    assert.match(serialized, /"operation":"adjust"/);
+    assert.doesNotMatch(serialized, /founder|@confenge\.invalid|Remote-/i);
+    assert.doesNotMatch(serialized, new RegExp(TOKEN));
+    // Neither the edited copy nor the frozen hash belongs in a log line.
+    assert.doesNotMatch(serialized, /Assunto revisado|Corpo revisado/);
+  });
+});

--- a/control-center/connectors/warmbly/tests/human-gate-negative-allowlist.test.ts
+++ b/control-center/connectors/warmbly/tests/human-gate-negative-allowlist.test.ts
@@ -1,0 +1,247 @@
+/**
+ * What the human gate must never be able to construct.
+ *
+ * The load-bearing property of this connector is negative: there is no generic
+ * proxy route, and no route that can send, dispatch, queue, resume, auto-send or
+ * charge. Adding `adjust` is the first widening of this surface in a while, so
+ * these tests hold the boundary from the outside — by enumerating the routes an
+ * attacker would want and proving each one is unreachable, at every prefix and
+ * through every coercion that has worked on fixed-route proxies before.
+ *
+ * Every assertion also checks that `fetch` was never called: a 404 that still
+ * touched Warmbly would not be a refusal.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  FORBIDDEN_HUMAN_GATE_SEGMENTS,
+  HUMAN_GATE_OPERATIONS,
+  isCanonicalUuid,
+} from "../src/human-gate/contract.ts";
+import {
+  createHumanGateHttpHandler,
+  HUMAN_GATE_PREFIX,
+  HUMAN_GATE_ROUTES,
+} from "../src/human-gate/http.ts";
+import { defaultOperatorIdentityPolicy } from "../src/operator/identity.ts";
+
+const hop = "10.89.0.2";
+const COHORT = "11111111-1111-4111-8111-111111111111";
+const CANDIDATE = "22222222-2222-4222-8222-222222222222";
+
+function request(method: string, url: string, groups = "admins,operators", body: unknown = {}) {
+  return {
+    method,
+    url,
+    remoteAddress: hop,
+    headers: {
+      "Remote-User": "founder",
+      "Remote-Groups": groups,
+      "Remote-Name": "Founder",
+      "Remote-Email": "founder@confenge.invalid",
+    },
+    body,
+  };
+}
+
+/** A handler that records every upstream attempt, so "refused" can be proven. */
+function trap() {
+  const attempts: string[] = [];
+  const handler = createHumanGateHttpHandler({
+    baseUrl: "https://warmbly.invalid",
+    token: "wmbly_fixture_operator_credential",
+    identityPolicy: defaultOperatorIdentityPolicy([hop]),
+    fetchImpl: async (input) => {
+      attempts.push(String(input));
+      return new Response(JSON.stringify({ receipt: "should-never-happen" }), { status: 200 });
+    },
+  });
+  return { attempts, handler };
+}
+
+const WRITE_BODY = {
+  idempotency_key: "idem-negative-0001",
+  reason: "fixture",
+  confirmation: "v3",
+  subject: "s",
+  body_text: "b",
+  expected_frozen_hash: "sha256:x",
+};
+
+describe("the human gate cannot construct an outbound-send route", () => {
+  for (const segment of FORBIDDEN_HUMAN_GATE_SEGMENTS) {
+    it(`refuses every shape of "${segment}"`, async () => {
+      const { attempts, handler } = trap();
+      const shapes = [
+        `${HUMAN_GATE_PREFIX}/${segment}`,
+        `${HUMAN_GATE_PREFIX}/${COHORT}/${segment}`,
+        `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/${segment}`,
+        `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/adjust/${segment}`,
+        `${HUMAN_GATE_PREFIX}/${COHORT}/${segment}/candidates/${CANDIDATE}/adjust`,
+        `/v1/warmbly/operator/${segment}`,
+        `/v1/confenge/${segment}`,
+      ];
+      for (const shape of shapes) {
+        for (const method of ["POST", "GET", "PUT", "PATCH", "DELETE"]) {
+          const res = await handler(request(method, shape, "admins,operators", WRITE_BODY));
+          assert.equal(res.status, 404, `${method} ${shape} must be outside the allowlist`);
+          assert.equal(res.body.code, "human_gate_route_not_allowed");
+        }
+      }
+      assert.deepEqual(attempts, [], `"${segment}" must never reach Warmbly`);
+    });
+  }
+
+  it("has no generic proxy route: an arbitrary path is refused, not forwarded", async () => {
+    const { attempts, handler } = trap();
+    const arbitrary = [
+      `${HUMAN_GATE_PREFIX}/anything`,
+      `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/anything`,
+      "/v1/warmbly/operator/cohorts-proxy",
+      "/v1/warmbly/operator/cohortsx",
+      "/",
+      "",
+      `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/adjust/confirm`,
+    ];
+    for (const path of arbitrary) {
+      const res = await handler(request("POST", path, "admins,operators", WRITE_BODY));
+      assert.equal(res.status, 404, path);
+    }
+    assert.deepEqual(attempts, []);
+  });
+
+  it("exposes no operation name outside the fixed vocabulary", () => {
+    const declared = HUMAN_GATE_ROUTES.map((route) => route.operation);
+    for (const operation of declared) {
+      assert.ok(
+        (HUMAN_GATE_OPERATIONS as readonly string[]).includes(operation),
+        `${operation} is not a declared human-gate operation`,
+      );
+    }
+    for (const forbidden of FORBIDDEN_HUMAN_GATE_SEGMENTS) {
+      assert.ok(
+        !(HUMAN_GATE_OPERATIONS as readonly string[]).includes(forbidden),
+        `${forbidden} must never become an operation`,
+      );
+    }
+    // Exactly the five pre-existing writes plus adjust, plus three reads.
+    assert.deepEqual([...declared].sort(), [
+      "adjust", "create", "decision", "list_cohorts", "read_candidate",
+      "read_cohort", "reproduce", "review", "validation",
+    ]);
+  });
+});
+
+describe("adjust cannot be coerced into another route by its identifiers", () => {
+  it("refuses a cohort id that tries to traverse out of the cohort route", async () => {
+    const { attempts, handler } = trap();
+    const hostile = [
+      "..",
+      "../..",
+      "../dispatch",
+      `${COHORT}/../dispatch`,
+      `..%2Fdispatch`,
+      "%2e%2e%2fdispatch",
+      "%2E%2E/queue",
+      `${COHORT}%2F..%2Fsend`,
+      "https:%2F%2Fevil.invalid%2Fv1%2Fconfenge%2Fsend",
+      "..\\dispatch",
+    ];
+    for (const id of hostile) {
+      for (const path of [
+        `${HUMAN_GATE_PREFIX}/${id}/candidates/${CANDIDATE}/adjust`,
+        `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${id}/adjust`,
+      ]) {
+        const res = await handler(request("POST", path, "admins,operators", WRITE_BODY));
+        assert.equal(res.status, 404, `${path} must not match any allowlisted route`);
+      }
+    }
+    assert.deepEqual(attempts, [], "a hostile identifier must never reach Warmbly");
+  });
+
+  it("refuses an absolute URL smuggled in as an identifier", async () => {
+    const { attempts, handler } = trap();
+    for (const id of [
+      "https://evil.invalid",
+      "http://169.254.169.254/latest/meta-data",
+      "//evil.invalid",
+      "https%3A%2F%2Fevil.invalid",
+    ]) {
+      const res = await handler(
+        request("POST", `${HUMAN_GATE_PREFIX}/${id}/candidates/${CANDIDATE}/adjust`, "admins,operators", WRITE_BODY),
+      );
+      assert.equal(res.status, 404, id);
+    }
+    assert.deepEqual(attempts, []);
+  });
+
+  it("ignores an attacker-chosen host on the request line and always uses the configured base", async () => {
+    const { attempts, handler } = trap();
+    const res = await handler(
+      request(
+        "POST",
+        `https://evil.invalid${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/adjust`,
+        "admins,operators",
+        WRITE_BODY,
+      ),
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(attempts, [
+      `https://warmbly.invalid/v1/confenge/cohorts/${COHORT}/candidates/${CANDIDATE}/adjust`,
+    ]);
+  });
+
+  it("validates identifiers as canonical UUIDs before any URL is built", async () => {
+    const { attempts, handler } = trap();
+    const notUuids = [
+      "-".repeat(36),
+      "1111111111114111811111111111111z",
+      "11111111-1111-4111-8111-11111111111",
+      "11111111-1111-4111-8111-1111111111111",
+      "11111111111141118111111111111111",
+      "11111111-1111-4111-8111-111111111111 ",
+      "*",
+      "%00",
+    ];
+    for (const id of notUuids) {
+      assert.equal(isCanonicalUuid(id), false, `${JSON.stringify(id)} is not a canonical UUID`);
+      const res = await handler(
+        request("POST", `${HUMAN_GATE_PREFIX}/${id}/candidates/${CANDIDATE}/adjust`, "admins,operators", WRITE_BODY),
+      );
+      assert.equal(res.status, 404, JSON.stringify(id));
+    }
+    assert.deepEqual(attempts, []);
+    // The previous pattern, `[0-9a-fA-F-]{36}`, matched 36 hyphens. Pinned so a
+    // loosening of the identifier pattern is a visible regression.
+    assert.equal(/^[0-9a-fA-F-]{36}$/.test("-".repeat(36)), true);
+    assert.equal(isCanonicalUuid("11111111-1111-4111-8111-111111111111"), true);
+  });
+
+  it("refuses every method on adjust except POST", async () => {
+    const { attempts, handler } = trap();
+    const path = `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/adjust`;
+    for (const method of ["GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]) {
+      const res = await handler(request(method, path, "admins,operators", WRITE_BODY));
+      assert.equal(res.status, 404, method);
+    }
+    assert.deepEqual(attempts, []);
+  });
+
+  it("does not let a query string move the write to another upstream route", async () => {
+    const { attempts, handler } = trap();
+    const res = await handler(
+      request(
+        "POST",
+        `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/adjust?redirect=/v1/confenge/dispatch/send`,
+        "admins,operators",
+        WRITE_BODY,
+      ),
+    );
+    assert.equal(res.status, 200);
+    // The query is dropped on writes: only GET carries `url.search` upstream.
+    assert.deepEqual(attempts, [
+      `https://warmbly.invalid/v1/confenge/cohorts/${COHORT}/candidates/${CANDIDATE}/adjust`,
+    ]);
+  });
+});

--- a/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
+++ b/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
@@ -188,8 +188,21 @@ services:
     build:
       context: ../../..
       dockerfile: services/context/Dockerfile
-    image: confenge-control-center-context:local
+      # Stamp the release onto the image itself. A ":local" tag is reusable and
+      # says nothing about its contents, so "health 200" could never prove which
+      # code was running. The default stays "local" because compose interpolates
+      # this file on every command, and a required variable here would block an
+      # operator running `docker compose ps` or an emergency restart. The release
+      # is enforced instead by verify-release.sh, which refuses a container whose
+      # label does not match the deployed repository SHA.
+      labels:
+        org.opencontainers.image.revision: "${CC_RELEASE_SHA:-local}"
+        org.opencontainers.image.version: "${CC_RELEASE_SHA:-local}"
+        org.opencontainers.image.source: "https://github.com/tjsasakifln/Governance"
+        br.com.confenge.service: "context"
+    image: confenge-control-center-context:${CC_RELEASE_SHA:-local}
     environment:
+      CC_RELEASE_SHA: "${CC_RELEASE_SHA:-local}"
       HOST: 0.0.0.0
       PORT: "8080"
       NODE_ENV: production
@@ -223,7 +236,19 @@ services:
     build:
       context: ../../..
       dockerfile: services/mcp/Dockerfile
-    image: confenge-control-center-mcp:local
+      # Stamp the release onto the image itself. A ":local" tag is reusable and
+      # says nothing about its contents, so "health 200" could never prove which
+      # code was running. The default stays "local" because compose interpolates
+      # this file on every command, and a required variable here would block an
+      # operator running `docker compose ps` or an emergency restart. The release
+      # is enforced instead by verify-release.sh, which refuses a container whose
+      # label does not match the deployed repository SHA.
+      labels:
+        org.opencontainers.image.revision: "${CC_RELEASE_SHA:-local}"
+        org.opencontainers.image.version: "${CC_RELEASE_SHA:-local}"
+        org.opencontainers.image.source: "https://github.com/tjsasakifln/Governance"
+        br.com.confenge.service: "mcp"
+    image: confenge-control-center-mcp:${CC_RELEASE_SHA:-local}
     environment:
       HOST: 0.0.0.0
       CONFENGE_MCP_HTTP_HOST: 0.0.0.0
@@ -249,7 +274,19 @@ services:
     build:
       context: ../../..
       dockerfile: connectors/runner/Dockerfile
-    image: confenge-control-center-collector:local
+      # Stamp the release onto the image itself. A ":local" tag is reusable and
+      # says nothing about its contents, so "health 200" could never prove which
+      # code was running. The default stays "local" because compose interpolates
+      # this file on every command, and a required variable here would block an
+      # operator running `docker compose ps` or an emergency restart. The release
+      # is enforced instead by verify-release.sh, which refuses a container whose
+      # label does not match the deployed repository SHA.
+      labels:
+        org.opencontainers.image.revision: "${CC_RELEASE_SHA:-local}"
+        org.opencontainers.image.version: "${CC_RELEASE_SHA:-local}"
+        org.opencontainers.image.source: "https://github.com/tjsasakifln/Governance"
+        br.com.confenge.service: "collector"
+    image: confenge-control-center-collector:${CC_RELEASE_SHA:-local}
     environment:
       HOST: 0.0.0.0
       PORT: "8080"
@@ -274,8 +311,21 @@ services:
     build:
       context: ../../..
       dockerfile: apps/web-shell/Dockerfile
-    image: confenge-control-center-web:local
+      # Stamp the release onto the image itself. A ":local" tag is reusable and
+      # says nothing about its contents, so "health 200" could never prove which
+      # code was running. The default stays "local" because compose interpolates
+      # this file on every command, and a required variable here would block an
+      # operator running `docker compose ps` or an emergency restart. The release
+      # is enforced instead by verify-release.sh, which refuses a container whose
+      # label does not match the deployed repository SHA.
+      labels:
+        org.opencontainers.image.revision: "${CC_RELEASE_SHA:-local}"
+        org.opencontainers.image.version: "${CC_RELEASE_SHA:-local}"
+        org.opencontainers.image.source: "https://github.com/tjsasakifln/Governance"
+        br.com.confenge.service: "web"
+    image: confenge-control-center-web:${CC_RELEASE_SHA:-local}
     environment:
+      CC_RELEASE_SHA: "${CC_RELEASE_SHA:-local}"
       HOST: 0.0.0.0
       PORT: "8080"
       CC_TRUSTED_PROXY_CIDRS: "${CC_TRUSTED_PROXY_CIDRS:?CC_TRUSTED_PROXY_CIDRS must be set}"

--- a/control-center/deploy/overlays/production-edge/verify-release.sh
+++ b/control-center/deploy/overlays/production-edge/verify-release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Reconcile repository SHA -> image digest -> running container for the
+# control-center services. "Health 200" only proves a process answered; it
+# says nothing about which code answered. This script is the acceptance gate.
+#
+# Usage: verify-release.sh <expected-sha> [service...]
+set -euo pipefail
+
+EXPECTED="${1:?usage: verify-release.sh <expected-sha> [service...]}"
+shift || true
+SERVICES=("$@")
+if [ ${#SERVICES[@]} -eq 0 ]; then
+  SERVICES=(web context)
+fi
+
+fail=0
+for svc in "${SERVICES[@]}"; do
+  container="confenge-control-center-${svc}-1"
+  if ! docker inspect "$container" >/dev/null 2>&1; then
+    echo "FAIL ${svc}: container ${container} not found"
+    fail=1
+    continue
+  fi
+
+  image_ref=$(docker inspect "$container" --format '{{.Config.Image}}')
+  image_id=$(docker inspect "$container" --format '{{.Image}}')
+  label=$(docker inspect "$image_id" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || echo "")
+  envsha=$(docker inspect "$container" --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^CC_RELEASE_SHA=//p' | head -1)
+  running=$(docker inspect "$container" --format '{{.State.Running}}')
+
+  echo "--- ${svc}"
+  echo "    container   : ${container} (running=${running})"
+  echo "    image ref   : ${image_ref}"
+  echo "    image id    : ${image_id}"
+  echo "    image label : ${label:-<none>}"
+  echo "    runtime env : ${envsha:-<none>}"
+
+  if [ "$running" != "true" ]; then
+    echo "    -> FAIL: container is not running"
+    fail=1
+    continue
+  fi
+  if [ -z "$label" ] || [ "$label" = "local" ] || [ "$label" = "unknown" ]; then
+    echo "    -> FAIL: image carries no release revision label; it cannot be proven"
+    fail=1
+    continue
+  fi
+  # Accept a short SHA prefix so a 12-character tag reconciles with a full SHA.
+  case "$EXPECTED" in
+    "$label"*) ;;
+    *) echo "    -> FAIL: image label ${label} does not match expected ${EXPECTED}"; fail=1; continue ;;
+  esac
+  if [ -n "$envsha" ]; then
+    case "$EXPECTED" in
+      "$envsha"*) ;;
+      *) echo "    -> FAIL: runtime CC_RELEASE_SHA ${envsha} does not match expected ${EXPECTED}"; fail=1; continue ;;
+    esac
+  fi
+  echo "    -> OK: repo ${EXPECTED} reconciles with image label and runtime"
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "RELEASE VERIFICATION FAILED - do not treat this deploy as done"
+  exit 1
+fi
+echo
+echo "RELEASE VERIFICATION PASSED for ${EXPECTED}"

--- a/control-center/services/context/test/warmbly-human-gate-adjust-mount.test.ts
+++ b/control-center/services/context/test/warmbly-human-gate-adjust-mount.test.ts
@@ -1,0 +1,402 @@
+/**
+ * The cohort `adjust` operation as actually mounted by the Context Service.
+ *
+ * Everything here runs the real `createRequestListener` over a real socket with
+ * the real `createWarmblyOperatorHandlerFromEnv` wiring, against a stub Warmbly
+ * on loopback. Unit tests in the connector prove the route is narrow; this file
+ * proves the deployment does not widen it — same `CC_WARMBLY_OPERATOR_ENABLED`
+ * gate, same narrowed trusted hop, same Authelia-only actor, and a 404 rather
+ * than a half-mount when the channel is off.
+ *
+ * The credential is an obvious fixture string in a temp file; no real secret,
+ * mailbox or PII appears anywhere in this file.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { createRequestListener } from "../src/http.ts";
+import { silentLogger } from "../src/log.ts";
+import { createWarmblyOperatorHandlerFromEnv } from "../src/warmbly-operator/from-env.ts";
+import { makeService } from "./helpers.ts";
+
+const FIXTURE_CREDENTIAL = "wmbly_fixture_operator_credential_0001";
+const COHORT = "11111111-1111-4111-8111-111111111111";
+const CANDIDATE = "22222222-2222-4222-8222-222222222222";
+const ADJUST = `/v1/warmbly/operator/cohorts/${COHORT}/candidates/${CANDIDATE}/adjust`;
+const PAUSE = "/v1/warmbly/operator/dispatch/pause";
+const LOOPBACK_HOPS = "127.0.0.1,::1,::ffff:127.0.0.1";
+
+const AUTHELIA = {
+  "Remote-User": "founder",
+  "Remote-Groups": "operators",
+  "Remote-Name": "Founder Confenge",
+  "Remote-Email": "founder@confenge.invalid",
+};
+
+function adjustBody(extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    subject: "Assunto revisado da versao congelada",
+    body_text: "Corpo revisado, sem destinatario.",
+    reason: "ajuste de copy aprovado em revisao",
+    confirmation: "v3",
+    expected_frozen_hash: "sha256:frozen-fixture-before",
+    idempotency_key: "idem-adjust-mount-01",
+    ...extra,
+  });
+}
+
+interface UpstreamHit {
+  method: string | undefined;
+  url: string | undefined;
+  authorization: string | undefined;
+  idempotencyKey: string | undefined;
+  body: string;
+}
+
+/** A stub Warmbly on loopback that records what the edge actually sent. */
+async function stubWarmbly(): Promise<{ base: string; hits: UpstreamHit[]; close: () => Promise<void> }> {
+  const hits: UpstreamHit[] = [];
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      hits.push({
+        method: req.method,
+        url: req.url,
+        authorization: req.headers.authorization as string | undefined,
+        idempotencyKey: req.headers["idempotency-key"] as string | undefined,
+        body: Buffer.concat(chunks).toString("utf8"),
+      });
+      res.writeHead(201, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          contract_version: "confenge.human-gate.v1",
+          cohort: { id: COHORT, version: 4 },
+          adjustment: {
+            id: "33333333-3333-4333-8333-333333333333",
+            cohort_id: COHORT,
+            from_version: 3,
+            to_version: 4,
+            candidate_id: CANDIDATE,
+            before_content_hash: "sha256:content-before",
+            after_content_hash: "sha256:content-after",
+            before_frozen_hash: "sha256:frozen-fixture-before",
+            after_frozen_hash: "sha256:frozen-fixture-after",
+            diff: [{ field: "subject", before: "antes", after: "depois" }],
+            revoked_authorization_id: "44444444-4444-4444-8444-444444444444",
+            actor_id: "authelia:0000000000000000",
+            correlation_id: "wmbly:adjust:fixture",
+            receipt: "adjust:r1",
+            created_at: "2026-08-23T12:00:00Z",
+          },
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object");
+  return {
+    base: `http://127.0.0.1:${addr.port}`,
+    hits,
+    close: () => new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve()))),
+  };
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object");
+  return `http://127.0.0.1:${addr.port}`;
+}
+
+/**
+ * Boots the Context Service with the operator channel wired from `env` exactly
+ * as production does — no injected fetch, no injected handler.
+ */
+async function withContext(
+  env: NodeJS.ProcessEnv,
+  fn: (base: string, wired: boolean) => Promise<void>,
+): Promise<void> {
+  const { service } = makeService();
+  const handler = await createWarmblyOperatorHandlerFromEnv(env, { logger: silentLogger });
+  const server = createServer(
+    createRequestListener({
+      service,
+      logger: silentLogger,
+      ...(handler ? { warmblyOperator: handler } : {}),
+    }),
+  );
+  const base = await listen(server);
+  try {
+    await fn(base, handler !== undefined);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+  }
+}
+
+function credentialFile(): { dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), "cc-adjust-mount-"));
+  const path = join(dir, "warmbly_operator_credential");
+  writeFileSync(path, `${FIXTURE_CREDENTIAL}\n`, { mode: 0o600 });
+  return { dir, path };
+}
+
+/** Writes a request line verbatim, without the client-side URL normalisation. */
+async function rawPost(base: string, path: string): Promise<string> {
+  const { port } = new URL(base);
+  const body = adjustBody();
+  return await new Promise<string>((resolve, reject) => {
+    const socket = connect(Number(port), "127.0.0.1", () => {
+      socket.write(
+        `POST ${path} HTTP/1.1\r\n`
+          + `Host: 127.0.0.1:${port}\r\n`
+          + `Content-Type: application/json\r\n`
+          + Object.entries(AUTHELIA).map(([k, v]) => `${k}: ${v}\r\n`).join("")
+          + `Content-Length: ${Buffer.byteLength(body)}\r\n`
+          + `Connection: close\r\n\r\n`
+          + body,
+      );
+    });
+    const chunks: Buffer[] = [];
+    socket.on("data", (c: Buffer) => chunks.push(c));
+    socket.on("error", reject);
+    socket.on("close", () => resolve(Buffer.concat(chunks).toString("utf8")));
+  });
+}
+
+test("adjust 404s exactly like the other operator routes when the channel is disabled", async () => {
+  const upstream = await stubWarmbly();
+  const { dir, path } = credentialFile();
+  try {
+    for (const enabled of [undefined, "false", "TRUE", "1"]) {
+      await withContext(
+        {
+          ...(enabled === undefined ? {} : { CC_WARMBLY_OPERATOR_ENABLED: enabled }),
+          CC_WARMBLY_BASE_URL: upstream.base,
+          CC_WARMBLY_OPERATOR_TOKEN_FILE: path,
+          CC_WARMBLY_OPERATOR_TRUSTED_HOPS: LOOPBACK_HOPS,
+        } as NodeJS.ProcessEnv,
+        async (base, wired) => {
+          assert.equal(wired, false, `CC_WARMBLY_OPERATOR_ENABLED=${enabled} must not wire the channel`);
+          for (const route of [ADJUST, PAUSE]) {
+            const res = await fetch(`${base}${route}`, {
+              method: "POST",
+              headers: { "content-type": "application/json", ...AUTHELIA },
+              body: adjustBody(),
+            });
+            assert.equal(res.status, 404, route);
+            const body = (await res.json()) as { code?: string };
+            assert.equal(body.code, "operator_channel_not_configured");
+          }
+        },
+      );
+    }
+    assert.deepEqual(upstream.hits, [], "a disabled channel must never reach Warmbly");
+  } finally {
+    await upstream.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("adjust stays unmounted when the narrowed trusted hop is missing or the credential is unreadable", async () => {
+  const upstream = await stubWarmbly();
+  const { dir, path } = credentialFile();
+  try {
+    const broken: [string, NodeJS.ProcessEnv][] = [
+      ["no trusted hop", { CC_WARMBLY_OPERATOR_ENABLED: "true", CC_WARMBLY_BASE_URL: upstream.base, CC_WARMBLY_OPERATOR_TOKEN_FILE: path }],
+      ["empty trusted hop list", { CC_WARMBLY_OPERATOR_ENABLED: "true", CC_WARMBLY_BASE_URL: upstream.base, CC_WARMBLY_OPERATOR_TOKEN_FILE: path, CC_WARMBLY_OPERATOR_TRUSTED_HOPS: " , " }],
+      ["no base url", { CC_WARMBLY_OPERATOR_ENABLED: "true", CC_WARMBLY_OPERATOR_TOKEN_FILE: path, CC_WARMBLY_OPERATOR_TRUSTED_HOPS: LOOPBACK_HOPS }],
+      ["unreadable credential", { CC_WARMBLY_OPERATOR_ENABLED: "true", CC_WARMBLY_BASE_URL: upstream.base, CC_WARMBLY_OPERATOR_TOKEN_FILE: join(dir, "absent"), CC_WARMBLY_OPERATOR_TRUSTED_HOPS: LOOPBACK_HOPS }],
+    ];
+    for (const [label, env] of broken) {
+      await withContext(env, async (base, wired) => {
+        assert.equal(wired, false, label);
+        const res = await fetch(`${base}${ADJUST}`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...AUTHELIA },
+          body: adjustBody(),
+        });
+        assert.equal(res.status, 404, label);
+      });
+    }
+    assert.deepEqual(upstream.hits, [], "a misconfigured channel must never reach Warmbly");
+  } finally {
+    await upstream.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the mounted adjust route carries the file-backed credential and the idempotency key upstream", async () => {
+  const upstream = await stubWarmbly();
+  const { dir, path } = credentialFile();
+  try {
+    await withContext(
+      {
+        CC_WARMBLY_OPERATOR_ENABLED: "true",
+        CC_WARMBLY_BASE_URL: upstream.base,
+        CC_WARMBLY_OPERATOR_TOKEN_FILE: path,
+        CC_WARMBLY_OPERATOR_TRUSTED_HOPS: LOOPBACK_HOPS,
+      },
+      async (base, wired) => {
+        assert.equal(wired, true);
+        const res = await fetch(`${base}${ADJUST}`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...AUTHELIA },
+          body: adjustBody(),
+        });
+        assert.equal(res.status, 201);
+        const body = (await res.json()) as Record<string, unknown>;
+        assert.equal(body.operation, "adjust");
+        assert.equal(body.outcome, "APPLIED");
+        assert.equal(body.receipt, "adjust:r1");
+        assert.deepEqual(body.resource, {
+          kind: "cohort",
+          id: COHORT,
+          version: 4,
+          adjustment_id: "33333333-3333-4333-8333-333333333333",
+          from_version: 3,
+          to_version: 4,
+        });
+        assert.equal(body.auto_send_enabled, false);
+      },
+    );
+    assert.equal(upstream.hits.length, 1);
+    const hit = upstream.hits[0]!;
+    assert.equal(hit.method, "POST");
+    assert.equal(hit.url, `/v1/confenge/cohorts/${COHORT}/candidates/${CANDIDATE}/adjust`);
+    assert.equal(hit.authorization, `Bearer ${FIXTURE_CREDENTIAL}`);
+    assert.equal(hit.idempotencyKey, "idem-adjust-mount-01");
+    // The edge-only idempotency key is not duplicated into the forwarded body.
+    assert.deepEqual(Object.keys(JSON.parse(hit.body) as Record<string, unknown>).sort(), [
+      "body_text", "confirmation", "expected_frozen_hash", "reason", "subject",
+    ]);
+  } finally {
+    await upstream.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("adjust accepts no client-settable actor and no identity from an untrusted hop", async () => {
+  const upstream = await stubWarmbly();
+  const { dir, path } = credentialFile();
+  try {
+    // Same narrowed hop production uses. The loopback test client is not it.
+    await withContext(
+      {
+        CC_WARMBLY_OPERATOR_ENABLED: "true",
+        CC_WARMBLY_BASE_URL: upstream.base,
+        CC_WARMBLY_OPERATOR_TOKEN_FILE: path,
+        CC_WARMBLY_OPERATOR_TRUSTED_HOPS: "10.89.0.2/32",
+      },
+      async (base, wired) => {
+        assert.equal(wired, true);
+        const res = await fetch(`${base}${ADJUST}`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...AUTHELIA },
+          body: adjustBody(),
+        });
+        assert.equal(res.status, 401, "Remote-* from an untrusted peer must not authenticate a write");
+      },
+    );
+
+    await withContext(
+      {
+        CC_WARMBLY_OPERATOR_ENABLED: "true",
+        CC_WARMBLY_BASE_URL: upstream.base,
+        CC_WARMBLY_OPERATOR_TOKEN_FILE: path,
+        CC_WARMBLY_OPERATOR_TRUSTED_HOPS: LOOPBACK_HOPS,
+      },
+      async (base) => {
+        // No Remote-* at all: the client-settable actor headers this service uses
+        // elsewhere must not stand in for Authelia here.
+        const forged = await fetch(`${base}${ADJUST}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-actor-id": "founder",
+            "x-actor-kind": "human",
+          },
+          body: adjustBody(),
+        });
+        assert.equal(forged.status, 401);
+        const body = (await forged.json()) as Record<string, unknown>;
+        assert.equal(body.operation, "adjust");
+        assert.equal(body.outcome, "REFUSED");
+
+        // A cross-origin form POST is CORS-simple; requiring JSON is what stops it.
+        const formish = await fetch(`${base}${ADJUST}`, {
+          method: "POST",
+          headers: { "content-type": "text/plain", ...AUTHELIA },
+          body: adjustBody(),
+        });
+        assert.equal(formish.status, 415);
+      },
+    );
+    assert.deepEqual(upstream.hits, [], "no unauthenticated adjust may reach Warmbly");
+  } finally {
+    await upstream.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the mount adds no send, dispatch or queue cohort route alongside adjust", async () => {
+  const upstream = await stubWarmbly();
+  const { dir, path } = credentialFile();
+  try {
+    await withContext(
+      {
+        CC_WARMBLY_OPERATOR_ENABLED: "true",
+        CC_WARMBLY_BASE_URL: upstream.base,
+        CC_WARMBLY_OPERATOR_TOKEN_FILE: path,
+        CC_WARMBLY_OPERATOR_TRUSTED_HOPS: LOOPBACK_HOPS,
+      },
+      async (base) => {
+        const hostile = [
+          `/v1/warmbly/operator/cohorts/${COHORT}/send`,
+          `/v1/warmbly/operator/cohorts/${COHORT}/dispatch`,
+          `/v1/warmbly/operator/cohorts/${COHORT}/queue`,
+          `/v1/warmbly/operator/cohorts/${COHORT}/candidates/${CANDIDATE}/send`,
+          `/v1/warmbly/operator/cohorts/${COHORT}/candidates/${CANDIDATE}/adjust/send`,
+        ];
+        for (const route of hostile) {
+          const res = await fetch(`${base}${route}`, {
+            method: "POST",
+            headers: { "content-type": "application/json", ...AUTHELIA },
+            body: adjustBody(),
+          });
+          assert.ok(res.status === 404, `${route} answered ${res.status}`);
+          await res.text();
+        }
+
+        // `fetch` collapses `..` before the request line is written, so a raw
+        // socket is the only way to make the server itself see the traversal.
+        //
+        // What it proves is worth stating precisely, because the answer is not a
+        // 404. `createRequestListener` normalises the path through `new URL`
+        // before dispatch, so `cohorts/../dispatch/resume` becomes the operator
+        // channel's own `dispatch/resume` — a route that has been deliberately
+        // allowlisted since long before adjust existed. Traversal therefore
+        // reaches nothing it could not reach by asking for it directly, and that
+        // route fail-closes on its own two-step confirmation: 428, outcome
+        // `refused`, and no byte written to Warmbly. The property under test is
+        // that traversal grants no new capability, not that the string 404s.
+        const raw = await rawPost(base, `/v1/warmbly/operator/cohorts/../dispatch/resume`);
+        assert.match(raw, /^HTTP\/1\.1 428 /, raw.split("\r\n")[0] ?? "");
+        assert.match(raw, /"outcome":"refused"/);
+        assert.match(raw, /"code":"confirmation_required"/);
+        assert.doesNotMatch(raw, /adjust:r1/, "traversal must not reach the cohort surface");
+      },
+    );
+    assert.deepEqual(upstream.hits, [], "no hostile cohort route may reach Warmbly");
+  } finally {
+    await upstream.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Pairs with tjsasakifln/warmbly#136. Deploy that first: this branch calls the `adjust` route it adds.

The backend and the surfaces both already existed. The founder still could not run the pilot, for five separate reasons — all observed on the live cohort `4d52c6cd` on 2026-08-23, none inferred.

## What was actually wrong

**Nothing led anywhere.** `#/warmbly` opened on the pause/resume cockpit alone. "Revisão" in the subnav linked without a resource, so it dropped the selected cohort. The only route to the right version was a small "v1" link on Cohorts.

**The message was hidden.** Recipient, subject and body sat inside a closed `<details>` labelled "Ver mensagem exata congelada" — the one thing a reviewer must read.

**Writes were invisible.** `outcomeBlock` rendered only on the operation surface, so create, reproduce, validation, review and GO performed from Cohorts or Revisão showed *nothing at all*: no success, no refusal, no code, no receipt, no next action. The adapter also collapsed distinct results into "Decisão registrada" and discarded the resource the server returned.

**The forms lied.** APPROVE, HOLD and REJECT shared one `required` acknowledgement checkbox, so HOLD and REJECT demanded a confirmation that belongs only to APPROVE. APPROVE rendered as actionable for INVALID and UNKNOWN candidates; the server refused, the UI neither prevented nor explained it. No pending state, no double-click guard.

**RBAC was opaque.** The screen showed a technical identifier and never the effective capability, so "GO is greyed out" and "GO failed" were indistinguishable.

## What this changes

`#/warmbly` opens on a Fonte → Cohort → Validação → Revisão → GO → Handoff stepper showing where the pilot stands, with the latest cohort and an explicit "Abrir revisão". The subnav carries the resource; with none, Revisão offers a selector rather than a dead end.

Recipient, exact subject and exact body render by default on every card, still collapsible, with expand/collapse all, alongside provenance, CTA, content hash, policy and composer version, validation expiry and blockers.

One shared `writeResultBlock` serves all three surfaces, with a claim-once router so the outcome renders exactly once, on the affected card. After a definitive result the gate re-GETs and reports `confirmed` / `not_confirmed` / `unavailable` instead of asserting a state change it never observed. An UNKNOWN keeps its idempotency key and does not advance, because the honest reading of a timeout is "this may have been applied".

APPROVE keys on the server's own VALID verdict and renders disabled with the reason otherwise. HOLD and REJECT need a reason and nothing else.

Adjust is two-step: the first submit writes nothing and shows a diff against the frozen original; the second sends exactly the five canonical copy fields and opens vN+1 with validation, review and GO shown as pending. Mailbox, evidence, source, policy and route class are not editable anywhere.

**"Not in the payload" is now a rendered value**, not a zero and not a frontend derivation. A preview carrying 7 considered and nothing else says so rather than implying 7 eligible.

## Security boundary

One new allowlisted control-plane operation, `adjust`. Still no generic proxy route, and still nothing for send, dispatch, queue, resume, auto-send or payment — now asserted by negative tests rather than left to convention. The adjust schema is closed-world: `mailbox`, `recipient`, `evidence`, `source`, `policy_version`, `route_class` and `composer_version` are refused by name, because a field silently dropped reads to the caller as a field accepted. Identifiers are validated as canonical UUIDs before any URL is built. No actor header is ever sent from the browser; Authelia at the edge remains the authority. GO stays admins-only and neither queues nor sends.

The context service needed no source change — adjust rides the existing operator prefix and inherits its enable gate, narrowed trusted hop, Authelia-only actor and JSON content-type requirement. Tests now prove that inheritance instead of assuming it.

## Release fingerprint

Images were built as `:local`, which is reusable and says nothing about its contents, so the previous rollout could only be accepted on "health 200" — which proves a process answered, not which code answered. Builds now stamp `org.opencontainers.image.revision` and pass `CC_RELEASE_SHA` into the container, and `verify-release.sh` reconciles repo → image → runtime and refuses an unlabelled image.

## Checked rather than assumed

The web-shell work was reported as blocked on the ground that the connector strips unknown body fields. It does not: that allowlist is the fallback for routes without a validator, and adjust carries its own. Driving the real handler confirms all five copy fields reach `/v1/confenge/.../adjust` with the idempotency key as a header. The degrade path for a missing route is kept anyway, since it costs nothing and covers a partial rollout.

The upstream prefix is `/v1/confenge/...`, not `/api/v1/...`: `routes.go` roots the protected tree at `r.Group("/v1")`, and the `/api/v1` strings elsewhere are full literal paths for webhooks on the root router.

## Verification

typecheck clean across the workspace. web-shell 312 pass (276 before), connector 159 pass / 1 skip, context 106 pass, security 40 pass, root suite 55 pass. 26 mutations verified across the two workstreams — each applied, the matching test run and seen to fail, then reverted.

REAL_EMAIL_SENT=false
DISPATCH_CONFIRM_RUN=false
OUTBOUND_RESUMED=false
AUTO_SEND_ENABLED=false