### PR TITLE
fix(cc-warmbly): send the version's frozen hash on adjust

### DIFF
--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -1363,7 +1363,12 @@ function candidateCard(
     ? candidate.blocked_by.filter((entry): entry is string => typeof entry === "string")
     : [];
   const gate = approvalGate(candidate);
-  const frozenHash = show(candidate.frozen_hash ?? candidate.content_hash);
+  // expected_frozen_hash guards the VERSION the operator was looking at, so it
+  // is the cohort's frozen_hash. A candidate carries content_hash and
+  // evidence_hash and no frozen_hash of its own, so reading it from the
+  // candidate sent the content hash and the server refused every adjust with
+  // frozen_hash_mismatch. The candidate value is kept only as a last resort.
+  const frozenHash = show(cohort.frozen_hash ?? candidate.frozen_hash ?? candidate.content_hash);
   const version = show(cohort.version);
   const draft = adjustDraft(candidateId);
 

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -42,7 +42,6 @@ function candidate(overrides: Record<string, unknown> = {}): Record<string, unkn
     evidence_source: "fixture://diario-oficial",
     evidence_observed_at: "2026-08-22T12:00:00Z",
     content_hash: "content-fixture-001",
-    frozen_hash: "frozen-fixture-001",
     evidence_hash: "evidence-fixture-001",
     composer_version: "composer.v3",
     copy_qa: { failures: ["assunto_generico"] },
@@ -61,6 +60,10 @@ function cohort(overrides: Record<string, unknown> = {}): Record<string, unknown
   return {
     id: COHORT_ID,
     version: 1,
+    // frozen_hash belongs to the version, which is what expected_frozen_hash
+    // guards. A candidate has content_hash and evidence_hash and no frozen
+    // hash of its own.
+    frozen_hash: "frozen-fixture-001",
     source: "extra-cli",
     as_of: "2026-08-23T12:00:00Z",
     freshness: "FRESH",
@@ -1110,3 +1113,4 @@ test("the operation cockpit reads the gate too, because its stepper has to know 
     "#/warmbly must read the cohort list",
   );
 });
+

--- a/control-center/tests/journey/boot-gate-context.ts
+++ b/control-center/tests/journey/boot-gate-context.ts
@@ -1,0 +1,7 @@
+// The real production context entrypoint, started in-process so the Warmbly
+// operator channel is mounted from env exactly as it is in production. Using
+// the real server is the point: a bespoke bootstrap would not prove the route
+// is mounted where production mounts it.
+import { startServer } from "../../services/context/src/server.ts";
+const { host, port } = await startServer();
+console.log(JSON.stringify({ ok: true, host, port }));

--- a/control-center/tests/journey/fake-edge.mjs
+++ b/control-center/tests/journey/fake-edge.mjs
@@ -1,0 +1,32 @@
+/**
+ * Stands in for Caddy AFTER Authelia has authenticated. It injects exactly the
+ * Remote-* forward-auth headers the production edge injects, and nothing else.
+ * This does not bypass Authelia: production still enforces two_factor. It
+ * reproduces the contract downstream of it so the journey can be driven.
+ */
+import { createServer } from "node:http";
+import { request as httpRequest } from "node:http";
+
+const PORT = Number(process.env.PORT || 8096);
+const UPSTREAM_HOST = "127.0.0.1";
+const UPSTREAM_PORT = Number(process.env.UPSTREAM_PORT || 8098);
+const GROUPS = process.env.EDGE_GROUPS || "operators";
+
+createServer((req, res) => {
+  const headers = { ...req.headers };
+  // Strip anything a client might have tried to send, then set our own.
+  for (const k of Object.keys(headers)) {
+    if (k.toLowerCase().startsWith("remote-")) delete headers[k];
+  }
+  headers["remote-user"] = "founder";
+  headers["remote-groups"] = GROUPS;
+  headers["remote-name"] = "Founder";
+  headers["remote-email"] = "founder@confenge.invalid";
+  headers.host = `${UPSTREAM_HOST}:${UPSTREAM_PORT}`;
+  const up = httpRequest(
+    { host: UPSTREAM_HOST, port: UPSTREAM_PORT, method: req.method, path: req.url, headers },
+    (r) => { res.writeHead(r.statusCode || 502, r.headers); r.pipe(res); },
+  );
+  up.on("error", (e) => { res.writeHead(502, { "content-type": "application/json" }); res.end(JSON.stringify({ code: "edge_upstream_error", message: e.message })); });
+  req.pipe(up);
+}).listen(PORT, "127.0.0.1", () => console.log(`fake-edge on ${PORT} -> ${UPSTREAM_PORT} groups=${GROUPS}`));

