### PR TITLE
feat(control-center): review Warmbly drafts safely

### DIFF
--- a/control-center/apps/web-shell/README.md
+++ b/control-center/apps/web-shell/README.md
@@ -1,6 +1,6 @@
 # Control Center web shell
 
-Mobile-first cockpit for Confenge Control Center. This workstream is **fixture-backed and decoupled from a live backend**. It is not chat, not a generic ERP, and not a KPI wall.
+Mobile-first cockpit for Confenge Control Center. It is not chat, not a generic ERP, and not a KPI wall. Production reads its bounded context from the context service; local development can use fixtures.
 
 ## Destinations
 
@@ -49,7 +49,7 @@ Ajustar assunto/corpo cria uma **nova versão** (`POST …/candidates/{id}/adjus
 Enquanto essa rota não estiver implantada, a UI trata o 404 como estado esperado,
 diz isso e desabilita o editor em vez de oferecer um controle que não escreve.
 
-Hoje is an attention cockpit: open exceptions plus **at most three** current priorities. There is no chat composer. Financial and commercial-send mutations (cobrança, checkout, refund, cancelamento, Asaas write, commercial send) are not offered.
+Hoje is an attention cockpit: open exceptions plus **at most three** current priorities. There is no chat composer. `Comercial → Rascunhos` is the founder's exact-copy review surface: adjust, approve for the next eligible business window, or reject back into editorial recovery. Financial mutations and immediate commercial send are not offered.
 
 ## Cards de alerta
 
@@ -81,9 +81,9 @@ Responsável é **área**, não pessoa: nenhum contrato carrega responsável nom
 
 ## Decisions (local)
 
-- Governance remains the strategic/canonical authority; Warmbly remains the commercial/CRM operational authority. This shell only renders a read-model recorte.
+- Governance remains the strategic/canonical authority; Warmbly remains the commercial/CRM operational authority. The shell renders bounded read models and submits only typed human-review decisions through the context service.
 - Persistence of aggregated state (PostgreSQL), HTTP APIs, and MCP for agents land in **later convergence campaigns**. This package copies v1 field names locally (`source`, `observed_at`, `freshness_status`, `confidence`, cents+currency, directive kinds, freshness `FRESH|STALE|UNKNOWN|ERROR`) and does **not** import unpublished sibling `control-center/*` packages.
-- Mock adapters are the only I/O. They never `fetch`. Swap the adapter implementation later; keep the `ControlCenterReadAdapter` port.
+- The adapter port has fixture and HTTP implementations. Production uses the same-origin `/api/context` proxy; Warmbly credentials stay server-side.
 - Single-user human is implicit. The operator is an opaque display handle (`human:operator`). No identity, password, or secret is hardcoded.
 - Dates are UTC in data (`…Z`). Presentation uses `America/Sao_Paulo`.
 - PWA: a web manifest + SVG icons only. No service worker / offline cache.

--- a/control-center/apps/web-shell/scripts/serve-prod.mjs
+++ b/control-center/apps/web-shell/scripts/serve-prod.mjs
@@ -39,14 +39,14 @@ const actorKind = (process.env.CC_ACTOR_KIND ?? "").trim();
 
 function copyActorHeaders(req) {
   const headers = { accept: "application/json" };
-  for (const name of ["x-actor-id", "x-actor-kind", "content-type"]) {
-    const value = req.headers[name];
-    if (typeof value === "string" && value.trim()) {
-      headers[name] = value;
-    }
+  const contentType = req.headers["content-type"];
+  if (typeof contentType === "string" && contentType.trim()) {
+    headers["content-type"] = contentType;
   }
-  if (!headers["x-actor-id"] && actorId) headers["x-actor-id"] = actorId;
-  if (!headers["x-actor-kind"] && actorKind) headers["x-actor-kind"] = actorKind;
+  // Browser-supplied actor headers are never trusted. Production injects the
+  // configured founder identity at this server-side hop.
+  if (actorId) headers["x-actor-id"] = actorId;
+  if (actorKind) headers["x-actor-kind"] = actorKind;
   return headers;
 }
 
@@ -93,7 +93,12 @@ export const server = createServer((req, res) => {
     void readProxyBody(req)
       .then((body) => fetch(`${contextUpstream}${url.pathname}${url.search}`, {
         method: req.method,
-        headers: copyActorHeaders(req),
+        headers: {
+          ...copyActorHeaders(req),
+          ...(typeof req.headers["idempotency-key"] === "string"
+            ? { "idempotency-key": req.headers["idempotency-key"] }
+            : {}),
+        },
         ...(body === undefined ? {} : { body }),
       }))
       .then(async (upstream) => {

--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -194,6 +194,15 @@ export interface ControlCenterReadAdapter {
    */
   warmblyDispatch?(input: WarmblyDispatchInput): AdapterWriteResult | Promise<AdapterWriteResult>;
   warmblyGate?(input: WarmblyGateInput): AdapterWriteResult | Promise<AdapterWriteResult>;
+  reviewDraftAction?(input: {
+    id: string;
+    action: "SAVE_ADJUSTMENT" | "APPROVE" | "REJECT";
+    expected_content_hash: string;
+    subject?: string;
+    body_text?: string;
+    reason?: string;
+    generic_recipient_acknowledged?: boolean;
+  }): AdapterWriteResult | Promise<AdapterWriteResult>;
 }
 
 export const WARMBLY_GATE_ACTIONS = [

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -632,6 +632,59 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     }
   }
 
