### PR TITLE
fix(control-center): trust authenticated review operator

### DIFF
--- a/control-center/connectors/warmbly/README.md
+++ b/control-center/connectors/warmbly/README.md
@@ -1,6 +1,6 @@
 # Warmbly connector (Control Center)
 
-Read adapter that turns Warmbly's commercial runtime into a `CommercialSnapshot` plus `observations` so the cockpit can answer **o que exige atenção comercial** without owning the CRM pipeline. It also defines one narrow **operator action channel** (`src/operator/`) for three operational controls and a separate founder-only human-review bridge in `control-center/services/context`.
+Read adapter that turns Warmbly's commercial runtime into a `CommercialSnapshot` plus `observations` so the cockpit can answer **o que exige atenção comercial** without owning the CRM pipeline. It also defines one narrow **operator action channel** (`src/operator/`) for three operational controls and a separate trusted-edge human-review bridge in `control-center/services/context`.
 
 Canonical CRM remains Warmbly. This workstream does not persist leads/deals/stages as Control Center source of truth.
 

--- a/control-center/deploy/PRODUCTION-RUNBOOK.md
+++ b/control-center/deploy/PRODUCTION-RUNBOOK.md
@@ -195,7 +195,7 @@ GitHub/infra/PNCP/Warmbly/Asaas persist honestly. `UNKNOWN`/`STALE`/`ERROR`/`BLO
 - Asaas is read-only (zero POST/PUT/PATCH/DELETE/refund/checkout).
 - The generic Warmbly collector remains read-only. The explicit human-gate control
   plane may write only immutable gate records through its fixed endpoint allowlist;
-  it has no send endpoint and no send permission. The founder-only review bridge
+  it has no send endpoint and no send permission. The trusted operator review bridge
   may read drafts and submit typed `SAVE_ADJUSTMENT`, `APPROVE`, `REJECT`, or
   bounded batch decisions. Approval queues the exact reviewed content for the
   next eligible business window; it never sends immediately. Never flip auto-send

--- a/control-center/services/context/README.md
+++ b/control-center/services/context/README.md
@@ -58,7 +58,7 @@ POST /v1/commercial/review-drafts/:id
 POST /v1/commercial/review-batches
 ```
 
-As quatro rotas comerciais são uma ponte server-side e founder-only para o human gate do Warmbly. `APPROVE` vincula `expected_content_hash` e agenda a próxima janela útil; não existe envio imediato nessa ponte.
+As quatro rotas comerciais são uma ponte server-side protegida pela identidade operacional autenticada no edge para o human gate do Warmbly. `APPROVE` vincula `expected_content_hash` e agenda a próxima janela útil; não existe envio imediato nessa ponte.
 
 Headers obrigatórios em tudo exceto `/healthz`: `X-Actor-Id`, `X-Actor-Kind` (`human` | `agent` | `system`).
 

--- a/control-center/services/context/src/boot.ts
+++ b/control-center/services/context/src/boot.ts
@@ -86,7 +86,7 @@ function assembleBoot(
     storeName === "postgres"
       ? createPostgresOperatorActionService((store as PostgresStore).persistence, founderActorId)
       : createMemoryOperatorActionService(founderActorId);
-  const warmblyReview = createWarmblyReviewPortFromEnv(env, founderActorId);
+  const warmblyReview = createWarmblyReviewPortFromEnv(env);
   return { service, operational, operatorActions, warmblyReview, founderActorId, defaultScope, fixture, storeName, repoDomains };
 }
 

--- a/control-center/services/context/src/operational/warmbly-review.ts
+++ b/control-center/services/context/src/operational/warmbly-review.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "node:fs";
 
-import { assertFounder } from "../actor.ts";
 import { invalid, ServiceError } from "../errors.ts";
 import type { ActorRef } from "../types.ts";
 
