### PR TITLE
fix(control-center): the review card shows the message, and what changes the decision

### DIFF
--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -995,7 +995,25 @@ function reviewList(value: unknown): string | null {
   return parts.length === 0 ? null : parts.join(", ");
 }
 
-/** Fato de leitura. Ausência vira palavra explícita, nunca campo escondido. */
+/** Valor cru para o bloco técnico. Ausente é "", e o bloco descarta "". */
+function reviewTech(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry) => typeof entry === "string" || typeof entry === "number")
+      .map(String)
+      .join(",");
+  }
+  return String(value);
+}
+
+/**
+ * Fato de leitura.
+ *
+ * Ausência vira palavra explícita nas linhas em que a ausência muda a decisão.
+ * Onde ela não muda nada, a linha simplesmente não é emitida: uma pilha de
+ * "ausente" sob uma mensagem de quatro linhas esconde a mensagem.
+ */
 function reviewFact(label: string, value: string | null, absentWord = REVIEW_ABSENT, extra = ""): string {
   return value === null
     ? fact(label, escapeHtml(absentWord), ` data-absent="true"`)
@@ -1022,13 +1040,6 @@ function reviewProvenance(row: Record<string, unknown>): string | null {
   const source = reviewText(row.fact_source);
   if (evidence === null && source === null) return null;
   return `${evidence ?? "sem identificador de evidência"} (origem: ${source ?? REVIEW_UNREPORTED})`;
-}
-
-function reviewComposer(row: Record<string, unknown>): string | null {
-  const composer = reviewText(row.composer_version);
-  const prompt = reviewText(row.prompt_version);
-  if (composer === null && prompt === null) return null;
-  return `${composer ?? REVIEW_UNREPORTED} (prompt: ${prompt ?? REVIEW_UNREPORTED})`;
 }
 
 function reviewTargetFit(value: unknown): string | null {
@@ -1081,16 +1092,49 @@ function reviewDraftCard(item: unknown): string {
     : ` data-reason-codes="${escapeHtml(editorial.reasonCodes.join(" "))}"`;
   const subjectRows = reviewRows(subject, 2, 4);
   const bodyRows = reviewRows(bodyText, 12, 40);
+  const factUsed = reviewText(row.fact_used);
+  const provenance = reviewProvenance(row);
+  const targetFit = reviewTargetFit(row.target_fit);
+  // Um corpo escrito afirma uma observação específica ao destinatário. Se o
+  // fato ou a origem dele não vieram, isso não some do card: é o motivo para
+  // não aprovar.
+  const factGap =
+    reviewText(bodyText) === null || (factUsed !== null && provenance !== null)
+      ? null
+      : factUsed === null && provenance === null
+        ? "nem o fato observado nem a proveniência dele"
+        : factUsed === null
+          ? "o fato observado"
+          : "a proveniência do fato";
+  const factGapBanner =
+    factGap === null
+      ? ""
+      : `<p class="banner error" role="alert" data-fact-missing="true">O rascunho afirma uma observação específica sobre este lead, mas o servidor não enviou ${escapeHtml(factGap)}. Não dá para conferir o que a mensagem diz ao destinatário: recupere a evidência antes de aprovar.</p>`;
   const contextFacts = `<dl class="facts" data-review-context="${escapeHtml(id)}">
-                ${reviewFact("Fato observado", reviewText(row.fact_used))}
-                ${reviewFact("Proveniência", reviewProvenance(row))}
+                ${reviewFact("Fato observado", factUsed)}
+                ${reviewFact("Proveniência", provenance)}
                 ${reviewFact("Classe de rota", reviewRouteClass(routeClass), REVIEW_UNREPORTED, routeClassAttr)}
-                ${reviewFact("Target fit", reviewTargetFit(row.target_fit), REVIEW_UNREPORTED)}
-                ${reviewFact("Composer", reviewComposer(row), REVIEW_UNREPORTED)}
-                ${reviewFact("Content hash", reviewText(row.content_hash))}
                 ${reviewFact("Estado editorial", editorialReading)}
-                ${reviewFact("Reason codes", reviewReasonCodes(editorial.reasonCodes), REVIEW_ABSENT, reasonAttr)}
+                ${targetFit === null ? "" : fact("Target fit", escapeHtml(targetFit))}
+                ${editorial.reasonCodes.length === 0 ? "" : fact("Reason codes", escapeHtml(reviewReasonCodes(editorial.reasonCodes)), reasonAttr)}
               </dl>`;
+  // Hashes, versões e códigos são prova de auditoria, não entrada da decisão.
+  const auditFacts = technicalDetails(
+    [
+      { term: "draft_id", value: id },
+      { term: "account_id", value: reviewTech(row.account_id) },
+      { term: "content_hash", value: reviewTech(row.content_hash) },
+      { term: "composer_version", value: reviewTech(row.composer_version) },
+      { term: "prompt_version", value: reviewTech(row.prompt_version) },
+      { term: "policy_version", value: reviewTech(row.policy_version) },
+      { term: "route_class", value: reviewTech(row.route_class) },
+      { term: "fact_source", value: reviewTech(row.fact_source) },
+      { term: "evidence_ids", value: reviewTech(row.evidence_ids) },
+      { term: "editorial_state", value: reviewTech(rawEditorialState) },
+      { term: "editorial_reason_codes", value: editorial.reasonCodes.join(",") },
+    ],
+    "review-draft",
+  );
   const decision = actionable
     ? `<form data-review-form="${escapeHtml(id)}" class="operator-form">
                 <input type="hidden" name="expected_content_hash" value="${escapeHtml(contentHash)}" />
@@ -1115,8 +1159,10 @@ function reviewDraftCard(item: unknown): string {
               <p>Destinatário: ${escapeHtml(String(row.recipient ?? "ausente"))}</p>
               <p>Razão: ${escapeHtml(String(row.stop_reason ?? row.generation_error ?? "pronto para revisão"))}</p>
               ${actionable ? "" : `<p class="banner stale" role="note" data-editorial-notice="true">${escapeHtml(notice)}</p>`}
+              ${factGapBanner}
               ${contextFacts}
               ${decision}
+              ${auditFacts}
             </article>`;
 }
 

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -43,6 +43,7 @@ import {
 import {
   operatorActionLabel,
   operatorOutcomeLabel,
+  routeClassLabel,
   technicalDetails,
 } from "./labels";
 import { provenanceBlock } from "./provenance";
@@ -1338,20 +1339,82 @@ function previewBlock(preview: Record<string, unknown>): string {
     </article>`;
 }
 
-function listFacts(label: string, value: unknown): string {
-  if (Array.isArray(value)) {
-    const rows = value.filter((entry) => typeof entry === "string" || typeof entry === "number");
-    return fact(label, rows.length > 0 ? rows.map(String).join(", ") : "nenhum");
+/** Texto observado, ou nada. Objeto, vazio e nulo não contam como leitura. */
+function textOf(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed === "" ? null : trimmed;
   }
-  return fact(label, fromPayload(value));
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+/** Primeira leitura observada entre as chaves que o servidor já usou. */
+function firstText(...values: readonly unknown[]): string | null {
+  for (const value of values) {
+    const text = textOf(value);
+    if (text !== null) return text;
+  }
+  return null;
+}
+
+/** Linha que só existe quando o servidor mandou o campo. Ausência não vira linha. */
+function factWhenPresent(label: string, value: unknown, extra = ""): string {
+  const text = textOf(value);
+  return text === null ? "" : fact(label, text, extra);
 }
 
 /**
- * One candidate, message first.
+ * Linha cuja ausência muda a decisão, então a ausência fica escrita.
+ * Sumir com um fato que falta é quase afirmar que ele está lá.
+ */
+function factOrAbsent(label: string, value: string | null, extra = ""): string {
+  return value === null
+    ? fact(label, NOT_IN_PAYLOAD, ` data-absent="true"${extra}`)
+    : fact(label, value, extra);
+}
+
+/** Sinalizador do servidor: vira linha só quando é verdadeiro. false não é notícia. */
+function flagText(value: unknown): string | null {
+  if (value === true) return "sim";
+  const text = textOf(value);
+  if (text === null) return null;
+  return ["false", "não", "nao", "nenhuma", "nenhum", "0"].includes(text.toLowerCase()) ? null : text;
+}
+
+/** Lista para o bloco técnico. Vazia vira "", e o bloco descarta "". */
+function listValue(value: unknown): string {
+  return Array.isArray(value)
+    ? value
+        .filter((entry) => typeof entry === "string" || typeof entry === "number")
+        .map(String)
+        .join(",")
+    : "";
+}
+
+/** Valor cru para o bloco técnico. Ausente é "", que o bloco não renderiza. */
+function techValue(value: unknown): string {
+  return value === undefined || value === null ? "" : String(value);
+}
+
+/**
+ * One candidate, in three tiers: the message, the decision, the audit trail.
  *
- * Recipient, exact subject and exact body are visible by default. Hiding the
- * only thing a reviewer is there to review behind a closed `<details>` labelled
- * "Ver mensagem exata congelada" turns a review gate into a rubber stamp.
+ * Tier 1 is the exact subject and body, open by default. Hiding the only thing
+ * a reviewer is there to review behind a closed `<details>` turns a review gate
+ * into a rubber stamp.
+ *
+ * Tier 2 is the short block the founder actually judges an outbound email on:
+ * recipient, kind of mailbox, route class, the observed fact and where it came
+ * from, editorial state, and anything blocking. A field the server did not send
+ * renders no row at all, with one deliberate exception: a missing fact, a
+ * missing provenance, a missing validation and every blocker stay written out,
+ * because their absence is the decision.
+ *
+ * Tier 3 is `technicalDetails`: hashes, versions, ids and the validation and
+ * review receipts. They are evidence for an audit, not input to the judgement,
+ * and stacked as visible rows they buried the message under a wall of
+ * "não informado pelo servidor".
  */
 function candidateCard(
   cohort: Record<string, unknown>,
@@ -1364,7 +1427,24 @@ function candidateCard(
   const candidateId = show(candidate.candidate_id);
   const validation = record(candidate.validation);
   const review = record(candidate.review);
+  // Produção manda `observed_fact` e `fact_source` como texto simples. Ler o
+  // texto como objeto fazia o fato real sair como "não informado pelo servidor"
+  // embaixo de uma mensagem que afirmava exatamente esse fato. O formato objeto
+  // de versões antigas continua sendo aceito como alternativa.
   const evidence = record(candidate.evidence ?? candidate.observed_fact);
+  const observedFact = firstText(
+    candidate.observed_fact,
+    candidate.observed_fact_text,
+    evidence.text,
+    evidence.summary,
+  );
+  const factSource = firstText(
+    candidate.fact_source,
+    candidate.evidence_source,
+    evidence.source,
+    evidence.locator,
+  );
+  const observedAt = firstText(candidate.evidence_observed_at, evidence.observed_at);
   const copyQa = record(candidate.copy_qa);
   const blockers = Array.isArray(candidate.blocked_by)
     ? candidate.blocked_by.filter((entry): entry is string => typeof entry === "string")
@@ -1381,6 +1461,54 @@ function candidateCard(
   const frozenHash = show(cohort.frozen_hash ?? candidate.frozen_hash ?? candidate.content_hash);
   const version = show(cohort.version);
   const draft = adjustDraft(candidateId);
+
+  const routeClassRaw = textOf(candidate.route_class);
+  const routeClassLabelText = routeClassRaw === null ? null : routeClassLabel(routeClassRaw);
+  const routeClassText =
+    routeClassRaw === null || routeClassLabelText === null
+      ? null
+      : routeClassLabelText === routeClassRaw
+        ? routeClassRaw
+        : `${routeClassLabelText} (${routeClassRaw})`;
+  const routeClassAttr =
+    routeClassRaw === null ? "" : ` data-route-class="${escapeHtml(routeClassRaw)}"`;
+
+  // mailbox_purpose usa o mesmo vocabulário da classe de rota. UNKNOWN é o
+  // servidor dizendo que não classificou: não muda a decisão e a classe de
+  // rota logo acima já responde se a caixa é genérica ou de departamento.
+  // O valor cru continua no detalhe técnico.
+  const purposeRaw = textOf(candidate.mailbox_purpose);
+  const purposeText =
+    purposeRaw === null || purposeRaw.toUpperCase() === "UNKNOWN"
+      ? null
+      : routeClassLabel(purposeRaw) === purposeRaw
+        ? purposeRaw
+        : `${routeClassLabel(purposeRaw)} (${purposeRaw})`;
+
+  // VALID já está no pill do topo. A linha existe para o que trava a decisão:
+  // um estado que não é VALID, ou nenhuma validação lida.
+  const validationStatus = textOf(validation.status);
+  const validationReason = textOf(validation.reason);
+  const validationVisible = validationStatus === null || validationStatus.toUpperCase() !== "VALID";
+  const validationLine =
+    validationStatus === null
+      ? null
+      : validationReason === null
+        ? validationStatus
+        : `${validationStatus}: ${validationReason}`;
+
+  // Um corpo escrito afirma uma observação específica ao destinatário. Se o
+  // fato ou a origem dele não vieram, isso não some do card: é o motivo para
+  // não aprovar.
+  const bodyAsserts = textOf(candidate.body_text) !== null;
+  const factGap =
+    !bodyAsserts || (observedFact !== null && factSource !== null)
+      ? null
+      : observedFact === null && factSource === null
+        ? "nem o fato observado nem a proveniência dele"
+        : observedFact === null
+          ? "o fato observado"
+          : "a proveniência do fato";
 
   const validateKey = `validate:${cohortId}:${candidateId}:`;
   const approveKey = `review:${cohortId}:${candidateId}:APPROVE`;
@@ -1435,58 +1563,70 @@ function candidateCard(
     : `<p class="constraint" data-non-actionable-notice="true">Versão histórica, não enviável. Verificar o destinatário, aprovar, segurar e ajustar não são oferecidos aqui. Abra a versão corrente pelo link no topo desta página.</p>`;
 
   return `<article class="card" data-candidate-id="${escapeHtml(candidateId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}" data-approve-allowed="${gate.allowed && editorial.actionable ? "true" : "false"}">
-    <p class="kicker">${validationPill(candidate)}${editorial.legacy ? ` <span class="pill error" data-non-actionable="true">NÃO ACIONÁVEL</span>` : ""} · ${escapeHtml(show(candidate.route_class))} · ${escapeHtml(show(candidate.source))}</p>
+    <p class="kicker">${validationPill(candidate)}${editorial.legacy ? ` <span class="pill error" data-non-actionable="true">NÃO ACIONÁVEL</span>` : ""} · ${escapeHtml(show(candidate.source))}</p>
     <h3>${escapeHtml(show(candidate.company))}</h3>
     ${feedback.forCandidate(candidateId)}
-    <dl class="facts" data-candidate-identity="true">
-      ${fact("Destinatário exato", show(candidate.mailbox))}
-      ${fact("Purpose do destinatário", show(candidate.mailbox_purpose))}
-      ${fact("Classe de rota", show(candidate.route_class))}
-    </dl>
     <details data-message-preview="true"${expandAll ? " open" : ""}>
       <summary>Mensagem exata congelada (assunto e corpo). ${editorial.legacy ? "Versão histórica, não enviar." : "Versão corrente."}</summary>
       <p data-exact-subject="true"><strong>Assunto:</strong> ${escapeHtml(show(candidate.subject))}</p>
       <pre class="message-preview" data-exact-body="true">${escapeHtml(show(candidate.body_text))}</pre>
     </details>
-    <dl class="facts" data-observed-fact="true">
-      ${fact("Fato observado", fromPayload(candidate.observed_fact_text ?? evidence.text ?? evidence.summary))}
-      ${fact("Proveniência do fato", fromPayload(candidate.evidence_source ?? evidence.source ?? evidence.locator))}
-      ${fact("Observado em", fromPayload(candidate.evidence_observed_at ?? evidence.observed_at))}
-      ${fact("Evidence hash", fromPayload(candidate.evidence_hash))}
-    </dl>
-    <dl class="facts" data-candidate-integrity="true">
-      ${fact("Content hash", fromPayload(candidate.content_hash))}
-      ${fact("Frozen hash", fromPayload(candidate.frozen_hash))}
-      ${fact("Policy version", fromPayload(cohort.policy_version))}
-      ${fact("Composer version", fromPayload(candidate.composer_version ?? cohort.composer_version))}
-      ${fact("Estado editorial", editorial.legacy ? "Versão histórica (não enviável)" : "Versão corrente")}
-      ${editorial.reasonCodes.length > 0 ? listFacts("Motivos do estado editorial", editorial.reasonCodes.map(editorialReasonLabel)) : ""}
-      ${fact("Validação", fromPayload(validation.status))}
-      ${fact("Motivo da validação", fromPayload(validation.reason))}
-      ${fact("Validação vence em", validation.expires_at ? stamp(validation.expires_at) : NOT_IN_PAYLOAD)}
-      ${fact("Revisão registrada", fromPayload(review.decision))}
-      ${fact("Revisão efetiva", fromPayload(review.effective))}
-      ${listFacts("Bloqueios", candidate.blocked_by)}
-      ${listFacts("Reprovações de copy QA", copyQaFailures.length > 0 ? copyQaFailures : copyQa.failures)}
-      ${fact("Duplicidade apontada pelo servidor", fromPayload(candidate.duplicate_of ?? candidate.duplicate))}
-      ${fact("Proveniência ausente", fromPayload(candidate.missing_provenance))}
-      ${fact("Hard bounce registrado", fromPayload(candidate.hard_bounce))}
-      ${fact("Excluído do preview por", fromPayload(candidate.exclusion_reason ?? candidate.excluded_reason))}
-    </dl>
+    ${
+      factGap
+        ? `<p class="banner error" role="alert" data-fact-missing="true">A mensagem afirma uma observação específica sobre esta empresa, mas o servidor não enviou ${escapeHtml(factGap)}. Não dá para conferir o que a mensagem diz ao destinatário: recupere a evidência antes de aprovar.</p>`
+        : ""
+    }
     ${
       blockers.length > 0
         ? `<p class="banner error" role="alert" data-candidate-blockers="${escapeHtml(blockers.join(" "))}">O servidor registrou ${blockers.length} bloqueio(s) neste candidato: ${escapeHtml(blockers.join(", "))}.</p>`
         : ""
     }
+    <dl class="facts" data-candidate-identity="true" data-candidate-decision="true">
+      ${fact("Destinatário exato", show(candidate.mailbox))}
+      ${factWhenPresent("Tipo de caixa", purposeText)}
+      ${factOrAbsent("Classe de rota", routeClassText, routeClassAttr)}
+      ${factOrAbsent("Fato observado", observedFact, ` data-observed-fact="true"`)}
+      ${factOrAbsent("Proveniência do fato", factSource, ` data-fact-source="true"`)}
+      ${fact("Estado editorial", editorial.legacy ? "Versão histórica (não enviável)" : "Versão corrente")}
+      ${editorial.reasonCodes.length > 0 ? fact("Motivos do estado editorial", editorial.reasonCodes.map(editorialReasonLabel).join(", ")) : ""}
+      ${validationVisible ? factOrAbsent("Validação", validationLine) : ""}
+      ${copyQaFailures.length > 0 ? fact("Reprovações de copy QA", copyQaFailures.join(", ")) : ""}
+      ${factWhenPresent("Duplicidade apontada pelo servidor", flagText(candidate.duplicate_of ?? candidate.duplicate))}
+      ${factWhenPresent("Proveniência ausente", flagText(candidate.missing_provenance))}
+      ${factWhenPresent("Hard bounce registrado", flagText(candidate.hard_bounce))}
+      ${factWhenPresent("Excluído do preview por", flagText(candidate.exclusion_reason ?? candidate.excluded_reason))}
+    </dl>
 
     ${controls}
     ${technicalDetails(
       [
         { term: "candidate_id", value: candidateId },
-        { term: "content_hash", value: show(candidate.content_hash) },
-        { term: "frozen_hash", value: frozenHash },
-        { term: "evidence_hash", value: show(candidate.evidence_hash) },
+        { term: "candidate_ref", value: techValue(candidate.candidate_ref) },
+        { term: "account_id", value: techValue(candidate.account_id) },
+        { term: "account_ref", value: techValue(candidate.account_ref) },
+        { term: "route_class", value: techValue(candidate.route_class) },
+        { term: "mailbox_purpose", value: techValue(candidate.mailbox_purpose) },
+        { term: "content_hash", value: techValue(candidate.content_hash) },
+        // frozen_hash é da versão, não do candidato: é o que expected_frozen_hash
+        // guarda. Ler do candidato mostrava vazio e escondia o hash real.
+        { term: "frozen_hash", value: techValue(cohort.frozen_hash ?? candidate.frozen_hash) },
+        { term: "evidence_hash", value: techValue(candidate.evidence_hash) },
+        { term: "policy_version", value: techValue(cohort.policy_version) },
+        { term: "composer_version", value: techValue(candidate.composer_version ?? cohort.composer_version) },
+        { term: "fact_observed_at", value: observedAt === null ? "" : observedAt },
+        { term: "validation_status", value: techValue(validation.status) },
+        { term: "validation_reason", value: techValue(validation.reason) },
+        { term: "validation_expires_at", value: validation.expires_at ? stamp(validation.expires_at) : "" },
+        { term: "review_decision", value: techValue(review.decision) },
+        { term: "review_effective", value: techValue(review.effective) },
         { term: "blocked_by", value: blockers.join(",") },
+        { term: "copy_qa_failures", value: copyQaFailures.length > 0 ? copyQaFailures.join(",") : listValue(copyQa.failures) },
+        { term: "admission_reasons", value: listValue(candidate.admission_reasons) },
+        { term: "route_reasons", value: listValue(candidate.route_reasons) },
+        { term: "duplicate_of", value: techValue(candidate.duplicate_of ?? candidate.duplicate) },
+        { term: "missing_provenance", value: techValue(candidate.missing_provenance) },
+        { term: "hard_bounce", value: techValue(candidate.hard_bounce) },
+        { term: "exclusion_reason", value: techValue(candidate.exclusion_reason ?? candidate.excluded_reason) },
         { term: "editorial_state", value: editorial.state },
         { term: "editorial_reason_codes", value: editorial.reasonCodes.join(",") },
       ],

--- a/control-center/apps/web-shell/tests/review-drafts.test.ts
+++ b/control-center/apps/web-shell/tests/review-drafts.test.ts
@@ -104,9 +104,15 @@ test("review surface renders the judging context inline, with no details disclos
   assert.match(html, /<dt>Proveniência<\/dt><dd>ev-pncp-1, ev-pncp-2 \(origem: fact_to_mention\)<\/dd>/);
   assert.match(html, /<dt>Classe de rota<\/dt><dd>caixa genérica da empresa, como contato@ ou comercial@ \(GENERIC_COMPANY\)<\/dd>/);
   assert.match(html, /<dt>Target fit<\/dt><dd>FIT \(leitura atual; apurado em 2026-08-20T12:00:00Z; porte e setor compatíveis\)<\/dd>/);
-  assert.match(html, /<dt>Composer<\/dt><dd>confenge\.composer\.v5 \(prompt: confenge\.draft\.v6\)<\/dd>/);
-  assert.match(html, /<dt>Content hash<\/dt><dd>sha256:exact<\/dd>/);
   assert.match(html, /<dt>Estado editorial<\/dt><dd>atual<\/dd>/);
+  // Hash e versão são prova de auditoria, não entrada da decisão: vão para o
+  // detalhe técnico recolhido, não para a tabela visível.
+  assert.doesNotMatch(html, /<dt>Content hash<\/dt>/);
+  assert.doesNotMatch(html, /<dt>Composer<\/dt>/);
+  assert.match(html, /<dt>content_hash<\/dt><dd><code>sha256:exact<\/code><\/dd>/);
+  assert.match(html, /<dt>composer_version<\/dt><dd><code>confenge\.composer\.v5<\/code><\/dd>/);
+  assert.match(html, /<dt>prompt_version<\/dt><dd><code>confenge\.draft\.v6<\/code><\/dd>/);
+  assert.match(html, /<details class="tech" data-tech="review-draft">/);
   assert.match(html, /<dt>Reason codes<\/dt><dd>FACT_FRESH; ROUTE_OK<\/dd>/);
   assert.match(html, /data-editorial-state="CURRENT"/);
   assert.match(html, /data-composer-version="confenge\.composer\.v5"/);
@@ -148,10 +154,14 @@ test("absent editorial fields render an explicit word instead of undefined", asy
   assert.match(html, /<dt>Fato observado<\/dt><dd>ausente<\/dd>/);
   assert.match(html, /<dt>Proveniência<\/dt><dd>ausente<\/dd>/);
   assert.match(html, /<dt>Classe de rota<\/dt><dd>não informado<\/dd>/);
-  assert.match(html, /<dt>Target fit<\/dt><dd>não informado<\/dd>/);
-  assert.match(html, /<dt>Composer<\/dt><dd>não informado<\/dd>/);
-  assert.match(html, /<dt>Reason codes<\/dt><dd>nenhum<\/dd>/);
   assert.match(html, /<dt>Estado editorial<\/dt><dd>atual \(não informado pelo servidor, tratado como atual\)<\/dd>/);
+  // Ausência que não muda a decisão não vira linha: some do card.
+  assert.doesNotMatch(html, /<dt>Target fit<\/dt>/);
+  assert.doesNotMatch(html, /<dt>Composer<\/dt>/);
+  assert.doesNotMatch(html, /<dt>Reason codes<\/dt>/);
+  // Fato e proveniência faltando debaixo de um corpo escrito é dito em voz alta.
+  assert.match(html, /data-fact-missing="true"/);
+  assert.match(html, /nem o fato observado nem a proveniência dele/);
   // An older backend still yields a decidable row.
   assert.match(html, /data-editorial-state="CURRENT"/);
   assert.match(html, /data-editorial-actionable="true"/);
@@ -169,7 +179,8 @@ test("a partially reported target fit degrades field by field without crashing",
   }]);
   assert.doesNotMatch(html, /undefined/);
   assert.match(html, /<dt>Proveniência<\/dt><dd>sem identificador de evidência \(origem: fact_to_mention\)<\/dd>/);
-  assert.match(html, /<dt>Composer<\/dt><dd>confenge\.composer\.v5 \(prompt: não informado\)<\/dd>/);
+  assert.match(html, /<dt>composer_version<\/dt><dd><code>confenge\.composer\.v5<\/code><\/dd>/);
+  assert.doesNotMatch(html, /<dt>prompt_version<\/dt>/);
   assert.match(html, /<dt>Target fit<\/dt><dd>FIT \(frescor não informado; apurado em não informado\)<\/dd>/);
 });
 
@@ -289,6 +300,31 @@ test("mixed rows keep decidable and historical drafts side by side", async () =>
   assert.equal(html.match(/class="card review-draft"/g)?.length, 2);
   assert.equal(html.match(/data-review-form=/g)?.length, 1);
   assert.equal(html.match(/<button type="submit">/g)?.length, 1);
+});
+
+test("um rascunho com fato e proveniência não ganha alerta de evidência inventado", async () => {
+  const html = await reviewSurface([RICH_DRAFT]);
+  assert.doesNotMatch(html, /data-fact-missing="true"/);
+});
+
+test("só a proveniência faltando é dita sem misturar com o fato", async () => {
+  const html = await reviewSurface([{ ...RICH_DRAFT, evidence_ids: [], fact_source: "" }]);
+  assert.match(html, /data-fact-missing="true"/);
+  assert.match(html, /não enviou a proveniência do fato/);
+  assert.match(html, /<dt>Fato observado<\/dt><dd>Publicou edital de reforma do bloco B em 20\/08<\/dd>/);
+});
+
+test("um rascunho histórico mantém a auditoria recolhida e nenhuma decisão", async () => {
+  const html = await reviewSurface([{
+    ...RICH_DRAFT,
+    id: LEGACY_ID,
+    editorial_state: "LEGACY_SUPERSEDED",
+    editorial_actionable: false,
+  }]);
+  assert.match(html, /<details class="tech" data-tech="review-draft">/);
+  assert.match(html, /<dt>content_hash<\/dt><dd><code>sha256:exact<\/code><\/dd>/);
+  assert.match(html, /<dt>editorial_state<\/dt><dd><code>LEGACY_SUPERSEDED<\/code><\/dd>/);
+  assert.doesNotMatch(html, /<button type="submit">/);
 });
 
 test("the empty state survives the new context block", async () => {

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -38,8 +38,10 @@ function candidate(overrides: Record<string, unknown> = {}): Record<string, unkn
     subject: "Assunto exato congelado",
     body_text: "Corpo exato congelado da mensagem.",
     cta: "Posso enviar uma segunda leitura técnica?",
-    observed_fact_text: "Fato público de fixture",
-    evidence_source: "fixture://diario-oficial",
+    // As chaves que a API de produção manda mesmo: texto simples, não objeto,
+    // e nenhum frozen_hash no candidato.
+    observed_fact: "Fato público de fixture",
+    fact_source: "fixture://diario-oficial",
     evidence_observed_at: "2026-08-22T12:00:00Z",
     content_hash: "content-fixture-001",
     evidence_hash: "evidence-fixture-001",
@@ -406,27 +408,205 @@ test("the messages collapse only when the operator asks, through the expand/coll
   assert.match(collapsed, /Expandir todas as mensagens/);
 });
 
-test("provenance, hashes, versions, expiry and every blocker travel with the candidate", () => {
+test("o fato observado e a proveniência saem das chaves que a produção manda mesmo", () => {
+  reset();
+  // observed_fact e fact_source chegam como texto simples. Lidos como objeto,
+  // o fato real virava "não informado pelo servidor" embaixo de uma mensagem
+  // que afirmava exatamente esse fato.
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  assert.match(html, /<dt>Fato observado<\/dt><dd>Fato público de fixture<\/dd>/);
+  assert.match(html, /<dt>Proveniência do fato<\/dt><dd>fixture:\/\/diario-oficial<\/dd>/);
+  assert.doesNotMatch(html, /<dt>Fato observado<\/dt><dd>não informado pelo servidor<\/dd>/);
+  assert.doesNotMatch(html, /<dt>Proveniência do fato<\/dt><dd>não informado pelo servidor<\/dd>/);
+});
+
+test("o formato antigo de evidence em objeto continua sendo lido", () => {
+  reset();
+  const legacyShape = cohort({
+    candidates: [
+      candidate({
+        observed_fact: undefined,
+        fact_source: undefined,
+        evidence: { text: "Fato vindo do formato objeto", source: "objeto://origem" },
+      }),
+    ],
+  });
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], legacyShape) }),
+    "revisao",
+  );
+  assert.match(html, /<dt>Fato observado<\/dt><dd>Fato vindo do formato objeto<\/dd>/);
+  assert.match(html, /<dt>Proveniência do fato<\/dt><dd>objeto:\/\/origem<\/dd>/);
+});
+
+test("o bloco de decisão carrega só o que muda a decisão do fundador", () => {
   reset();
   const html = warmblyBlock(surfaceInput(), "revisao");
+  const decision = html.match(/<dl class="facts" data-candidate-identity="true"[\s\S]*?<\/dl>/);
+  assert.ok(decision, "o bloco de decisão precisa existir");
+  const visible = decision[0]!;
   for (const label of [
+    "Destinatário exato",
+    "Classe de rota",
     "Fato observado",
     "Proveniência do fato",
+    "Estado editorial",
+  ]) {
+    assert.ok(visible.includes(label), `${label} sumiu do bloco de decisão`);
+  }
+  // Bloqueio e reprovação de copy QA aparecem porque travam a aprovação.
+  assert.match(html, /data-candidate-blockers="approval_missing_or_invalid"/);
+  assert.match(visible, /<dt>Reprovações de copy QA<\/dt><dd>assunto_generico<\/dd>/);
+  // Auditoria não é decisão: hash, versão e recibo não ocupam o bloco visível.
+  for (const label of [
     "Content hash",
     "Frozen hash",
+    "Evidence hash",
     "Policy version",
     "Composer version",
+    "Observado em",
+    "Motivo da validação",
     "Validação vence em",
-    "Reprovações de copy QA",
+    "Revisão registrada",
+    "Revisão efetiva",
+  ]) {
+    assert.ok(!visible.includes(label), `${label} não devia estar no bloco de decisão`);
+  }
+});
+
+test("hash, versão e recibo moram no detalhe técnico recolhido, não na tabela visível", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  const tech = html.match(/<details class="tech" data-tech="warmbly-candidate">[\s\S]*?<\/details>/);
+  assert.ok(tech, "o detalhe técnico do candidato precisa existir");
+  const audit = tech[0]!;
+  assert.match(audit, /<dt>content_hash<\/dt><dd><code>content-fixture-001<\/code><\/dd>/);
+  assert.match(audit, /<dt>evidence_hash<\/dt><dd><code>evidence-fixture-001<\/code><\/dd>/);
+  assert.match(audit, /<dt>policy_version<\/dt><dd><code>bounded-cohort-policy\.v1<\/code><\/dd>/);
+  assert.match(audit, /<dt>composer_version<\/dt><dd><code>composer\.v3<\/code><\/dd>/);
+  assert.match(audit, /<dt>validation_status<\/dt><dd><code>VALID<\/code><\/dd>/);
+  assert.match(audit, /<dt>review_decision<\/dt><dd><code>HOLD<\/code><\/dd>/);
+  assert.match(audit, /<dt>review_effective<\/dt><dd><code>false<\/code><\/dd>/);
+});
+
+test("o frozen hash exibido é o da versão, porque o candidato não tem um", () => {
+  reset();
+  // Mesma lição do PR #96 para expected_frozen_hash: frozen_hash pertence à
+  // versão. Lido do candidato, saía vazio na tela e não batia com o servidor.
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  const tech = html.match(/<details class="tech" data-tech="warmbly-candidate">[\s\S]*?<\/details>/);
+  assert.ok(tech);
+  assert.match(tech[0]!, /<dt>frozen_hash<\/dt><dd><code>frozen-fixture-001<\/code><\/dd>/);
+});
+
+test("campo ausente que não muda a decisão não vira linha nenhuma", () => {
+  reset();
+  // O candidato de produção não manda observed_at, duplicidade, hard bounce,
+  // motivo de exclusão nem recibo de revisão. Onze linhas de "não informado
+  // pelo servidor" empilhadas sob quatro linhas de e-mail escondiam o e-mail.
+  const sparse = cohort({
+    frozen_hash: undefined,
+    candidates: [
+      candidate({
+        copy_qa: undefined,
+        duplicate_of: undefined,
+        missing_provenance: undefined,
+        hard_bounce: undefined,
+        exclusion_reason: undefined,
+        evidence_observed_at: undefined,
+        review: undefined,
+        blocked_by: [],
+      }),
+    ],
+  });
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], sparse) }),
+    "revisao",
+  );
+  const card = html.match(/<article class="card" data-candidate-id=[\s\S]*?<\/article>/);
+  assert.ok(card);
+  for (const label of [
+    "Observado em",
     "Duplicidade apontada pelo servidor",
     "Proveniência ausente",
     "Hard bounce registrado",
     "Excluído do preview por",
+    "Revisão registrada",
+    "Revisão efetiva",
+    "Reprovações de copy QA",
+    "Bloqueios",
   ]) {
-    assert.ok(html.includes(label), `${label} is missing from the candidate card`);
+    assert.ok(!card[0]!.includes(label), `${label} devia ter sumido, não virado "não informado"`);
   }
