### PR TITLE
feat(control-center): make a cohort's current version the only operable one

### DIFF
--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -22,6 +22,7 @@ import {
   queueFocusDomId,
   queueFocusToken,
 } from "./lead-detail";
+import { editorialReasonLabel, readEditorialState } from "./editorial-state";
 import { renderFilteredList } from "./list";
 import { provenanceBlock } from "./provenance";
 import {
@@ -960,6 +961,165 @@ function exceptionOpsCard(row: Record<string, unknown>, writesAllowed: boolean):
   </article>`;
 }
 
+/* ------------------------------------------------------------------ */
+/* Revisão editorial (Comercial -> Rascunhos)                          */
+/* ------------------------------------------------------------------ */
+
+/** Dado que não chegou. Não é vazio nem zero. */
+const REVIEW_ABSENT = "ausente";
+/** Campo que o servidor desta versão simplesmente não reporta. */
+const REVIEW_UNREPORTED = "não informado";
+
+const EDITORIAL_STATE_LABELS: Record<string, string> = {
+  CURRENT: "atual",
+  LEGACY_SUPERSEDED: "histórico, substituído",
+};
+
+const EDITORIAL_LEGACY_NOTICE =
+  "Rascunho histórico: uma versão mais recente o substituiu. Fica visível para auditoria e não aceita decisão.";
+
+function reviewText(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed === "" ? null : trimmed;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function reviewList(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  const parts = value
+    .map((entry) => reviewText(entry))
+    .filter((entry): entry is string => entry !== null);
+  return parts.length === 0 ? null : parts.join(", ");
+}
+
+/** Fato de leitura. Ausência vira palavra explícita, nunca campo escondido. */
+function reviewFact(label: string, value: string | null, absentWord = REVIEW_ABSENT, extra = ""): string {
+  return value === null
+    ? fact(label, escapeHtml(absentWord), ` data-absent="true"`)
+    : fact(label, escapeHtml(value), extra);
+}
+
+/** Rótulo em português com o token cru ao lado. Código sem tradução sai uma vez só. */
+function reviewCode(raw: string, label: string): string {
+  return label === raw ? raw : `${label} (${raw})`;
+}
+
+function reviewRouteClass(raw: string | null): string | null {
+  return raw === null ? null : reviewCode(raw, routeClassLabel(raw));
+}
+
+/** Motivos do estado editorial em português, sem perder o código original. */
+function reviewReasonCodes(codes: readonly string[]): string {
+  if (codes.length === 0) return "nenhum";
+  return codes.map((code) => reviewCode(code, editorialReasonLabel(code))).join("; ");
+}
+
+function reviewProvenance(row: Record<string, unknown>): string | null {
+  const evidence = reviewList(row.evidence_ids);
+  const source = reviewText(row.fact_source);
+  if (evidence === null && source === null) return null;
+  return `${evidence ?? "sem identificador de evidência"} (origem: ${source ?? REVIEW_UNREPORTED})`;
+}
+
+function reviewComposer(row: Record<string, unknown>): string | null {
+  const composer = reviewText(row.composer_version);
+  const prompt = reviewText(row.prompt_version);
+  if (composer === null && prompt === null) return null;
+  return `${composer ?? REVIEW_UNREPORTED} (prompt: ${prompt ?? REVIEW_UNREPORTED})`;
+}
+
+function reviewTargetFit(value: unknown): string | null {
+  const fit = value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  if (!fit) return null;
+  const state = reviewText(fit.state);
+  const reason = reviewText(fit.reason);
+  const asOf = reviewText(fit.as_of);
+  const knownFresh = typeof fit.fresh === "boolean";
+  if (state === null && asOf === null && reason === null && !knownFresh) return null;
+  const freshness = knownFresh
+    ? (fit.fresh === true ? "leitura atual" : "leitura desatualizada")
+    : "frescor não informado";
+  const parts = [freshness, `apurado em ${asOf ?? REVIEW_UNREPORTED}`];
+  if (reason !== null) parts.push(reason);
+  return `${state ?? REVIEW_UNREPORTED} (${parts.join("; ")})`;
+}
+
+/**
+ * Altura pelo conteúdo: o fundador lê assunto e corpo inteiros na lista, sem
+ * abrir nada. Os campos continuam editáveis quando a decisão é permitida.
+ */
+function reviewRows(text: string, min: number, max: number): number {
+  const lines = text
+    .split("\n")
+    .reduce((total, line) => total + Math.max(1, Math.ceil(line.length / 78)), 0);
+  return Math.min(max, Math.max(min, lines + 1));
+}
+
+function reviewDraftCard(item: unknown): string {
+  const row = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+  const account = row.account && typeof row.account === "object" ? (row.account as Record<string, unknown>) : {};
+  const id = String(row.id ?? "");
+  const contentHash = String(row.content_hash ?? "");
+  const subject = String(row.subject ?? "");
+  const bodyText = String(row.body_text ?? "");
+  const rawEditorialState = reviewText(row.editorial_state);
+  // Estado e acionabilidade vêm da leitura compartilhada; a regra não se repete aqui.
+  const editorial = readEditorialState({ ...row, actionable: row.editorial_actionable });
+  const actionable = editorial.actionable;
+  const editorialReading = rawEditorialState === null
+    ? "atual (não informado pelo servidor, tratado como atual)"
+    : ownMapValue(EDITORIAL_STATE_LABELS, rawEditorialState) ?? rawEditorialState;
+  const composerVersion = reviewText(row.composer_version);
+  const notice = reviewText(editorial.notice) ?? EDITORIAL_LEGACY_NOTICE;
+  const routeClass = reviewText(row.route_class);
+  const routeClassAttr = routeClass === null ? "" : ` data-route-class="${escapeHtml(routeClass)}"`;
+  const reasonAttr = editorial.reasonCodes.length === 0
+    ? ""
+    : ` data-reason-codes="${escapeHtml(editorial.reasonCodes.join(" "))}"`;
+  const subjectRows = reviewRows(subject, 2, 4);
+  const bodyRows = reviewRows(bodyText, 12, 40);
+  const contextFacts = `<dl class="facts" data-review-context="${escapeHtml(id)}">
+                ${reviewFact("Fato observado", reviewText(row.fact_used))}
+                ${reviewFact("Proveniência", reviewProvenance(row))}
+                ${reviewFact("Classe de rota", reviewRouteClass(routeClass), REVIEW_UNREPORTED, routeClassAttr)}
+                ${reviewFact("Target fit", reviewTargetFit(row.target_fit), REVIEW_UNREPORTED)}
+                ${reviewFact("Composer", reviewComposer(row), REVIEW_UNREPORTED)}
+                ${reviewFact("Content hash", reviewText(row.content_hash))}
+                ${reviewFact("Estado editorial", editorialReading)}
+                ${reviewFact("Reason codes", reviewReasonCodes(editorial.reasonCodes), REVIEW_ABSENT, reasonAttr)}
+              </dl>`;
+  const decision = actionable
+    ? `<form data-review-form="${escapeHtml(id)}" class="operator-form">
+                <input type="hidden" name="expected_content_hash" value="${escapeHtml(contentHash)}" />
+                <label>Assunto <textarea name="subject" rows="${subjectRows}">${escapeHtml(subject)}</textarea></label>
+                <label>Corpo <textarea name="body_text" rows="${bodyRows}">${escapeHtml(bodyText)}</textarea></label>
+                <label>Decisão <select name="action">
+                  <option value="SAVE_ADJUSTMENT">Salvar ajuste</option>
+                  <option value="APPROVE">Aprovar e agendar</option>
+                  <option value="REJECT">Rejeitar e reescrever</option>
+                </select></label>
+                <label>Motivo da rejeição <textarea name="reason"></textarea></label>
+                <label>Caixa genérica/departamental <select name="generic_ack"><option value="false">não confirmar</option><option value="true">confirmo conscientemente</option></select></label>
+                <button type="submit">Registrar decisão</button>
+              </form>`
+    : `<div class="operator-form review-readonly" data-review-readonly="${escapeHtml(id)}">
+                <label>Assunto <textarea name="subject" rows="${subjectRows}" readonly>${escapeHtml(subject)}</textarea></label>
+                <label>Corpo <textarea name="body_text" rows="${bodyRows}" readonly>${escapeHtml(bodyText)}</textarea></label>
+              </div>`;
+  return `<article class="card review-draft" data-draft-id="${escapeHtml(id)}" data-state="${escapeHtml(String(row.state ?? ""))}" data-editorial-state="${escapeHtml(editorial.state)}" data-editorial-actionable="${actionable ? "true" : "false"}" data-composer-version="${escapeHtml(composerVersion ?? "")}">
+              <p class="kicker">${escapeHtml(String(row.state ?? ""))} · ${escapeHtml(String(row.purpose ?? ""))} · toque ${escapeHtml(String(row.ordinal ?? ""))}</p>
+              <h3>${escapeHtml(String(account.nome_fantasia ?? account.razao_social ?? row.account_id ?? "Lead"))}</h3>
+              <p>Destinatário: ${escapeHtml(String(row.recipient ?? "ausente"))}</p>
+              <p>Razão: ${escapeHtml(String(row.stop_reason ?? row.generation_error ?? "pronto para revisão"))}</p>
+              ${actionable ? "" : `<p class="banner stale" role="note" data-editorial-notice="true">${escapeHtml(notice)}</p>`}
+              ${contextFacts}
+              ${decision}
+            </article>`;
+}
+
 function commercialOps(
   snapshot: CommercialSnapshot,
   surface: string | null,
@@ -988,31 +1148,7 @@ function commercialOps(
       <p class="constraint">Aprovar vincula o hash exato e agenda a próxima janela útil. Nenhum botão envia imediatamente.</p>
       <div class="stack">${reviewDrafts.length === 0
         ? `<p class="banner empty">Nenhum rascunho aguardando revisão.</p>`
-        : reviewDrafts.map((item) => {
-            const row = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
-            const account = row.account && typeof row.account === "object" ? (row.account as Record<string, unknown>) : {};
-            const id = String(row.id ?? "");
-            const hash = String(row.content_hash ?? "");
-            return `<article class="card review-draft" data-draft-id="${escapeHtml(id)}" data-state="${escapeHtml(String(row.state ?? ""))}">
-              <p class="kicker">${escapeHtml(String(row.state ?? ""))} · ${escapeHtml(String(row.purpose ?? ""))} · toque ${escapeHtml(String(row.ordinal ?? ""))}</p>
-              <h3>${escapeHtml(String(account.nome_fantasia ?? account.razao_social ?? row.account_id ?? "Lead"))}</h3>
-              <p>Destinatário: ${escapeHtml(String(row.recipient ?? "ausente"))}</p>
-              <p>Razão: ${escapeHtml(String(row.stop_reason ?? row.generation_error ?? "pronto para revisão"))}</p>
-              <form data-review-form="${escapeHtml(id)}" class="operator-form">
-                <input type="hidden" name="expected_content_hash" value="${escapeHtml(hash)}" />
-                <label>Assunto <textarea name="subject">${escapeHtml(String(row.subject ?? ""))}</textarea></label>
-                <label>Corpo <textarea name="body_text">${escapeHtml(String(row.body_text ?? ""))}</textarea></label>
-                <label>Decisão <select name="action">
-                  <option value="SAVE_ADJUSTMENT">Salvar ajuste</option>
-                  <option value="APPROVE">Aprovar e agendar</option>
-                  <option value="REJECT">Rejeitar e reescrever</option>
-                </select></label>
-                <label>Motivo da rejeição <textarea name="reason"></textarea></label>
-                <label>Caixa genérica/departamental <select name="generic_ack"><option value="false">não confirmar</option><option value="true">confirmo conscientemente</option></select></label>
-                <button type="submit">Registrar decisão</button>
-              </form>
-            </article>`;
-          }).join("")}</div>
+        : reviewDrafts.map((item) => reviewDraftCard(item)).join("")}</div>
     </section>`;
   } else if (current === "cohorts") {
     const acquisition = Array.isArray(cohorts.acquisition) ? cohorts.acquisition : [];

--- a/control-center/apps/web-shell/src/ui/editorial-state.ts
+++ b/control-center/apps/web-shell/src/ui/editorial-state.ts
@@ -1,0 +1,101 @@
+/**
+ * Editorial state of a frozen cohort version.
+ *
+ * A version composed by a superseded composer still has to be readable for
+ * audit, but it is not sendable. The founder saw defective legacy copy offered
+ * with APPROVE and GO beside it, so this reading exists to tell the surface
+ * which of the two it is looking at.
+ *
+ * Defaulting rule: an absent `editorial_state` is an older backend, not a
+ * legacy version. Absent reads as CURRENT and actionable so the working flow
+ * keeps working; only `LEGACY_SUPERSEDED` (or an explicit `actionable: false`)
+ * turns on the historical treatment.
+ */
+
+import { ownMapValue } from "../own-map";
+
+export const LEGACY_EDITORIAL_STATE = "LEGACY_SUPERSEDED";
+export const CURRENT_EDITORIAL_STATE = "CURRENT";
+
+export type EditorialState = typeof CURRENT_EDITORIAL_STATE | typeof LEGACY_EDITORIAL_STATE;
+
+export interface EditorialReading {
+  /** What the surface renders in `data-editorial-state`. */
+  state: EditorialState;
+  /** True when the historical treatment applies. */
+  legacy: boolean;
+  /** False removes every decision affordance from the markup. */
+  actionable: boolean;
+  reasonCodes: string[];
+  /** pt-BR sentence written by the server. Empty when it did not send one. */
+  notice: string;
+  /** Highest version number for this cohort, as sent. Empty when absent. */
+  currentVersion: string;
+  /** Version id to link to. Empty when absent. */
+  currentVersionId: string;
+  isCurrentVersion: boolean | undefined;
+}
+
+const REASON_LABELS: Readonly<Record<string, string>> = {
+  composer_superseded: "composta por um redator anterior ao vigente",
+  composer_unstamped: "sem carimbo de redator",
+  policy_superseded: "criada sob uma policy anterior",
+};
+
+/** Unknown codes are shown verbatim: inventing a translation would hide them. */
+export function editorialReasonLabel(code: string): string {
+  return ownMapValue(REASON_LABELS, code) ?? code;
+}
+
+export function editorialReasonSentence(codes: readonly string[]): string {
+  const labels = codes.map(editorialReasonLabel).filter((label) => label !== "");
+  return labels.length > 0 ? labels.join("; ") : "";
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+export function readEditorialState(source: Record<string, unknown>): EditorialReading {
+  const declaredLegacy = text(source.editorial_state) === LEGACY_EDITORIAL_STATE;
+  const actionable = source.actionable === false ? false : !declaredLegacy;
+  const legacy = declaredLegacy || !actionable;
+  const reasonCodes = Array.isArray(source.editorial_reason_codes)
+    ? source.editorial_reason_codes.filter((entry): entry is string => typeof entry === "string" && entry !== "")
+    : [];
+  const currentVersion =
+    typeof source.current_version === "number" || typeof source.current_version === "string"
+      ? String(source.current_version)
+      : "";
+  return {
+    state: legacy ? LEGACY_EDITORIAL_STATE : CURRENT_EDITORIAL_STATE,
+    legacy,
+    actionable,
+    reasonCodes,
+    notice: text(source.editorial_notice),
+    currentVersion,
+    currentVersionId: text(source.current_version_id),
+    isCurrentVersion: typeof source.is_current_version === "boolean" ? source.is_current_version : undefined,
+  };
+}
+
+/**
+ * A candidate inherits the version's verdict: a candidate cannot be actionable
+ * inside a historical version, and its own reason codes win when it has any.
+ */
+export function mergeEditorialState(
+  cohort: EditorialReading,
+  candidate: EditorialReading,
+): EditorialReading {
+  const legacy = cohort.legacy || candidate.legacy;
+  return {
+    state: legacy ? LEGACY_EDITORIAL_STATE : CURRENT_EDITORIAL_STATE,
+    legacy,
+    actionable: cohort.actionable && candidate.actionable,
+    reasonCodes: candidate.reasonCodes.length > 0 ? candidate.reasonCodes : cohort.reasonCodes,
+    notice: candidate.notice || cohort.notice,
+    currentVersion: cohort.currentVersion,
+    currentVersionId: cohort.currentVersionId,
+    isCurrentVersion: cohort.isCurrentVersion,
+  };
+}

--- a/control-center/apps/web-shell/src/ui/labels.ts
+++ b/control-center/apps/web-shell/src/ui/labels.ts
@@ -367,6 +367,9 @@ export const UNRECOGNIZED_COMMERCIAL_STATE_LABEL = "estado não reconhecido";
 export const ROUTE_CLASS_LABELS: Record<string, string> = {
   DIRECT_PERSON: "pessoa identificada diretamente",
   DIRECT_COMPANY: "empresa identificada diretamente",
+  GENERIC_COMPANY: "caixa genérica da empresa, como contato@ ou comercial@",
+  ROLE_OR_DEPARTMENT: "caixa de cargo ou departamento",
+  PUBLIC_COMPANY_FREEMAIL: "empresa em domínio de e-mail gratuito",
   INBOUND: "mensagem recebida",
   UNKNOWN: "classe de rota desconhecida",
 };

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -34,6 +34,13 @@ import { AUTH_HOST, PRODUCTIVE_HOST } from "../topology";
 import type { ActorRef, CommercialSnapshot } from "../types";
 import type { PendingResumeConfirmation } from "../warmbly-confirmation";
 import {
+  editorialReasonLabel,
+  editorialReasonSentence,
+  mergeEditorialState,
+  readEditorialState,
+  type EditorialReading,
+} from "./editorial-state";
+import {
   operatorActionLabel,
   operatorOutcomeLabel,
   technicalDetails,
@@ -1363,6 +1370,9 @@ function candidateCard(
     ? candidate.blocked_by.filter((entry): entry is string => typeof entry === "string")
     : [];
   const gate = approvalGate(candidate);
+  // A candidate inherits the version's editorial verdict: nothing inside a
+  // historical version is decidable, however the candidate itself is stamped.
+  const editorial = mergeEditorialState(readEditorialState(cohort), readEditorialState(candidate));
   // expected_frozen_hash guards the VERSION the operator was looking at, so it
   // is the cohort's frozen_hash. A candidate carries content_hash and
   // evidence_hash and no frozen_hash of its own, so reading it from the
@@ -1383,50 +1393,10 @@ function candidateCard(
       ? candidate.copy_qa_failures.filter((entry): entry is string => typeof entry === "string")
       : [];
 
-  return `<article class="card" data-candidate-id="${escapeHtml(candidateId)}" data-approve-allowed="${gate.allowed ? "true" : "false"}">
-    <p class="kicker">${validationPill(candidate)} · ${escapeHtml(show(candidate.route_class))} · ${escapeHtml(show(candidate.source))}</p>
-    <h3>${escapeHtml(show(candidate.company))}</h3>
-    ${feedback.forCandidate(candidateId)}
-    <dl class="facts" data-candidate-identity="true">
-      ${fact("Destinatário exato", show(candidate.mailbox))}
-      ${fact("Purpose do destinatário", show(candidate.mailbox_purpose))}
-      ${fact("Classe de rota", show(candidate.route_class))}
-    </dl>
-    <details data-message-preview="true"${expandAll ? " open" : ""}>
-      <summary>Mensagem exata congelada (assunto e corpo)</summary>
-      <p data-exact-subject="true"><strong>Assunto:</strong> ${escapeHtml(show(candidate.subject))}</p>
-      <pre class="message-preview" data-exact-body="true">${escapeHtml(show(candidate.body_text))}</pre>
-      <p data-cta="true"><strong>Chamada para ação (CTA):</strong> ${escapeHtml(fromPayload(candidate.cta ?? candidate.cta_text))}</p>
-    </details>
-    <dl class="facts" data-observed-fact="true">
-      ${fact("Fato observado", fromPayload(candidate.observed_fact_text ?? evidence.text ?? evidence.summary))}
-      ${fact("Proveniência do fato", fromPayload(candidate.evidence_source ?? evidence.source ?? evidence.locator))}
-      ${fact("Observado em", fromPayload(candidate.evidence_observed_at ?? evidence.observed_at))}
-      ${fact("Evidence hash", fromPayload(candidate.evidence_hash))}
-    </dl>
-    <dl class="facts" data-candidate-integrity="true">
-      ${fact("Content hash", fromPayload(candidate.content_hash))}
-      ${fact("Frozen hash", fromPayload(candidate.frozen_hash))}
-      ${fact("Policy version", fromPayload(cohort.policy_version))}
-      ${fact("Composer version", fromPayload(candidate.composer_version ?? cohort.composer_version))}
-      ${fact("Validação", fromPayload(validation.status))}
-      ${fact("Motivo da validação", fromPayload(validation.reason))}
-      ${fact("Validação vence em", validation.expires_at ? stamp(validation.expires_at) : NOT_IN_PAYLOAD)}
-      ${fact("Revisão registrada", fromPayload(review.decision))}
-      ${fact("Revisão efetiva", fromPayload(review.effective))}
-      ${listFacts("Bloqueios", candidate.blocked_by)}
-      ${listFacts("Reprovações de copy QA", copyQaFailures.length > 0 ? copyQaFailures : copyQa.failures)}
-      ${fact("Duplicidade apontada pelo servidor", fromPayload(candidate.duplicate_of ?? candidate.duplicate))}
-      ${fact("Proveniência ausente", fromPayload(candidate.missing_provenance))}
-      ${fact("Hard bounce registrado", fromPayload(candidate.hard_bounce))}
-      ${fact("Excluído do preview por", fromPayload(candidate.exclusion_reason ?? candidate.excluded_reason))}
-    </dl>
-    ${
-      blockers.length > 0
-        ? `<p class="banner error" role="alert" data-candidate-blockers="${escapeHtml(blockers.join(" "))}">O servidor registrou ${blockers.length} bloqueio(s) neste candidato: ${escapeHtml(blockers.join(", "))}.</p>`
-        : ""
-    }
-
+  // Not merely disabled: a historical version emits no decision markup at all,
+  // so there is nothing for devtools to re-enable.
+  const controls = editorial.actionable
+    ? `
     ${gateInFlight(validateKey) ? pendingBlock("Pedindo a verificação do destinatário") : ""}
     <form class="operator-form" data-human-gate="validate" data-gate-key="${escapeHtml(validateKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
       <p class="constraint">Pede ao Warmbly que verifique agora se este endereço aceita entrega. Não envia mensagem nenhuma.</p>
@@ -1461,6 +1431,56 @@ function candidateCard(
     </form>
 
     ${adjustBlock({ cohortId, candidateId, version, frozenHash, candidate, authority, adjustKey, draft })}
+`
+    : `<p class="constraint" data-non-actionable-notice="true">Versão histórica, não enviável. Verificar o destinatário, aprovar, segurar e ajustar não são oferecidos aqui. Abra a versão corrente pelo link no topo desta página.</p>`;
+
+  return `<article class="card" data-candidate-id="${escapeHtml(candidateId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}" data-approve-allowed="${gate.allowed && editorial.actionable ? "true" : "false"}">
+    <p class="kicker">${validationPill(candidate)}${editorial.legacy ? ` <span class="pill error" data-non-actionable="true">NÃO ACIONÁVEL</span>` : ""} · ${escapeHtml(show(candidate.route_class))} · ${escapeHtml(show(candidate.source))}</p>
+    <h3>${escapeHtml(show(candidate.company))}</h3>
+    ${feedback.forCandidate(candidateId)}
+    <dl class="facts" data-candidate-identity="true">
+      ${fact("Destinatário exato", show(candidate.mailbox))}
+      ${fact("Purpose do destinatário", show(candidate.mailbox_purpose))}
+      ${fact("Classe de rota", show(candidate.route_class))}
+    </dl>
+    <details data-message-preview="true"${expandAll ? " open" : ""}>
+      <summary>Mensagem exata congelada (assunto e corpo). ${editorial.legacy ? "Versão histórica, não enviar." : "Versão corrente."}</summary>
+      <p data-exact-subject="true"><strong>Assunto:</strong> ${escapeHtml(show(candidate.subject))}</p>
+      <pre class="message-preview" data-exact-body="true">${escapeHtml(show(candidate.body_text))}</pre>
+      <p data-cta="true"><strong>Chamada para ação (CTA):</strong> ${escapeHtml(fromPayload(candidate.cta ?? candidate.cta_text))}</p>
+    </details>
+    <dl class="facts" data-observed-fact="true">
+      ${fact("Fato observado", fromPayload(candidate.observed_fact_text ?? evidence.text ?? evidence.summary))}
+      ${fact("Proveniência do fato", fromPayload(candidate.evidence_source ?? evidence.source ?? evidence.locator))}
+      ${fact("Observado em", fromPayload(candidate.evidence_observed_at ?? evidence.observed_at))}
+      ${fact("Evidence hash", fromPayload(candidate.evidence_hash))}
+    </dl>
+    <dl class="facts" data-candidate-integrity="true">
+      ${fact("Content hash", fromPayload(candidate.content_hash))}
+      ${fact("Frozen hash", fromPayload(candidate.frozen_hash))}
+      ${fact("Policy version", fromPayload(cohort.policy_version))}
+      ${fact("Composer version", fromPayload(candidate.composer_version ?? cohort.composer_version))}
+      ${fact("Estado editorial", editorial.legacy ? "Versão histórica (não enviável)" : "Versão corrente")}
+      ${editorial.reasonCodes.length > 0 ? listFacts("Motivos do estado editorial", editorial.reasonCodes.map(editorialReasonLabel)) : ""}
+      ${fact("Validação", fromPayload(validation.status))}
+      ${fact("Motivo da validação", fromPayload(validation.reason))}
+      ${fact("Validação vence em", validation.expires_at ? stamp(validation.expires_at) : NOT_IN_PAYLOAD)}
+      ${fact("Revisão registrada", fromPayload(review.decision))}
+      ${fact("Revisão efetiva", fromPayload(review.effective))}
+      ${listFacts("Bloqueios", candidate.blocked_by)}
+      ${listFacts("Reprovações de copy QA", copyQaFailures.length > 0 ? copyQaFailures : copyQa.failures)}
+      ${fact("Duplicidade apontada pelo servidor", fromPayload(candidate.duplicate_of ?? candidate.duplicate))}
+      ${fact("Proveniência ausente", fromPayload(candidate.missing_provenance))}
+      ${fact("Hard bounce registrado", fromPayload(candidate.hard_bounce))}
+      ${fact("Excluído do preview por", fromPayload(candidate.exclusion_reason ?? candidate.excluded_reason))}
+    </dl>
+    ${
+      blockers.length > 0
+        ? `<p class="banner error" role="alert" data-candidate-blockers="${escapeHtml(blockers.join(" "))}">O servidor registrou ${blockers.length} bloqueio(s) neste candidato: ${escapeHtml(blockers.join(", "))}.</p>`
+        : ""
+    }
+
+    ${controls}
     ${technicalDetails(
       [
         { term: "candidate_id", value: candidateId },
@@ -1468,6 +1488,8 @@ function candidateCard(
         { term: "frozen_hash", value: frozenHash },
         { term: "evidence_hash", value: show(candidate.evidence_hash) },
         { term: "blocked_by", value: blockers.join(",") },
+        { term: "editorial_state", value: editorial.state },
+        { term: "editorial_reason_codes", value: editorial.reasonCodes.join(",") },
       ],
       "warmbly-candidate",
     )}
@@ -1536,6 +1558,31 @@ function adjustBlock(args: {
     </details>`;
 }
 
+/**
+ * The founder's escape hatch out of a historical version.
+ *
+ * Loud, first thing on the page, and carrying the link to the current version
+ * as its primary control. Nothing below it is decidable.
+ */
+function legacyBanner(editorial: EditorialReading, cohortId: string): string {
+  if (!editorial.legacy) return "";
+  const reasons = editorialReasonSentence(editorial.reasonCodes);
+  const linkable = editorial.currentVersionId !== "" && editorial.currentVersionId !== cohortId;
+  return `<section class="banner error" role="alert" data-legacy-banner="true" data-editorial-state="${escapeHtml(editorial.state)}">
+    <h3>Versão histórica. Não enviar.</h3>
+    <p data-legacy-summary="true">Esta é uma versão antiga desta cohort, mantida legível só para auditoria. A mensagem abaixo não é enviável: aprovar, ajustar, verificar e registrar GO não são oferecidos nesta tela.</p>
+    ${reasons ? `<p data-legacy-reasons="true">Por que ficou histórica: ${escapeHtml(reasons)}.</p>` : ""}
+    ${editorial.notice ? `<p data-editorial-notice="true">${escapeHtml(editorial.notice)}</p>` : ""}
+    ${
+      linkable
+        ? `<p><a class="button" data-open-current="true" href="#/warmbly/revisao?resource=${escapeHtml(editorial.currentVersionId)}">Abrir versão corrente</a>${
+            editorial.currentVersion ? ` <span class="scope">v${escapeHtml(editorial.currentVersion)}</span>` : ""
+          }</p>`
+        : `<p class="constraint" data-open-current="absent">O servidor não informou qual é a versão corrente desta cohort, então esta tela não inventa um link. Abra Cohorts para achá-la.</p>`
+    }
+  </section>`;
+}
+
 function reviewSurface(input: WarmblySurfaceInput): string {
   const selected = gateSection(input, "selected");
   const list = gateSection(input, "list");
@@ -1578,22 +1625,36 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   const cohortFeedback = feedback.forCohort(cohortId);
   const leftover = feedback.remainder();
   const decisionValue = fromPayload(record(cohort.decision).decision);
-  return `<section class="stack" aria-labelledby="review-title" data-review-cohort="${escapeHtml(cohortId)}"><h2 id="review-title">Revisão v${escapeHtml(version)}</h2>
-  ${leftover}${cohortFeedback}
-  ${gateUnreadableBanner(selected, "a versão selecionada")}
-  <p class="constraint">${escapeHtml(show(cohort.source))}, as_of ${escapeHtml(show(cohort.as_of))}, ${escapeHtml(show(cohort.freshness))}, policy ${escapeHtml(show(cohort.policy_version))}. Receipt ${escapeHtml(show(cohort.receipt))}.</p>
-  ${identityBlock(input)}
-  ${previewBlock(preview)}
-  <p><button type="button" data-toggle-messages="true" aria-expanded="${expandAll ? "true" : "false"}">${expandAll ? "Recolher todas as mensagens" : "Expandir todas as mensagens"}</button></p>
+  const editorial = readEditorialState(cohort);
+  // A historical version emits neither the GO/NO-GO form nor the reproduce
+  // form. The facts below them stay: this removes decisions, not information.
+  const reproduceControl = editorial.actionable
+    ? `
   ${gateInFlight(reproduceKey) ? pendingBlock("Reproduzindo a versão imutável") : ""}
   <form class="operator-form" data-human-gate="reproduce" data-gate-key="${escapeHtml(reproduceKey)}" data-version="${escapeHtml(cohortId)}"><button type="submit"${gateInFlight(reproduceKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(reproduceKey) ? "Enviando…" : "Reproduzir versão imutável"}</button></form>
-  ${candidateCards || `<p class="banner error">Cohort vazia: GO bloqueado.</p>`}
+`
+    : "";
+  const decideControl = editorial.actionable
+    ? `
   ${gateInFlight(decideKey) ? pendingBlock("Registrando GO/NO-GO") : ""}
   <form class="operator-form" data-human-gate="decide" data-gate-key="${escapeHtml(decideKey)}" data-version="${escapeHtml(cohortId)}"><label>Decisão final<select name="decision"><option value="NO_GO">NO_GO</option><option value="GO">GO</option></select></label><label>Motivo<input name="reason" required minlength="3"></label><label>Confirme digitando <code>v${escapeHtml(version)}</code><input name="confirmation" required pattern="v${escapeHtml(version)}"></label><button type="submit"${authority.canDecide && !gateInFlight(decideKey) ? "" : " disabled"}>${gateInFlight(decideKey) ? "Enviando…" : "Registrar GO/NO-GO"}</button>${
     authority.canDecide
       ? ""
       : `<p class="constraint" data-go-authority="absent">GO/NO-GO está desabilitado nesta sessão: ele exige o grupo <code>admins</code> no Authelia. Peça a inclusão nesse grupo e reautentique; revisar candidatos continua permitido com <code>operators</code>.</p>`
   }</form>
+`
+    : `<p class="constraint" data-non-actionable-surface="true">Versão histórica, não enviável. GO/NO-GO e a reprodução da versão imutável não são oferecidos aqui. Decida na versão corrente.</p>`;
+  return `<section class="stack" aria-labelledby="review-title" data-review-cohort="${escapeHtml(cohortId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}"><h2 id="review-title">Revisão v${escapeHtml(version)}</h2>
+  ${legacyBanner(editorial, cohortId)}
+  ${leftover}${cohortFeedback}
+  ${gateUnreadableBanner(selected, "a versão selecionada")}
+  <p class="constraint">${escapeHtml(show(cohort.source))}, as_of ${escapeHtml(show(cohort.as_of))}, ${escapeHtml(show(cohort.freshness))}, policy ${escapeHtml(show(cohort.policy_version))}. Receipt ${escapeHtml(show(cohort.receipt))}.</p>
+  ${identityBlock(input)}
+  ${previewBlock(preview)}
+  <p><button type="button" data-toggle-messages="true" aria-expanded="${expandAll ? "true" : "false"}">${expandAll ? "Recolher todas as mensagens" : "Expandir todas as mensagens"}</button></p>
+  ${reproduceControl}
+  ${candidateCards || `<p class="banner error">Cohort vazia: GO bloqueado.</p>`}
+  ${decideControl}
   <dl class="facts"><div><dt>Decisão final registrada</dt><dd>${escapeHtml(decisionValue)}</dd></div></dl>
   <p class="constraint">GO não envia e-mail. O Control Center não expõe dispatch, queue ou send neste gate.</p></section>`;
 }

--- a/control-center/apps/web-shell/tests/review-drafts.test.ts
+++ b/control-center/apps/web-shell/tests/review-drafts.test.ts
@@ -56,3 +56,243 @@ test("review decision posts the expected hash and reports next-window scheduling
   const headers = request?.headers as Record<string, string>;
   assert.match(String(headers["idempotency-key"]), /sha256:exact/);
 });
+
+const LEGACY_ID = "99999999-8888-4777-8666-555555555555";
+
+function reviewSurface(rows: unknown[]): Promise<string> {
+  const router = operationalRouter();
+  const { fetchImpl } = recordingFetch((path) => {
+    if (path.startsWith("/v1/commercial/review-drafts")) return { data: rows };
+    return router(path);
+  });
+  const adapter = createHttpAdapter("http://context.test", fetchImpl, { kind: "human", id: "founder-local" });
+  return adapter.readDestination("comercial").then((result) => {
+    assert.equal(result.ok, true);
+    if (!result.ok || result.loading) throw new Error("comercial não carregou");
+    return commercialBlock(result.page.commercial!, "rascunhos");
+  });
+}
+
+const RICH_DRAFT = {
+  id: DRAFT_ID,
+  account_id: "account-1",
+  recipient: "obras@construtora.test",
+  subject: "Laudo estrutural do bloco B",
+  body_text: "Olá,\n\nVi o edital publicado ontem.\n\nAbraço.",
+  state: "NEEDS_REVIEW",
+  purpose: "INITIAL",
+  ordinal: 1,
+  content_hash: "sha256:exact",
+  account: { nome_fantasia: "Construtora Exemplo" },
+  fact_used: "Publicou edital de reforma do bloco B em 20/08",
+  evidence_ids: ["ev-pncp-1", "ev-pncp-2"],
+  fact_source: "fact_to_mention",
+  policy_version: "confenge.policy.v3",
+  route_class: "GENERIC_COMPANY",
+  composer_version: "confenge.composer.v5",
+  prompt_version: "confenge.draft.v6",
+  editorial_state: "CURRENT",
+  editorial_actionable: true,
+  editorial_reason_codes: ["FACT_FRESH", "ROUTE_OK"],
+  target_fit: { state: "FIT", reason: "porte e setor compatíveis", fresh: true, as_of: "2026-08-20T12:00:00Z" },
+};
+
+test("review surface renders the judging context inline, with no details disclosure to open", async () => {
+  const html = await reviewSurface([RICH_DRAFT]);
+  assert.match(html, /data-review-context="11111111-2222-4333-8444-555555555555"/);
+  assert.match(html, /<dt>Fato observado<\/dt><dd>Publicou edital de reforma do bloco B em 20\/08<\/dd>/);
+  assert.match(html, /<dt>Proveniência<\/dt><dd>ev-pncp-1, ev-pncp-2 \(origem: fact_to_mention\)<\/dd>/);
+  assert.match(html, /<dt>Classe de rota<\/dt><dd>caixa genérica da empresa, como contato@ ou comercial@ \(GENERIC_COMPANY\)<\/dd>/);
+  assert.match(html, /<dt>Target fit<\/dt><dd>FIT \(leitura atual; apurado em 2026-08-20T12:00:00Z; porte e setor compatíveis\)<\/dd>/);
+  assert.match(html, /<dt>Composer<\/dt><dd>confenge\.composer\.v5 \(prompt: confenge\.draft\.v6\)<\/dd>/);
+  assert.match(html, /<dt>Content hash<\/dt><dd>sha256:exact<\/dd>/);
+  assert.match(html, /<dt>Estado editorial<\/dt><dd>atual<\/dd>/);
+  assert.match(html, /<dt>Reason codes<\/dt><dd>FACT_FRESH; ROUTE_OK<\/dd>/);
+  assert.match(html, /data-editorial-state="CURRENT"/);
+  assert.match(html, /data-composer-version="confenge\.composer\.v5"/);
+  // The message itself is read as text on the list; nothing is folded away.
+  assert.match(html, /Vi o edital publicado ontem/);
+  assert.doesNotMatch(html, /<details[^>]*>\s*<summary>Mensagem/);
+});
+
+test("a CURRENT row keeps the full editable decision form", async () => {
+  const html = await reviewSurface([RICH_DRAFT]);
+  assert.match(html, new RegExp(`data-review-form="${DRAFT_ID}"`));
+  assert.match(html, /name="expected_content_hash" value="sha256:exact"/);
+  assert.match(html, /<option value="SAVE_ADJUSTMENT">/);
+  assert.match(html, /<option value="APPROVE">/);
+  assert.match(html, /<option value="REJECT">/);
+  assert.match(html, /name="reason"/);
+  assert.match(html, /name="generic_ack"/);
+  assert.match(html, /<button type="submit">Registrar decisão<\/button>/);
+  assert.match(html, /data-editorial-actionable="true"/);
+  // Only subject and body are editable; the judging context is plain text.
+  assert.doesNotMatch(html, /<textarea name="subject"[^>]*readonly/);
+  assert.match(html, /Aprovar vincula o hash exato e agenda a próxima janela útil\./);
+});
+
+test("absent editorial fields render an explicit word instead of undefined", async () => {
+  const html = await reviewSurface([{
+    id: DRAFT_ID,
+    recipient: "contato@example.test",
+    subject: "Assunto legado",
+    body_text: "Corpo legado.",
+    state: "NEEDS_REVIEW",
+    purpose: "INITIAL",
+    ordinal: 1,
+    content_hash: "sha256:legacy",
+    account: { nome_fantasia: "Construtora Exemplo" },
+  }]);
+  assert.doesNotMatch(html, /undefined/);
+  assert.doesNotMatch(html, /\[object Object\]/);
+  assert.match(html, /<dt>Fato observado<\/dt><dd>ausente<\/dd>/);
+  assert.match(html, /<dt>Proveniência<\/dt><dd>ausente<\/dd>/);
+  assert.match(html, /<dt>Classe de rota<\/dt><dd>não informado<\/dd>/);
+  assert.match(html, /<dt>Target fit<\/dt><dd>não informado<\/dd>/);
+  assert.match(html, /<dt>Composer<\/dt><dd>não informado<\/dd>/);
+  assert.match(html, /<dt>Reason codes<\/dt><dd>nenhum<\/dd>/);
+  assert.match(html, /<dt>Estado editorial<\/dt><dd>atual \(não informado pelo servidor, tratado como atual\)<\/dd>/);
+  // An older backend still yields a decidable row.
+  assert.match(html, /data-editorial-state="CURRENT"/);
+  assert.match(html, /data-editorial-actionable="true"/);
+  assert.match(html, new RegExp(`data-review-form="${DRAFT_ID}"`));
+  assert.match(html, /data-composer-version=""/);
+});
+
+test("a partially reported target fit degrades field by field without crashing", async () => {
+  const html = await reviewSurface([{
+    ...RICH_DRAFT,
+    evidence_ids: [],
+    fact_source: "fact_to_mention",
+    prompt_version: "",
+    target_fit: { state: "FIT" },
+  }]);
+  assert.doesNotMatch(html, /undefined/);
+  assert.match(html, /<dt>Proveniência<\/dt><dd>sem identificador de evidência \(origem: fact_to_mention\)<\/dd>/);
+  assert.match(html, /<dt>Composer<\/dt><dd>confenge\.composer\.v5 \(prompt: não informado\)<\/dd>/);
+  assert.match(html, /<dt>Target fit<\/dt><dd>FIT \(frescor não informado; apurado em não informado\)<\/dd>/);
+});
+
+test("a LEGACY_SUPERSEDED row is auditable but offers no decision control at all", async () => {
+  const html = await reviewSurface([{
+    ...RICH_DRAFT,
+    id: LEGACY_ID,
+    subject: "Assunto substituído",
+    body_text: "Corpo histórico que segue auditável.",
+    editorial_state: "LEGACY_SUPERSEDED",
+    editorial_actionable: false,
+    editorial_reason_codes: ["SUPERSEDED_BY_NEWER_DRAFT"],
+    editorial_notice: "Rascunho substituído por uma recomposição mais recente. Mantido apenas para auditoria.",
+  }]);
+  assert.match(html, /data-editorial-state="LEGACY_SUPERSEDED"/);
+  assert.match(html, /data-editorial-actionable="false"/);
+  assert.match(html, /Rascunho substituído por uma recomposição mais recente\. Mantido apenas para auditoria\./);
+  assert.match(html, /<dt>Estado editorial<\/dt><dd>histórico, substituído<\/dd>/);
+  assert.match(html, /<dt>Reason codes<\/dt><dd>SUPERSEDED_BY_NEWER_DRAFT<\/dd>/);
+  // History stays readable.
+  assert.match(html, /Corpo histórico que segue auditável\./);
+  assert.match(html, /<textarea name="body_text" rows="\d+" readonly>/);
+  assert.match(html, /<textarea name="subject" rows="\d+" readonly>/);
+  // No decision surface is emitted, not even disabled.
+  assert.doesNotMatch(html, new RegExp(`data-review-form="${LEGACY_ID}"`));
+  assert.doesNotMatch(html, /SAVE_ADJUSTMENT/);
+  assert.doesNotMatch(html, /name="generic_ack"/);
+  assert.doesNotMatch(html, /<button type="submit">/);
+});
+
+test("a legacy row without an editorial_notice still states why it cannot be decided", async () => {
+  const html = await reviewSurface([{ ...RICH_DRAFT, id: LEGACY_ID, editorial_state: "LEGACY_SUPERSEDED" }]);
+  assert.match(html, /uma versão mais recente o substituiu/);
+  assert.doesNotMatch(html, /<button type="submit">/);
+});
+
+test("reason codes are read in Portuguese with the original token beside them", async () => {
+  const html = await reviewSurface([{
+    ...RICH_DRAFT,
+    editorial_reason_codes: ["composer_superseded", "composer_unstamped", "policy_superseded"],
+  }]);
+  assert.match(
+    html,
+    /<dt>Reason codes<\/dt><dd>composta por um redator anterior ao vigente \(composer_superseded\); sem carimbo de redator \(composer_unstamped\); criada sob uma policy anterior \(policy_superseded\)<\/dd>/,
+  );
+  // The untranslated truth stays machine-readable next to the sentence.
+  assert.match(html, /data-reason-codes="composer_superseded composer_unstamped policy_superseded"/);
+});
+
+test("a reason code with no authored translation is shown verbatim, never dropped", async () => {
+  const html = await reviewSurface([{
+    ...RICH_DRAFT,
+    editorial_reason_codes: ["composer_superseded", "code_the_backend_just_invented"],
+  }]);
+  assert.match(
+    html,
+    /<dt>Reason codes<\/dt><dd>composta por um redator anterior ao vigente \(composer_superseded\); code_the_backend_just_invented<\/dd>/,
+  );
+  // Unknown codes are not doubled up as "label (token)" with the token as the label.
+  assert.doesNotMatch(html, /code_the_backend_just_invented \(code_the_backend_just_invented\)/);
+  assert.match(html, /data-reason-codes="composer_superseded code_the_backend_just_invented"/);
+});
+
+test("every route class the composer emits has a Portuguese reading", async () => {
+  const cases: Array<[string, RegExp]> = [
+    ["ROLE_OR_DEPARTMENT", /<dd>caixa de cargo ou departamento \(ROLE_OR_DEPARTMENT\)<\/dd>/],
+    ["PUBLIC_COMPANY_FREEMAIL", /<dd>empresa em domínio de e-mail gratuito \(PUBLIC_COMPANY_FREEMAIL\)<\/dd>/],
+    ["DIRECT_PERSON", /<dd>pessoa identificada diretamente \(DIRECT_PERSON\)<\/dd>/],
+  ];
+  for (const [routeClass, expected] of cases) {
+    const html = await reviewSurface([{ ...RICH_DRAFT, route_class: routeClass }]);
+    assert.match(html, expected, `${routeClass} não foi traduzida`);
+    assert.match(html, new RegExp(`data-route-class="${routeClass}"`));
+  }
+});
+
+test("an unrecognized route class falls back to the authored label and keeps the token", async () => {
+  const html = await reviewSurface([{ ...RICH_DRAFT, route_class: "ROUTE_THE_BACKEND_JUST_INVENTED" }]);
+  assert.match(
+    html,
+    /<dt>Classe de rota<\/dt><dd>classe de rota não reconhecida \(ROUTE_THE_BACKEND_JUST_INVENTED\)<\/dd>/,
+  );
+});
+
+test("a historical row translates its reasons and still offers no form", async () => {
+  const html = await reviewSurface([{
+    ...RICH_DRAFT,
+    id: LEGACY_ID,
+    editorial_state: "LEGACY_SUPERSEDED",
+    editorial_actionable: false,
+    editorial_reason_codes: ["composer_superseded", "policy_superseded"],
+  }]);
+  assert.match(html, /composta por um redator anterior ao vigente \(composer_superseded\)/);
+  assert.match(html, /criada sob uma policy anterior \(policy_superseded\)/);
+  assert.match(html, /data-editorial-state="LEGACY_SUPERSEDED"/);
+  assert.match(html, /data-editorial-actionable="false"/);
+  assert.doesNotMatch(html, /<button type="submit">/);
+});
+
+test("payload values are escaped before reaching innerHTML", async () => {
+  const html = await reviewSurface([{
+    ...RICH_DRAFT,
+    fact_used: '<img src=x onerror="alert(1)">',
+    route_class: "<script>alert(2)</script>",
+    evidence_ids: ["<b>ev</b>"],
+  }]);
+  assert.doesNotMatch(html, /<script>alert\(2\)<\/script>/);
+  assert.doesNotMatch(html, /<img src=x/);
+  assert.match(html, /&lt;img src=x/);
+});
+
+test("mixed rows keep decidable and historical drafts side by side", async () => {
+  const html = await reviewSurface([
+    RICH_DRAFT,
+    { ...RICH_DRAFT, id: LEGACY_ID, editorial_state: "LEGACY_SUPERSEDED", editorial_actionable: false },
+  ]);
+  assert.equal(html.match(/class="card review-draft"/g)?.length, 2);
+  assert.equal(html.match(/data-review-form=/g)?.length, 1);
+  assert.equal(html.match(/<button type="submit">/g)?.length, 1);
+});
+
+test("the empty state survives the new context block", async () => {
+  const html = await reviewSurface([]);
+  assert.match(html, /Nenhum rascunho aguardando revisão\./);
+  assert.match(html, /Aprovar vincula o hash exato e agenda a próxima janela útil\. Nenhum botão envia imediatamente\./);
+});

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -1114,3 +1114,193 @@ test("the operation cockpit reads the gate too, because its stepper has to know 
   );
 });
 
+
+/* ------------------------------------------------------------------ *
+ * 12. Legacy copy is history, not an offer.
+ *
+ * A founder opened a version composed by a superseded composer and found
+ * defective copy presented exactly like current copy, with APPROVE, adjust and
+ * GO beside it. Nothing on the screen said the text was historical. These
+ * tests pin the fix: the version stays fully readable for audit, and every
+ * decision affordance stops being emitted at all.
+ * ------------------------------------------------------------------ */
+
+const LEGACY_NOTICE =
+  "Esta versão foi congelada por um redator que não é mais o vigente e por isso não pode ser enviada.";
+
+function legacyCohort(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return cohort({
+    editorial_state: "LEGACY_SUPERSEDED",
+    actionable: false,
+    editorial_reason_codes: ["composer_superseded"],
+    editorial_notice: LEGACY_NOTICE,
+    is_current_version: false,
+    current_version: 3,
+    current_version_id: NEXT_COHORT_ID,
+    candidates: [
+      candidate({
+        editorial_state: "LEGACY_SUPERSEDED",
+        actionable: false,
+        editorial_reason_codes: ["composer_superseded"],
+      }),
+    ],
+    ...overrides,
+  });
+}
+
+function legacyInput(overrides: Record<string, unknown> = {}): Parameters<typeof warmblyBlock>[0] {
+  return surfaceInput({ gate: gatePayload(["operators", "admins"], legacyCohort(overrides)) });
+}
+
+test("a historical version says so at the top, in plain Portuguese, with the reason", () => {
+  reset();
+  const html = warmblyBlock(legacyInput(), "revisao");
+  assert.match(html, /data-legacy-banner="true"/);
+  assert.match(html, /data-review-cohort="[^"]*" data-editorial-state="LEGACY_SUPERSEDED"/);
+  assert.match(html, /data-actionable="false"/);
+  assert.ok(html.includes("Versão histórica. Não enviar."), "the banner must name the state plainly");
+  assert.ok(
+    html.includes("composta por um redator anterior ao vigente"),
+    "composer_superseded must be translated, not shown as a raw code",
+  );
+  assert.ok(html.includes(LEGACY_NOTICE), "the server's own notice must be rendered");
+});
+
+test("every editorial reason code has a Portuguese sentence, and an unknown one is shown verbatim", () => {
+  reset();
+  const html = warmblyBlock(
+    legacyInput({
+      editorial_reason_codes: ["composer_unstamped", "policy_superseded", "motivo_desconhecido"],
+    }),
+    "revisao",
+  );
+  assert.ok(html.includes("sem carimbo de redator"));
+  assert.ok(html.includes("criada sob uma policy anterior"));
+  assert.ok(html.includes("motivo_desconhecido"), "an unknown code must not be silently dropped");
+});
+
+test("the historical banner offers the current version as its primary way out", () => {
+  reset();
+  const html = warmblyBlock(legacyInput(), "revisao");
+  const link = html.match(/<a class="button" data-open-current="true" href="([^"]+)">([^<]+)<\/a>/);
+  assert.ok(link, "the escape hatch link must exist");
+  assert.equal(link[1], `#/warmbly/revisao?resource=${NEXT_COHORT_ID}`);
+  assert.equal(link[2], "Abrir versão corrente");
+  assert.ok(html.includes("v3"), "the current version number travels with the link");
+});
+
+test("without a current_version_id the banner says so instead of inventing a link", () => {
+  reset();
+  const html = warmblyBlock(legacyInput({ current_version_id: undefined, current_version: undefined }), "revisao");
+  assert.match(html, /data-legacy-banner="true"/);
+  assert.doesNotMatch(html, /data-open-current="true"/);
+  assert.match(html, /data-open-current="absent"/);
+});
+
+test("a historical version emits no approve, hold, validate, adjust, reproduce or GO markup at all", () => {
+  reset();
+  const html = warmblyBlock(legacyInput(), "revisao");
+  for (const gate of ["validate", "review", "adjust", "reproduce", "decide"]) {
+    assert.doesNotMatch(
+      html,
+      new RegExp(`data-human-gate="${gate}"`),
+      `${gate} must not be rendered on a historical version, not even disabled`,
+    );
+  }
+  assert.doesNotMatch(html, /data-adjust-editor=/);
+  assert.doesNotMatch(html, /Registrar APPROVE|Registrar HOLD\/REJECT|Registrar GO\/NO-GO/);
+  assert.match(html, /data-non-actionable-notice="true"/);
+  assert.match(html, /data-non-actionable-surface="true"/);
+});
+
+test("a historical version stays fully readable: message, CTA, facts and hashes all render", () => {
+  reset();
+  const html = warmblyBlock(legacyInput(), "revisao");
+  assert.match(html, /data-exact-body="true">Corpo exato congelado/);
+  assert.match(html, /data-exact-subject="true"[^>]*><strong>Assunto:<\/strong> Assunto exato congelado/);
+  assert.match(html, /data-cta="true"/);
+  assert.match(html, /compras@empresa\.invalid/);
+  for (const label of ["Content hash", "Frozen hash", "Policy version", "Composer version", "Estado editorial"]) {
+    assert.ok(html.includes(label), `${label} must survive on a historical version`);
+  }
+  assert.ok(html.includes("Versão histórica (não enviável)"));
+});
+
+test("the frozen message never claims to be current when it is not", () => {
+  reset();
+  const historical = warmblyBlock(legacyInput(), "revisao");
+  assert.ok(historical.includes("Mensagem exata congelada (assunto e corpo). Versão histórica, não enviar."));
+  const current = warmblyBlock(surfaceInput(), "revisao");
+  assert.ok(current.includes("Mensagem exata congelada (assunto e corpo). Versão corrente."));
+  for (const html of [historical, current]) {
+    assert.doesNotMatch(
+      html,
+      /Mensagem exata congelada \(assunto e corpo\)<\/summary>/,
+      "the bare label that told the operator nothing must be gone",
+    );
+  }
+});
+
+test("a historical card is marked as such and carries a non-actionable chip", () => {
+  reset();
+  const html = warmblyBlock(legacyInput(), "revisao");
+  assert.match(html, /<article class="card" data-candidate-id="[^"]*" data-editorial-state="LEGACY_SUPERSEDED"/);
+  assert.match(html, /data-non-actionable="true"/);
+  assert.match(html, /data-approve-allowed="false"/);
+});
+
+test("a current version keeps every control exactly as before", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  for (const gate of ["validate", "review", "adjust", "reproduce", "decide"]) {
+    assert.match(html, new RegExp(`data-human-gate="${gate}"`), `${gate} must still be offered on a current version`);
+  }
+  assert.match(html, /data-review-cohort="[^"]*" data-editorial-state="CURRENT" data-actionable="true"/);
+  assert.doesNotMatch(html, /data-legacy-banner="true"/);
+  assert.doesNotMatch(html, /data-non-actionable-notice="true"/);
+  assert.doesNotMatch(html, /data-non-actionable-surface="true"/);
+});
+
+test("an absent editorial_state is an older backend, not a historical version", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  assert.match(html, /data-editorial-state="CURRENT"/);
+  assert.doesNotMatch(html, /data-legacy-banner="true"/);
+  assert.match(html, /data-human-gate="decide"/);
+  assert.match(html, /data-human-gate="review"/);
+});
+
+test("actionable:false alone is enough to withdraw the controls", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], cohort({ actionable: false })) }),
+    "revisao",
+  );
+  assert.match(html, /data-legacy-banner="true"/);
+  assert.doesNotMatch(html, /data-human-gate="decide"/);
+});
+
+test("a non-actionable candidate loses its controls even inside a current version", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: gatePayload(
+        ["operators", "admins"],
+        cohort({
+          candidates: [
+            candidate({
+              editorial_state: "LEGACY_SUPERSEDED",
+              editorial_reason_codes: ["composer_unstamped"],
+            }),
+          ],
+        }),
+      ),
+    }),
+    "revisao",
+  );
+  assert.match(html, /data-editorial-state="LEGACY_SUPERSEDED"/, "the card carries the candidate's own state");
+  assert.doesNotMatch(html, /data-human-gate="review"/);
+  assert.doesNotMatch(html, /data-adjust-editor=/);
+  assert.match(html, /data-human-gate="decide"/, "the version itself is still decidable");
+  assert.ok(html.includes("sem carimbo de redator"));
+});