@@ -21,7 +20,6 @@ function boundedInt(value: string | null, fallback: number, max: number): number
 
 export function createWarmblyReviewPortFromEnv(
   env: NodeJS.ProcessEnv,
-  founderActorId: string,
   fetchImpl: typeof fetch = globalThis.fetch,
 ): WarmblyReviewPort | undefined {
   const baseUrl = (env.WARMBLY_BASE_URL ?? env.CC_WARMBLY_BASE_URL ?? "")
@@ -76,19 +74,16 @@ export function createWarmblyReviewPortFromEnv(
   }
 
   return {
-    async list(actor, query) {
-      assertFounder(actor, founderActorId);
+    async list(_actor, query) {
       const limit = boundedInt(query.get("limit"), 100, 200);
       const offset = boundedInt(query.get("offset"), 0, 100_000);
       return request(`/v1/confenge/review/drafts?limit=${limit}&offset=${offset}`);
     },
-    async get(actor, id) {
-      assertFounder(actor, founderActorId);
+    async get(_actor, id) {
       assertId(id);
       return request(`/v1/confenge/review/drafts/${id}`);
     },
-    async decide(actor, id, body, idempotencyKey) {
-      assertFounder(actor, founderActorId);
+    async decide(_actor, id, body, idempotencyKey) {
       assertId(id);
       if (!idempotencyKey) throw invalid("Idempotency-Key is required");
       return request(`/v1/confenge/review/drafts/${id}/decision`, {
@@ -97,8 +92,7 @@ export function createWarmblyReviewPortFromEnv(
         body: JSON.stringify(body),
       });
     },
-    async approveBatch(actor, body, idempotencyKey) {
-      assertFounder(actor, founderActorId);
+    async approveBatch(_actor, body, idempotencyKey) {
       if (!idempotencyKey) throw invalid("Idempotency-Key is required");
       return request("/v1/confenge/review/batches", {
         method: "POST",

--- a/control-center/services/context/test/warmbly-review.test.ts
+++ b/control-center/services/context/test/warmbly-review.test.ts
@@ -8,9 +8,10 @@ import { createWarmblyReviewPortFromEnv } from "../src/operational/warmbly-revie
 import type { WarmblyReviewPort } from "../src/operational/warmbly-review.ts";
 
 const FOUNDER = { kind: "human" as const, id: "founder-local" };
+const AUTHENTICATED_OPERATOR = { kind: "human" as const, id: "operator" };
 const DRAFT_ID = "11111111-2222-4333-8444-555555555555";
 
-test("Warmbly review proxy is founder-only and preserves exact-hash decision metadata", async () => {
+test("Warmbly review proxy preserves exact-hash decision metadata", async () => {
   const calls: Array<{ url: string; init: RequestInit }> = [];
   const fetchImpl = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
     calls.push({ url: String(input), init });
@@ -22,7 +23,7 @@ test("Warmbly review proxy is founder-only and preserves exact-hash decision met
   const port = createWarmblyReviewPortFromEnv({
     WARMBLY_BASE_URL: "https://warmbly.example.test/",
     WARMBLY_API_TOKEN: "test-token",
-  }, FOUNDER.id, fetchImpl);
+  }, fetchImpl);
   assert.ok(port);
 
   await port.list(FOUNDER, new URLSearchParams({ limit: "999", offset: "12" }));
@@ -37,12 +38,10 @@ test("Warmbly review proxy is founder-only and preserves exact-hash decision met
   assert.equal(headers.authorization, "Bearer test-token");
   assert.equal(headers["idempotency-key"], "review-key");
   assert.match(String(calls[1]?.init.body), /expected_content_hash/);
-
-  await assert.rejects(() => port.list({ kind: "agent", id: "agent-1" }, new URLSearchParams()));
 });
 
 test("Warmbly review proxy stays absent when its credential is not configured", () => {
-  assert.equal(createWarmblyReviewPortFromEnv({}, FOUNDER.id), undefined);
+  assert.equal(createWarmblyReviewPortFromEnv({}), undefined);
 });
 
 test("review HTTP routes use trusted-edge identity and require JSON for decisions", async () => {
@@ -72,7 +71,7 @@ test("review HTTP routes use trusted-edge identity and require JSON for decision
     warmblyReview,
     operatorActor(req: IncomingMessage) {
       assert.equal(req.headers["x-actor-id"], "browser-forgery");
-      return FOUNDER;
+      return AUTHENTICATED_OPERATOR;
     },
   });
   const server = createServer(listener);
@@ -84,7 +83,7 @@ test("review HTTP routes use trusted-edge identity and require JSON for decision
       headers: { "x-actor-id": "browser-forgery" },
     });
     assert.equal(listed.status, 200);
-    assert.deepEqual(observed[0]?.actor, FOUNDER);
+    assert.deepEqual(observed[0]?.actor, AUTHENTICATED_OPERATOR);
 
     const rejectedForm = await fetch(`${base}/v1/commercial/review-drafts/${DRAFT_ID}`, {
       method: "POST",
@@ -104,7 +103,7 @@ test("review HTTP routes use trusted-edge identity and require JSON for decision
       body: JSON.stringify({ action: "APPROVE", expected_content_hash: "sha256:exact" }),
     });
     assert.equal(decided.status, 200);
-    assert.deepEqual(observed[1]?.actor, FOUNDER);
+    assert.deepEqual(observed[1]?.actor, AUTHENTICATED_OPERATOR);
     assert.equal(observed[1]?.key, "review-http-key");
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));


### PR DESCRIPTION
The production Authelia username and the random internal founder id are intentionally different. The draft-review HTTP routes already require a trusted Caddy hop plus an authenticated operator group, so the second id equality check made every real review fail.

This keeps trusted-edge authentication, ignores browser actor headers, preserves the file-backed no-send Warmbly credential, and removes only the incompatible duplicate comparison.

Validation: Context typecheck and all 109 Context tests passed; the HTTP regression proves an authenticated operator whose id differs from the founder id can review, while browser identity is ignored and non-JSON writes are refused.