--- a/control-center/tests/journey/fake-warmbly.mjs
+++ b/control-center/tests/journey/fake-warmbly.mjs
@@ -1,0 +1,164 @@
+/**
+ * A faithful stand-in for the Warmbly human-gate API, shaped from the real
+ * production payload of cohort 4d52c6cd (mailboxes replaced with .invalid).
+ * It exists so the founder journey can be driven in a real browser without
+ * touching production or bypassing Authelia.
+ */
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+
+const COHORT_ID = "6579171e-1094-4cad-9a24-761d9d6e124f";
+const PORT = Number(process.env.PORT || 8099);
+const TOKEN = process.env.TOKEN || "stub-operator-token";
+
+function member(i, mailbox, status, subject, body) {
+  return {
+    account_id: `0000000${i}-0000-4000-8000-000000000001`,
+    account_ref: `cnpj:0000000000010${i}`,
+    candidate_id: `0000000${i}-0000-4000-8000-0000000000c1`,
+    candidate_ref: `ref-${i}`,
+    mailbox,
+    route_class: "GENERIC_COMPANY",
+    source: "extra-cli",
+    content_hash: `content-hash-${i}`,
+    evidence_hash: `evidence-hash-${i}`,
+    composer_version: "confenge.composer.v4",
+    subject,
+    body_text: body,
+    greeting: "Olá, equipe",
+    person_unknown: true,
+    company: `Empresa ${i} LTDA`,
+    mailbox_purpose: "UNKNOWN",
+    observed_fact: subject,
+    fact_source: "fact_to_mention",
+    cta: "Você consegue me indicar a pessoa responsável?",
+    cta_source: "routing_ask",
+    admission_reasons: ["admitted_by=controlled_route_eligible", "route_class=GENERIC_COMPANY", "copy_qa=passed"],
+    route_reasons: ["chosen_route_class=GENERIC_COMPANY"],
+    validation: status
+      ? { id: randomUUID(), status, reason: status === "VALID" ? "rcpt accepted" : "identity_rdns_missing: prober identity refused", provider: "in-house", method: "smtp_rcpt", evidence_hash: `v-${i}`, checked_at: "2026-08-23T18:00:00Z", expires_at: "2026-08-24T18:00:00Z", correlation_id: `corr-${i}`, receipt: `receipt-validation-${i}` }
+      : null,
+    review: null,
+    blocked_by: status === "VALID" ? [] : [`validation_not_valid:${status ?? "MISSING"}`],
+  };
+}
+
+const versions = new Map();
+function seed() {
+  const v1 = {
+    contract_version: "confenge.human-gate.v1",
+    id: "4d52c6cd-22c5-4e7a-aff2-0c26331c1357",
+    cohort_id: COHORT_ID,
+    version: 1,
+    derivation: "CREATE",
+    parent_version: null,
+    source: "extra-cli",
+    source_run_id: "run-e344a47972aa53fd",
+    as_of: "2026-08-23T17:09:01Z",
+    freshness: "FRESH",
+    fresh_until: "2026-08-24T17:09:01Z",
+    policy_version: "bounded-cohort-policy.v1",
+    frozen_hash: "38fac98598e67c8bf8e47d96e0fec3f4068a262f3b139e38a5c360caa46fb997",
+    manifest: {
+      schema_version: "confenge.frozen_cohort.v1",
+      cohort_hash: "38fac98598e6",
+      composer_version: "confenge.composer.v4",
+      policy_version: "bounded-cohort-policy.v1",
+      max_daily_volume: 5,
+      preview: { considered: 10, eligible: 5, excluded: 5, final: 5, copy_qa_failures: 0, duplicates: 1, missing_provenance: 0, hard_bounce: 0 },
+      members: [],
+    },
+    candidates: [
+      member(1, "contato@empresa-um.invalid", "VALID", "recuperação estrutural da ponte", "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: recuperação estrutural da ponte sobre o Rio Sapucaí.\n\nVocê consegue me indicar a pessoa responsável?"),
+      member(2, "contato@empresa-dois.invalid", "VALID", "pavimentação asfáltica em vias urbanas", "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: pavimentação asfáltica em vias urbanas.\n\nVocê consegue me indicar a pessoa responsável?"),
+      member(3, "contato@empresa-tres.invalid", "INVALID", "reforma da escola municipal", "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: reforma da escola municipal.\n\nVocê consegue me indicar a pessoa responsável?"),
+      member(4, "contato@empresa-quatro.invalid", "UNKNOWN", "ampliação da rede de esgoto", "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: ampliação da rede de esgoto.\n\nVocê consegue me indicar a pessoa responsável?"),
+      member(5, "contato@empresa-cinco.invalid", null, "drenagem urbana", "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: drenagem urbana.\n\nVocê consegue me indicar a pessoa responsável?"),
+    ],
+    decision: null,
+    reason: [],
+    correlation_id: "corr-v1",
+    receipt: "receipt-v1",
+    created_at: "2026-08-23T17:11:35Z",
+  };
+  v1.manifest.members = v1.candidates;
+  versions.set(v1.id, v1);
+}
+seed();
+
+const send = (res, status, body) => {
+  const s = JSON.stringify(body);
+  res.writeHead(status, { "content-type": "application/json", "content-length": Buffer.byteLength(s) });
+  res.end(s);
+};
+
+createServer((req, res) => {
+  if (req.headers.authorization !== `Bearer ${TOKEN}`) return send(res, 401, { code: "unauthorized" });
+  const url = new URL(req.url, "http://x");
+  const p = url.pathname;
+  let raw = "";
+  req.on("data", (c) => (raw += c));
+  req.on("end", () => {
+    const body = raw ? JSON.parse(raw) : {};
+    const list = [...versions.values()].sort((a, b) => b.version - a.version);
+
+    if (req.method === "GET" && p === "/v1/confenge/cohorts") return send(res, 200, { data: list });
+
+    const one = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)$/);
+    if (req.method === "GET" && one) {
+      const v = versions.get(one[1]);
+      return v ? send(res, 200, { data: v }) : send(res, 404, { code: "not_found" });
+    }
+
+    const rev = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)\/candidates\/([0-9a-f-]+)\/review$/);
+    if (req.method === "POST" && rev) {
+      const v = versions.get(rev[1]);
+      if (!v) return send(res, 404, { code: "not_found" });
+      const c = v.candidates.find((x) => x.candidate_id === rev[2]);
+      if (!c) return send(res, 404, { code: "candidate_not_found" });
+      if (body.decision === "APPROVE" && c.validation?.status !== "VALID") {
+        return send(res, 422, { code: "validation_not_valid", message: "APPROVE requires a current VALID validation" });
+      }
+      c.review = { id: randomUUID(), decision: body.decision, reason: body.reason ?? "", effective: true, invalidated_by: [], actor_id: "00000000-0000-4000-8000-00000000000a", created_at: new Date(0).toISOString(), correlation_id: "corr-review", receipt: `receipt-review-${body.decision}` };
+      return send(res, 200, { data: v, receipt: c.review.receipt, correlation_id: "corr-review" });
+    }
+
+    const adj = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)\/candidates\/([0-9a-f-]+)\/adjust$/);
+    if (req.method === "POST" && adj) {
+      const v = versions.get(adj[1]);
+      if (!v) return send(res, 404, { code: "not_found" });
+      if (body.expected_frozen_hash !== v.frozen_hash) return send(res, 409, { code: "frozen_hash_mismatch", message: "the frozen hash does not match this version" });
+      if (body.confirmation !== `v${v.version}`) return send(res, 409, { code: "confirmation_mismatch", message: "confirmation must name the current version" });
+      const next = JSON.parse(JSON.stringify(v));
+      next.id = randomUUID();
+      next.version = v.version + 1;
+      next.derivation = "ADJUST";
+      next.parent_version = v.version;
+      next.frozen_hash = `frozen-hash-v${next.version}`;
+      next.decision = null;
+      const c = next.candidates.find((x) => x.candidate_id === adj[2]);
+      const before = { subject: c.subject, body: c.body_text };
+      c.subject = body.subject;
+      c.body_text = body.body_text;
+      c.content_hash = `content-hash-v${next.version}`;
+      for (const x of next.candidates) { x.validation = null; x.review = null; x.blocked_by = ["validation_missing"]; }
+      versions.set(next.id, next);
+      return send(res, 201, {
+        contract_version: "confenge.human-gate.v1",
+        cohort: next,
+        adjustment: {
+          id: randomUUID(), cohort_id: next.cohort_id, from_version: v.version, to_version: next.version,
+          candidate_id: adj[2], before_content_hash: `content-hash-1`, after_content_hash: c.content_hash,
+          before_frozen_hash: v.frozen_hash, after_frozen_hash: next.frozen_hash,
+          diff: [
+            { field: "subject", before: before.subject, after: c.subject },
+            { field: "body_text", before: before.body, after: c.body_text },
+          ],
+          revoked_authorization_id: null, actor_id: "00000000-0000-4000-8000-00000000000a",
+          correlation_id: "corr-adjust", receipt: `receipt-adjust-v${next.version}`, created_at: new Date(0).toISOString(),
+        },
+      });
+    }
+    return send(res, 404, { code: "route_not_found", path: p });
+  });
+}).listen(PORT, "127.0.0.1", () => console.log(`fake-warmbly listening on ${PORT}`));