### PR DESCRIPTION
A founder opened Operação Warmbly → Revisão in production and read defective copy presented under "Mensagem exata congelada", with APPROVE, adjust and GO controls beside it. The copy belonged to a cohort version frozen by an earlier composer. The screen gave no signal that the text was historical, and nothing on it distinguished a version that can still be sent from one that only exists for audit.

This makes the distinction impossible to miss.

**Revisão (`#/warmbly/revisao`)**
- A historical version now opens under an unmistakable banner ("Versão histórica. Não enviar.") that names why it became historical, in Portuguese, from the backend's reason codes.
- The banner carries an explicit "Abrir versão corrente" link to the current version, so the founder never has to understand version numbers to find the sendable one.
- Every operational control is withdrawn on a historical version: validate, APPROVE, HOLD/REJECT, adjust, reproduce and GO/NO-GO are not rendered at all, so there is nothing to re-enable from devtools. A single line explains the state and points at the current version.
- The frozen-message disclosure now always says which it is: "Versão corrente." or "Versão histórica, não enviar."
- Everything informational still renders. History stays fully readable, because auditing it is the reason to keep it.

**Comercial → Rascunhos**
- Each draft now shows, inline and without opening any disclosure: fato observado, proveniência, classe de rota, target fit, composer, content hash, estado editorial and reason codes.
- Reason codes and route classes render as Portuguese sentences with the raw token kept beside them.
- Subject and body size to their content, so the founder reads the whole message on the list.
- A superseded draft renders read-only with no decision form.

A new `src/ui/editorial-state.ts` is the single reader for the backend's editorial verdict, shared by both surfaces. It defaults to CURRENT and actionable when the field is absent, so this is safe to deploy before or after the backend change.

340 tests pass, `tsc --noEmit` clean.