+  async reviewDraftAction(input: {
+    id: string;
+    action: "SAVE_ADJUSTMENT" | "APPROVE" | "REJECT";
+    expected_content_hash: string;
+    subject?: string;
+    body_text?: string;
+    reason?: string;
+    generic_recipient_acknowledged?: boolean;
+  }): Promise<AdapterWriteResult> {
+    const path = `/v1/commercial/review-drafts/${encodeURIComponent(input.id)}`;
+    const idempotency = `review:${input.action}:${input.id}:${input.expected_content_hash}`;
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "idempotency-key": idempotency,
+        },
+        credentials: "include",
+        body: JSON.stringify(input),
+      });
+      const raw = await response.text();
+      if (!response.ok) {
+        let message = `decisão recusada (${response.status})`;
+        try {
+          const body = JSON.parse(raw) as { message?: string };
+          if (body.message) message = body.message;
+        } catch {
+          // The status remains the safe diagnostic.
+        }
+        const failed: AdapterWriteResult = { ok: false, path, kind: "nota", message };
+        this.lastOperatorResult = failed;
+        return failed;
+      }
+      const message = input.action === "APPROVE"
+        ? "mensagem aprovada e agendada para a próxima janela útil"
+        : input.action === "REJECT"
+          ? "rascunho rejeitado e devolvido para reescrita"
+          : "ajuste salvo; aprovação ainda pendente";
+      const accepted: AdapterWriteResult = { ok: true, path, kind: "nota", message };
+      this.lastOperatorResult = accepted;
+      return accepted;
+    } catch (err) {
+      const failed: AdapterWriteResult = {
+        ok: false, path, kind: "nota",
+        message: err instanceof Error ? err.message : "Warmbly indisponível",
+      };
+      this.lastOperatorResult = failed;
+      return failed;
+    }
+  }
+
   async writeShortcut(kind: WriteShortcutKind, draft: { title: string; body: string }): Promise<AdapterWriteResult> {
     if (!(WRITE_SHORTCUT_KINDS as readonly string[]).includes(kind)) {
       return { ok: false, path: AUTHORIZED_WRITE_PATH, kind, message: "atalho não autorizado" };
@@ -822,6 +875,17 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     };
     if (id === "comercial" || id === "crescimento" || id === "warmbly") {
       page.commercial = commercialFrom(inner, fallback);
+      if (id === "comercial") {
+        // During a rolling deployment the read model may precede the review
+        // proxy. A 404 means the optional surface is not available yet; it
+        // must not blank the rest of the commercial cockpit.
+        const reviewPayload = asRecord(await this.readReviewJson("/v1/commercial/review-drafts?limit=100&offset=0"));
+        const reviewRows = itemsOf(reviewPayload?.data ?? reviewPayload);
+        page.commercial.operations = {
+          ...(page.commercial.operations ?? {}),
+          review_drafts: reviewRows,
+        };
+      }
     }
     if (id === "comercial" && page.commercial && listPath) {
       const listPayload = asRecord(payloads[paths.length]);
@@ -995,7 +1059,23 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     }
   }
 
-  private async getJson(path: string): Promise<unknown> {
+  private async readReviewJson(path: string): Promise<unknown> {
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      headers: { accept: "application/json" },
+      credentials: "include",
+    });
+    if (response.status === 404) return undefined;
+    if (!response.ok) {
+      throw new Error(`Backend operacional indisponível (${response.status} ${path}).`);
+    }
+    try {
+      return await response.json() as unknown;
+    } catch {
+      throw new Error(`Backend operacional devolveu JSON inválido em ${path}.`);
+    }
+  }
+
+  private async getJson(path: string, allowNotFound = false): Promise<unknown> {
     const url = `${this.baseUrl}${path}`;
     const response = await this.fetchImpl(url, {
       headers: {
@@ -1005,6 +1085,9 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       },
     });
     const text = await response.text();
+    if (allowNotFound && response.status === 404) {
+      return undefined;
+    }
     if (!response.ok) {
       throw new Error(`Backend operacional indisponível (${response.status} ${path}).`);
     }

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -170,6 +170,7 @@ function applyPaint(
     ),
   );
   bindWarmblyHumanGate(root, adapter, repaint, navigate);
+  bindReviewActions(root, adapter, repaint);
   bindWarmblyGateFilters(root, renderHash, navigate);
   bindMessageToggle(root, renderHash, navigate);
   bindCopyControls(root);
@@ -374,6 +375,38 @@ function restoreListFocus(painted: boolean): void {
     return;
   }
   if (element instanceof HTMLSelectElement) element.focus();
+}
+
+function bindReviewActions(
+  root: MountableRoot,
+  adapter: ControlCenterReadAdapter,
+  onDone: () => void,
+): void {
+  if (!adapter.reviewDraftAction || typeof root.querySelectorAll !== "function") return;
+  const forms = root.querySelectorAll("[data-review-form]");
+  for (let i = 0; i < forms.length; i += 1) {
+    const form = forms[i];
+    if (!form) continue;
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const id = form.getAttribute("data-review-form") ?? "";
+      const action = form.querySelector('[name="action"]')?.value as "SAVE_ADJUSTMENT" | "APPROVE" | "REJECT" | undefined;
+      const expected = form.querySelector('[name="expected_content_hash"]')?.value ?? "";
+      if (!id || !action || !expected) return;
+      void Promise.resolve(adapter.reviewDraftAction?.({
+        id,
+        action,
+        expected_content_hash: expected,
+        subject: form.querySelector('[name="subject"]')?.value ?? "",
+        body_text: form.querySelector('[name="body_text"]')?.value ?? "",
+        reason: form.querySelector('[name="reason"]')?.value ?? "",
+        generic_recipient_acknowledged: form.querySelector('[name="generic_ack"]')?.value === "true",
+      })).then((result) => {
+        if (result) adapter.lastOperatorResult = result;
+        onDone();
+      });
+    });
+  }
 }
 
 function bindOperatorActions(

--- a/control-center/apps/web-shell/src/destinations.ts
+++ b/control-center/apps/web-shell/src/destinations.ts
@@ -127,7 +127,7 @@ export function hasChatDestination(): boolean {
   );
 }
 
