### PR TITLE
fix(control-center): make the browser journey prove the current UI

### DIFF
--- a/control-center/tests/journey/run.sh
+++ b/control-center/tests/journey/run.sh
@@ -18,8 +18,25 @@ TOKEN=stub-operator-token
 TOKFILE="$WORK/token"; printf %s "$TOKEN" > "$TOKFILE"
 
 PIDS=()
-cleanup() { for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null; done; rm -rf "$WORK"; }
+# npx tsx and npx vite fan out into a child chain, so killing only the pid we
+# backgrounded orphans the server and leaves its port held for the next run.
+# Sweep the ports we own as well.
+cleanup() {
+  for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null; done
+  for port in $WPORT $CPORT $SPORT $EPORT; do
+    for pid in $(lsof -t -i ":$port" -sTCP:LISTEN 2>/dev/null); do kill "$pid" 2>/dev/null; done
+  done
+  rm -rf "$WORK"
+}
 trap cleanup EXIT
+
+# serve-prod.mjs serves dist/, which is not tracked by git. An absent or stale
+# bundle would serve a UI older than the one under test, so build first: a
+# journey that proves the previous release is worse than no journey.
+echo "building the web shell the journey will drive..."
+if ! ( cd "$APP" && npm run build ) >"$WORK/build.log" 2>&1; then
+  echo "web shell build failed"; tail -30 "$WORK/build.log"; exit 1
+fi
 
 PORT=$WPORT TOKEN=$TOKEN node "$HERE/fake-warmbly.mjs" > "$WORK/warmbly.log" 2>&1 & PIDS+=($!)
 


### PR DESCRIPTION
`tests/journey/run.sh` starts `serve-prod.mjs`, which serves `apps/web-shell/dist`. That directory is not tracked by git and the script never built it.

On this machine the leftover bundle was from an earlier build and contained zero occurrences of `data-exact-subject`, `data-open-review`, `data-editorial-state` or the string `revisao`. It had no review route at all. The journey would have driven a browser against a UI older than the one under test and reported PASS, which is worse than having no journey.

Nothing in CI calls this script, so it is a manual proof harness, and a manual proof harness that silently asserts against the previous release is a trap. It now builds first and fails loudly if the build fails.

Second fix: `npx tsx` and `npx vite` fan out into a child chain, so killing only the backgrounded pid orphans the Context Service and the web shell and leaves 8097/8098 held, which makes the next run fail for an unrelated reason. Cleanup now also sweeps the four ports the script owns.

Verified: `bash tests/journey/run.sh` → 26/26 passed, no orphans, repeatable back to back.