-  assert.match(html, /data-candidate-blockers="approval_missing_or_invalid"/);
-  assert.match(html, /assunto_generico/);
+  const decision = card[0]!.match(/<dl class="facts" data-candidate-identity="true"[\s\S]*?<\/dl>/);
+  assert.ok(decision);
+  assert.doesNotMatch(decision[0]!, /não informado pelo servidor/);
+});
+
+test("o tipo de caixa é lido em português, e UNKNOWN não ocupa linha nenhuma", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  assert.match(html, /<dt>Tipo de caixa<\/dt><dd>caixa de cargo ou departamento \(ROLE_OR_DEPARTMENT\)<\/dd>/);
+  const unknownPurpose = cohort({ candidates: [candidate({ mailbox_purpose: "UNKNOWN" })] });
+  const unclassified = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], unknownPurpose) }),
+    "revisao",
+  );
+  // O servidor dizendo "não classifiquei" não muda a decisão, e a classe de
+  // rota logo acima já responde se a caixa é genérica ou de departamento.
+  assert.ok(!unclassified.includes("Tipo de caixa"));
+  // O valor cru não some do sistema: continua no detalhe técnico.
+  assert.match(unclassified, /<dt>mailbox_purpose<\/dt><dd><code>UNKNOWN<\/code><\/dd>/);
+});
+
+test("sinalizador verdadeiro do servidor vira linha, e falso não", () => {
+  reset();
+  const flagged = cohort({
+    candidates: [
+      candidate({ missing_provenance: true, hard_bounce: false, duplicate_of: "outro-candidato" }),
+    ],
+  });
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], flagged) }),
+    "revisao",
+  );
+  assert.match(html, /<dt>Proveniência ausente<\/dt><dd>sim<\/dd>/);
+  assert.match(html, /<dt>Duplicidade apontada pelo servidor<\/dt><dd>outro-candidato<\/dd>/);
+  assert.ok(!html.includes("Hard bounce registrado"));
+});
+
+test("fato faltando debaixo de uma mensagem que afirma uma observação é dito em voz alta", () => {
+  reset();
+  const noEvidence = cohort({
+    candidates: [candidate({ observed_fact: undefined, fact_source: undefined })],
+  });
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], noEvidence) }),
+    "revisao",
+  );
+  assert.match(html, /data-fact-missing="true"/);
+  assert.match(html, /nem o fato observado nem a proveniência dele/);
+  assert.match(html, /<dt>Fato observado<\/dt><dd>não informado pelo servidor<\/dd>/);
+  assert.match(html, /<div data-absent="true"[^>]*><dt>Fato observado<\/dt>/);
+  assert.match(html, /<div data-absent="true"[^>]*><dt>Proveniência do fato<\/dt>/);
+});
+
+test("só a proveniência faltando também é dita, sem misturar com o fato", () => {
+  reset();
+  const noSource = cohort({ candidates: [candidate({ fact_source: undefined })] });
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], noSource) }),
+    "revisao",
+  );
+  assert.match(html, /data-fact-missing="true"/);
+  assert.match(html, /não enviou a proveniência do fato/);
+  assert.match(html, /<dt>Fato observado<\/dt><dd>Fato público de fixture<\/dd>/);
+});
+
+test("com fato e proveniência no payload nenhum alerta de evidência é inventado", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  assert.doesNotMatch(html, /data-fact-missing="true"/);
 });
 
 test("preview denominators are rendered verbatim, and an absent number says so instead of being derived", () => {
@@ -787,7 +967,10 @@ test("the new version opens with validation, review and GO all pending", () => {
   );
   assert.match(html, /Revisão v2/);
   assert.match(html, /data-approve-allowed="false"/, "a fresh version cannot already be approvable");
-  assert.match(html, /<dt>Revisão registrada<\/dt><dd>não informado pelo servidor<\/dd>/);
+  // Sem revisão registrada não há linha de revisão: ausência que não muda a
+  // decisão não vira "não informado pelo servidor" na cara do fundador.
+  assert.ok(!html.includes("Revisão registrada"));
+  assert.match(html, /<dt>Validação<\/dt><dd>UNKNOWN<\/dd>/);
   assert.match(html, /<dt>Decisão final registrada<\/dt><dd>não informado pelo servidor<\/dd>/);
 });
 
@@ -1218,10 +1401,15 @@ test("a historical version stays fully readable: message, facts and hashes all r
   assert.match(html, /data-exact-body="true">Corpo exato congelado/);
   assert.match(html, /data-exact-subject="true"[^>]*><strong>Assunto:<\/strong> Assunto exato congelado/);
   assert.match(html, /compras@empresa\.invalid/);
-  for (const label of ["Content hash", "Frozen hash", "Policy version", "Composer version", "Estado editorial"]) {
-    assert.ok(html.includes(label), `${label} must survive on a historical version`);
-  }
+  assert.ok(html.includes("Estado editorial"));
   assert.ok(html.includes("Versão histórica (não enviável)"));
+  assert.match(html, /<dt>Fato observado<\/dt><dd>Fato público de fixture<\/dd>/);
+  // A auditoria de uma versão histórica é justamente o que ela ainda serve.
+  const tech = html.match(/<details class="tech" data-tech="warmbly-candidate">[\s\S]*?<\/details>/);
+  assert.ok(tech, "o detalhe técnico precisa sobreviver na versão histórica");
+  for (const term of ["content_hash", "frozen_hash", "policy_version", "composer_version", "editorial_state"]) {
+    assert.ok(tech[0]!.includes(`<dt>${term}</dt>`), `${term} must survive on a historical version`);
+  }
 });
 
 test("the frozen message never claims to be current when it is not", () => {


### PR DESCRIPTION
The founder reviewing an outbound message saw roughly ten "não informado pelo servidor" lines stacked under a four-line email, and three of them were lying.

## Three field-mapping bugs made real data look missing

`candidateCard()` read `candidate.observed_fact_text`, `candidate.evidence_source` and `candidate.frozen_hash`. The API sends `observed_fact` (a plain string), `fact_source` (a string), and no `frozen_hash` on a candidate at all, only on the cohort. Because `record()` was handed a string it returned `{}`, so `evidence.text` was always undefined.

The visible effect: **"Fato observado: não informado pelo servidor" on a candidate whose `observed_fact` really is `"Vi uma contratação envolvendo a Jatobeton Engenharia na recuperação estrutural da ponte sobre o Rio Sapucaí"`.** The screen told the founder the personalization had no evidence behind it, when it had. The frozen hash now falls back to `cohort.frozen_hash`, the same lesson PR #96 applied to `expected_frozen_hash`; it deliberately does not fall back to `content_hash`, because labelling a content hash "frozen_hash" in an audit block is worse than showing nothing.

## More than half the table was noise

Measured on a real production candidate: 8 of 15 fact rows were absent and rendered the literal string "não informado pelo servidor".

The card is now three tiers. The message stays primary and open. A short visible block carries only what an outbound email is judged on: recipient, mailbox type, route class in Portuguese, observed fact, provenance, editorial state, and a validation row only when the validation is not VALID. Hashes, policy version, composer version, receipts, admission and route reasons collapse into the `technicalDetails` block that already existed for exactly this.

Absent fields stop rendering as rows, with one deliberate exception: a missing fact or provenance while the body asserts a specific observation is called out loudly in its own alert, because that absence changes the answer. Blockers keep their existing loud banner. Affirmative-only flags (duplicate, missing provenance, hard bounce, exclusion) render only when the server actually says yes.

Result on the real candidate: five rows, all populated, zero "não informado".

Comercial → Rascunhos gets the same treatment and the same missing-fact callout.

## Preserved

Every `data-` hook other code and the browser journey depend on. The CTA is still absent from the message preview and its two tests pass untouched. A LEGACY_SUPERSEDED version still renders the message, the facts and the full audit block, and still emits no approve, decide, adjust or validate markup of any kind.

`tsc --noEmit` clean, 355 tests pass (baseline 342), and `tests/journey/run.sh` reports 26/26 in a real browser.