### PR TITLE
fix(control-center): name the dead end instead of blaming the server

### DIFF
--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -1717,7 +1717,9 @@ function legacyBanner(editorial: EditorialReading, cohortId: string): string {
         ? `<p><a class="button" data-open-current="true" href="#/warmbly/revisao?resource=${escapeHtml(editorial.currentVersionId)}">Abrir versão corrente</a>${
             editorial.currentVersion ? ` <span class="scope">v${escapeHtml(editorial.currentVersion)}</span>` : ""
           }</p>`
-        : `<p class="constraint" data-open-current="absent">O servidor não informou qual é a versão corrente desta cohort, então esta tela não inventa um link. Abra Cohorts para achá-la.</p>`
+        : editorial.isCurrentVersion === true
+          ? `<p class="constraint" data-open-current="none">Esta já é a versão mais recente desta cohort e mesmo assim não é enviável, então não há versão corrente para abrir. Recompor não resolve: prepare uma cohort nova para estes leads.</p>`
+          : `<p class="constraint" data-open-current="absent">O servidor não informou qual é a versão corrente desta cohort, então esta tela não inventa um link. Abra Cohorts para achá-la.</p>`
     }
   </section>`;
 }

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -1524,3 +1524,26 @@ test("a historical version's message preview is equally free of annotation", () 
     assert.ok(preview.includes("data-exact-body"));
   }
 });
+
+// 14. A legacy version that is also the newest version of its cohort is a dead
+// end: there is no current version to open, and saying "the server did not say"
+// blames a data gap for what is actually the cohort's real state.
+test("a legacy version with no successor says so instead of blaming the server", () => {
+  reset();
+  const html = warmblyBlock(legacyInput({ is_current_version: true, current_version_id: "" }), "revisao");
+  assert.match(html, /data-open-current="none"/);
+  assert.ok(html.includes("prepare uma cohort nova"), "must name the way forward");
+  assert.ok(!html.includes("O servidor não informou qual é a versão corrente"), "must not blame the server");
+  assert.match(html, /data-legacy-banner="true"/);
+  assert.ok(!/data-human-gate="(review|decide|adjust|validate)"/.test(html), "still no controls");
+});
+
+test("a legacy version that does have a successor still links to it", () => {
+  reset();
+  const html = warmblyBlock(
+    legacyInput({ is_current_version: false, current_version_id: "11111111-2222-3333-4444-555555555555" }),
+    "revisao",
+  );
+  assert.match(html, /data-open-current="true"/);
+  assert.ok(html.includes("Abrir versão corrente"));
+});


### PR DESCRIPTION
Production has a cohort whose only version is `LEGACY_SUPERSEDED` and which recompose refuses, because its members store the previous composer's own sentence as their observed fact and re-digesting our prose would throw the lead away. It is therefore both superseded and the newest version of itself: there is no current version to open.

The banner fell through to "O servidor não informou qual é a versão corrente desta cohort", which blames a data gap for what is actually the cohort's real state. The server said everything it knows; there simply is no successor.

When `is_current_version` is true and the version is still superseded, the banner now says so and names the way out: recomposing will not help, a new cohort has to be prepared for those leads. The `data-open-current="absent"` branch stays for the genuine case where the backend sent no `current_version_id` at all, which is a different situation and should still read as a data gap.

Caught by the production browser journey, which asserted every legacy version offers the link. That assertion was right in general and wrong for this case; it now accepts either a link or an explicit explanation that there is none.

357 tests pass, `tsc --noEmit` clean.