### PR TITLE
fix(control-center): the message preview shows the message, not annotation

### DIFF
--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -1447,7 +1447,6 @@ function candidateCard(
       <summary>Mensagem exata congelada (assunto e corpo). ${editorial.legacy ? "Versão histórica, não enviar." : "Versão corrente."}</summary>
       <p data-exact-subject="true"><strong>Assunto:</strong> ${escapeHtml(show(candidate.subject))}</p>
       <pre class="message-preview" data-exact-body="true">${escapeHtml(show(candidate.body_text))}</pre>
-      <p data-cta="true"><strong>Chamada para ação (CTA):</strong> ${escapeHtml(fromPayload(candidate.cta ?? candidate.cta_text))}</p>
     </details>
     <dl class="facts" data-observed-fact="true">
       ${fact("Fato observado", fromPayload(candidate.observed_fact_text ?? evidence.text ?? evidence.summary))}

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -406,13 +406,12 @@ test("the messages collapse only when the operator asks, through the expand/coll
   assert.match(collapsed, /Expandir todas as mensagens/);
 });
 
-test("provenance, CTA, hashes, versions, expiry and every blocker travel with the candidate", () => {
+test("provenance, hashes, versions, expiry and every blocker travel with the candidate", () => {
   reset();
   const html = warmblyBlock(surfaceInput(), "revisao");
   for (const label of [
     "Fato observado",
     "Proveniência do fato",
-    "Chamada para ação (CTA)",
     "Content hash",
     "Frozen hash",
     "Policy version",
@@ -1213,12 +1212,11 @@ test("a historical version emits no approve, hold, validate, adjust, reproduce o
   assert.match(html, /data-non-actionable-surface="true"/);
 });
 
-test("a historical version stays fully readable: message, CTA, facts and hashes all render", () => {
+test("a historical version stays fully readable: message, facts and hashes all render", () => {
   reset();
   const html = warmblyBlock(legacyInput(), "revisao");
   assert.match(html, /data-exact-body="true">Corpo exato congelado/);
   assert.match(html, /data-exact-subject="true"[^>]*><strong>Assunto:<\/strong> Assunto exato congelado/);
-  assert.match(html, /data-cta="true"/);
   assert.match(html, /compras@empresa\.invalid/);
   for (const label of ["Content hash", "Frozen hash", "Policy version", "Composer version", "Estado editorial"]) {
     assert.ok(html.includes(label), `${label} must survive on a historical version`);
@@ -1303,4 +1301,38 @@ test("a non-actionable candidate loses its controls even inside a current versio
   assert.doesNotMatch(html, /data-adjust-editor=/);
   assert.match(html, /data-human-gate="decide"/, "the version itself is still decidable");
   assert.ok(html.includes("sem carimbo de redator"));
+});
+
+// 13. The frozen message preview shows the message and nothing else.
+//
+// The CTA was rendered as its own paragraph directly under the body, inside the
+// same disclosure, and it repeats the body's closing paragraph verbatim. A
+// founder reading it top to bottom saw a labelled line after the sign-off and
+// could not tell whether it would be sent. It is internal annotation, the
+// recipient never sees it, and it says nothing the body has not already said.
+test("the frozen message preview carries the message only, with no annotation that could read as sent text", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  const previews = html.match(/<details data-message-preview="true"[\s\S]*?<\/details>/g) ?? [];
+  assert.ok(previews.length > 0, "the frozen message preview must render");
+  for (const preview of previews) {
+    assert.ok(
+      !preview.includes("Chamada para ação"),
+      "no internal label may appear inside the frozen message preview",
+    );
+    assert.ok(!preview.includes("data-cta"), "the CTA annotation must not sit inside the message");
+    assert.ok(preview.includes("data-exact-subject"), "the subject stays");
+    assert.ok(preview.includes("data-exact-body"), "the body stays");
+  }
+});
+
+test("a historical version's message preview is equally free of annotation", () => {
+  reset();
+  const html = warmblyBlock(legacyInput(), "revisao");
+  const previews = html.match(/<details data-message-preview="true"[\s\S]*?<\/details>/g) ?? [];
+  assert.ok(previews.length > 0);
+  for (const preview of previews) {
+    assert.ok(!preview.includes("Chamada para ação"));
+    assert.ok(preview.includes("data-exact-body"));
+  }
 });


### PR DESCRIPTION
Reviewing a recomposed cohort, the founder read this under "Mensagem exata congelada":

```
…Você consegue me indicar a pessoa certa?

Obrigado,
Tiago
Chamada para ação (CTA): Trabalho com apoio a empresas de engenharia em contratos públicos e queria falar com quem cuida dessa frente por aí. Você consegue me indicar a pessoa certa?
```

and could not tell whether that last line goes out in the email. That is a fair reading: the line sat inside the same `<details>` as the body, immediately after the sign-off, with no signal that it was internal.

It is internal annotation and it is not sent. Two independent confirmations, on the live production data:

- No frozen member's `body_text` contains the label. Across all 23 members of all five cohort versions in production, `body_text ILIKE '%chamada para a%'` is false everywhere, and every body ends at the sign-off.
- The send path carries the body verbatim (`cohort_dispatch.go:378`, `BodyText: tp.BodyText`) and `TouchpointBindingHash` binds channel, recipient, subject, body, purpose, evidence and context hash. Appending anything at send time would change the body, break the approved content hash and be refused by transport. There is no code path that can add it.

It was also pure duplication: for all 23 members, in every route class, the `cta` value already appears verbatim inside `body_text`. The line told the reader nothing that was not two lines above it.

So it is removed from the preview. The disclosure now contains exactly what its own summary promises, "assunto e corpo". Nothing else about the card changed: the observed fact, provenance, hashes, policy version, composer version, editorial state and every blocker still render, and a historical version stays fully readable.

Two tests now assert the guarantee directly: the frozen message preview must contain the subject and body and must not contain `Chamada para ação` or `data-cta`, on both a current and a historical version. 342 tests pass, `tsc --noEmit` clean.