--- a/control-center/tests/journey/journey.mjs
+++ b/control-center/tests/journey/journey.mjs
@@ -1,0 +1,190 @@
+/**
+ * Founder journey in a real browser, driven end to end through the real
+ * Context Service and the real human-gate connector, with a faithful stand-in
+ * for the Warmbly backend. Production itself sits behind Authelia two-factor,
+ * which must not be bypassed, so this is the strongest journey proof available
+ * without the founder's own second factor.
+ */
+import { createRequire } from "node:module";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Playwright is not a dependency of this workspace; resolve it the same way
+// scripts/launch-probe.mjs does, so the journey runs wherever that probe does.
+function chromiumFrom(mod) {
+  const c = mod?.chromium ?? mod?.default?.chromium;
+  return c && typeof c.launch === "function" ? c : null;
+}
+async function loadChromium() {
+  for (const spec of ["playwright", "playwright-core"]) {
+    try {
+      const c = chromiumFrom(await import(spec));
+      if (c) return c;
+    } catch {
+      /* try the next source */
+    }
+  }
+  const require = createRequire(import.meta.url);
+  for (const root of [join(homedir(), ".npm/_npx"), join(homedir(), ".cache/npx")]) {
+    if (!existsSync(root)) continue;
+    for (const entry of readdirSync(root)) {
+      const candidate = join(root, entry, "node_modules/playwright");
+      if (!existsSync(join(candidate, "package.json"))) continue;
+      try {
+        const c = chromiumFrom(await import(require.resolve(candidate)));
+        if (c) return c;
+      } catch {
+        /* keep looking */
+      }
+    }
+  }
+  throw new Error("playwright is not installed; install it or set CC_CHROMIUM and provide playwright");
+}
+const chromium = await loadChromium();
+
+const BASE = process.argv[2];
+const exe = process.env.CC_CHROMIUM ?? (process.env.HOME + "/.cache/ms-playwright/chromium-1237/chrome-linux64/chrome");
+
+const results = [];
+const check = (name, ok, detail = "") => {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  :: " + detail : ""}`);
+};
+
+const browser = await chromium.launch({ headless: true, executablePath: exe, args: ["--no-sandbox"] });
+const ctx = await browser.newContext();
+const consoleErrors = [];
+const failedRequests = [];
+ctx.on("weberror", (e) => consoleErrors.push(String(e.error())));
+
+async function newPage() {
+  const p = await ctx.newPage();
+  p.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text()); });
+  p.on("pageerror", (e) => consoleErrors.push(String(e)));
+  p.on("requestfailed", (r) => failedRequests.push(`${r.method()} ${r.url()} ${r.failure()?.errorText}`));
+  p.on("response", (r) => { if (r.status() >= 500) failedRequests.push(`${r.status()} ${r.url()}`); });
+  return p;
+}
+
+const page = await newPage();
+
+// ---- 1. Discoverability from #/warmbly
+await page.goto(`${BASE}/#/warmbly`, { waitUntil: "networkidle" });
+await page.waitForTimeout(1200);
+check("#/warmbly renders the pilot stepper", await page.locator("[data-pilot-stepper]").count() > 0);
+check("#/warmbly names the pilot steps", (await page.locator("[data-step]").count()) >= 5,
+  `${await page.locator("[data-step]").count()} steps`);
+const openReview = page.locator("[data-open-review]").first();
+const ORIGINAL_RESOURCE = "4d52c6cd-22c5-4e7a-aff2-0c26331c1357";
+check("#/warmbly offers an explicit 'Abrir revisão'", await openReview.count() > 0);
+
+// ---- 2. Reaching the review without a deep link
+if (await openReview.count() > 0) {
+  await openReview.click();
+  await page.waitForTimeout(1200);
+}
+check("clicking through reaches a review with a resource", /#\/warmbly\/revisao/.test(page.url()) && /[0-9a-f-]{36}/.test(page.url()), page.url().split("#")[1] || "");
+
+// ---- 3. The message is readable by default
+// data-candidate sits on each per-candidate FORM (validate, approve, hold,
+// adjust), so counting it counts forms. The editor is one per candidate.
+const nCards = await page.locator("[data-adjust-editor]").count();
+check("every cohort member is listed", nCards === 5, `${nCards} candidates`);
+const subj = page.locator("[data-exact-subject]").first();
+const body = page.locator("[data-exact-body]").first();
+check("exact subject is visible without opening anything", await subj.isVisible().catch(() => false));
+check("exact body is visible without opening anything", await body.isVisible().catch(() => false));
+check("recipient is shown on the card", (await page.locator("[data-candidate-identity]").first().innerText().catch(() => "")).includes("@"));
+check("preview denominators are rendered", await page.locator("[data-preview-denominators]").count() > 0);
+
+// ---- 4. APPROVE gating follows the server's verdict
+const approveAllowed = await page.locator("[data-approve-allowed='true']").count();
+const approveBlocked = await page.locator("[data-approve-blocked]").count();
+check("APPROVE is offered only for VALID candidates", approveAllowed === 2, `allowed=${approveAllowed}`);
+check("APPROVE is blocked, with a reason, for the rest", approveBlocked === 3, `blocked=${approveBlocked}`);
+const blockedReason = await page.locator("[data-approve-blocked]").first().innerText().catch(() => "");
+check("the APPROVE block explains itself", blockedReason.trim().length > 0, blockedReason.replace(/\s+/g, " ").slice(0, 70));
+
+// ---- 5. HOLD / REJECT do not inherit the APPROVE acknowledgement
+check("HOLD/REJECT are marked as needing no acknowledgement",
+  await page.locator("[data-no-ack-required]").count() > 0);
+
+// ---- 6. RBAC is visible
+check("effective operator capability is shown", await page.locator("[data-can-review]").count() > 0);
+check("GO authority is stated explicitly", await page.locator("[data-go-authority], [data-can-decide]").count() > 0);
+
+// ---- 7. Adjust: two-step, diff before write, then vN+1
+const adjustEditor = page.locator("[data-adjust-editor]").first();
+check("an adjust editor exists on the candidate", await adjustEditor.count() > 0);
+let adjusted = false;
+if (await adjustEditor.count() > 0) {
+  // The editor is a <details>; open it the way an operator would.
+  await adjustEditor.locator("summary").first().click().catch(() => {});
+  await page.waitForTimeout(400);
+  const sIn = adjustEditor.locator("[name='subject']").first();
+  const bIn = adjustEditor.locator("[name='body_text']").first();
+  const rIn = adjustEditor.locator("[name='reason']").first();
+  if (await sIn.count() && await bIn.count() && await rIn.count()) {
+    await sIn.fill("recuperacao estrutural da ponte revisada");
+    await bIn.fill("Ola, equipe,\n\nSou da CONFENGE.\n\ncontratacao publica: recuperacao estrutural da ponte revisada.\n\nVoce consegue me indicar a pessoa responsavel?");
+    await rIn.fill("ajuste de copy aprovado na revisao do fundador");
+    const cIn = adjustEditor.locator("[name='confirmation']").first();
+    if (await cIn.count()) await cIn.fill("v1");
+    const submit = adjustEditor.locator("button[type=submit], [data-gate-action='adjust']").first();
+    await submit.click();
+    await page.waitForTimeout(900);
+    const diffShown = await page.locator("[data-adjust-diff]").count() > 0;
+    check("the first submit shows a diff and writes nothing", diffShown);
+    const confirm = page.locator("[data-adjust-step='confirm'] button[type=submit], [data-adjust-diff] button[type=submit]").first();
+    if (await confirm.count() > 0) {
+      await confirm.click();
+      await page.waitForTimeout(1800);
+      adjusted = true;
+    }
+  }
+}
+if (adjusted) {
+  // The proof that a new immutable version exists is that the surface moved to
+  // a different resource id; the previous one is untouched and still readable.
+  const movedTo = (page.url().split("resource=")[1] || "").slice(0, 36);
+  check("adjust opened a NEW version, leaving the original intact",
+    movedTo.length === 36 && movedTo !== ORIGINAL_RESOURCE, `now on ${movedTo}`);
+  const pend = await page.locator("[data-validation-status]").allInnerTexts().catch(() => []);
+  check("the new version starts with validation pending, nothing inherited",
+    pend.length > 0 && pend.every((t) => !/VALID\b/.test(t)), pend.slice(0, 3).join(" | "));
+  // The original must still be readable, byte-for-byte, at its own address.
+  const prev = await newPage();
+  await prev.goto(`${BASE}/#/warmbly/revisao?resource=${ORIGINAL_RESOURCE}`, { waitUntil: "networkidle" });
+  await prev.waitForTimeout(1200);
+  const prevSubject = await prev.locator("[data-exact-subject]").first().innerText().catch(() => "");
+  check("the superseded version is still readable at its own address",
+    prevSubject.trim().length > 0, prevSubject.replace(/\s+/g, " ").slice(0, 60));
+  await prev.close();
+  const wr = await page.locator("[data-write-result]").count();
+  check("the write reports its outcome on the surface", wr > 0, `${wr} result blocks`);
+  const receipt = await page.locator("[data-write-evidence], [data-write-result]").first().innerText().catch(() => "");
+  check("the outcome carries a receipt", /receipt|recibo/i.test(receipt), receipt.replace(/\s+/g, " ").slice(0, 80));
+}
+
+// ---- 8. Reload keeps the operator where they were
+const before = page.url();
+await page.reload({ waitUntil: "networkidle" });
+await page.waitForTimeout(1000);
+check("a reload keeps the same resource", page.url() === before, page.url().split("#")[1] || "");
+
+// ---- 9. A second tab sees the same server truth
+const tab2 = await newPage();
+await tab2.goto(before, { waitUntil: "networkidle" });
+await tab2.waitForTimeout(1200);
+check("a second tab renders the same cohort", (await tab2.locator("[data-adjust-editor]").count()) === 5,
+  `${await tab2.locator("[data-adjust-editor]").count()} candidates in tab 2`);
+
+// ---- 10. Console / network hygiene
+check("no application errors in the browser console", consoleErrors.length === 0, consoleErrors.slice(0, 3).join(" | "));
+check("no failed or 5xx requests", failedRequests.length === 0, failedRequests.slice(0, 3).join(" | "));
+
+await browser.close();
+const failed = results.filter((r) => !r.ok);
+console.log(`\nJOURNEY: ${results.length - failed.length}/${results.length} passed`);
+process.exit(failed.length === 0 ? 0 : 1);

--- a/control-center/tests/journey/run.sh
+++ b/control-center/tests/journey/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Founder journey in a real browser, end to end through the real Context
+# Service and the real human-gate connector, against a faithful stand-in for
+# the Warmbly backend.
+#
+# Production sits behind Authelia two_factor, which must not be bypassed, so
+# fake-edge injects the same Remote-* forward-auth headers Caddy injects AFTER
+# Authelia has authenticated. It reproduces the contract downstream of the
+# boundary; it does not weaken the boundary.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CC="$(cd "$HERE/../.." && pwd)"
+APP="$CC/apps/web-shell"
+WORK="$(mktemp -d)"
+
+WPORT=${WPORT:-8099}; CPORT=${CPORT:-8098}; SPORT=${SPORT:-8097}; EPORT=${EPORT:-8096}
+TOKEN=stub-operator-token
+TOKFILE="$WORK/token"; printf %s "$TOKEN" > "$TOKFILE"
+
+PIDS=()
+cleanup() { for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null; done; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+PORT=$WPORT TOKEN=$TOKEN node "$HERE/fake-warmbly.mjs" > "$WORK/warmbly.log" 2>&1 & PIDS+=($!)
+
+( cd "$CC" && HOST=127.0.0.1 PORT=$CPORT NODE_ENV=test \
+  CONTEXT_SERVICE_FIXTURE=representative \
+  CONTROL_CENTER_FOUNDER_ACTOR_ID=founder-local \
+  CC_WARMBLY_OPERATOR_ENABLED=true \
+  CC_WARMBLY_BASE_URL=http://127.0.0.1:$WPORT \
+  CC_WARMBLY_OPERATOR_TOKEN_FILE="$TOKFILE" \
+  CC_WARMBLY_OPERATOR_TRUSTED_HOPS=127.0.0.1/32 \
+  CC_OPERATOR_ACTION_TRUSTED_HOPS=127.0.0.1/32 \
+  CC_TRUSTED_PROXY_CIDRS=127.0.0.1/32 \
+  npx tsx "$HERE/boot-gate-context.ts" > "$WORK/context.log" 2>&1 ) & PIDS+=($!)
+
+PORT=$EPORT UPSTREAM_PORT=$CPORT EDGE_GROUPS="${EDGE_GROUPS:-operators}" \
+  node "$HERE/fake-edge.mjs" > "$WORK/edge.log" 2>&1 & PIDS+=($!)
+
+( cd "$APP" && HOST=127.0.0.1 PORT=$SPORT CC_CONTEXT_UPSTREAM=http://127.0.0.1:$EPORT \
+  CC_ACTOR_ID=founder-local CC_ACTOR_KIND=human \
+  node scripts/serve-prod.mjs > "$WORK/web.log" 2>&1 ) & PIDS+=($!)
+
+for i in $(seq 1 80); do curl -fsS "http://127.0.0.1:$CPORT/healthz" >/dev/null 2>&1 && break; sleep 0.5; done
+for i in $(seq 1 60); do curl -fsS "http://127.0.0.1:$SPORT/healthz" >/dev/null 2>&1 && break; sleep 0.5; done
+
+gate=$(curl -s -o /dev/null -w '%{http_code}' -H 'x-actor-id: founder-local' -H 'x-actor-kind: human' "http://127.0.0.1:$SPORT/v1/warmbly/operator/cohorts")
+echo "gate through the shell: $gate"
+if [ "$gate" != "200" ]; then
+  echo "the human gate is not reachable through the shell; the journey would prove nothing"
+  tail -20 "$WORK/context.log"; exit 1
+fi
+
+( cd "$APP" && node "$HERE/journey.mjs" "http://127.0.0.1:$SPORT" )


### PR DESCRIPTION
Follow-up to #95, found by driving the real browser rather than by reading the code.

Adjust would have failed for **every** candidate in production. The candidate card read `expected_frozen_hash` from the *candidate*, which carries `content_hash` and `evidence_hash` and no frozen hash of its own, so it fell back to `content_hash` and the backend refused with `frozen_hash_mismatch`. `expected_frozen_hash` guards the **version** the operator was looking at, so it is the cohort's.

No unit test caught it because the fixture was wrong in the same direction: it put `frozen_hash` on the candidate, so "the right value is sent" was true of the fixture and false of production. The fixture now matches the real payload, which gives the existing assertion teeth — reverting the card to read from the candidate now fails it (verified).

Also brings the harness that found it into the repository. `control-center/tests/journey` runs the founder path end to end through the real Context Service and the real human-gate connector, against a stand-in for the Warmbly backend shaped from the live cohort payload with mailboxes replaced by `.invalid`.

Production sits behind Authelia `two_factor`, which must not be bypassed, so `fake-edge` injects exactly the `Remote-*` forward-auth headers Caddy injects *after* Authelia has authenticated, and strips any a client tried to send. It reproduces the contract downstream of the boundary; it does not weaken it. The runner refuses to score the journey at all if the gate is not reachable through the shell, because a green run against a 404 proves nothing.

26 assertions, all passing: stepper and an explicit route into review, resource surviving the subnav, subject and body visible without opening anything, APPROVE offered only for the two VALID candidates and blocked with a reason for the other three, HOLD and REJECT free of the APPROVE acknowledgement, the first adjust submit showing a diff and writing nothing, the second opening a new version with validation pending and nothing inherited, the superseded version still readable at its own address, an outcome with a receipt on the surface the action was fired from, reload, a second tab, and zero console errors or failed requests.

REAL_EMAIL_SENT=false
DISPATCH_CONFIRM_RUN=false
OUTBOUND_RESUMED=false
AUTO_SEND_ENABLED=false