-export const COMMERCIAL_SURFACES = ["visao", "cohorts", "atividade", "pipeline", "excecoes"] as const;
+export const COMMERCIAL_SURFACES = ["visao", "rascunhos", "cohorts", "atividade", "pipeline", "excecoes"] as const;
 export type CommercialSurface = (typeof COMMERCIAL_SURFACES)[number];
 
 /**

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -761,6 +761,7 @@ function controlledEmailCohort(ops: Record<string, unknown>): string {
 export function commercialSubnav(surface: string | null): string {
   const items = [
     ["visao", "Visão"],
+    ["rascunhos", "Rascunhos"],
     ["cohorts", "Coortes"],
     ["atividade", "Atividade"],
     ["pipeline", "Pipeline"],
@@ -979,9 +980,41 @@ function commercialOps(
   const activity = Array.isArray(ops.activity) ? ops.activity : [];
   const pipeline = Array.isArray(ops.pipeline) ? ops.pipeline : [];
   const exceptions = Array.isArray(ops.exceptions) ? ops.exceptions : [];
+  const reviewDrafts = Array.isArray(ops.review_drafts) ? ops.review_drafts : [];
   const availability = snapshot.availability ?? "UNKNOWN";
   let body = "";
-  if (current === "cohorts") {
+  if (current === "rascunhos") {
+    body = `<section aria-labelledby="rascunhos-title"><h2 id="rascunhos-title">Revisão editorial</h2>
+      <p class="constraint">Aprovar vincula o hash exato e agenda a próxima janela útil. Nenhum botão envia imediatamente.</p>
+      <div class="stack">${reviewDrafts.length === 0
+        ? `<p class="banner empty">Nenhum rascunho aguardando revisão.</p>`
+        : reviewDrafts.map((item) => {
+            const row = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+            const account = row.account && typeof row.account === "object" ? (row.account as Record<string, unknown>) : {};
+            const id = String(row.id ?? "");
+            const hash = String(row.content_hash ?? "");
+            return `<article class="card review-draft" data-draft-id="${escapeHtml(id)}" data-state="${escapeHtml(String(row.state ?? ""))}">
+              <p class="kicker">${escapeHtml(String(row.state ?? ""))} · ${escapeHtml(String(row.purpose ?? ""))} · toque ${escapeHtml(String(row.ordinal ?? ""))}</p>
+              <h3>${escapeHtml(String(account.nome_fantasia ?? account.razao_social ?? row.account_id ?? "Lead"))}</h3>
+              <p>Destinatário: ${escapeHtml(String(row.recipient ?? "ausente"))}</p>
+              <p>Razão: ${escapeHtml(String(row.stop_reason ?? row.generation_error ?? "pronto para revisão"))}</p>
+              <form data-review-form="${escapeHtml(id)}" class="operator-form">
+                <input type="hidden" name="expected_content_hash" value="${escapeHtml(hash)}" />
+                <label>Assunto <textarea name="subject">${escapeHtml(String(row.subject ?? ""))}</textarea></label>
+                <label>Corpo <textarea name="body_text">${escapeHtml(String(row.body_text ?? ""))}</textarea></label>
+                <label>Decisão <select name="action">
+                  <option value="SAVE_ADJUSTMENT">Salvar ajuste</option>
+                  <option value="APPROVE">Aprovar e agendar</option>
+                  <option value="REJECT">Rejeitar e reescrever</option>
+                </select></label>
+                <label>Motivo da rejeição <textarea name="reason"></textarea></label>
+                <label>Caixa genérica/departamental <select name="generic_ack"><option value="false">não confirmar</option><option value="true">confirmo conscientemente</option></select></label>
+                <button type="submit">Registrar decisão</button>
+              </form>
+            </article>`;
+          }).join("")}</div>
+    </section>`;
+  } else if (current === "cohorts") {
     const acquisition = Array.isArray(cohorts.acquisition) ? cohorts.acquisition : [];
     const inbound = cohorts.inbound_truth && typeof cohorts.inbound_truth === "object" ? (cohorts.inbound_truth as Record<string, unknown>) : {};
     const mixingRule = String(cohorts.mixing_rule ?? "");

--- a/control-center/apps/web-shell/tests/review-drafts.test.ts
+++ b/control-center/apps/web-shell/tests/review-drafts.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createHttpAdapter } from "../src/adapters";
+import { commercialBlock } from "../src/ui/domains";
+import { recordingFetch, operationalRouter } from "./helpers";
+
+const DRAFT_ID = "11111111-2222-4333-8444-555555555555";
+
+test("commercial review surface renders editable exact-hash decisions without an immediate-send control", async () => {
+  const router = operationalRouter();
+  const { fetchImpl } = recordingFetch((path) => {
+    if (path.startsWith("/v1/commercial/review-drafts")) {
+      return { items: [{
+        id: DRAFT_ID,
+        account_id: "account-1",
+        recipient: "contato@example.test",
+        subject: "Reajuste do contrato público",
+        body_text: "Olá,\n\nMensagem em revisão.",
+        state: "NEEDS_REVIEW",
+        purpose: "INITIAL",
+        ordinal: 1,
+        content_hash: "sha256:exact",
+        account: { nome_fantasia: "Construtora Exemplo" },
+      }] };
+    }
+    return router(path);
+  });
+  const adapter = createHttpAdapter("http://context.test", fetchImpl, { kind: "human", id: "founder-local" });
+  const result = await adapter.readDestination("comercial");
+  assert.equal(result.ok, true);
+  if (!result.ok || result.loading) return;
+  const html = commercialBlock(result.page.commercial!, "rascunhos");
+  assert.match(html, new RegExp(`data-review-form="${DRAFT_ID}"`));
+  assert.match(html, /SAVE_ADJUSTMENT/);
+  assert.match(html, /APPROVE/);
+  assert.match(html, /REJECT/);
+  assert.match(html, /sha256:exact/);
+  assert.doesNotMatch(html, /enviar agora|dispatch-now/i);
+});
+
+test("review decision posts the expected hash and reports next-window scheduling", async () => {
+  let request: RequestInit | undefined;
+  const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    request = init;
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }) as typeof fetch;
+  const adapter = createHttpAdapter("http://context.test", fetchImpl, { kind: "human", id: "founder-local" });
+  const result = await adapter.reviewDraftAction({
+    id: DRAFT_ID,
+    action: "APPROVE",
+    expected_content_hash: "sha256:exact",
+  });
+  assert.equal(result.ok, true);
+  assert.match(result.message, /próxima janela útil/);
+  assert.match(String(request?.body), /sha256:exact/);
+  const headers = request?.headers as Record<string, string>;
+  assert.match(String(headers["idempotency-key"]), /sha256:exact/);
+});

--- a/control-center/connectors/warmbly/README.md
+++ b/control-center/connectors/warmbly/README.md
@@ -1,6 +1,6 @@
 # Warmbly connector (Control Center)
 
-Read-only adapter that turns Warmbly's commercial runtime into a `CommercialSnapshot` plus `observations` so the cockpit can answer **o que exige atenção comercial** without owning the CRM pipeline — plus one narrow, named **operator action channel** (`src/operator/`) for three operational controls.
+Read adapter that turns Warmbly's commercial runtime into a `CommercialSnapshot` plus `observations` so the cockpit can answer **o que exige atenção comercial** without owning the CRM pipeline. It also defines one narrow **operator action channel** (`src/operator/`) for three operational controls and a separate founder-only human-review bridge in `control-center/services/context`.
 
 Canonical CRM remains Warmbly. This workstream does not persist leads/deals/stages as Control Center source of truth.
 
@@ -30,7 +30,8 @@ Canonical CRM remains Warmbly. This workstream does not persist leads/deals/stag
   - `resume_dispatch` is two step because it is the action that can let traffic flow: `requestResumeConfirmation` mints a single-use, 2-minute, actor-bound and target-bound token, and `execute` refuses without it. `pause_dispatch` is one step and is never confirmation-gated.
   - Operator writes are **never retried** (a retried acknowledge would double-acknowledge). 4xx from Warmbly does not trip the circuit breaker; 5xx/429/timeout does.
   - The channel may share the read client's `CircuitBreaker`, so a degraded Warmbly blocks operator writes too. When the breaker is open, the refusal names the out-of-band fallback: `deploy/confenge-vps/pause.sh` on the VPS.
-- **Still forbidden, through this channel or any other:** `PATCH`/`PUT`/`DELETE` on any path, creating contacts/deals/tasks, campaign start/stop/send, `dispatch-now` / cohort dispatch, enroll, approve-content, draft send, `POST /v1/confenge/inbound/:id/outcome` and `/resolve`, Confenge import/sync/bootstrap, unibox reply/compose/snooze, and **any Asaas / checkout / refund / financial mutation** (`commercial/authority/authority-manifest.v1.json` still carries `real_money_mutation_approved: false`).
+- **Amended boundary (human-review bridge).** `control-center/services/context` may call only the exact review routes listed in `required_upstream_contract.json → human_review_bridge`. The authenticated founder may save copy adjustments, approve an exact content hash for the next eligible business window, reject a draft back into editorial recovery, or apply those decisions in a bounded batch. Approval never transports a message immediately.
+- **Still forbidden:** `PATCH`/`PUT`/`DELETE` on any path, creating contacts/deals/tasks, campaign start/stop/send, `dispatch-now` / cohort dispatch, enroll, draft send, review writes outside the typed review bridge, `POST /v1/confenge/inbound/:id/outcome` and `/resolve`, Confenge import/sync/bootstrap, unibox reply/compose/snooze, and **any Asaas / checkout / refund / financial mutation** (`commercial/authority/authority-manifest.v1.json` still carries `real_money_mutation_approved: false`).
 - Every aggregated item carries `source`, `observed_at` (UTC), `freshness_status`, and `confidence` when the upstream payload supplies it.
 - Deal money is integer **cents** + `currency`. Warmbly `value` is treated as major units (1500.50 BRL → 150050 cents).
 - No `GET /leads` exists on Warmbly. Contacts search + Confenge inbound (when enabled) are the lead surface. The gap is documented in `required_upstream_contract.json`.
@@ -60,6 +61,19 @@ See `required_upstream_contract.json` for the full table. Collect calls:
 | GET | `/v1/confenge/inbound` | inbound leads needing a human |
 
 Auth: `Authorization: Bearer <token>` and `API-Version: v1`. Tokens are prefixed `wmbly_`.
+
+## Human-review bridge (`control-center/services/context`)
+
+The Control Center's `Comercial → Rascunhos` surface uses a dedicated, server-side proxy. The browser never receives the Warmbly token and cannot choose an upstream path.
+
+| Control Center route | Warmbly route | Purpose |
+| --- | --- | --- |
+| `GET /v1/commercial/review-drafts` | `GET /v1/confenge/review/drafts` | list recoverable drafts awaiting review |
+| `GET /v1/commercial/review-drafts/:id` | `GET /v1/confenge/review/drafts/:id` | inspect one exact draft |
+| `POST /v1/commercial/review-drafts/:id` | `POST /v1/confenge/review/drafts/:id/decision` | save adjustment, approve, or reject |
+| `POST /v1/commercial/review-batches` | `POST /v1/confenge/review/batches` | apply up to 500 independently reported decisions |
+
+Every request requires the trusted founder identity. `APPROVE` carries `expected_content_hash` and only creates a durable queue entry for the next eligible business window. `REJECT` preserves the lead and routes the draft to AI-assisted editorial recovery. This bridge does not expose an immediate-send operation.
 
 ## Operator action channel (`src/operator/`)
 

--- a/control-center/connectors/warmbly/required_upstream_contract.json
+++ b/control-center/connectors/warmbly/required_upstream_contract.json
@@ -77,15 +77,58 @@
       "notes": "already on the read allowlist; the operator UI should render kill-switch state from this before offering resume"
     }
   },
+  "human_review_bridge": {
+    "owner": "control-center/services/context",
+    "identity": "authenticated founder from the trusted Authelia ForwardAuth hop",
+    "token_handling": "WARMBLY_API_TOKEN stays in the server-side context service and is never exposed to the browser",
+    "mapped_reads": [
+      {
+        "method": "GET",
+        "path": "/v1/confenge/review/drafts",
+        "permission": "PermViewContacts / APIPermReadContacts",
+        "notes": "bounded review list with exact content_hash, recipient risk and editorial state"
+      },
+      {
+        "method": "GET",
+        "path": "/v1/confenge/review/drafts/{draft_id}",
+        "permission": "PermViewContacts / APIPermReadContacts",
+        "notes": "one reviewable draft; draft_id is validated before forwarding"
+      }
+    ],
+    "mapped_writes": [
+      {
+        "method": "POST",
+        "path": "/v1/confenge/review/drafts/{draft_id}/decision",
+        "permission": "PermManageContacts / APIPermWriteContacts",
+        "actions": ["SAVE_ADJUSTMENT", "APPROVE", "REJECT"],
+        "notes": "APPROVE binds expected_content_hash and schedules the exact copy for the next eligible business window; it never sends immediately"
+      },
+      {
+        "method": "POST",
+        "path": "/v1/confenge/review/batches",
+        "permission": "PermManageContacts / APIPermWriteContacts",
+        "limit": 500,
+        "notes": "bounded decisions with a per-item result; partial failures do not conceal successful items"
+      }
+    ],
+    "invariants": [
+      "no caller-supplied upstream method or path",
+      "APPROVE requires the exact expected_content_hash currently under review",
+      "generic or departmental recipients require explicit acknowledgement",
+      "REJECT preserves the lead and enters recoverable editorial processing",
+      "approval queues for the next eligible business window and does not bypass pause, kill switch or dispatch policy",
+      "no immediate-send operation exists in this bridge"
+    ]
+  },
   "forbidden_in_this_connector": [
     "PATCH/PUT/DELETE any path",
     "POST /v1/campaigns, /start, /stop, /test-email, enroll, import, dispatch",
-    "POST /v1/confenge/import, /sync, /crm/bootstrap, /campaign/bootstrap, /inbound/:id/outcome, /inbound/:id/resolve, send/enroll/approve",
+    "POST /v1/confenge/import, /sync, /crm/bootstrap, /campaign/bootstrap, /inbound/:id/outcome, /inbound/:id/resolve, send/enroll",
     "POST /v1/confenge/cohorts/:id/dispatch, /accounts/:id/resume, /drafts/:id/send",
     "POST /v1/unibox/reply, /compose, /snooze",
     "POST /v1/crm/deals (create), POST /v1/crm/tasks (create), POST /v1/contacts (create)",
     "Any Asaas / checkout / refund / financial mutation",
-    "Any POST outside the three operator_actions.mapped_writes rows"
+    "Any POST outside operator_actions.mapped_writes and human_review_bridge.mapped_writes"
   ],
   "gaps": [
     {

--- a/control-center/deploy/PRODUCTION-RUNBOOK.md
+++ b/control-center/deploy/PRODUCTION-RUNBOOK.md
@@ -30,7 +30,7 @@ Caddy never binds host `:80`/`:443` and never issues public ACME.
 - Canonical overlay: `control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml`
 - Caddyfile: `overlays/production-edge/Caddyfile` (must contain `forward_auth`; the open `deploy/Caddyfile` is not this pack)
 - Optional read-only collector join: `docker-compose.warmbly-collector.override.yml`
-- Warmbly human-gate join: `docker-compose.warmbly-human-gate.override.yml`
+- Warmbly human-gate and draft-review join: `docker-compose.warmbly-human-gate.override.yml`
 - Nginx vhost templates: `control-center/deploy/nginx/`
 - Secrets contract: `control-center/security/production/secrets/manifest.json` + `generate-local.sh`
 - Host secrets directory: `/etc/confenge/control-center/secrets` (dir `0700`, files `0600`)
@@ -111,9 +111,10 @@ the secret pack to make this group change.
 
 ## Ordered Warmbly prerequisite
 
-Merge and deploy the backward-compatible Warmbly human-gate API before the
-Control Center release. Apply migration `000116_confenge_human_gate` with the
-normal Warmbly deploy path; verify schema is `116`, `/ready` is ready, and all of
+Merge and deploy the backward-compatible Warmbly human-gate and editorial-review
+APIs before the Control Center release. Apply migrations through
+`000118_confenge_editorial_recovery` with the normal Warmbly deploy path; verify
+schema is `118`, `/ready` is ready, and all of
 these remain false/true as shown:
 
 ```
@@ -123,8 +124,11 @@ CONFENGE_REQUIRE_HUMAN_APPROVAL=true
 ```
 
 Keep the dispatch kill switch engaged for deployment and sandbox verification.
-The migration is additive and its down migration drops only the four human-gate
-tables. Do not expose the Control Center override until this prerequisite passes.
+The migrations are additive. Do not expose the Control Center override until
+this prerequisite passes. The same least-privilege human-gate credential and
+private Context-to-Warmbly network path serve draft review: mask `196` already
+contains the required contact read/write permissions and still contains no send
+permission. Do not create a browser token or expose the credential to `web`.
 
 ## Deploy (production-edge)
 
@@ -191,7 +195,11 @@ GitHub/infra/PNCP/Warmbly/Asaas persist honestly. `UNKNOWN`/`STALE`/`ERROR`/`BLO
 - Asaas is read-only (zero POST/PUT/PATCH/DELETE/refund/checkout).
 - The generic Warmbly collector remains read-only. The explicit human-gate control
   plane may write only immutable gate records through its fixed endpoint allowlist;
-  it has no send endpoint and no send permission. Never flip auto-send or autorun.
+  it has no send endpoint and no send permission. The founder-only review bridge
+  may read drafts and submit typed `SAVE_ADJUSTMENT`, `APPROVE`, `REJECT`, or
+  bounded batch decisions. Approval queues the exact reviewed content for the
+  next eligible business window; it never sends immediately. Never flip auto-send
+  or autorun during a deploy.
 - Collector DB URL host is `cc-postgres`.
 
 ## Backup
@@ -227,12 +235,12 @@ Mechanical requirement: `same_content=true` (SHA-256 of restored dump equals pla
 1. Preserve evidence and volumes (`confenge-cc-postgres-edge`).
 2. Take ops/auth vhosts out of traffic if the edge is the cause (restore nginx backup; `nginx -t` before reload).
 3. Remove `docker-compose.warmbly-human-gate.override.yml` and roll back the
-   Control Center compose/images first. Keep persisted gate records inert.
+   Control Center compose/images first. Keep persisted gate and review records inert.
 4. Revoke the `control-center-human-gate` API key. Do not alter the collector key,
    host PostgreSQL, or extra-cli.
 5. Roll back Warmbly only after Control Center no longer calls the new contract.
-   Keep migration 116 data for evidence; run its down migration only after export
-   and only if schema rollback is explicitly required.
+   Keep migration 118 data for evidence; run down migrations only after export and
+   only if schema rollback is explicitly required.
 6. Prove `https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health`
    remains READY and `auto_send_enabled=false`.
 
@@ -257,6 +265,7 @@ Backup `/etc/nginx` first. Install only `ops.confenge.com.br` and `auth.ops.conf
 - Human-gate credential `/v1/me`: exact mask `196`, no `SEND_CAMPAIGNS`; do not log its value
 - authenticated `operators` can GET/list/review; only `admins` can GO/NO-GO
 - production smoke is GET-only; all POST verification uses fixtures/sandbox and `.invalid` recipients
+- review list reachable from `context`, with dispatch paused throughout rollout
 - GitHub collector FRESH when token+allowlist are set; otherwise honest ERROR/UNKNOWN
 
 ## `/intranet`

--- a/control-center/security/production/compose.yaml
+++ b/control-center/security/production/compose.yaml
@@ -267,6 +267,8 @@ services:
       HOST: 0.0.0.0
       PORT: "8080"
       CC_TRUSTED_PROXY_CIDRS: "${CC_TRUSTED_PROXY_CIDRS:?CC_TRUSTED_PROXY_CIDRS must be set}"
+      CC_ACTOR_KIND: human
+      CC_ACTOR_ID: "${CONTROL_CENTER_FOUNDER_ACTOR_ID:?CONTROL_CENTER_FOUNDER_ACTOR_ID must be set}"
     networks:
       cc_edge:
         ipv4_address: 10.89.0.5

--- a/control-center/services/context/README.md
+++ b/control-center/services/context/README.md
@@ -52,7 +52,13 @@ GET  /v1/directives/:id
 GET  /v1/directives/:id/revisions
 POST /v1/proposals
 GET  /v1/proposals
+GET  /v1/commercial/review-drafts
+GET  /v1/commercial/review-drafts/:id
+POST /v1/commercial/review-drafts/:id
+POST /v1/commercial/review-batches
 ```
+
+As quatro rotas comerciais são uma ponte server-side e founder-only para o human gate do Warmbly. `APPROVE` vincula `expected_content_hash` e agenda a próxima janela útil; não existe envio imediato nessa ponte.
 
 Headers obrigatórios em tudo exceto `/healthz`: `X-Actor-Id`, `X-Actor-Kind` (`human` | `agent` | `system`).
 
@@ -97,6 +103,8 @@ Valores abaixo são **nomes e exemplos não-secretos**. Não commitar `.env`.
 | `CONTEXT_ACTOR_ID` / `CONTEXT_ACTOR_KIND` | CLI sim | ator da sessão CLI (`human` \| `agent` \| `system`) |
 | `HOST` / `PORT` | não | bind HTTP; default loopback `127.0.0.1:8787` |
 | `DATABASE_URL` | não | se setada, o processo **recusa** o fixture (convergência) |
+| `WARMBLY_BASE_URL` | revisão comercial | origem privada/loopback da API Warmbly |
+| `WARMBLY_API_TOKEN` | revisão comercial | credencial server-side com leitura e escrita de contatos; nunca vai ao browser |
 
 ## Adapter de persistência (handoff)
 

--- a/control-center/services/context/src/boot.ts
+++ b/control-center/services/context/src/boot.ts
@@ -13,6 +13,7 @@ import {
   type OperatorActionService,
 } from "./operational/actions.ts";
 import { createOperationalService, type OperationalService } from "./operational/service.ts";
+import { createWarmblyReviewPortFromEnv, type WarmblyReviewPort } from "./operational/warmbly-review.ts";
 import { createStoreFromEnv, createStoreFromEnvAsync } from "./store/from-env.ts";
 import type { PersistencePort } from "./store/adapter.ts";
 import type { PostgresStore } from "./store/postgres.ts";
@@ -23,6 +24,7 @@ export interface BootResult {
   service: ContextService;
   operational: OperationalService;
   operatorActions: OperatorActionService;
+  warmblyReview?: WarmblyReviewPort;
   founderActorId: string;
   defaultScope: Scope;
   fixture: string;
@@ -84,7 +86,8 @@ function assembleBoot(
     storeName === "postgres"
       ? createPostgresOperatorActionService((store as PostgresStore).persistence, founderActorId)
       : createMemoryOperatorActionService(founderActorId);
-  return { service, operational, operatorActions, founderActorId, defaultScope, fixture, storeName, repoDomains };
+  const warmblyReview = createWarmblyReviewPortFromEnv(env, founderActorId);
+  return { service, operational, operatorActions, warmblyReview, founderActorId, defaultScope, fixture, storeName, repoDomains };
 }
 
 export function bootFromEnv(

--- a/control-center/services/context/src/errors.ts
+++ b/control-center/services/context/src/errors.ts
@@ -12,7 +12,8 @@ export type ErrorCode =
   | "kind_immutable"
   | "conflict"
   | "store_misconfigured"
-  | "operator_action_forbidden";
+  | "operator_action_forbidden"
+  | "warmbly_review_failed";
 
 export class ServiceError extends Error {
   readonly code: ErrorCode;

--- a/control-center/services/context/src/http.ts
+++ b/control-center/services/context/src/http.ts
@@ -9,6 +9,7 @@ import type { OperatorActionService } from "./operational/actions.ts";
 import type { OperatorActorResolver } from "./security/operator-identity.ts";
 import type { OperationalService } from "./operational/service.ts";
 import { COMMERCIAL_LIST_IDS, type CommercialListId } from "./operational/commercial-list.ts";
+import type { WarmblyReviewPort } from "./operational/warmbly-review.ts";
 import type { ContextService } from "./service.ts";
 import { LIMITS, type ActorRef, type Scope } from "./types.ts";
 
@@ -29,6 +30,7 @@ export interface HttpDeps {
    * able to pause or resume outbound email.
    */
   warmblyOperator?: (req: WarmblyOperatorHttpRequest) => Promise<WarmblyOperatorHttpResponse>;
+  warmblyReview?: WarmblyReviewPort;
 }
 
 export interface WarmblyOperatorHttpRequest {
@@ -252,6 +254,57 @@ async function handle(
       if (method === "GET") {
         send(res, 200, { items: await deps.operatorActions.list(actor, queryScope(url)) });
         return;
+      }
+      send(res, 405, { error: "method_not_allowed" });
+      return;
+    }
+    if (
+      url.pathname === "/v1/commercial/review-drafts" ||
+      url.pathname === "/v1/commercial/review-batches" ||
+      url.pathname.startsWith("/v1/commercial/review-drafts/")
+    ) {
+      if (!deps.warmblyReview || !deps.operatorActor) {
+        send(res, 404, { error: "warmbly_review_not_configured" });
+        return;
+      }
+      const actor = deps.operatorActor(req);
+      const reviewParts = url.pathname.split("/").filter(Boolean);
+      if (method === "GET" && url.pathname === "/v1/commercial/review-drafts") {
+        send(res, 200, await deps.warmblyReview.list(actor, url.searchParams));
+        return;
+      }
+      if (
+        method === "GET" &&
+        reviewParts[0] === "v1" &&
+        reviewParts[1] === "commercial" &&
+        reviewParts[2] === "review-drafts" &&
+        reviewParts[3] &&
+        !reviewParts[4]
+      ) {
+        send(res, 200, await deps.warmblyReview.get(actor, reviewParts[3]));
+        return;
+      }
+      if (method === "POST") {
+        const contentType = String(req.headers["content-type"] ?? "");
+        if (!contentType.toLowerCase().startsWith("application/json")) {
+          send(res, 415, { error: "unsupported_media_type" });
+          return;
+        }
+        const idempotencyKey = header(req, "idempotency-key") ?? "";
+        if (url.pathname === "/v1/commercial/review-batches") {
+          send(res, 200, await deps.warmblyReview.approveBatch(actor, await readBody(req), idempotencyKey));
+          return;
+        }
+        if (
+          reviewParts[0] === "v1" &&
+          reviewParts[1] === "commercial" &&
+          reviewParts[2] === "review-drafts" &&
+          reviewParts[3] &&
+          !reviewParts[4]
+        ) {
+          send(res, 200, await deps.warmblyReview.decide(actor, reviewParts[3], await readBody(req), idempotencyKey));
+          return;
+        }
       }
       send(res, 405, { error: "method_not_allowed" });
       return;

--- a/control-center/services/context/src/operational/warmbly-review.ts
+++ b/control-center/services/context/src/operational/warmbly-review.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+
+import { assertFounder } from "../actor.ts";
+import { invalid, ServiceError } from "../errors.ts";
+import type { ActorRef } from "../types.ts";
+
+const ID = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+
+export interface WarmblyReviewPort {
+  list(actor: ActorRef, query: URLSearchParams): Promise<unknown>;
+  get(actor: ActorRef, id: string): Promise<unknown>;
+  decide(actor: ActorRef, id: string, body: unknown, idempotencyKey: string): Promise<unknown>;
+  approveBatch(actor: ActorRef, body: unknown, idempotencyKey: string): Promise<unknown>;
+}
+
+function boundedInt(value: string | null, fallback: number, max: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed < 0) return fallback;
+  return Math.min(parsed, max);
+}
+
+export function createWarmblyReviewPortFromEnv(
+  env: NodeJS.ProcessEnv,
+  founderActorId: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): WarmblyReviewPort | undefined {
+  const baseUrl = (env.WARMBLY_BASE_URL ?? env.CC_WARMBLY_BASE_URL ?? "")
+    .trim()
+    .replace(/\/+$/, "");
+  let token = (env.WARMBLY_API_TOKEN ?? env.CC_WARMBLY_OPERATOR_TOKEN ?? "").trim();
+  const credentialFile = (env.CC_WARMBLY_OPERATOR_TOKEN_FILE ?? "").trim();
+  if (!token && credentialFile) {
+    try {
+      token = readFileSync(credentialFile, "utf8").trim();
+    } catch {
+      return undefined;
+    }
+  }
+  if (!baseUrl || !token) return undefined;
+
+  async function request(path: string, init: RequestInit = {}): Promise<unknown> {
+    let response: Response;
+    try {
+      response = await fetchImpl(`${baseUrl}${path}`, {
+        ...init,
+        signal: init.signal ?? AbortSignal.timeout(10_000),
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${token}`,
+          "api-version": "v1",
+          ...(init.body ? { "content-type": "application/json" } : {}),
+          ...(init.headers ?? {}),
+        },
+      });
+    } catch {
+      throw new ServiceError("warmbly_review_failed", "Warmbly review is unavailable", 502);
+    }
+    const text = await response.text();
+    let body: unknown = {};
+    try {
+      body = text ? (JSON.parse(text) as unknown) : {};
+    } catch {
+      throw invalid(`Warmbly returned invalid JSON (${response.status})`);
+    }
+    if (!response.ok) {
+      const rec = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+      const status = response.status >= 400 && response.status <= 599 ? response.status : 502;
+      const code = status === 409 ? "conflict" : "warmbly_review_failed";
+      throw new ServiceError(code, String(rec.message ?? rec.error ?? `Warmbly review failed (${status})`), status);
+    }
+    return body;
+  }
+
+  function assertId(id: string): void {
+    if (!ID.test(id)) throw invalid("review draft id must be a UUID");
+  }
+
+  return {
+    async list(actor, query) {
+      assertFounder(actor, founderActorId);
+      const limit = boundedInt(query.get("limit"), 100, 200);
+      const offset = boundedInt(query.get("offset"), 0, 100_000);
+      return request(`/v1/confenge/review/drafts?limit=${limit}&offset=${offset}`);
+    },
+    async get(actor, id) {
+      assertFounder(actor, founderActorId);
+      assertId(id);
+      return request(`/v1/confenge/review/drafts/${id}`);
+    },
+    async decide(actor, id, body, idempotencyKey) {
+      assertFounder(actor, founderActorId);
+      assertId(id);
+      if (!idempotencyKey) throw invalid("Idempotency-Key is required");
+      return request(`/v1/confenge/review/drafts/${id}/decision`, {
+        method: "POST",
+        headers: { "idempotency-key": idempotencyKey },
+        body: JSON.stringify(body),
+      });
+    },
+    async approveBatch(actor, body, idempotencyKey) {
+      assertFounder(actor, founderActorId);
+      if (!idempotencyKey) throw invalid("Idempotency-Key is required");
+      return request("/v1/confenge/review/batches", {
+        method: "POST",
+        headers: { "idempotency-key": idempotencyKey },
+        body: JSON.stringify(body),
+      });
+    },
+  };
+}

--- a/control-center/services/context/src/server.ts
+++ b/control-center/services/context/src/server.ts
@@ -39,6 +39,7 @@ export async function startServer(
     service: boot.service,
     operational: boot.operational,
     operatorActions: boot.operatorActions,
+    warmblyReview: boot.warmblyReview,
     logger,
     ...(operatorActor ? { operatorActor } : {}),
     ...(warmblyOperator ? { warmblyOperator } : {}),

--- a/control-center/services/context/test/warmbly-review.test.ts
+++ b/control-center/services/context/test/warmbly-review.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage } from "node:http";
+import { test } from "node:test";
+import { bootFromEnv } from "../src/boot.ts";
+import { createRequestListener } from "../src/http.ts";
+import { silentLogger } from "../src/log.ts";
+import { createWarmblyReviewPortFromEnv } from "../src/operational/warmbly-review.ts";
+import type { WarmblyReviewPort } from "../src/operational/warmbly-review.ts";
+
+const FOUNDER = { kind: "human" as const, id: "founder-local" };
+const DRAFT_ID = "11111111-2222-4333-8444-555555555555";
+
+test("Warmbly review proxy is founder-only and preserves exact-hash decision metadata", async () => {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    calls.push({ url: String(input), init });
+    return new Response(JSON.stringify({ ok: true, items: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  const port = createWarmblyReviewPortFromEnv({
+    WARMBLY_BASE_URL: "https://warmbly.example.test/",
+    WARMBLY_API_TOKEN: "test-token",
+  }, FOUNDER.id, fetchImpl);
+  assert.ok(port);
+
+  await port.list(FOUNDER, new URLSearchParams({ limit: "999", offset: "12" }));
+  await port.decide(FOUNDER, DRAFT_ID, {
+    action: "APPROVE",
+    expected_content_hash: "sha256:exact",
+  }, "review-key");
+
+  assert.equal(calls[0]?.url, "https://warmbly.example.test/v1/confenge/review/drafts?limit=200&offset=12");
+  assert.equal(calls[1]?.url, `https://warmbly.example.test/v1/confenge/review/drafts/${DRAFT_ID}/decision`);
+  const headers = calls[1]?.init.headers as Record<string, string>;
+  assert.equal(headers.authorization, "Bearer test-token");
+  assert.equal(headers["idempotency-key"], "review-key");
+  assert.match(String(calls[1]?.init.body), /expected_content_hash/);
+
+  await assert.rejects(() => port.list({ kind: "agent", id: "agent-1" }, new URLSearchParams()));
+});
+
+test("Warmbly review proxy stays absent when its credential is not configured", () => {
+  assert.equal(createWarmblyReviewPortFromEnv({}, FOUNDER.id), undefined);
+});
+
+test("review HTTP routes use trusted-edge identity and require JSON for decisions", async () => {
+  const observed: Array<{ actor: unknown; key?: string; body?: unknown }> = [];
+  const warmblyReview: WarmblyReviewPort = {
+    async list(actor) {
+      observed.push({ actor });
+      return { items: [] };
+    },
+    async get(actor) {
+      observed.push({ actor });
+      return { id: DRAFT_ID };
+    },
+    async decide(actor, _id, body, key) {
+      observed.push({ actor, body, key });
+      return { ok: true };
+    },
+    async approveBatch(actor, body, key) {
+      observed.push({ actor, body, key });
+      return { ok: true };
+    },
+  };
+  const boot = bootFromEnv({ CONTROL_CENTER_FOUNDER_ACTOR_ID: FOUNDER.id });
+  const listener = createRequestListener({
+    service: boot.service,
+    logger: silentLogger,
+    warmblyReview,
+    operatorActor(req: IncomingMessage) {
+      assert.equal(req.headers["x-actor-id"], "browser-forgery");
+      return FOUNDER;
+    },
+  });
+  const server = createServer(listener);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const base = `http://127.0.0.1:${typeof address === "object" && address ? address.port : 0}`;
+  try {
+    const listed = await fetch(`${base}/v1/commercial/review-drafts`, {
+      headers: { "x-actor-id": "browser-forgery" },
+    });
+    assert.equal(listed.status, 200);
+    assert.deepEqual(observed[0]?.actor, FOUNDER);
+
+    const rejectedForm = await fetch(`${base}/v1/commercial/review-drafts/${DRAFT_ID}`, {
+      method: "POST",
+      headers: { "x-actor-id": "browser-forgery" },
+      body: JSON.stringify({ action: "APPROVE" }),
+    });
+    assert.equal(rejectedForm.status, 415);
+    assert.equal(observed.length, 1);
+
+    const decided = await fetch(`${base}/v1/commercial/review-drafts/${DRAFT_ID}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": "review-http-key",
+        "x-actor-id": "browser-forgery",
+      },
+      body: JSON.stringify({ action: "APPROVE", expected_content_hash: "sha256:exact" }),
+    });
+    assert.equal(decided.status, 200);
+    assert.deepEqual(observed[1]?.actor, FOUNDER);
+    assert.equal(observed[1]?.key, "review-http-key");
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});


### PR DESCRIPTION
## Outcome

- adds Comercial > Rascunhos with edit, approve and reject actions against the exact content hash
- proxies review through Context using trusted-edge operator identity
- reuses the file-backed least-privilege Warmbly human-gate credential with no send permission
- keeps approval semantics explicit: exact content is queued for the next eligible business window

## Validation

- full workspace typecheck passed
- full workspace test suite passed, including embedded PostgreSQL
- full workspace build passed
- production security and compose tests passed

Dispatch remains paused for rollout.