### PR TITLE
feat(control-center): Revisão as a queue of human decisions — one valid message, one click

### DIFF
--- a/control-center/apps/web-shell/README.md
+++ b/control-center/apps/web-shell/README.md
@@ -33,6 +33,39 @@ O `resource` viaja na subnav: abrir “Revisão” a partir de “Cohorts” **n
 versão selecionada, e uma Revisão sem `resource` oferece a lista de versões em vez
 de uma página vazia.
 
+#### Revisão é uma fila de decisões, não um formulário
+
+`#/warmbly/revisao` abre no recorte **Pendentes** (`?estado=pendentes`, que é o
+padrão e por isso não aparece na URL) e diz quanto falta:
+`N pendentes · N aprovadas · N em ajuste · N no total`. Os recortes
+`aprovadas`, `ajuste` e `todas` continuam legíveis e preservam `resource` e o
+estado de expansão das mensagens.
+
+No caminho feliz, **uma mensagem válida é aprovada com uma única ação**: sem
+motivo digitado, sem caixa de ciência e sem acionar a verificação do destinatário
+antes. O clique em Aprovar é a ciência e viaja como `acknowledged=true`; um
+APPROVE sem comentário registra `approved_by_human_reviewer` e o comentário
+opcional vence esse padrão. Quando o candidato não tem validação vigente, a
+própria aprovação pede a verificação ao Warmbly, relê o estado e só registra o
+APPROVE se ele voltar `VALID` — caso contrário nada é decidido e a tela diz o
+estado observado.
+
+A aprovação sai da fila na hora (otimista) e volta para ela em qualquer desfecho
+que não seja aplicação confirmada: recusa, falha, desconhecido, ou releitura que
+não confirma o efeito. Nada disso é durável — um reload lê a fila do servidor.
+
+APPROVE continua bloqueado onde verificar de novo não resolve: sem destinatário,
+destinatário que não é endereço, veredito já resolvido como `INVALID`/`RISKY`, e
+bloqueios materiais declarados pelo servidor (`hard_bounce`, suppression,
+opt-out, duplicidade, copy QA, proveniência ausente). HOLD e REJECT continuam
+exigindo motivo escrito, e o controle “Verificar o destinatário agora” continua
+disponível como escape — só não é mais pré-requisito, e só aparece onde a
+validação não é VALID.
+
+Teclado: `A` aprova o card que já está sob o foco (nunca outro), `Ctrl/Cmd+Enter`
+aprova a primeira pendência. Nenhum dos dois dispara com o cursor dentro de um
+campo de texto — o editor de ajuste vive na mesma página.
+
 `#/comercial/cohorts` (“Comercial → Coortes”) é **outra coisa**: são coortes de
 aquisição e métricas por período. Nenhum runbook do gate humano deve apontar para
 lá — o caminho correto é **Operação Warmbly → Cohorts**. Pausar, retomar e

--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -219,6 +219,19 @@ export function isWarmblyGateAction(value: string | null): value is WarmblyGateA
   return typeof value === "string" && (WARMBLY_GATE_ACTIONS as readonly string[]).includes(value);
 }
 
+/**
+ * What the audit trail records when a reviewer approves a normal message and
+ * writes nothing.
+ *
+ * A required free-text field on the happy path bought the trail nothing: the
+ * reviewer types the same word every time, and the row that matters is already
+ * complete without it — actor, instant, version, frozen hash, recipient and
+ * decision all come from the server. This constant makes the ordinary case say
+ * exactly what it is, and leaves the optional comment for when the reviewer
+ * actually has something to record.
+ */
+export const APPROVAL_DEFAULT_REASON = "approved_by_human_reviewer";
+
 export interface WarmblyGateInput {
   action: WarmblyGateAction;
   version_id?: string;

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -445,6 +445,13 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
         "approval_acknowledgement_required",
       );
     }
+    if (
+      input.action === "review"
+      && (input.decision === "HOLD" || input.decision === "REJECT")
+      && !input.reason?.trim()
+    ) {
+      return refuse("HOLD/REJECT exige motivo escrito", "gate_precondition");
+    }
     if (input.action === "decide" && !input.confirmation?.trim()) {
       return refuse(
         "GO/NO-GO exige a confirmação digitada da versão imutável",

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -14,6 +14,7 @@ import type {
 } from "../types";
 import {
   ADAPTER_ACTIONS,
+  APPROVAL_DEFAULT_REASON,
   type AdapterAction,
   type AdapterReadResult,
   type AdapterWriteResult,
@@ -432,6 +433,12 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     ) {
       return refuse("alvo do gate incompleto", "gate_precondition");
     }
+    // The acknowledgement stays on the wire and stays mandatory here. What
+    // changed is where it comes from: the reviewer's click on Aprovar is the
+    // acknowledgement, and the button says so above itself, so there is no
+    // second checkbox asking them to declare the action they just took. This
+    // guard therefore no longer describes a control — it is the invariant that
+    // stops any other caller from constructing an APPROVE without one.
     if (input.action === "review" && input.decision === "APPROVE" && input.acknowledged !== true) {
       return refuse(
         "APPROVE exige ciência explícita do destinatário, mensagem, policy e evidência",
@@ -465,6 +472,13 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
         );
       }
     }
+    // An ordinary approval carries no typed motive, and the trail must not
+    // record an empty one. `approved_by_human_reviewer` is what "o revisor leu
+    // e aprovou" looks like as data; a comment the reviewer did write always
+    // wins over it.
+    const reason =
+      input.reason?.trim()
+      || (input.action === "review" && input.decision === "APPROVE" ? APPROVAL_DEFAULT_REASON : "");
     try {
       const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
         method: "POST",
@@ -474,7 +488,7 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
           idempotency_key: input.idempotency_key,
           ...(input.limit ? { limit: input.limit } : {}),
           ...(input.decision ? { decision: input.decision } : {}),
-          ...(input.reason ? { reason: input.reason } : {}),
+          ...(reason ? { reason } : {}),
           ...(input.acknowledged === true ? { acknowledged: true } : {}),
           ...(input.confirmation ? { confirmation: input.confirmation.trim().toLowerCase() } : {}),
           ...(input.action === "adjust"

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -29,7 +29,11 @@ import {
   resumeObservationFingerprint,
 } from "./warmbly-confirmation";
 import { pageIsEmpty, pageIsStale } from "./page";
-import { markReviewDecided, rollbackReviewDecided } from "./review-queue";
+import {
+  confirmReviewDecided,
+  markReviewDecided,
+  rollbackReviewDecided,
+} from "./review-queue";
 import {
   QUEUE_FOCUS_PARAM,
   QUEUE_FOCUS_TOKEN_PATTERN,
@@ -684,8 +688,9 @@ function bindWarmblyHumanGate(
           // can never press again without reloading.
           endGateFlight(key);
         }
-        if (optimistic && !confirmedApplication(result)) {
-          rollbackReviewDecided(versionId, candidateId);
+        if (optimistic) {
+          if (confirmedApplication(result)) confirmReviewDecided(versionId, candidateId);
+          else rollbackReviewDecided(versionId, candidateId);
         }
         if (raw === "adjust" && result.ok) clearAdjustDraft(candidateId);
         // The reviewer's hands stay where they were: the next pending card
@@ -763,11 +768,19 @@ async function settleGateIntent(
   intent: HumanGateIntent,
   result: AdapterWriteResult,
 ): Promise<AdapterWriteResult> {
-  // Only a definitive outcome advances the key. An `unknown` keeps it, so the
-  // retry of an uncertain intent is the same intent to the server.
-  settleHumanGateIntent(intent, result.outcome);
   if (result.code === "adjust_route_unavailable") markAdjustRouteMissing();
   const readback = await gateReadback(adapter, intent, result);
+  // A refusal is definitive before any write. An executed response is only
+  // definitive after the resource readback confirms it. If that GET fails or
+  // disagrees, retaining the same idempotency key is what lets a later retry
+  // reconcile the original write instead of creating a second intent.
+  const settledOutcome =
+    result.outcome === "refused"
+      ? "refused"
+      : result.outcome === "executed" && readback.status === "confirmed"
+        ? "executed"
+        : undefined;
+  settleHumanGateIntent(intent, settledOutcome);
   const settled: AdapterWriteResult = { ...result, readback };
   adapter.lastOperatorResult = settled;
   return settled;
@@ -782,7 +795,7 @@ async function settleGateIntent(
  */
 function confirmedApplication(result: AdapterWriteResult): boolean {
   if (!result.ok || result.outcome !== "executed") return false;
-  return result.readback?.status !== "not_confirmed";
+  return result.readback?.status === "confirmed";
 }
 
 /**
@@ -826,7 +839,10 @@ async function approveCandidate(
         ...validated,
         ok: false,
         code: "approval_validation_unavailable",
-        message: `A verificação do destinatário não completou (${validated.code ?? validated.status ?? "sem código"}): ${validated.message}`,
+        message:
+          validated.outcome === "refused"
+            ? `A verificação do destinatário não completou (${validated.code ?? validated.status ?? "sem código"}): ${validated.message}. O APPROVE não foi enviado.`
+            : "A verificação foi pedida, mas a releitura não devolveu o estado dela, então esta tela não sabe se o destinatário está VALID. O APPROVE não foi enviado e nada foi decidido.",
         gateAction: "validate",
         gateTarget: target,
       };
@@ -988,10 +1004,12 @@ export function approvalShortcutScope(
     metaKey?: boolean;
     altKey?: boolean;
     shiftKey?: boolean;
+    repeat?: boolean;
   },
   editing: boolean,
+  blockingOverlay = false,
 ): ApprovalShortcutScope {
-  if (editing || event.altKey === true) return null;
+  if (editing || blockingOverlay || event.repeat === true || event.altKey === true) return null;
   const key = typeof event.key === "string" ? event.key : "";
   if (key === "Enter") {
     return event.ctrlKey === true || event.metaKey === true ? "first-pending" : null;
@@ -1005,12 +1023,19 @@ export function approvalShortcutScope(
 /** Bound once for the life of the page: a repaint drops markup, not documents. */
 let queueShortcutBound = false;
 
+/** A decision shortcut never crosses an active modal/overlay boundary. */
+function hasBlockingOverlay(): boolean {
+  return document.querySelector(
+    'dialog[open], [aria-modal="true"], [data-modal-open="true"], [data-overlay-open="true"]',
+  ) !== null;
+}
+
 function bindReviewQueueShortcut(): void {
   if (queueShortcutBound || typeof document === "undefined") return;
   queueShortcutBound = true;
   document.addEventListener("keydown", (event) => {
     const active = document.activeElement as HTMLElement | null;
-    const scope = approvalShortcutScope(event, isEditingTarget(active));
+    const scope = approvalShortcutScope(event, isEditingTarget(active), hasBlockingOverlay());
     if (!scope) return;
     // The card under the caret first, so a reviewer who tabbed into a specific
     // message approves that one and not whatever happens to be at the top.
@@ -1142,13 +1167,22 @@ async function gateReadback(
       if (!candidate) {
         return { status: "not_confirmed", detail: "O candidato não aparece nesta versão na releitura." };
       }
-      const recorded = gateRecord(candidate.review).decision;
-      return recorded === intent.decision
-        ? { status: "confirmed", detail: `O servidor registra ${String(recorded)} neste candidato.` }
-        : {
-            status: "not_confirmed",
-            detail: `O servidor ainda registra "${String(recorded ?? "nada")}" neste candidato.`,
-          };
+      const review = gateRecord(candidate.review);
+      const recorded = review.decision;
+      if (recorded !== intent.decision) {
+        return {
+          status: "not_confirmed",
+          detail: `O servidor ainda registra "${String(recorded ?? "nada")}" neste candidato.`,
+        };
+      }
+      if (intent.decision === "APPROVE" && review.effective !== true) {
+        return {
+          status: "not_confirmed",
+          detail:
+            "O servidor registra APPROVE, mas não confirma que a aprovação está efetiva para o destinatário, conteúdo, policy e evidência atuais.",
+        };
+      }
+      return { status: "confirmed", detail: `O servidor registra ${String(recorded)} neste candidato.` };
     }
     case "decide": {
       const recorded = gateRecord(cohort.decision).decision;

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -836,13 +836,25 @@ async function approveCandidate(
     const status = await readValidationStatus(adapter, versionId, candidateId);
     if (status !== "VALID") {
       releaseFlight();
+      // "O servidor disse RISKY" and "não deu para ler o que o servidor diz"
+      // are different answers, and only the first one is about the recipient.
+      // Collapsing them would tell the reviewer a mailbox is bad when what
+      // actually failed was a GET.
       const refusal: AdapterWriteResult = {
         ok: false,
         path: validated.path,
         kind: "nota",
         outcome: "refused",
-        code: "approval_validation_not_valid",
-        message: `A verificação foi feita agora e o servidor reporta ${status ?? "nenhum estado"}, não VALID. O APPROVE não foi enviado.`,
+        ...(status === null
+          ? {
+              code: "approval_validation_unavailable",
+              message:
+                "A verificação foi pedida, mas a releitura não devolveu o estado dela, então esta tela não sabe se o destinatário está VALID. O APPROVE não foi enviado e nada foi decidido.",
+            }
+          : {
+              code: "approval_validation_not_valid",
+              message: `A verificação foi feita agora e o servidor reporta ${status}, não VALID. O APPROVE não foi enviado.`,
+            }),
         gateAction: "validate",
         gateTarget: target,
         ...(validated.receiptId ? { receiptId: validated.receiptId } : {}),
@@ -1057,7 +1069,17 @@ async function readGateCandidate(
   const cohort = gateRecord(gateRecord(gateRecord(read.page.warmbly_gate).selected).data);
   if (!cohort.id) return null;
   const candidates = Array.isArray(cohort.candidates) ? cohort.candidates.map(gateRecord) : [];
-  return candidates.find((row) => row.candidate_id === candidateId) ?? null;
+  // The intent carries the id as the markup stamped it — a string, always. A
+  // strict comparison against a payload that typed it differently finds nothing
+  // and reports the write as unconfirmed, which rolls back a decision the
+  // server actually recorded.
+  return candidates.find((row) => gateCandidateId(row) === candidateId) ?? null;
+}
+
+/** The candidate id as a string, however the payload chose to type it. */
+function gateCandidateId(candidate: Record<string, unknown>): string {
+  const raw = candidate.candidate_id;
+  return raw === undefined || raw === null || raw === "" ? "" : String(raw);
 }
 
 /**
@@ -1100,7 +1122,7 @@ async function gateReadback(
   }
   const candidates = Array.isArray(cohort.candidates) ? cohort.candidates.map(gateRecord) : [];
   const candidate = intent.candidate_id
-    ? candidates.find((row) => row.candidate_id === intent.candidate_id)
+    ? candidates.find((row) => gateCandidateId(row) === intent.candidate_id)
     : undefined;
   switch (intent.action) {
     case "create":

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -6,7 +6,7 @@ import type {
   GateReadback,
   WarmblyGateAction,
 } from "./adapters/contract";
-import { isWarmblyGateAction } from "./adapters/contract";
+import { APPROVAL_DEFAULT_REASON, isWarmblyGateAction } from "./adapters/contract";
 import { WARMBLY_DISPATCH_PATHS, type WriteShortcutKind } from "./adapters/paths";
 import { parseHash } from "./destinations";
 import { LIST_FORM_FIELDS, defaultParamValues, listHref, listSpecById } from "./filter";
@@ -29,6 +29,7 @@ import {
   resumeObservationFingerprint,
 } from "./warmbly-confirmation";
 import { pageIsEmpty, pageIsStale } from "./page";
+import { markReviewDecided, rollbackReviewDecided } from "./review-queue";
 import {
   QUEUE_FOCUS_PARAM,
   QUEUE_FOCUS_TOKEN_PATTERN,
@@ -175,12 +176,14 @@ function applyPaint(
   bindMessageToggle(root, renderHash, navigate);
   bindCopyControls(root);
   bindListFilters(root, renderHash, navigate);
+  bindReviewQueueShortcut();
   consumeQueueFocus(
     root,
     hash,
     view.kind === "ready" || view.kind === "stale",
     replaceLocation,
   );
+  advanceReviewQueue(root, view.kind === "ready" || view.kind === "stale");
 }
 
 /**
@@ -576,11 +579,11 @@ function bindWarmblyHumanGate(
       const key = form.getAttribute("data-gate-key") ?? `${raw}:${versionId}:${candidateId}:`;
       // The APPROVE form carries its decision on the element, because APPROVE
       // and HOLD/REJECT are different forms with different requirements: one
-      // demands the acknowledgement, the other must never demand it.
+      // may resolve the recipient verification on the way and needs no typed
+      // motive, the other always demands one and never verifies anything.
       const fixedDecision = form.getAttribute("data-decision");
       const decision = fixedDecision ?? form.querySelector('[name="decision"]')?.value;
       const limit = Number(form.querySelector('[name="limit"]')?.value ?? 0);
-      const acknowledgement = form.querySelector('[name="ack"]')?.checked === true;
       const confirmation = form.querySelector('[name="confirmation"]')?.value?.trim() ?? "";
       const reason = form.querySelector('[name="reason"]')?.value ?? "";
 
@@ -610,14 +613,26 @@ function bindWarmblyHumanGate(
       }
 
       if (!beginGateFlight(key)) return;
+      const isApprove = raw === "review" && decision === "APPROVE";
       const intent: HumanGateIntent = {
         action: raw,
         ...(versionId ? { version_id: versionId } : {}),
         ...(candidateId ? { candidate_id: candidateId } : {}),
         ...(limit > 0 ? { limit } : {}),
         ...(decision === "APPROVE" || decision === "REJECT" || decision === "HOLD" || decision === "GO" || decision === "NO_GO" ? { decision } : {}),
-        ...(reason ? { reason } : {}),
-        ...(decision === "APPROVE" ? { acknowledged: acknowledgement } : {}),
+        // An ordinary approval types nothing, and the trail must still say what
+        // happened. The default is folded in here, not only at the wire, so the
+        // idempotency identity and the recorded motive are the same string.
+        ...(isApprove
+          ? { reason: reason.trim() || APPROVAL_DEFAULT_REASON }
+          : reason
+            ? { reason }
+            : {}),
+        // Pressing Aprovar *is* the acknowledgement. The form carries no
+        // checkbox because a second click declaring the first one adds nothing
+        // to the trail: actor, instant, version, frozen hash and recipient are
+        // all recorded already.
+        ...(isApprove ? { acknowledged: true } : {}),
         ...((raw === "decide" || raw === "adjust") && confirmation ? { confirmation } : {}),
         ...(raw === "adjust"
           ? {
@@ -627,51 +642,56 @@ function bindWarmblyHumanGate(
             }
           : {}),
       };
+      // Optimistic, and only for the two decisions that take a candidate out of
+      // the pending queue. The mark goes up before the write so the next
+      // message is on screen immediately; every outcome short of a confirmed
+      // application rolls it back.
+      const optimistic =
+        raw === "review" && versionId && candidateId
+          ? decision === "APPROVE"
+            ? "aprovado"
+            : decision === "HOLD" || decision === "REJECT"
+              ? "ajuste"
+              : null
+          : null;
+      if (optimistic) markReviewDecided(versionId, candidateId, optimistic);
       // Paint the pending state before the await. The key is computed first so
       // this paint already renders the form as busy.
       onDone();
       void (async () => {
-        let result: AdapterWriteResult | undefined;
+        let result: AdapterWriteResult;
         try {
-          result = await Promise.resolve(
-            adapter.warmblyGate?.({
-              ...intent,
-              idempotency_key: humanGateIdempotencyKey(intent),
-            }),
-          );
+          result = isApprove
+            ? await approveCandidate(adapter, intent, {
+                versionId,
+                candidateId,
+                autoValidate: form.getAttribute("data-auto-validate") === "true",
+                releaseFlight: () => endGateFlight(key),
+              })
+            : await (async () => {
+                const written = await writeGateIntent(adapter, intent, raw, versionId, candidateId);
+                endGateFlight(key);
+                return settleGateIntent(adapter, intent, written);
+              })();
         } catch {
-          // The adapter threw instead of answering, so this client cannot know
-          // whether the POST reached the gate. `unknown` is the only honest
-          // verdict — and it is the one that keeps the idempotency key.
-          result = {
-            ok: false,
-            path: "",
-            kind: "nota",
-            message: "O canal falhou sem responder.",
-            outcome: "unknown",
-            code: "browser_transport",
-            gateAction: raw,
-            ...(versionId || candidateId
-              ? {
-                  gateTarget: {
-                    ...(versionId ? { cohort_id: versionId } : {}),
-                    ...(candidateId ? { candidate_id: candidateId } : {}),
-                  },
-                }
-              : {}),
-          };
+          // Belt and braces over the guards each step already has. A chain that
+          // threw leaves this client unable to say what reached the gate, so
+          // the verdict is `unknown` and the optimistic mark comes back down.
+          result = browserTransportResult(raw, versionId, candidateId);
+          adapter.lastOperatorResult = result;
         } finally {
+          // A form left claimed by a chain that died is a control the operator
+          // can never press again without reloading.
           endGateFlight(key);
         }
-        // Only a definitive outcome advances the key. An `unknown` keeps it, so
-        // the retry of an uncertain intent is the same intent to the server.
-        settleHumanGateIntent(intent, result?.outcome);
-        if (result) {
-          if (result.code === "adjust_route_unavailable") markAdjustRouteMissing();
-          const readback = await gateReadback(adapter, intent, result);
-          adapter.lastOperatorResult = { ...result, readback };
-          if (raw === "adjust" && result.ok) clearAdjustDraft(candidateId);
+        if (optimistic && !confirmedApplication(result)) {
+          rollbackReviewDecided(versionId, candidateId);
         }
+        if (raw === "adjust" && result.ok) clearAdjustDraft(candidateId);
+        // The reviewer's hands stay where they were: the next pending card
+        // takes the focus so the following approval needs no scroll and no
+        // pointer hunt.
+        if (raw === "review" && confirmedApplication(result)) requestQueueAdvance();
         const next = gateNavigation(raw, result);
         if (next) {
           navigate(next);
@@ -681,6 +701,317 @@ function bindWarmblyHumanGate(
       })();
     });
   }
+}
+
+/** The verdict this client falls back to when the adapter never answered at all. */
+function browserTransportResult(
+  action: WarmblyGateAction,
+  versionId: string,
+  candidateId: string,
+): AdapterWriteResult {
+  return {
+    ok: false,
+    path: "",
+    kind: "nota",
+    message: "O canal falhou sem responder.",
+    outcome: "unknown",
+    code: "browser_transport",
+    gateAction: action,
+    ...(versionId || candidateId
+      ? {
+          gateTarget: {
+            ...(versionId ? { cohort_id: versionId } : {}),
+            ...(candidateId ? { candidate_id: candidateId } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+/**
+ * One gate write, and nothing else.
+ *
+ * An adapter that throws instead of answering leaves this client unable to say
+ * whether the POST reached the gate, so `unknown` is the only honest verdict —
+ * and it is the one that keeps the idempotency key for the retry.
+ */
+async function writeGateIntent(
+  adapter: ControlCenterReadAdapter,
+  intent: HumanGateIntent,
+  action: WarmblyGateAction,
+  versionId: string,
+  candidateId: string,
+): Promise<AdapterWriteResult> {
+  try {
+    const result = await Promise.resolve(
+      adapter.warmblyGate?.({ ...intent, idempotency_key: humanGateIdempotencyKey(intent) }),
+    );
+    if (result) return result;
+  } catch {
+    // Falls through to the same unknown verdict as an absent channel.
+  }
+  return browserTransportResult(action, versionId, candidateId);
+}
+
+/**
+ * Everything a write owes after the channel answered: settle the idempotency
+ * generation, re-read the resource, and publish the outcome the next paint
+ * renders.
+ */
+async function settleGateIntent(
+  adapter: ControlCenterReadAdapter,
+  intent: HumanGateIntent,
+  result: AdapterWriteResult,
+): Promise<AdapterWriteResult> {
+  // Only a definitive outcome advances the key. An `unknown` keeps it, so the
+  // retry of an uncertain intent is the same intent to the server.
+  settleHumanGateIntent(intent, result.outcome);
+  if (result.code === "adjust_route_unavailable") markAdjustRouteMissing();
+  const readback = await gateReadback(adapter, intent, result);
+  const settled: AdapterWriteResult = { ...result, readback };
+  adapter.lastOperatorResult = settled;
+  return settled;
+}
+
+/**
+ * Whether a write may be treated as applied.
+ *
+ * Accepted-by-the-channel is not applied, and a readback that says the server
+ * does not record the change is the clearest possible "no". Only these two
+ * together let an optimistic mark stand.
+ */
+function confirmedApplication(result: AdapterWriteResult): boolean {
+  if (!result.ok || result.outcome !== "executed") return false;
+  return result.readback?.status !== "not_confirmed";
+}
+
+/**
+ * Approving a candidate, as one reviewer action.
+ *
+ * The server refuses APPROVE outside a current VALID validation and will go on
+ * refusing it — that invariant is Warmbly's and it is not weakened here. What
+ * this removes is the human step in front of it: obtaining the validation is a
+ * deterministic call with no judgement in it, so the approve action makes it,
+ * reads the resulting status back from the server, and only then registers the
+ * decision. A verification that does not come back VALID stops the chain with
+ * the reason written out; APPROVE is not attempted, and nothing is guessed
+ * about a status the server did not state.
+ */
+async function approveCandidate(
+  adapter: ControlCenterReadAdapter,
+  intent: HumanGateIntent,
+  args: {
+    versionId: string;
+    candidateId: string;
+    autoValidate: boolean;
+    releaseFlight: () => void;
+  },
+): Promise<AdapterWriteResult> {
+  const { versionId, candidateId, autoValidate, releaseFlight } = args;
+  const target = { cohort_id: versionId, candidate_id: candidateId };
+  if (autoValidate) {
+    const validateIntent: HumanGateIntent = {
+      action: "validate",
+      version_id: versionId,
+      candidate_id: candidateId,
+    };
+    const validated = await settleGateIntent(
+      adapter,
+      validateIntent,
+      await writeGateIntent(adapter, validateIntent, "validate", versionId, candidateId),
+    );
+    if (!confirmedApplication(validated)) {
+      releaseFlight();
+      const refusal: AdapterWriteResult = {
+        ...validated,
+        ok: false,
+        code: "approval_validation_unavailable",
+        message: `A verificação do destinatário não completou (${validated.code ?? validated.status ?? "sem código"}): ${validated.message}`,
+        gateAction: "validate",
+        gateTarget: target,
+      };
+      adapter.lastOperatorResult = refusal;
+      return refusal;
+    }
+    const status = await readValidationStatus(adapter, versionId, candidateId);
+    if (status !== "VALID") {
+      releaseFlight();
+      const refusal: AdapterWriteResult = {
+        ok: false,
+        path: validated.path,
+        kind: "nota",
+        outcome: "refused",
+        code: "approval_validation_not_valid",
+        message: `A verificação foi feita agora e o servidor reporta ${status ?? "nenhum estado"}, não VALID. O APPROVE não foi enviado.`,
+        gateAction: "validate",
+        gateTarget: target,
+        ...(validated.receiptId ? { receiptId: validated.receiptId } : {}),
+        ...(validated.correlationId ? { correlationId: validated.correlationId } : {}),
+      };
+      adapter.lastOperatorResult = refusal;
+      return refusal;
+    }
+  }
+  const written = await writeGateIntent(adapter, intent, "review", versionId, candidateId);
+  releaseFlight();
+  return settleGateIntent(adapter, intent, written);
+}
+
+/** The validation status the server reports for one candidate, right now. */
+async function readValidationStatus(
+  adapter: ControlCenterReadAdapter,
+  cohortId: string,
+  candidateId: string,
+): Promise<string | null> {
+  const candidate = await readGateCandidate(adapter, cohortId, candidateId);
+  if (!candidate) return null;
+  const status = gateRecord(candidate.validation).status;
+  return typeof status === "string" && status !== "" ? status.toUpperCase() : null;
+}
+
+/* ------------------------------------------------------------------ *
+ * Queue advance.
+ * ------------------------------------------------------------------ */
+
+/**
+ * Whether the next paint owes the reviewer the focus of the next pending card.
+ *
+ * Module scope for the same reason `restoreFocusId` is: the repaint replaces
+ * `root.innerHTML` wholesale, so the handler that asked for the advance is gone
+ * long before the markup that can satisfy it exists.
+ */
+let queueAdvancePending = false;
+
+export function requestQueueAdvance(): void {
+  queueAdvancePending = true;
+}
+
+/**
+ * Puts the reviewer on the next pending approval.
+ *
+ * Only a paint that actually rendered the queue may consume the request — a
+ * loading frame would swallow it and leave the reviewer's focus on nothing.
+ * `preventScroll` plus an explicit `scrollIntoView` keeps the page from
+ * jumping: the card is centred deliberately rather than yanked to the top by
+ * the browser's own focus scroll.
+ */
+export function advanceReviewQueue(root: MountableRoot, painted: boolean): boolean {
+  if (!queueAdvancePending) return false;
+  if (typeof root.querySelectorAll !== "function") return false;
+  const buttons = root.querySelectorAll("[data-approve-submit]");
+  let next: (typeof buttons)[number] | undefined;
+  for (let index = 0; index < buttons.length; index += 1) {
+    const button = buttons[index];
+    // A disabled control is not somewhere to leave a reviewer: it is a
+    // candidate the server blocked, and landing on it would look like the queue
+    // had stalled.
+    if (button && button.getAttribute("disabled") === null) {
+      next = button;
+      break;
+    }
+  }
+  if (!next) {
+    // Nothing left to approve. The request is spent either way: the queue-empty
+    // card is the thing the reviewer should be reading now.
+    if (painted) queueAdvancePending = false;
+    return false;
+  }
+  queueAdvancePending = false;
+  next.focus?.({ preventScroll: true });
+  next.scrollIntoView?.({ block: "center", inline: "nearest" });
+  return true;
+}
+
+/** Test seam. Production never needs to forget a pending advance. */
+export function resetQueueAdvance(): void {
+  queueAdvancePending = false;
+}
+
+/* ------------------------------------------------------------------ *
+ * Keyboard.
+ * ------------------------------------------------------------------ */
+
+/**
+ * Whether the caret is somewhere a keystroke means text, not a decision.
+ *
+ * The adjust editor is a real editor on the same page as the approve controls,
+ * so a shortcut that fires while someone is writing a subject line would
+ * approve an outbound message as a side effect of typing. Every field is out of
+ * bounds; a focused button is not, because that is where the queue advance
+ * leaves the reviewer.
+ */
+export function isEditingTarget(
+  element: { tagName?: string; isContentEditable?: boolean } | null | undefined,
+): boolean {
+  if (!element) return false;
+  if (element.isContentEditable === true) return true;
+  const tag = typeof element.tagName === "string" ? element.tagName.toUpperCase() : "";
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
+
+/**
+ * What a keystroke is allowed to reach.
+ *
+ * `focused-card` may only approve the message the reviewer is already on;
+ * `first-pending` may fall back to the top of the queue.
+ */
+export type ApprovalShortcutScope = "focused-card" | "first-pending" | null;
+
+/**
+ * The two keystrokes that approve, and how far each one reaches.
+ *
+ * Bare `A` is the throughput shortcut and is deliberately the narrower of the
+ * two: it approves only the card that already has the focus, which after an
+ * approval is the next pending one. A stray `a` typed while reading anything
+ * else authorises no outbound message. Ctrl/Cmd+Enter is explicit enough to
+ * address the queue.
+ *
+ * Modifiers are refused rather than ignored — `Ctrl+A` is select-all and must
+ * stay select-all — and nothing at all fires while a field has the caret.
+ */
+export function approvalShortcutScope(
+  event: {
+    key?: string;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    altKey?: boolean;
+    shiftKey?: boolean;
+  },
+  editing: boolean,
+): ApprovalShortcutScope {
+  if (editing || event.altKey === true) return null;
+  const key = typeof event.key === "string" ? event.key : "";
+  if (key === "Enter") {
+    return event.ctrlKey === true || event.metaKey === true ? "first-pending" : null;
+  }
+  if (key.toLowerCase() !== "a") return null;
+  return event.ctrlKey !== true && event.metaKey !== true && event.shiftKey !== true
+    ? "focused-card"
+    : null;
+}
+
+/** Bound once for the life of the page: a repaint drops markup, not documents. */
+let queueShortcutBound = false;
+
+function bindReviewQueueShortcut(): void {
+  if (queueShortcutBound || typeof document === "undefined") return;
+  queueShortcutBound = true;
+  document.addEventListener("keydown", (event) => {
+    const active = document.activeElement as HTMLElement | null;
+    const scope = approvalShortcutScope(event, isEditingTarget(active));
+    if (!scope) return;
+    // The card under the caret first, so a reviewer who tabbed into a specific
+    // message approves that one and not whatever happens to be at the top.
+    const scoped = active?.closest?.("[data-candidate-id]") ?? null;
+    const button =
+      scoped?.querySelector("[data-approve-submit]:not([disabled])")
+      ?? (scope === "first-pending"
+        ? document.querySelector("[data-approve-submit]:not([disabled])")
+        : null);
+    if (!(button instanceof HTMLElement)) return;
+    event.preventDefault();
+    button.click();
+  });
 }
 
 /** Where the operator is taken after a write, according to the server's answer. */
@@ -700,6 +1031,33 @@ function gateRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+/**
+ * One candidate, as the server reports it right now.
+ *
+ * Shared by the readback and by the approve chain so both ask the same question
+ * of the same route: a second way of reading the gate is a second way of being
+ * wrong about it.
+ */
+async function readGateCandidate(
+  adapter: ControlCenterReadAdapter,
+  cohortId: string,
+  candidateId: string,
+): Promise<Record<string, unknown> | null> {
+  let read: import("./adapters/contract").AdapterReadResult;
+  try {
+    read = await Promise.resolve(
+      adapter.readDestination("warmbly", `#/warmbly/revisao?resource=${encodeURIComponent(cohortId)}`),
+    );
+  } catch {
+    return null;
+  }
+  if (!read.ok || read.loading || !read.page) return null;
+  const cohort = gateRecord(gateRecord(gateRecord(read.page.warmbly_gate).selected).data);
+  if (!cohort.id) return null;
+  const candidates = Array.isArray(cohort.candidates) ? cohort.candidates.map(gateRecord) : [];
+  return candidates.find((row) => row.candidate_id === candidateId) ?? null;
 }
 
 /**

--- a/control-center/apps/web-shell/src/review-queue.ts
+++ b/control-center/apps/web-shell/src/review-queue.ts
@@ -70,6 +70,19 @@ function record(value: unknown): Record<string, unknown> {
 }
 
 /**
+ * The candidate id, stringified exactly the way the renderer stamps it onto the
+ * form.
+ *
+ * The mark is written from the form's `data-candidate` and read back from the
+ * payload, so the two have to agree on what "the id" is. Reading only `string`
+ * here while the form stamped `String(3)` would make the mark silently never
+ * apply — an approved message back at the top of the queue.
+ */
+function idOf(value: unknown): string {
+  return value === undefined || value === null || value === "" ? "" : String(value);
+}
+
+/**
  * The server's own verdict on this candidate, and nothing inferred.
  *
  * An APPROVE the server itself marks `effective: false` was invalidated by
@@ -149,7 +162,7 @@ export function reviewQueueState(
   cohortId: string,
   candidate: Record<string, unknown>,
 ): ReviewQueueReading {
-  const candidateId = typeof candidate.candidate_id === "string" ? candidate.candidate_id : "";
+  const candidateId = idOf(candidate.candidate_id);
   const local = candidateId ? decidedReviewState(cohortId, candidateId) : undefined;
   const server = serverReviewState(candidate);
   if (local === undefined) return { state: server, optimistic: false };

--- a/control-center/apps/web-shell/src/review-queue.ts
+++ b/control-center/apps/web-shell/src/review-queue.ts
@@ -1,0 +1,183 @@
+/**
+ * The review queue: what is still work, what is already decided, and what this
+ * browser decided a moment ago and has not seen confirmed yet.
+ *
+ * Revisão used to render every candidate of a version in payload order, decided
+ * or not. At five candidates that is merely untidy; at fifty it is the reviewer
+ * scrolling past their own finished work to find the next thing to do. The
+ * default recorte is therefore `pendentes`, and an approval leaves that recorte
+ * the moment it is registered.
+ *
+ * Two rules keep the optimistic layer honest:
+ *
+ * 1. A local mark is only ever *set* by an action this browser took, and only
+ *    for the exact version and candidate it took it on.
+ * 2. A local mark survives a repaint until it is rolled back, so a slow or
+ *    stale server read can never resurrect an approved message as pending —
+ *    which is the one failure mode that would get a message approved twice.
+ *
+ * Nothing here is durable: a reload drops every local mark and the surface goes
+ * back to reading the server. That is deliberate. The server is the record; this
+ * is only the gap between the click and the confirmation.
+ */
+
+/** Where a candidate stands as far as the human queue is concerned. */
+export const REVIEW_QUEUE_STATES = ["pendente", "aprovado", "ajuste"] as const;
+export type ReviewQueueState = (typeof REVIEW_QUEUE_STATES)[number];
+
+/** The recortes a reviewer can ask for. `pendentes` is the operational default. */
+export const REVIEW_QUEUE_FILTERS = ["pendentes", "aprovadas", "ajuste", "todas"] as const;
+export type ReviewQueueFilter = (typeof REVIEW_QUEUE_FILTERS)[number];
+
+export const DEFAULT_REVIEW_QUEUE_FILTER: ReviewQueueFilter = "pendentes";
+
+/** URL parameter that carries the recorte, so it survives the wholesale repaint. */
+export const REVIEW_QUEUE_PARAM = "estado";
+
+export const REVIEW_QUEUE_FILTER_LABELS: Record<ReviewQueueFilter, string> = {
+  pendentes: "Pendentes",
+  aprovadas: "Aprovadas",
+  ajuste: "Ajuste ou rejeitadas",
+  todas: "Todas",
+};
+
+export function resolveReviewQueueFilter(raw: string | null | undefined): ReviewQueueFilter {
+  return REVIEW_QUEUE_FILTERS.includes(raw as ReviewQueueFilter)
+    ? (raw as ReviewQueueFilter)
+    : DEFAULT_REVIEW_QUEUE_FILTER;
+}
+
+export function reviewQueueFilterMatches(
+  filter: ReviewQueueFilter,
+  state: ReviewQueueState,
+): boolean {
+  switch (filter) {
+    case "pendentes":
+      return state === "pendente";
+    case "aprovadas":
+      return state === "aprovado";
+    case "ajuste":
+      return state === "ajuste";
+    case "todas":
+      return true;
+  }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * The server's own verdict on this candidate, and nothing inferred.
+ *
+ * An APPROVE the server itself marks `effective: false` was invalidated by
+ * drift — recipient, copy, policy or evidence moved under it — so it is work
+ * again, and hiding it from the pending recorte would hide exactly the message
+ * that has to be re-decided before GO. HOLD and REJECT carry no `effective`
+ * flag of their own: they are decisions, not authorisations.
+ */
+export function serverReviewState(candidate: Record<string, unknown>): ReviewQueueState {
+  const review = record(candidate.review);
+  const decision = typeof review.decision === "string" ? review.decision.toUpperCase() : "";
+  if (decision === "APPROVE") return review.effective === false ? "pendente" : "aprovado";
+  if (decision === "HOLD" || decision === "REJECT") return "ajuste";
+  return "pendente";
+}
+
+/* ------------------------------------------------------------------ *
+ * Optimistic layer.
+ * ------------------------------------------------------------------ */
+
+const decided = new Map<string, ReviewQueueState>();
+
+function markKey(cohortId: string, candidateId: string): string {
+  return `${cohortId} ${candidateId}`;
+}
+
+/** Records what this browser just decided, before the server has confirmed it. */
+export function markReviewDecided(
+  cohortId: string,
+  candidateId: string,
+  state: ReviewQueueState,
+): void {
+  if (!cohortId || !candidateId) return;
+  decided.set(markKey(cohortId, candidateId), state);
+}
+
+/**
+ * Undoes a local mark.
+ *
+ * Called on every outcome that is not a confirmed application — a refusal, a
+ * failure, and deliberately also an `unknown`. "Pode ter sido aplicada" is not
+ * "foi aplicada", and the safe side of that doubt is the message staying in the
+ * queue with the outcome banner on it: retrying replays the same idempotency
+ * key, so the server, not this screen, decides whether it is a second write.
+ */
+export function rollbackReviewDecided(cohortId: string, candidateId: string): void {
+  decided.delete(markKey(cohortId, candidateId));
+}
+
+export function decidedReviewState(
+  cohortId: string,
+  candidateId: string,
+): ReviewQueueState | undefined {
+  return decided.get(markKey(cohortId, candidateId));
+}
+
+/** Test seam, and the only way to forget every mark at once. */
+export function resetReviewQueue(): void {
+  decided.clear();
+}
+
+export interface ReviewQueueReading {
+  state: ReviewQueueState;
+  /** True when the state shown came from this browser, not from the payload. */
+  optimistic: boolean;
+}
+
+/**
+ * The state the queue renders: the local mark when there is one, the server's
+ * verdict otherwise.
+ *
+ * The local mark wins even when the payload disagrees, and only until it is
+ * rolled back. A read that has not caught up yet must not put an approved
+ * message back in front of the reviewer.
+ */
+export function reviewQueueState(
+  cohortId: string,
+  candidate: Record<string, unknown>,
+): ReviewQueueReading {
+  const candidateId = typeof candidate.candidate_id === "string" ? candidate.candidate_id : "";
+  const local = candidateId ? decidedReviewState(cohortId, candidateId) : undefined;
+  const server = serverReviewState(candidate);
+  if (local === undefined) return { state: server, optimistic: false };
+  return { state: local, optimistic: local !== server };
+}
+
+export interface ReviewQueueCounts {
+  pendentes: number;
+  aprovadas: number;
+  ajuste: number;
+  total: number;
+}
+
+export function reviewQueueCounts(
+  cohortId: string,
+  candidates: readonly Record<string, unknown>[],
+): ReviewQueueCounts {
+  const counts: ReviewQueueCounts = {
+    pendentes: 0,
+    aprovadas: 0,
+    ajuste: 0,
+    total: candidates.length,
+  };
+  for (const candidate of candidates) {
+    const { state } = reviewQueueState(cohortId, candidate);
+    if (state === "pendente") counts.pendentes += 1;
+    else if (state === "aprovado") counts.aprovadas += 1;
+    else counts.ajuste += 1;
+  }
+  return counts;
+}

--- a/control-center/apps/web-shell/src/review-queue.ts
+++ b/control-center/apps/web-shell/src/review-queue.ts
@@ -12,9 +12,9 @@
  *
  * 1. A local mark is only ever *set* by an action this browser took, and only
  *    for the exact version and candidate it took it on.
- * 2. A local mark survives a repaint until it is rolled back, so a slow or
- *    stale server read can never resurrect an approved message as pending —
- *    which is the one failure mode that would get a message approved twice.
+ * 2. A local mark survives only while the write is in flight. Confirmation or
+ *    rollback removes it, so a later server HOLD, invalidation or another tab's
+ *    decision immediately becomes authoritative.
  *
  * Nothing here is durable: a reload drops every local mark and the surface goes
  * back to reading the server. That is deliberate. The server is the record; this
@@ -94,7 +94,12 @@ function idOf(value: unknown): string {
 export function serverReviewState(candidate: Record<string, unknown>): ReviewQueueState {
   const review = record(candidate.review);
   const decision = typeof review.decision === "string" ? review.decision.toUpperCase() : "";
-  if (decision === "APPROVE") return review.effective === false ? "pendente" : "aprovado";
+  // The decision token alone is not an effective approval. Warmbly binds an
+  // approval to the current recipient, copy, policy, evidence and validation;
+  // `effective: true` is the server's proof that those bindings still hold.
+  // Missing is therefore fail-closed just like false, especially during a
+  // partial/rolling response where the decision can arrive before its effect.
+  if (decision === "APPROVE") return review.effective === true ? "aprovado" : "pendente";
   if (decision === "HOLD" || decision === "REJECT") return "ajuste";
   return "pendente";
 }
@@ -129,6 +134,18 @@ export function markReviewDecided(
  * key, so the server, not this screen, decides whether it is a second write.
  */
 export function rollbackReviewDecided(cohortId: string, candidateId: string): void {
+  decided.delete(markKey(cohortId, candidateId));
+}
+
+/**
+ * Hands the candidate back to the server after a successful readback.
+ *
+ * A confirmed optimistic mark has finished its only job. Keeping it forever
+ * would let this tab overrule a later HOLD, invalidation or decision from a
+ * second tab until reload, which turns a short-lived UX bridge into a second
+ * source of truth.
+ */
+export function confirmReviewDecided(cohortId: string, candidateId: string): void {
   decided.delete(markKey(cohortId, candidateId));
 }
 

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -206,6 +206,19 @@ a {
   background: var(--bg-card);
 }
 
+/*
+ * The queue's own recortes, inside the progress card.
+ *
+ * Deliberately not sticky: the Warmbly subnav already owns the top of the
+ * viewport, and two sticky rows stacked over the message being reviewed is the
+ * message losing to its own chrome on a phone.
+ */
+.subnav.queue-filters {
+  position: static;
+  margin: 0.5rem 0 0.2rem;
+  padding: 0;
+}
+
 .operator-form {
   display: grid;
   gap: 0.45rem;
@@ -1360,4 +1373,28 @@ button[data-toggle-messages] {
   color: var(--fg);
   font: inherit;
   text-decoration: none;
+}
+
+/*
+ * The single action of the happy path, told apart from the exception controls
+ * around it. A reviewer scanning a card must not have to read four identical
+ * buttons to find the one that means "aprovar".
+ */
+.approve-form button[data-approve-submit] {
+  background: var(--accent);
+  color: var(--bg);
+  font-weight: 600;
+}
+
+.approve-form button[data-approve-submit][disabled] {
+  background: var(--bg-elev);
+  color: var(--fg);
+  font-weight: 400;
+}
+
+/* The optional comment is optional-looking: closed, quiet, out of the path. */
+.approve-form [data-approve-comment] > summary {
+  cursor: pointer;
+  font-size: 0.9rem;
+  opacity: 0.8;
 }

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -1723,7 +1723,7 @@ ${validateControl}
 `
     : `<p class="constraint" data-non-actionable-notice="true">Versão histórica, não enviável. Verificar o destinatário, aprovar, segurar e ajustar não são oferecidos aqui. Abra a versão corrente pelo link no topo desta página.</p>`;
 
-  return `<article class="card" data-candidate-id="${escapeHtml(candidateId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}" data-queue-state="${escapeHtml(queue.state)}" data-queue-optimistic="${queue.optimistic ? "true" : "false"}" data-approve-allowed="${gate.allowed && editorial.actionable ? "true" : "false"}" data-approve-needs-validation="${gate.needsValidation && gate.allowed ? "true" : "false"}"
+  return `<article class="card" data-candidate-id="${escapeHtml(candidateId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}" data-queue-state="${escapeHtml(queue.state)}" data-queue-optimistic="${queue.optimistic ? "true" : "false"}" data-approve-allowed="${gate.allowed && editorial.actionable ? "true" : "false"}" data-approve-needs-validation="${gate.needsValidation && gate.allowed ? "true" : "false"}">
     <p class="kicker">${validationPill(candidate)}${editorial.legacy ? ` <span class="pill error" data-non-actionable="true">NÃO ACIONÁVEL</span>` : ""} · ${escapeHtml(show(candidate.source))}</p>
     <h3>${escapeHtml(show(candidate.company))}</h3>
     ${feedback.forCandidate(candidateId)}
@@ -1950,12 +1950,19 @@ function emptyQueueBlock(
   counts: ReturnType<typeof reviewQueueCounts>,
   filter: ReviewQueueFilter,
   params: URLSearchParams,
+  actionable: boolean,
 ): string {
   const everything = `<p><a class="button" data-queue-see-all="true" href="${escapeHtml(queueFilterHref(params, "todas"))}">Ver todas as ${counts.total}</a></p>`;
   if (filter === "pendentes") {
+    // A historical version offers no GO control at all, so naming GO as the
+    // next step there would point the founder at a button this screen refuses
+    // to render.
+    const next = actionable
+      ? "O próximo passo é o GO/NO-GO logo abaixo, e ele continua exigindo a confirmação digitada da versão."
+      : "Esta versão é histórica e não é enviável, então não há próximo passo aqui: decida na versão corrente.";
     return `<article class="card banner ok" role="status" data-queue-empty="pendentes">
       <h3>Fila vazia: nada pendente nesta versão.</h3>
-      <p>Os ${counts.total} candidatos desta versão já foram decididos — ${counts.aprovadas} aprovado(s) e ${counts.ajuste} em ajuste ou rejeitado(s). O próximo passo é o GO/NO-GO logo abaixo, e ele continua exigindo a confirmação digitada da versão.</p>
+      <p>Os ${counts.total} candidatos desta versão já foram decididos — ${counts.aprovadas} aprovado(s) e ${counts.ajuste} em ajuste ou rejeitado(s). ${escapeHtml(next)}</p>
       ${everything}
     </article>`;
   }
@@ -2073,7 +2080,7 @@ function reviewSurface(input: WarmblySurfaceInput): string {
     candidateCards
       || (candidates.length === 0
         ? `<p class="banner error">Cohort vazia: GO bloqueado.</p>`
-        : emptyQueueBlock(counts, queueFilter, queueParams))
+        : emptyQueueBlock(counts, queueFilter, queueParams, editorial.actionable))
   }
   ${decideControl}
   <dl class="facts"><div><dt>Decisão final registrada</dt><dd>${escapeHtml(decisionValue)}</dd></div></dl>

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -23,13 +23,24 @@ import {
   isWarmblySurface,
   type WarmblySurface,
 } from "../destinations";
-import type { AdapterWriteResult } from "../adapters/contract";
+import { APPROVAL_DEFAULT_REASON, type AdapterWriteResult } from "../adapters/contract";
 import {
   adjustDraft,
   adjustRouteMissing,
   gateInFlight,
   type AdjustDraft,
 } from "../human-gate-flight";
+import {
+  DEFAULT_REVIEW_QUEUE_FILTER,
+  REVIEW_QUEUE_FILTERS,
+  REVIEW_QUEUE_FILTER_LABELS,
+  REVIEW_QUEUE_PARAM,
+  resolveReviewQueueFilter,
+  reviewQueueCounts,
+  reviewQueueFilterMatches,
+  reviewQueueState,
+  type ReviewQueueFilter,
+} from "../review-queue";
 import { AUTH_HOST, PRODUCTIVE_HOST } from "../topology";
 import type { ActorRef, CommercialSnapshot } from "../types";
 import type { PendingResumeConfirmation } from "../warmbly-confirmation";
@@ -309,6 +320,24 @@ const OUTCOME_BY_CODE: Record<string, OutcomeRule> = {
     title: "Recusada: candidato não encontrado nesta versão",
     recovery:
       "O candidato não existe mais nesta versão da cohort. Recarregue a revisão antes de agir de novo.",
+  },
+  /* ---------------------------------------------------------------- *
+   * Aprovação que resolve a verificação do destinatário no caminho.
+   * Os dois códigos abaixo nascem no cliente, e existem porque "a
+   * verificação falhou" e "a aprovação foi recusada" mandam o operador
+   * para lugares diferentes.
+   * ---------------------------------------------------------------- */
+  approval_validation_unavailable: {
+    kind: "refused",
+    title: "Recusada: a verificação do destinatário não completou",
+    recovery:
+      "O APPROVE não chegou a ser enviado e nada foi decidido neste candidato. Leia o motivo da verificação no detalhe técnico; se for indisponibilidade do verificador, tente aprovar de novo em seguida. Se persistir, registre HOLD com o motivo.",
+  },
+  approval_validation_not_valid: {
+    kind: "refused",
+    title: "Recusada: o destinatário foi verificado agora e não voltou VALID",
+    recovery:
+      "A verificação foi feita nesta ação e o APPROVE não foi enviado, então nada foi decidido. O Warmbly recusa aprovação fora de uma validação VALID: registre HOLD ou REJECT, ou corrija a origem do contato e recomponha.",
   },
   adjust_route_unavailable: {
     kind: "refused",
@@ -1232,41 +1261,140 @@ function validationPill(candidate: Record<string, unknown>): string {
 }
 
 /**
- * Whether APPROVE is offered at all for this candidate.
+ * A mailbox this screen can tell apart from a typo.
  *
- * The server refuses APPROVE on anything but a current VALID validation. A UI
- * that renders the control anyway teaches the operator that approving is a
- * thing they may try, and then hands them a refusal with no explanation. The
- * verdict comes from the server's own `validation.status` plus its own
- * `blocked_by` — never from a date this screen compared itself.
+ * Deliberately crude: one local part, one `@`, one dotted domain, no spaces.
+ * Deliverability is Warmbly's verdict, not a regex's — this only catches the
+ * case where there is nothing to deliver to at all.
  */
-export function approvalGate(candidate: Record<string, unknown>): {
-  allowed: boolean;
-  reason: string;
-} {
-  const status = show(record(candidate.validation).status).toUpperCase();
-  const blockers = Array.isArray(candidate.blocked_by)
+const SYNTACTIC_MAILBOX = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
+
+/**
+ * Blocker families that no amount of re-checking can clear.
+ *
+ * Matched by prefix against the server's own `blocked_by`. `approval_missing_or_invalid`
+ * is deliberately absent: it names the very thing the reviewer is about to do,
+ * and treating it as a block would make every candidate unapprovable.
+ */
+const MATERIAL_BLOCKER_PREFIXES = [
+  "hard_bounce",
+  "suppress",
+  "opt_out",
+  "optout",
+  "duplicate",
+  "copy_qa",
+  "missing_provenance",
+  "mailbox_",
+  "recipient_",
+  "route_not",
+  "policy_",
+] as const;
+
+/** Validation verdicts the server has actually resolved. Re-checking will not move them. */
+const SETTLED_INVALID_STATUSES = ["INVALID", "RISKY"] as const;
+
+/** Last uppercase word of a blocker code: the verdict it carries, if it carries one. */
+function lastToken(value: string): string {
+  const parts = value.toUpperCase().split(/[^A-Z]+/).filter(Boolean);
+  return parts[parts.length - 1] ?? "";
+}
+
+function blockersOf(candidate: Record<string, unknown>): string[] {
+  return Array.isArray(candidate.blocked_by)
     ? candidate.blocked_by.filter((entry): entry is string => typeof entry === "string")
     : [];
-  const validationBlocker = blockers.find((entry) => entry.startsWith("validation"));
-  if (validationBlocker) {
-    return {
-      allowed: false,
-      reason: `O servidor marcou este candidato com o bloqueio "${validationBlocker}". Peça uma nova verificação do destinatário antes de aprovar.`,
-    };
-  }
-  if (status === "VALID") return { allowed: true, reason: "" };
-  if (status === NOT_IN_PAYLOAD.toUpperCase() || status === "—") {
+}
+
+export interface ApprovalGate {
+  /** Whether the reviewer may press Aprovar at all. */
+  allowed: boolean;
+  /** Why not, when blocked. Always names the way forward. */
+  reason: string;
+  /**
+   * Whether pressing Aprovar has to obtain a validation first. The reviewer
+   * never asks for that: it is a deterministic machine step and the approve
+   * action performs it.
+   */
+  needsValidation: boolean;
+}
+
+/**
+ * Whether APPROVE is offered at all for this candidate, and whether approving
+ * has to verify the recipient on the way.
+ *
+ * The server refuses APPROVE outside a current VALID validation, and that
+ * invariant is untouched. What changed is who pays for it: obtaining the
+ * validation is a deterministic call with no human judgement in it, so the
+ * approve action makes it instead of demanding a preparatory click. A missing,
+ * stale or unresolved validation is therefore *not* a block — it is one extra
+ * request inside the same single reviewer action.
+ *
+ * A block survives only where re-checking provably cannot help: no mailbox at
+ * all, a mailbox that is not an address, a validation the server already
+ * settled as INVALID or RISKY, or a material blocker the server raised on its
+ * own (`hard_bounce`, suppression, opt-out, duplicate, copy QA, provenance).
+ * Every verdict here comes from the payload; nothing is inferred from a clock.
+ */
+export function approvalGate(candidate: Record<string, unknown>): ApprovalGate {
+  const mailbox = textOf(candidate.mailbox);
+  if (mailbox === null) {
     return {
       allowed: false,
       reason:
-        "O payload não trouxe o estado da validação deste candidato. Sem validação vigente o servidor recusa APPROVE.",
+        "O servidor não enviou destinatário nenhum para este candidato, então não há endereço a aprovar. Registre HOLD e recomponha a cohort.",
+      needsValidation: false,
     };
   }
-  return {
-    allowed: false,
-    reason: `A validação deste destinatário está ${status}, não VALID. O servidor recusa APPROVE fora de uma validação vigente: peça a verificação e aprove só depois que ela voltar VALID.`,
-  };
+  if (!SYNTACTIC_MAILBOX.test(mailbox)) {
+    return {
+      allowed: false,
+      reason: `O destinatário "${mailbox}" não é um endereço de e-mail. Registre REJECT e corrija a origem do contato antes de recompor.`,
+      needsValidation: false,
+    };
+  }
+  if (candidate.hard_bounce === true) {
+    return {
+      allowed: false,
+      reason:
+        "O servidor registra hard bounce neste endereço. Ele não pode receber entrega: registre REJECT.",
+      needsValidation: false,
+    };
+  }
+  const blockers = blockersOf(candidate);
+  const material = blockers.filter((entry) =>
+    MATERIAL_BLOCKER_PREFIXES.some((prefix) => entry.startsWith(prefix)),
+  );
+  if (material.length > 0) {
+    return {
+      allowed: false,
+      reason: `O servidor marcou este candidato com ${material.join(", ")}. Isso não se resolve verificando o destinatário de novo: registre HOLD ou REJECT com o motivo.`,
+      needsValidation: false,
+    };
+  }
+  const status = (textOf(record(candidate.validation).status) ?? "").toUpperCase();
+  const validationBlockers = blockers.filter((entry) => entry.startsWith("validation"));
+  // A validation blocker names its verdict in the last token — `validation_not_valid:INVALID`
+  // — and only that token is compared. Matching a suffix against the whole
+  // string read `approval_missing_or_invalid` as INVALID and blocked every
+  // candidate that was merely still waiting for its first review.
+  const settled = SETTLED_INVALID_STATUSES.find(
+    (entry) =>
+      status === entry
+      || validationBlockers.some((blocker) => lastToken(blocker) === entry),
+  );
+  if (settled) {
+    return {
+      allowed: false,
+      reason: `A verificação deste destinatário já voltou ${settled}, e o servidor recusa APPROVE fora de uma validação VALID. Verificar de novo não muda um veredito resolvido: registre HOLD ou REJECT.`,
+      needsValidation: false,
+    };
+  }
+  const validationBlocker = blockers.find((entry) => entry.startsWith("validation"));
+  // VALID with no validation blocker is the happy path and costs one request.
+  // Everything else here is unresolved rather than refused, so approving pays
+  // for the verification instead of the reviewer preparing it by hand.
+  const needsValidation = status !== "VALID" || validationBlocker !== undefined;
+  return { allowed: true, reason: "", needsValidation };
 }
 
 /* ------------------------------------------------------------------ *
@@ -1425,6 +1553,7 @@ function candidateCard(
 ): string {
   const cohortId = show(cohort.id);
   const candidateId = show(candidate.candidate_id);
+  const queue = reviewQueueState(cohortId, candidate);
   const validation = record(candidate.validation);
   const review = record(candidate.review);
   // Produção manda `observed_fact` e `fact_source` como texto simples. Ler o
@@ -1521,22 +1650,48 @@ function candidateCard(
       ? candidate.copy_qa_failures.filter((entry): entry is string => typeof entry === "string")
       : [];
 
-  // Not merely disabled: a historical version emits no decision markup at all,
-  // so there is nothing for devtools to re-enable.
-  const controls = editorial.actionable
-    ? `
+  // The manual re-check survives only where it is the actual next move: a
+  // candidate whose validation is not a current VALID. On the happy path the
+  // approve action obtains the validation itself, so offering this control
+  // there would be asking the reviewer to prepare work the machine does.
+  const validateControl =
+    gate.needsValidation || !gate.allowed
+      ? `
     ${gateInFlight(validateKey) ? pendingBlock("Pedindo a verificação do destinatário") : ""}
     <form class="operator-form" data-human-gate="validate" data-gate-key="${escapeHtml(validateKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
-      <p class="constraint">Pede ao Warmbly que verifique agora se este endereço aceita entrega. Não envia mensagem nenhuma.</p>
+      <p class="constraint">Pede ao Warmbly que verifique agora se este endereço aceita entrega. Não envia mensagem nenhuma${gate.needsValidation ? ", e aprovar já faz isso sozinho" : ""}.</p>
       <button type="submit"${gateInFlight(validateKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(validateKey) ? "Enviando…" : "Verificar o destinatário agora"}</button>
     </form>
+`
+      : "";
 
+  // An approved candidate keeps every exception tool and loses exactly one
+  // control: the one that would approve it a second time.
+  const approveControl =
+    queue.state === "aprovado"
+      ? `
+    <p class="banner ok" role="status" data-already-approved="${escapeHtml(queue.optimistic ? "local" : "server")}">${
+      queue.optimistic
+        ? "Aprovação registrada nesta sessão. A releitura do servidor ainda não voltou; se ela discordar, este candidato volta para a fila."
+        : "Este candidato já está aprovado nesta versão. Para reverter, registre HOLD ou REJECT abaixo."
+    }</p>
+`
+      : `
     ${gateInFlight(approveKey) ? pendingBlock("Registrando a aprovação") : ""}
-    <form class="operator-form" data-human-gate="review" data-gate-key="${escapeHtml(approveKey)}" data-decision="APPROVE" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
+    <form class="operator-form approve-form" data-human-gate="review" data-gate-key="${escapeHtml(approveKey)}" data-decision="APPROVE" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}"${gate.needsValidation ? ` data-auto-validate="true"` : ""}>
       <h4>Aprovar este candidato</h4>
-      <label>Motivo<input name="reason" required minlength="3"></label>
-      <label><input type="checkbox" name="ack"${gate.allowed ? " required" : ""}${gate.allowed ? "" : " disabled"}> Revisei destinatário, mensagem exata, policy e evidência desta versão</label>
-      <button type="submit"${gate.allowed && authority.canReview && !gateInFlight(approveKey) ? "" : " disabled"}>${gateInFlight(approveKey) ? "Enviando…" : "Registrar APPROVE"}</button>
+      <p class="constraint" data-approve-meaning="true">Clicar em Aprovar é a ciência: a trilha grava sua identidade do Authelia, o instante, esta versão v${escapeHtml(version)}, o hash congelado, o destinatário exato e a decisão. Não há segunda caixa a marcar.</p>
+      ${
+        gate.needsValidation
+          ? `<p class="constraint" data-approve-autovalidate="true">Este destinatário ainda não tem verificação vigente. Aprovar pede a verificação ao Warmbly primeiro e só registra o APPROVE se ela voltar VALID — você não precisa acionar nada antes.</p>`
+          : ""
+      }
+      <button type="submit" data-approve-submit="true"${gate.allowed && authority.canReview && !gateInFlight(approveKey) ? "" : " disabled"}>${gateInFlight(approveKey) ? "Enviando…" : "Aprovar"}</button>
+      <details data-approve-comment="true">
+        <summary>Comentário para a trilha (opcional)</summary>
+        <label>Observação<input name="reason" maxlength="200"></label>
+        <p class="constraint">Em branco, a trilha grava <code>${escapeHtml(APPROVAL_DEFAULT_REASON)}</code>. Aprovação comum não exige texto.</p>
+      </details>
       ${
         gate.allowed
           ? ""
@@ -1548,21 +1703,27 @@ function candidateCard(
           : `<p class="constraint" data-blocked-reason="review">Revisar exige o grupo <code>operators</code> no Authelia.</p>`
       }
     </form>
+`;
 
+  // Not merely disabled: a historical version emits no decision markup at all,
+  // so there is nothing for devtools to re-enable.
+  const controls = editorial.actionable
+    ? `
+    ${approveControl}
     ${gateInFlight(holdKey) ? pendingBlock("Registrando HOLD/REJECT") : ""}
     <form class="operator-form" data-human-gate="review" data-gate-key="${escapeHtml(holdKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
       <h4>Segurar ou rejeitar</h4>
       <label>Decisão<select name="decision"><option value="HOLD">HOLD</option><option value="REJECT">REJECT</option></select></label>
       <label>Motivo<input name="reason" required minlength="3"></label>
-      <p class="constraint" data-no-ack-required="true">HOLD e REJECT não pedem a ciência de aprovação: segurar ou rejeitar nunca autoriza uma mensagem.</p>
+      <p class="constraint" data-no-ack-required="true">HOLD e REJECT exigem motivo escrito: segurar ou rejeitar é a exceção, e o texto é o que explica a exceção depois.</p>
       <button type="submit"${authority.canReview && !gateInFlight(holdKey) ? "" : " disabled"}>${gateInFlight(holdKey) ? "Enviando…" : "Registrar HOLD/REJECT"}</button>
     </form>
-
+${validateControl}
     ${adjustBlock({ cohortId, candidateId, version, frozenHash, candidate, authority, adjustKey, draft })}
 `
     : `<p class="constraint" data-non-actionable-notice="true">Versão histórica, não enviável. Verificar o destinatário, aprovar, segurar e ajustar não são oferecidos aqui. Abra a versão corrente pelo link no topo desta página.</p>`;
 
-  return `<article class="card" data-candidate-id="${escapeHtml(candidateId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}" data-approve-allowed="${gate.allowed && editorial.actionable ? "true" : "false"}">
+  return `<article class="card" data-candidate-id="${escapeHtml(candidateId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}" data-queue-state="${escapeHtml(queue.state)}" data-queue-optimistic="${queue.optimistic ? "true" : "false"}" data-approve-allowed="${gate.allowed && editorial.actionable ? "true" : "false"}" data-approve-needs-validation="${gate.needsValidation && gate.allowed ? "true" : "false"}"
     <p class="kicker">${validationPill(candidate)}${editorial.legacy ? ` <span class="pill error" data-non-actionable="true">NÃO ACIONÁVEL</span>` : ""} · ${escapeHtml(show(candidate.source))}</p>
     <h3>${escapeHtml(show(candidate.company))}</h3>
     ${feedback.forCandidate(candidateId)}
@@ -1724,6 +1885,87 @@ function legacyBanner(editorial: EditorialReading, cohortId: string): string {
   </section>`;
 }
 
+/**
+ * The href of one recorte of the queue.
+ *
+ * Every other parameter on the route survives — the selected version above all,
+ * and the expand/collapse state the reviewer chose. A filter link that dropped
+ * `resource` would land the reviewer on an empty Revisão.
+ */
+function queueFilterHref(params: URLSearchParams, filter: ReviewQueueFilter): string {
+  const next = new URLSearchParams(params);
+  if (filter === DEFAULT_REVIEW_QUEUE_FILTER) next.delete(REVIEW_QUEUE_PARAM);
+  else next.set(REVIEW_QUEUE_PARAM, filter);
+  const rendered = next.toString();
+  return `#/warmbly/revisao${rendered ? `?${rendered}` : ""}`;
+}
+
+function queueFilterCount(counts: ReturnType<typeof reviewQueueCounts>, filter: ReviewQueueFilter): number {
+  switch (filter) {
+    case "pendentes":
+      return counts.pendentes;
+    case "aprovadas":
+      return counts.aprovadas;
+    case "ajuste":
+      return counts.ajuste;
+    case "todas":
+      return counts.total;
+  }
+}
+
+/**
+ * How much of the cohort is left, and which recorte is on screen.
+ *
+ * The counts are of this version's own candidates, not of the preview
+ * denominators above: the reviewer is asking "quanto falta para eu terminar",
+ * and only the payload's candidate list answers that.
+ */
+function queueBlock(
+  counts: ReturnType<typeof reviewQueueCounts>,
+  filter: ReviewQueueFilter,
+  params: URLSearchParams,
+): string {
+  const tabs = REVIEW_QUEUE_FILTERS.map(
+    (id) =>
+      `<a href="${escapeHtml(queueFilterHref(params, id))}" data-review-filter="${id}" aria-current="${filter === id ? "page" : "false"}">${escapeHtml(
+        ownMapValue(REVIEW_QUEUE_FILTER_LABELS, id) ?? id,
+      )} (${queueFilterCount(counts, id)})</a>`,
+  ).join("");
+  return `<article class="card" data-review-progress="true" data-queue-filter="${escapeHtml(filter)}" data-queue-pending="${counts.pendentes}" data-queue-approved="${counts.aprovadas}" data-queue-adjust="${counts.ajuste}" data-queue-total="${counts.total}">
+    <p class="kicker"><span class="pill">FILA</span></p>
+    <h3 data-queue-progress-text="true">${counts.pendentes} pendente(s) · ${counts.aprovadas} aprovada(s) · ${counts.ajuste} em ajuste · ${counts.total} no total</h3>
+    <nav class="subnav queue-filters" data-review-filters="true" aria-label="Estado da revisão">${tabs}</nav>
+    <p class="constraint">A fila abre em Pendentes. Uma mensagem aprovada sai daqui na hora e a próxima assume a posição; as concluídas continuam legíveis nos outros recortes.</p>
+  </article>`;
+}
+
+/**
+ * What the reviewer sees when the recorte they asked for is empty.
+ *
+ * "Nada aqui" is three different situations — o cohort inteiro está decidido,
+ * ninguém aprovou nada ainda, ninguém segurou nada — and each one has a
+ * different next move.
+ */
+function emptyQueueBlock(
+  counts: ReturnType<typeof reviewQueueCounts>,
+  filter: ReviewQueueFilter,
+  params: URLSearchParams,
+): string {
+  const everything = `<p><a class="button" data-queue-see-all="true" href="${escapeHtml(queueFilterHref(params, "todas"))}">Ver todas as ${counts.total}</a></p>`;
+  if (filter === "pendentes") {
+    return `<article class="card banner ok" role="status" data-queue-empty="pendentes">
+      <h3>Fila vazia: nada pendente nesta versão.</h3>
+      <p>Os ${counts.total} candidatos desta versão já foram decididos — ${counts.aprovadas} aprovado(s) e ${counts.ajuste} em ajuste ou rejeitado(s). O próximo passo é o GO/NO-GO logo abaixo, e ele continua exigindo a confirmação digitada da versão.</p>
+      ${everything}
+    </article>`;
+  }
+  return `<article class="card banner empty" data-queue-empty="${escapeHtml(filter)}">
+    <h3>Nenhum candidato neste recorte.</h3>
+    <p>Esta versão tem ${counts.pendentes} pendente(s), ${counts.aprovadas} aprovada(s) e ${counts.ajuste} em ajuste. Nada foi escondido: só o recorte escolhido está vazio.</p>
+    ${everything}
+  </article>`;
+}
+
 function reviewSurface(input: WarmblySurfaceInput): string {
   const selected = gateSection(input, "selected");
   const list = gateSection(input, "list");
@@ -1755,12 +1997,35 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   const manifest = record(cohort.manifest);
   const preview = record(manifest.preview);
   const candidates = array(cohort.candidates);
-  const expandAll = new URLSearchParams(input.query ?? "").get("mensagens") !== "recolhidas";
+  const params = new URLSearchParams(input.query ?? "");
+  const expandAll = params.get("mensagens") !== "recolhidas";
   const cohortId = show(cohort.id);
   const version = show(cohort.version);
   const reproduceKey = `reproduce:${cohortId}::`;
   const decideKey = `decide:${cohortId}::`;
-  const candidateCards = candidates
+  // The recorte links are built from the route's own query, and the selected
+  // version is restated into it when the route did not carry it. A filter that
+  // drops `resource` lands the reviewer on an empty Revisão, which is the exact
+  // defect the subnav already had to be fixed for.
+  const queueParams = new URLSearchParams(params);
+  if (!queueParams.get("resource") && cohort.id) queueParams.set("resource", cohortId);
+  const queueFilter = resolveReviewQueueFilter(params.get(REVIEW_QUEUE_PARAM));
+  const counts = reviewQueueCounts(cohortId, candidates);
+  const visible = candidates.filter((candidate) =>
+    reviewQueueFilterMatches(queueFilter, reviewQueueState(cohortId, candidate).state),
+  );
+  // A decision leaves the pending recorte the instant it is taken, so the card
+  // that would have carried the "enviando" state is already gone. The wait is
+  // reported here instead: a write in flight with no visible pending state is
+  // what invites the second click.
+  const decisionsInFlight = candidates.filter((candidate) => {
+    const id = show(candidate.candidate_id);
+    return (
+      gateInFlight(`review:${cohortId}:${id}:APPROVE`)
+      || gateInFlight(`review:${cohortId}:${id}:HOLD_REJECT`)
+    );
+  }).length;
+  const candidateCards = visible
     .map((candidate) => candidateCard(cohort, candidate, authority, feedback, expandAll))
     .join("");
   const cohortFeedback = feedback.forCohort(cohortId);
@@ -1794,7 +2059,22 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   ${previewBlock(preview)}
   <p><button type="button" data-toggle-messages="true" aria-expanded="${expandAll ? "true" : "false"}">${expandAll ? "Recolher todas as mensagens" : "Expandir todas as mensagens"}</button></p>
   ${reproduceControl}
-  ${candidateCards || `<p class="banner error">Cohort vazia: GO bloqueado.</p>`}
+  ${
+    decisionsInFlight > 0
+      ? pendingBlock(
+          decisionsInFlight === 1
+            ? "Registrando a decisão de 1 candidato"
+            : `Registrando a decisão de ${decisionsInFlight} candidatos`,
+        )
+      : ""
+  }
+  ${queueBlock(counts, queueFilter, queueParams)}
+  ${
+    candidateCards
+      || (candidates.length === 0
+        ? `<p class="banner error">Cohort vazia: GO bloqueado.</p>`
+        : emptyQueueBlock(counts, queueFilter, queueParams))
+  }
   ${decideControl}
   <dl class="facts"><div><dt>Decisão final registrada</dt><dd>${escapeHtml(decisionValue)}</dd></div></dl>
   <p class="constraint">GO não envia e-mail. O Control Center não expõe dispatch, queue ou send neste gate.</p></section>`;

--- a/control-center/apps/web-shell/tests/review-queue.test.ts
+++ b/control-center/apps/web-shell/tests/review-queue.test.ts
@@ -39,7 +39,7 @@ test("pendentes is the operational default, and an unknown recorte falls back to
 test("the server's own verdict decides the state, and an invalidated APPROVE is work again", () => {
   assert.equal(serverReviewState(candidate("a", null)), "pendente");
   assert.equal(serverReviewState(candidate("a", {})), "pendente");
-  assert.equal(serverReviewState(candidate("a", { decision: "APPROVE" })), "aprovado");
+  assert.equal(serverReviewState(candidate("a", { decision: "APPROVE" })), "pendente");
   assert.equal(serverReviewState(candidate("a", { decision: "APPROVE", effective: true })), "aprovado");
   // Drift under an approval — recipient, copy, policy or evidence moved — puts
   // the message back in front of the reviewer instead of hiding it as done.
@@ -95,7 +95,7 @@ test("the counts are of this version's candidates and add up to the total", () =
   resetReviewQueue();
   const rows = [
     candidate("c1", null),
-    candidate("c2", { decision: "APPROVE" }),
+    candidate("c2", { decision: "APPROVE", effective: true }),
     candidate("c3", { decision: "HOLD" }),
     candidate("c4", { decision: "APPROVE", effective: false }),
   ];

--- a/control-center/apps/web-shell/tests/review-queue.test.ts
+++ b/control-center/apps/web-shell/tests/review-queue.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The queue arithmetic, on its own.
+ *
+ * Everything here is what decides whether a message the reviewer just approved
+ * can come back and be approved a second time, so it is pinned away from the
+ * markup that renders it.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  DEFAULT_REVIEW_QUEUE_FILTER,
+  REVIEW_QUEUE_FILTERS,
+  markReviewDecided,
+  resetReviewQueue,
+  resolveReviewQueueFilter,
+  reviewQueueCounts,
+  reviewQueueFilterMatches,
+  reviewQueueState,
+  rollbackReviewDecided,
+  serverReviewState,
+} from "../src/review-queue";
+
+const COHORT = "11111111-1111-4111-8111-111111111111";
+
+function candidate(id: string, review: unknown): Record<string, unknown> {
+  return { candidate_id: id, review };
+}
+
+test("pendentes is the operational default, and an unknown recorte falls back to it", () => {
+  assert.equal(DEFAULT_REVIEW_QUEUE_FILTER, "pendentes");
+  assert.equal(resolveReviewQueueFilter(null), "pendentes");
+  assert.equal(resolveReviewQueueFilter("aprovadas"), "aprovadas");
+  assert.equal(resolveReviewQueueFilter("qualquer-coisa"), "pendentes");
+  assert.deepEqual([...REVIEW_QUEUE_FILTERS], ["pendentes", "aprovadas", "ajuste", "todas"]);
+});
+
+test("the server's own verdict decides the state, and an invalidated APPROVE is work again", () => {
+  assert.equal(serverReviewState(candidate("a", null)), "pendente");
+  assert.equal(serverReviewState(candidate("a", {})), "pendente");
+  assert.equal(serverReviewState(candidate("a", { decision: "APPROVE" })), "aprovado");
+  assert.equal(serverReviewState(candidate("a", { decision: "APPROVE", effective: true })), "aprovado");
+  // Drift under an approval — recipient, copy, policy or evidence moved — puts
+  // the message back in front of the reviewer instead of hiding it as done.
+  assert.equal(serverReviewState(candidate("a", { decision: "APPROVE", effective: false })), "pendente");
+  assert.equal(serverReviewState(candidate("a", { decision: "HOLD", effective: false })), "ajuste");
+  assert.equal(serverReviewState(candidate("a", { decision: "REJECT" })), "ajuste");
+});
+
+test("todas matches everything and each other recorte matches exactly one state", () => {
+  for (const state of ["pendente", "aprovado", "ajuste"] as const) {
+    assert.equal(reviewQueueFilterMatches("todas", state), true);
+  }
+  assert.equal(reviewQueueFilterMatches("pendentes", "pendente"), true);
+  assert.equal(reviewQueueFilterMatches("pendentes", "aprovado"), false);
+  assert.equal(reviewQueueFilterMatches("aprovadas", "aprovado"), true);
+  assert.equal(reviewQueueFilterMatches("ajuste", "ajuste"), true);
+  assert.equal(reviewQueueFilterMatches("ajuste", "pendente"), false);
+});
+
+test("a local mark wins over a payload that has not caught up, until it is rolled back", () => {
+  resetReviewQueue();
+  const row = candidate("c1", null);
+  assert.deepEqual(reviewQueueState(COHORT, row), { state: "pendente", optimistic: false });
+
+  markReviewDecided(COHORT, "c1", "aprovado");
+  assert.deepEqual(reviewQueueState(COHORT, row), { state: "aprovado", optimistic: true });
+
+  // The server catching up is not a change of state, only of provenance.
+  const confirmed = candidate("c1", { decision: "APPROVE", effective: true });
+  assert.deepEqual(reviewQueueState(COHORT, confirmed), { state: "aprovado", optimistic: false });
+
+  rollbackReviewDecided(COHORT, "c1");
+  assert.deepEqual(reviewQueueState(COHORT, row), { state: "pendente", optimistic: false });
+});
+
+test("a local mark belongs to one version and one candidate and leaks into neither", () => {
+  resetReviewQueue();
+  markReviewDecided(COHORT, "c1", "aprovado");
+  assert.equal(reviewQueueState(COHORT, candidate("c2", null)).state, "pendente");
+  assert.equal(reviewQueueState("outra-versao", candidate("c1", null)).state, "pendente");
+  resetReviewQueue();
+});
+
+test("an empty id never mints a mark that would match every candidate", () => {
+  resetReviewQueue();
+  markReviewDecided(COHORT, "", "aprovado");
+  markReviewDecided("", "c1", "aprovado");
+  assert.equal(reviewQueueState(COHORT, candidate("c1", null)).state, "pendente");
+  assert.equal(reviewQueueState(COHORT, { review: null }).state, "pendente");
+});
+
+test("the counts are of this version's candidates and add up to the total", () => {
+  resetReviewQueue();
+  const rows = [
+    candidate("c1", null),
+    candidate("c2", { decision: "APPROVE" }),
+    candidate("c3", { decision: "HOLD" }),
+    candidate("c4", { decision: "APPROVE", effective: false }),
+  ];
+  const counts = reviewQueueCounts(COHORT, rows);
+  assert.deepEqual(counts, { pendentes: 2, aprovadas: 1, ajuste: 1, total: 4 });
+  assert.equal(counts.pendentes + counts.aprovadas + counts.ajuste, counts.total);
+
+  markReviewDecided(COHORT, "c1", "aprovado");
+  assert.deepEqual(reviewQueueCounts(COHORT, rows), {
+    pendentes: 1,
+    aprovadas: 2,
+    ajuste: 1,
+    total: 4,
+  });
+  resetReviewQueue();
+});
+
+test("fifty pending candidates stay fifty pending candidates, and approving drains them one by one", () => {
+  resetReviewQueue();
+  const rows = Array.from({ length: 50 }, (_, index) => candidate(`c${index}`, null));
+  assert.equal(reviewQueueCounts(COHORT, rows).pendentes, 50);
+  for (let index = 0; index < 18; index += 1) markReviewDecided(COHORT, `c${index}`, "aprovado");
+  const counts = reviewQueueCounts(COHORT, rows);
+  assert.deepEqual(counts, { pendentes: 32, aprovadas: 18, ajuste: 0, total: 50 });
+  const pending = rows.filter((row) =>
+    reviewQueueFilterMatches("pendentes", reviewQueueState(COHORT, row).state),
+  );
+  assert.equal(pending.length, 32);
+  assert.equal(pending[0]!.candidate_id, "c18", "the next pending one takes the first position");
+  resetReviewQueue();
+});

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -21,7 +21,11 @@ import {
   resetQueueAdvance,
 } from "../src/app";
 import { resetGateFlight } from "../src/human-gate-flight";
-import { REVIEW_QUEUE_PARAM, resetReviewQueue } from "../src/review-queue";
+import {
+  REVIEW_QUEUE_PARAM,
+  decidedReviewState,
+  resetReviewQueue,
+} from "../src/review-queue";
 import { warmblyBlock } from "../src/ui/warmbly";
 import { clearPendingResumeConfirmation } from "../src/warmbly-confirmation";
 
@@ -2174,6 +2178,117 @@ test("uma releitura que não confirma o efeito devolve a mensagem para a fila", 
   assert.match(dom.root.innerHTML, /data-queue-pending="1"/, "sem confirmação, continua sendo trabalho");
 });
 
+test("uma escrita aceita cuja releitura falha não some da fila nem avança a chave de idempotência", async () => {
+  reset();
+  let readable = true;
+  let makeUnreadable = true;
+  const { adapter, seen } = gateAdapter({
+    gate: () =>
+      readable
+        ? gatePayload(["operators", "admins"], cohort())
+        : { list_status: "unreadable", selected_status: "unreadable" },
+    respond: () => {
+      if (makeUnreadable) readable = false;
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: "APPROVE aceito pelo canal.",
+        outcome: "executed",
+        gateAction: "review" as const,
+      };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.equal(
+    decidedReviewState(COHORT_ID, CANDIDATE_ID),
+    undefined,
+    "a marca local não pode sobreviver sem confirmação",
+  );
+  assert.match(dom.root.innerHTML, /data-readback="unavailable"/);
+
+  // O recurso volta a ser legível e a mesma intenção é repetida. Como a
+  // primeira escrita nunca foi confirmada, a chave precisa ser a mesma.
+  readable = true;
+  makeUnreadable = false;
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.equal(seen.length, 2);
+  assert.equal(seen[0]!.idempotency_key, seen[1]!.idempotency_key);
+});
+
+test("APPROVE gravado mas não efetivo continua pendente", async () => {
+  reset();
+  let review: Record<string, unknown> | null = null;
+  const { adapter } = gateAdapter({
+    gate: () =>
+      gatePayload(
+        ["operators", "admins"],
+        cohort({ candidates: [candidate({ review })] }),
+      ),
+    respond: () => {
+      review = { decision: "APPROVE", effective: false };
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: "decisão registrada sem efeito",
+        outcome: "executed",
+        gateAction: "review" as const,
+      };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.match(dom.root.innerHTML, /data-readback="not_confirmed"/);
+  assert.match(dom.root.innerHTML, /data-queue-state="pendente"/);
+});
+
+test("depois da confirmação a verdade de outra aba vence a antiga marca otimista", async () => {
+  reset();
+  let review: Record<string, unknown> | null = null;
+  const { adapter } = gateAdapter({
+    gate: () =>
+      gatePayload(
+        ["operators", "admins"],
+        cohort({ candidates: [candidate({ review })] }),
+      ),
+    respond: () => {
+      review = { decision: "APPROVE", effective: true };
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: "registrado",
+        outcome: "executed",
+        gateAction: "review" as const,
+      };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.equal(decidedReviewState(COHORT_ID, CANDIDATE_ID), undefined);
+
+  // Outra aba registra HOLD; repintar esta aba deve mostrar o servidor, não a
+  // aprovação que este browser decidiu antes.
+  review = { decision: "HOLD", effective: false };
+  paintShell(
+    dom.root as never,
+    adapter as never,
+    `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`,
+  );
+  assert.match(dom.root.innerHTML, /data-queue-state="ajuste"/);
+  assert.doesNotMatch(dom.root.innerHTML, /data-already-approved=/);
+});
+
 test("um duplo clique em Aprovar não vira duas aprovações, nem durante a verificação", async () => {
   reset();
   const state = validatingGate("VALID");
@@ -2285,6 +2400,9 @@ test("o atalho é A sozinho ou Ctrl/Cmd+Enter, e nada mais", () => {
   assert.equal(approvalShortcutScope({ key: "A" }, false), "focused-card");
   assert.equal(approvalShortcutScope({ key: "Enter", ctrlKey: true }, false), "first-pending");
   assert.equal(approvalShortcutScope({ key: "Enter", metaKey: true }, false), "first-pending");
+  assert.equal(approvalShortcutScope({ key: "Enter", ctrlKey: true, repeat: true }, false), null);
+  assert.equal(approvalShortcutScope({ key: "a", repeat: true }, false), null);
+  assert.equal(approvalShortcutScope({ key: "Enter", ctrlKey: true }, false, true), null);
   // Ctrl+A continua sendo selecionar tudo, e Enter sozinho continua sendo Enter.
   assert.equal(approvalShortcutScope({ key: "a", ctrlKey: true }, false), null);
   assert.equal(approvalShortcutScope({ key: "a", metaKey: true }, false), null);
@@ -2293,6 +2411,30 @@ test("o atalho é A sozinho ou Ctrl/Cmd+Enter, e nada mais", () => {
   assert.equal(approvalShortcutScope({ key: "Enter" }, false), null);
   assert.equal(approvalShortcutScope({ key: "b" }, false), null);
   assert.equal(approvalShortcutScope({}, false), null);
+});
+
+test("o adaptador recusa HOLD/REJECT sem motivo antes do fio", async () => {
+  reset();
+  let calls = 0;
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://control-center.fixture",
+    fetchImpl: (async () => {
+      calls += 1;
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as typeof fetch,
+  });
+  for (const decision of ["HOLD", "REJECT"] as const) {
+    const result = await adapter.warmblyGate({
+      action: "review",
+      version_id: COHORT_ID,
+      candidate_id: CANDIDATE_ID,
+      decision,
+      reason: "   ",
+      idempotency_key: `idem-${decision.toLowerCase()}`,
+    });
+    assert.equal(result.code, "gate_precondition");
+  }
+  assert.equal(calls, 0);
 });
 
 test("um canal que morre sem responder devolve a mensagem para a fila como desfecho desconhecido", async () => {

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -1828,13 +1828,13 @@ function statefulGate(initial: Record<string, unknown>[]): {
       gatePayload(["operators", "admins"], cohort({ candidates: rows.map((row) => ({ ...row })) })),
     respond: (input) => {
       if (input.action === "review") {
-        const row = rows.find((entry) => entry.candidate_id === input.candidate_id);
+        const row = rows.find((entry) => String(entry.candidate_id) === input.candidate_id);
         if (row) {
           row.review = { decision: input.decision, effective: input.decision === "APPROVE" };
         }
       }
       if (input.action === "validate") {
-        const row = rows.find((entry) => entry.candidate_id === input.candidate_id);
+        const row = rows.find((entry) => String(entry.candidate_id) === input.candidate_id);
         if (row) {
           row.validation = { status: "VALID", reason: "verificado no teste" };
           row.blocked_by = [];
@@ -2329,4 +2329,102 @@ test("reverter uma aprovação com HOLD leva a mensagem para o recorte de ajuste
   assert.equal(seen[0]!.decision, "HOLD");
   assert.match(dom.root.innerHTML, /data-queue-approved="0" data-queue-adjust="1"/);
   assert.match(dom.root.innerHTML, /data-gate-key="review:[^"]*:APPROVE"/, "e aprovar volta a ser oferecido");
+});
+
+test("uma releitura que não devolve o estado da verificação não vira acusação contra o destinatário", async () => {
+  reset();
+  // A verificação é aceita e a releitura não completa. "Não deu para ler" e "o
+  // servidor disse RISKY" mandam o operador para lugares diferentes: o primeiro
+  // é para tentar de novo, o segundo é para registrar HOLD.
+  let readable = true;
+  const { adapter, seen } = gateAdapter({
+    gate: () =>
+      readable
+        ? gatePayload(
+            ["operators", "admins"],
+            cohort({
+              candidates: [candidate({ validation: undefined, blocked_by: ["validation_missing"] })],
+            }),
+          )
+        : { list_status: "unreadable", selected_status: "unreadable" },
+    respond: (input) => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "verificação pedida",
+      outcome: "executed",
+      gateAction: input.action,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  readable = false;
+  approve(dom);
+  await settle();
+  assert.deepEqual(seen.map((call) => call.action), ["validate"], "o APPROVE não pode ser tentado");
+  assert.match(dom.root.innerHTML, /data-outcome-code="approval_validation_unavailable"/);
+  assert.ok(
+    dom.root.innerHTML.includes("esta tela não sabe se o destinatário está VALID"),
+    "não pode afirmar que o destinatário é ruim",
+  );
+});
+
+test("uma versão histórica com tudo decidido não aponta para um GO que ela não oferece", () => {
+  reset();
+  const decidedLegacy = cohort({
+    editorial_state: "LEGACY",
+    actionable: false,
+    candidates: [candidate({ review: { decision: "APPROVE", effective: true } })],
+  });
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], decidedLegacy) }),
+    "revisao",
+  );
+  assert.match(html, /data-queue-empty="pendentes"/);
+  assert.ok(!html.includes("O próximo passo é o GO/NO-GO"), "GO não é oferecido nesta versão");
+  assert.ok(html.includes("decida na versão corrente"));
+});
+
+test("um candidato cujo id não é string ainda sai da fila quando é aprovado", async () => {
+  reset();
+  // O renderizador carimba `data-candidate` com String(id); a fila e a
+  // releitura leem o mesmo campo do payload. Se os três discordassem sobre o
+  // que é "o id", a marca otimista nunca se aplicaria, a releitura diria
+  // not_confirmed, e a mensagem aprovada voltaria para o topo da fila.
+  const server = statefulGate([candidate({ candidate_id: 7 as never })]);
+  const { adapter } = gateAdapter({ gate: server.gate, respond: server.respond });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  assert.match(dom.root.innerHTML, /data-queue-pending="1"/);
+  dom.find(`[data-gate-key="review:${COHORT_ID}:7:APPROVE"]`).fire();
+  await settle();
+  assert.doesNotMatch(dom.root.innerHTML, /data-readback="not_confirmed"/);
+  assert.match(dom.root.innerHTML, /data-queue-pending="0" data-queue-approved="1"/);
+});
+
+test("toda tag aberta nesta superfície é fechada antes da próxima começar", () => {
+  reset();
+  // Um `>` esquecido no fim de uma tag de abertura não quebra teste nenhum e
+  // não quebra o navegador: o parser engole a tag seguinte como se fosse
+  // atributo e a página só fica errada. Foi assim que o card de candidato
+  // passou a emitir `<article ... data-approve-needs-validation="false"` sem
+  // fechar, com 391 testes e uma jornada em navegador real todos verdes.
+  const surfaces: string[] = [
+    warmblyBlock(surfaceInput(), "revisao"),
+    warmblyBlock(surfaceInput({ query: ALL_STATES, gate: gatePayload(["operators", "admins"], mixedCohort()) }), "revisao"),
+    warmblyBlock(surfaceInput(), "cohorts"),
+    warmblyBlock(surfaceInput(), "operacao"),
+    warmblyBlock(legacyInput(), "revisao"),
+  ];
+  for (const html of surfaces) {
+    for (const match of html.matchAll(/<[a-zA-Z][a-zA-Z0-9]*\b/g)) {
+      const close = html.indexOf(">", match.index);
+      assert.ok(close >= 0, `tag sem fechamento a partir de ${html.slice(match.index, match.index + 60)}`);
+      const inside = html.slice(match.index, close);
+      assert.ok(
+        !inside.includes("<", 1),
+        `tag de abertura não fechada: ${inside.slice(0, 120)}`,
+      );
+    }
+  }
 });

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -14,8 +14,14 @@ import { test } from "node:test";
 
 import type { AdapterWriteResult, WarmblyGateInput } from "../src/adapters/contract";
 import { HttpControlCenterAdapter } from "../src/adapters/http";
-import { paintShell } from "../src/app";
+import {
+  approvalShortcutScope,
+  isEditingTarget,
+  paintShell,
+  resetQueueAdvance,
+} from "../src/app";
 import { resetGateFlight } from "../src/human-gate-flight";
+import { REVIEW_QUEUE_PARAM, resetReviewQueue } from "../src/review-queue";
 import { warmblyBlock } from "../src/ui/warmbly";
 import { clearPendingResumeConfirmation } from "../src/warmbly-confirmation";
 
@@ -52,11 +58,17 @@ function candidate(overrides: Record<string, unknown> = {}): Record<string, unkn
     hard_bounce: false,
     exclusion_reason: "nenhuma",
     validation: { status: "VALID", reason: "MX confirmado no sandbox", expires_at: "2026-08-24T12:00:00Z" },
-    review: { decision: "HOLD", effective: false },
+    // Undecided, which is what a candidate looks like when the reviewer opens
+    // the queue. `pendentes` is the default recorte and this is what belongs in
+    // it; the tests that need a decided candidate say so explicitly.
+    review: null,
     blocked_by: ["approval_missing_or_invalid"],
     ...overrides,
   };
 }
+
+/** The recorte that shows everything, for the tests that are not about filtering. */
+const ALL_STATES = `${REVIEW_QUEUE_PARAM}=todas`;
 
 function cohort(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -129,11 +141,22 @@ interface FakeField {
 class FakeElement {
   readonly attributes: Record<string, string>;
   readonly fields: Record<string, FakeField>;
+  /** Whether the queue advance put the reviewer on this control. */
+  focused = false;
+  centred = false;
   private listeners: Array<{ type: string; listener: (event: Event) => void }> = [];
 
   constructor(attributes: Record<string, string>, fields: Record<string, FakeField>) {
     this.attributes = attributes;
     this.fields = fields;
+  }
+
+  focus(): void {
+    this.focused = true;
+  }
+
+  scrollIntoView(options?: { block?: "center" }): void {
+    this.centred = options?.block === "center";
   }
 
   addEventListener(type: string, listener: (event: Event) => void): void {
@@ -211,7 +234,13 @@ function elementsOf(html: string): FakeElement[] {
   }
   for (const match of html.matchAll(/<button\b([^>]*)>/g)) {
     const attributes = parseAttributes(match[1]!);
-    if (attributes["data-toggle-messages"] !== undefined) {
+    // The approve button is collected in its own right because the queue
+    // advance addresses it directly: it is what the reviewer's focus lands on
+    // between two approvals.
+    if (
+      attributes["data-toggle-messages"] !== undefined
+      || attributes["data-approve-submit"] !== undefined
+    ) {
       elements.push(new FakeElement(attributes, {}));
     }
   }
@@ -318,6 +347,8 @@ async function settle(): Promise<void> {
 
 function reset(): void {
   resetGateFlight();
+  resetReviewQueue();
+  resetQueueAdvance();
   clearPendingResumeConfirmation();
 }
 
@@ -476,7 +507,15 @@ test("o bloco de decisão carrega só o que muda a decisão do fundador", () => 
 
 test("hash, versão e recibo moram no detalhe técnico recolhido, não na tabela visível", () => {
   reset();
-  const html = warmblyBlock(surfaceInput(), "revisao");
+  // Um candidato já segurado, no recorte que mostra tudo: é onde a decisão
+  // registrada e a efetividade dela precisam continuar auditáveis.
+  const held = cohort({
+    candidates: [candidate({ review: { decision: "HOLD", effective: false } })],
+  });
+  const html = warmblyBlock(
+    surfaceInput({ query: ALL_STATES, gate: gatePayload(["operators", "admins"], held) }),
+    "revisao",
+  );
   const tech = html.match(/<details class="tech" data-tech="warmbly-candidate">[\s\S]*?<\/details>/);
   assert.ok(tech, "o detalhe técnico do candidato precisa existir");
   const audit = tech[0]!;
@@ -677,13 +716,16 @@ test("feedback for a candidate lands on that candidate's card, not at the top of
   assert.equal((html.match(/data-write-result=/g) ?? []).length, 1);
 });
 
-test("APPROVE is offered only against a current VALID validation, and explains itself otherwise", () => {
+test("a settled non-VALID verdict blocks APPROVE; an unresolved one is verified by the approval itself", () => {
   reset();
   const valid = warmblyBlock(surfaceInput(), "revisao");
   assert.match(valid, /data-approve-allowed="true"/);
   assert.doesNotMatch(valid, /data-approve-blocked="true"/);
+  assert.match(valid, /data-approve-needs-validation="false"/);
+  assert.doesNotMatch(valid, /data-human-gate="validate"/, "a VALID candidate needs no manual check");
 
-  for (const status of ["INVALID", "UNKNOWN", "RISKY", "STALE"]) {
+  // The server resolved these two and re-checking will not move them.
+  for (const status of ["INVALID", "RISKY"]) {
     const html = warmblyBlock(
       surfaceInput({
         gate: gatePayload(
@@ -696,12 +738,65 @@ test("APPROVE is offered only against a current VALID validation, and explains i
     assert.match(html, /data-approve-allowed="false"/, `${status} must not offer APPROVE`);
     assert.match(html, /data-approve-blocked="true"/, `${status} must explain the refusal`);
     const approveForm = html.match(/data-gate-key="review:[^"]*:APPROVE"[\s\S]*?<\/form>/)?.[0] ?? "";
-    assert.match(approveForm, /Registrar APPROVE<\/button>/);
-    assert.match(approveForm, /<button type="submit" disabled>/);
+    assert.match(approveForm, /Aprovar<\/button>/);
+    assert.match(approveForm, /<button type="submit" data-approve-submit="true" disabled>/);
+  }
+
+  // These the server never settled, so approving obtains the verification.
+  for (const validation of [{ status: "UNKNOWN" }, { status: "STALE" }, undefined]) {
+    const html = warmblyBlock(
+      surfaceInput({
+        gate: gatePayload(["operators"], cohort({ candidates: [candidate({ validation })] })),
+      }),
+      "revisao",
+    );
+    const label = validation?.status ?? "sem validação";
+    assert.match(html, /data-approve-allowed="true"/, `${label} must still offer APPROVE`);
+    assert.match(html, /data-approve-needs-validation="true"/, `${label} must verify first`);
+    assert.match(html, /data-approve-autovalidate="true"/, `${label} must say it verifies first`);
+    assert.doesNotMatch(html, /data-approve-blocked="true"/);
+    // The manual control survives as an escape hatch, never as a prerequisite.
+    assert.match(html, /data-human-gate="validate"/);
   }
 });
 
-test("a validation blocker from the server blocks APPROVE even when the status reads VALID", () => {
+test("um destinatário ausente ou que não é endereço trava a aprovação, e verificar de novo não é a saída", () => {
+  reset();
+  for (const [mailbox, needle] of [
+    [undefined, /não enviou destinatário nenhum/],
+    ["compras arroba empresa", /não é um endereço de e-mail/],
+  ] as const) {
+    const html = warmblyBlock(
+      surfaceInput({
+        gate: gatePayload(["operators"], cohort({ candidates: [candidate({ mailbox })] })),
+      }),
+      "revisao",
+    );
+    assert.match(html, /data-approve-allowed="false"/);
+    assert.match(html, /data-approve-needs-validation="false"/);
+    assert.match(html, needle);
+  }
+});
+
+test("um bloqueio material do servidor trava a aprovação mesmo com validação VALID", () => {
+  reset();
+  for (const blocker of ["hard_bounce", "suppressed_recipient", "opt_out", "copy_qa_failed"]) {
+    const html = warmblyBlock(
+      surfaceInput({
+        gate: gatePayload(
+          ["operators"],
+          cohort({ candidates: [candidate({ blocked_by: [blocker] })] }),
+        ),
+      }),
+      "revisao",
+    );
+    assert.match(html, /data-approve-allowed="false"/, `${blocker} devia travar APPROVE`);
+    assert.match(html, new RegExp(blocker));
+    assert.match(html, /não se resolve verificando o destinatário de novo/);
+  }
+});
+
+test("uma validação vencida deixa de ser um bloqueio e passa a ser trabalho da própria aprovação", () => {
   reset();
   const html = warmblyBlock(
     surfaceInput({
@@ -712,11 +807,12 @@ test("a validation blocker from the server blocks APPROVE even when the status r
     }),
     "revisao",
   );
-  assert.match(html, /data-approve-allowed="false"/);
-  assert.match(html, /validation_stale/);
+  assert.match(html, /data-approve-allowed="true"/);
+  assert.match(html, /data-approve-needs-validation="true"/);
+  assert.match(html, /validation_stale/, "o bloqueio do servidor continua visível");
 });
 
-test("HOLD and REJECT ask for a reason and never for the approval acknowledgement", () => {
+test("HOLD e REJECT exigem motivo escrito; aprovar não exige nem motivo nem caixa de ciência", () => {
   reset();
   const html = warmblyBlock(surfaceInput(), "revisao");
   const holdForm = html.match(/data-gate-key="review:[^"]*:HOLD_REJECT"[\s\S]*?<\/form>/)?.[0] ?? "";
@@ -728,7 +824,11 @@ test("HOLD and REJECT ask for a reason and never for the approval acknowledgemen
   assert.match(holdForm, /<option value="REJECT">/);
 
   const approveForm = html.match(/data-gate-key="review:[^"]*:APPROVE"[\s\S]*?<\/form>/)?.[0] ?? "";
-  assert.match(approveForm, /name="ack" required/, "APPROVE must still demand the acknowledgement");
+  assert.doesNotMatch(approveForm, /name="ack"/, "a caixa de ciência saiu do fluxo normal");
+  assert.doesNotMatch(approveForm, /name="reason" required/, "aprovação comum não exige texto");
+  assert.match(approveForm, /name="reason" maxlength="200"/, "o comentário continua disponível");
+  assert.match(approveForm, /data-approve-meaning="true"/, "o botão precisa dizer o que ele assume");
+  assert.match(approveForm, /approved_by_human_reviewer/);
 });
 
 test("HOLD really reaches the adapter without an acknowledgement", async () => {
@@ -966,7 +1066,11 @@ test("the new version opens with validation, review and GO all pending", () => {
     "revisao",
   );
   assert.match(html, /Revisão v2/);
-  assert.match(html, /data-approve-allowed="false"/, "a fresh version cannot already be approvable");
+  // A nova versão nasce sem validação vigente, e isso deixou de ser um
+  // bloqueio para o humano: aprovar obtém a verificação antes de registrar.
+  assert.match(html, /data-approve-needs-validation="true"/, "a fresh version has no live validation");
+  assert.match(html, /data-approve-autovalidate="true"/);
+  assert.match(html, /data-queue-pending="1"/, "nada foi decidido nesta versão ainda");
   // Sem revisão registrada não há linha de revisão: ausência que não muda a
   // decisão não vira "não informado pelo servidor" na cara do fundador.
   assert.ok(!html.includes("Revisão registrada"));
@@ -1438,9 +1542,19 @@ test("a historical card is marked as such and carries a non-actionable chip", ()
 test("a current version keeps every control exactly as before", () => {
   reset();
   const html = warmblyBlock(surfaceInput(), "revisao");
-  for (const gate of ["validate", "review", "adjust", "reproduce", "decide"]) {
+  for (const gate of ["review", "adjust", "reproduce", "decide"]) {
     assert.match(html, new RegExp(`data-human-gate="${gate}"`), `${gate} must still be offered on a current version`);
   }
+  // `validate` is the one control that moved: on a candidate the server already
+  // reports VALID it is not a step, so it is offered only where it is the
+  // actual next move. See the approval-gate tests above.
+  const pending = warmblyBlock(
+    surfaceInput({
+      gate: gatePayload(["operators", "admins"], cohort({ candidates: [candidate({ validation: undefined })] })),
+    }),
+    "revisao",
+  );
+  assert.match(pending, /data-human-gate="validate"/);
   assert.match(html, /data-review-cohort="[^"]*" data-editorial-state="CURRENT" data-actionable="true"/);
   assert.doesNotMatch(html, /data-legacy-banner="true"/);
   assert.doesNotMatch(html, /data-non-actionable-notice="true"/);
@@ -1546,4 +1660,673 @@ test("a legacy version that does have a successor still links to it", () => {
   );
   assert.match(html, /data-open-current="true"/);
   assert.ok(html.includes("Abrir versão corrente"));
+});
+
+/* ------------------------------------------------------------------ *
+ * A fila de revisão.
+ *
+ * Every test below pins something the old surface got wrong in real use: an
+ * approved message that stayed at the top of the list, a reviewer scrolling to
+ * find the next pending one, a preparatory click on "verificar destinatário", a
+ * required motive nobody read, and a checkbox declaring the click that had just
+ * been made.
+ * ------------------------------------------------------------------ */
+
+const SECOND_CANDIDATE = "33333333-3333-4333-8333-333333333333";
+const THIRD_CANDIDATE = "44444444-4444-4444-8444-444444444444";
+
+/** Three members, one in each queue state, so a recorte can be told apart. */
+function mixedCohort(): Record<string, unknown> {
+  return cohort({
+    candidates: [
+      candidate({ company: "Pendente SA" }),
+      candidate({
+        candidate_id: SECOND_CANDIDATE,
+        company: "Aprovada SA",
+        review: { decision: "APPROVE", effective: true },
+      }),
+      candidate({
+        candidate_id: THIRD_CANDIDATE,
+        company: "Segurada SA",
+        review: { decision: "HOLD", effective: false },
+      }),
+    ],
+  });
+}
+
+test("a fila abre em pendentes, e o trabalho já feito não disputa espaço com o que falta", () => {
+  reset();
+  const gate = gatePayload(["operators", "admins"], mixedCohort());
+  const html = warmblyBlock(surfaceInput({ gate }), "revisao");
+  assert.match(html, /data-queue-filter="pendentes"/);
+  assert.match(html, /data-queue-pending="1" data-queue-approved="1" data-queue-adjust="1" data-queue-total="3"/);
+  assert.ok(html.includes("Pendente SA"), "a pendente precisa estar na tela");
+  assert.ok(!html.includes("Aprovada SA"), "a aprovada saiu da fila operacional");
+  assert.ok(!html.includes("Segurada SA"), "a segurada saiu da fila operacional");
+
+  const all = warmblyBlock(surfaceInput({ gate, query: ALL_STATES }), "revisao");
+  for (const company of ["Pendente SA", "Aprovada SA", "Segurada SA"]) {
+    assert.ok(all.includes(company), `${company} precisa continuar legível em Todas`);
+  }
+});
+
+test("o progresso da fila é dito em números, e cada recorte carrega o seu", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], mixedCohort()) }),
+    "revisao",
+  );
+  const progress = html.match(/<h3 data-queue-progress-text="true">([^<]*)<\/h3>/);
+  assert.ok(progress, "a linha de progresso precisa existir");
+  assert.match(progress[1]!, /1 pendente\(s\).*1 aprovada\(s\).*1 em ajuste.*3 no total/);
+  assert.match(html, /data-review-filter="pendentes" aria-current="page">Pendentes \(1\)/);
+  assert.match(html, /data-review-filter="aprovadas" aria-current="false">Aprovadas \(1\)/);
+  assert.match(html, /data-review-filter="ajuste" aria-current="false">Ajuste ou rejeitadas \(1\)/);
+  assert.match(html, /data-review-filter="todas" aria-current="false">Todas \(3\)/);
+});
+
+test("um link de recorte nunca larga a versão selecionada nem o estado das mensagens", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: gatePayload(["operators", "admins"], mixedCohort()),
+      query: `resource=${COHORT_ID}&mensagens=recolhidas`,
+    }),
+    "revisao",
+  );
+  const hrefs = [...html.matchAll(/data-review-filter="([a-z]+)"/g)].map((match) => match[1]);
+  assert.deepEqual(hrefs, ["pendentes", "aprovadas", "ajuste", "todas"]);
+  const aprovadas = html.match(/href="([^"]*)" data-review-filter="aprovadas"/);
+  assert.ok(aprovadas);
+  assert.ok(aprovadas[1]!.includes(`resource=${COHORT_ID}`), "a versão selecionada viaja com o recorte");
+  assert.ok(aprovadas[1]!.includes("mensagens=recolhidas"), "o recorte não desfaz a escolha de leitura");
+  assert.ok(aprovadas[1]!.includes(`${REVIEW_QUEUE_PARAM}=aprovadas`));
+  // O padrão não polui a URL: pendentes é a ausência do parâmetro.
+  const pendentes = html.match(/href="([^"]*)" data-review-filter="pendentes"/);
+  assert.ok(pendentes);
+  assert.ok(!pendentes[1]!.includes(REVIEW_QUEUE_PARAM));
+});
+
+test("com tudo decidido a fila diz que acabou e aponta o GO, em vez de uma tela vazia", () => {
+  reset();
+  const done = cohort({
+    candidates: [
+      candidate({ review: { decision: "APPROVE", effective: true } }),
+      candidate({
+        candidate_id: SECOND_CANDIDATE,
+        review: { decision: "APPROVE", effective: true },
+      }),
+    ],
+  });
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], done) }),
+    "revisao",
+  );
+  assert.match(html, /data-queue-empty="pendentes"/);
+  assert.ok(html.includes("Fila vazia"));
+  assert.ok(html.includes("GO/NO-GO"), "o próximo passo precisa estar nomeado");
+  assert.match(html, /data-queue-see-all="true"/);
+  // A cohort vazia continua sendo outra coisa: ali GO está bloqueado.
+  const empty = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], cohort({ candidates: [] })) }),
+    "revisao",
+  );
+  assert.ok(empty.includes("Cohort vazia: GO bloqueado."));
+});
+
+test("um recorte vazio que não é pendentes diz que só o recorte está vazio", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: gatePayload(["operators", "admins"], cohort()),
+      query: `${REVIEW_QUEUE_PARAM}=aprovadas`,
+    }),
+    "revisao",
+  );
+  assert.match(html, /data-queue-empty="aprovadas"/);
+  assert.ok(html.includes("Nada foi escondido"));
+});
+
+test("um candidato aprovado não oferece aprovar de novo, e mantém segurar e ajustar", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: gatePayload(
+        ["operators", "admins"],
+        cohort({ candidates: [candidate({ review: { decision: "APPROVE", effective: true } })] }),
+      ),
+      query: ALL_STATES,
+    }),
+    "revisao",
+  );
+  assert.match(html, /data-queue-state="aprovado"/);
+  assert.match(html, /data-already-approved="server"/);
+  assert.ok(!/data-gate-key="review:[^"]*:APPROVE"/.test(html), "não pode haver segundo APPROVE");
+  assert.match(html, /data-gate-key="review:[^"]*:HOLD_REJECT"/, "reverter continua possível");
+  assert.match(html, /data-adjust-editor=/, "ajustar continua possível");
+});
+
+/* ------------------------------------------------------------------ *
+ * Uma decisão, uma ação.
+ * ------------------------------------------------------------------ */
+
+/**
+ * A gate that behaves like Warmbly: a review it accepts is a review its next
+ * GET reports.
+ *
+ * A mock that accepts writes and keeps answering the old payload would make the
+ * readback say `not_confirmed` on every call, which is a different scenario —
+ * pinned separately below — and would hide whether the queue really drains.
+ */
+function statefulGate(initial: Record<string, unknown>[]): {
+  gate: () => Record<string, unknown>;
+  respond: (input: WarmblyGateInput) => AdapterWriteResult;
+} {
+  const rows = initial.map((row) => ({ ...row }));
+  return {
+    gate: () =>
+      gatePayload(["operators", "admins"], cohort({ candidates: rows.map((row) => ({ ...row })) })),
+    respond: (input) => {
+      if (input.action === "review") {
+        const row = rows.find((entry) => entry.candidate_id === input.candidate_id);
+        if (row) {
+          row.review = { decision: input.decision, effective: input.decision === "APPROVE" };
+        }
+      }
+      if (input.action === "validate") {
+        const row = rows.find((entry) => entry.candidate_id === input.candidate_id);
+        if (row) {
+          row.validation = { status: "VALID", reason: "verificado no teste" };
+          row.blocked_by = [];
+        }
+      }
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: "registrado",
+        outcome: "executed",
+        gateAction: input.action,
+      };
+    },
+  };
+}
+
+/** Fires the approve control of a painted candidate, exactly as a click would. */
+function approve(dom: ReturnType<typeof paintingRoot>, candidateId = CANDIDATE_ID): FakeElement {
+  const form = dom.find(`[data-gate-key="review:${COHORT_ID}:${candidateId}:APPROVE"]`);
+  form.fire();
+  return form;
+}
+
+test("aprovar é uma única ação: sem motivo digitado, sem caixa de ciência, uma escrita só", async () => {
+  reset();
+  const { adapter, seen } = gateAdapter({
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "APPROVE registrado.",
+      outcome: "executed",
+      gateAction: "review" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.equal(seen.length, 1, "o caminho feliz custa exatamente uma escrita");
+  assert.equal(seen[0]!.action, "review");
+  assert.equal(seen[0]!.decision, "APPROVE");
+  assert.equal(seen[0]!.acknowledged, true, "o clique é a ciência e viaja como tal");
+  assert.equal(seen[0]!.reason, "approved_by_human_reviewer");
+});
+
+test("o comentário opcional, quando escrito, vence o motivo padrão", async () => {
+  reset();
+  const { adapter, seen } = gateAdapter({
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "APPROVE registrado.",
+      outcome: "executed",
+      gateAction: "review" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  const form = dom.find(`[data-gate-key="review:${COHORT_ID}:${CANDIDATE_ID}:APPROVE"]`);
+  form.set("reason", "conferi o edital citado no corpo");
+  form.fire();
+  await settle();
+  assert.equal(seen[0]!.reason, "conferi o edital citado no corpo");
+});
+
+test("a chave de idempotência de uma aprovação comum é estável entre tentativas", async () => {
+  reset();
+  let attempt = 0;
+  const { adapter, seen } = gateAdapter({
+    respond: () => {
+      attempt += 1;
+      return attempt === 1
+        ? {
+            ok: false,
+            path: "/x",
+            kind: "nota" as const,
+            message: "sem resposta",
+            outcome: "unknown",
+            code: "human_gate_transport_unknown",
+            gateAction: "review" as const,
+          }
+        : {
+            ok: true,
+            path: "/x",
+            kind: "nota" as const,
+            message: "registrado",
+            outcome: "executed",
+            gateAction: "review" as const,
+          };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  approve(dom);
+  await settle();
+  assert.equal(seen.length, 2);
+  assert.equal(seen[0]!.idempotency_key, seen[1]!.idempotency_key, "a intenção incerta repete idêntica");
+});
+
+/* ------------------------------------------------------------------ *
+ * Verificação do destinatário: máquina, não burocracia.
+ * ------------------------------------------------------------------ */
+
+/** A gate payload whose candidate gains a validation once one has been asked for. */
+function validatingGate(status: string): {
+  gate: () => Record<string, unknown>;
+  validated: () => boolean;
+  markValidated: () => void;
+} {
+  let done = false;
+  return {
+    gate: () =>
+      gatePayload(
+        ["operators", "admins"],
+        cohort({
+          candidates: [
+            candidate({
+              validation: done ? { status } : undefined,
+              blocked_by: done ? [] : ["validation_missing"],
+            }),
+          ],
+        }),
+      ),
+    validated: () => done,
+    markValidated: () => {
+      done = true;
+    },
+  };
+}
+
+test("aprovar um candidato sem verificação vigente pede a verificação e só então registra", async () => {
+  reset();
+  const state = validatingGate("VALID");
+  const { adapter, seen } = gateAdapter({
+    gate: state.gate,
+    respond: (input) => {
+      if (input.action === "validate") state.markValidated();
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: input.action === "validate" ? "verificação pedida" : "APPROVE registrado.",
+        outcome: "executed",
+        gateAction: input.action,
+      };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  assert.match(dom.root.innerHTML, /data-approve-needs-validation="true"/);
+  approve(dom);
+  await settle();
+  assert.deepEqual(seen.map((call) => call.action), ["validate", "review"]);
+  assert.equal(seen[1]!.decision, "APPROVE");
+  assert.equal(seen[1]!.acknowledged, true);
+});
+
+test("uma verificação que volta diferente de VALID interrompe a cadeia: o APPROVE não é tentado", async () => {
+  reset();
+  const state = validatingGate("RISKY");
+  const { adapter, seen } = gateAdapter({
+    gate: state.gate,
+    respond: (input) => {
+      if (input.action === "validate") state.markValidated();
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: "verificação pedida",
+        outcome: "executed",
+        gateAction: input.action,
+      };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.deepEqual(seen.map((call) => call.action), ["validate"]);
+  assert.match(dom.root.innerHTML, /data-outcome-code="approval_validation_not_valid"/);
+  assert.ok(dom.root.innerHTML.includes("RISKY"), "o estado observado precisa ser dito");
+  assert.ok(dom.root.innerHTML.includes("O APPROVE não foi enviado"));
+  // E o candidato continua na fila de pendências.
+  assert.match(dom.root.innerHTML, /data-queue-state="pendente"/);
+});
+
+test("uma verificação recusada interrompe a cadeia e diz que a aprovação não foi tentada", async () => {
+  reset();
+  const state = validatingGate("VALID");
+  const { adapter, seen } = gateAdapter({
+    gate: state.gate,
+    respond: () => ({
+      ok: false,
+      path: "/x",
+      kind: "nota" as const,
+      message: "o verificador recusou",
+      outcome: "refused",
+      code: "upstream_error",
+      gateAction: "validate" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.deepEqual(seen.map((call) => call.action), ["validate"]);
+  assert.match(dom.root.innerHTML, /data-outcome-code="approval_validation_unavailable"/);
+  assert.ok(dom.root.innerHTML.includes("A verificação do destinatário não completou"));
+  assert.match(dom.root.innerHTML, /data-queue-state="pendente"/);
+});
+
+/* ------------------------------------------------------------------ *
+ * Otimismo com rollback.
+ * ------------------------------------------------------------------ */
+
+test("a aprovação sai da fila na hora e a próxima assume a posição, com o foco junto", async () => {
+  reset();
+  const server = statefulGate([
+    candidate({ company: "Primeira SA" }),
+    candidate({ candidate_id: SECOND_CANDIDATE, company: "Segunda SA" }),
+  ]);
+  const { adapter } = gateAdapter({ gate: server.gate, respond: server.respond });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  assert.match(dom.root.innerHTML, /data-queue-pending="2"/);
+  approve(dom);
+  await settle();
+  assert.match(dom.root.innerHTML, /data-queue-pending="1"/);
+  assert.ok(!dom.root.innerHTML.includes("Primeira SA"), "a aprovada saiu da viewport de trabalho");
+  assert.ok(dom.root.innerHTML.includes("Segunda SA"), "a próxima assumiu a posição");
+  const next = dom.all("[data-approve-submit]")[0];
+  assert.ok(next?.focused, "o foco precisa cair no próximo Aprovar");
+  assert.ok(next?.centred, "e a próxima mensagem precisa ficar centrada, sem salto de página");
+});
+
+test("o card sai da fila antes da resposta chegar, e a espera fica dita na própria fila", async () => {
+  reset();
+  let release: (() => void) | undefined;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const server = statefulGate([
+    candidate({ company: "Primeira SA" }),
+    candidate({ candidate_id: SECOND_CANDIDATE, company: "Segunda SA" }),
+  ]);
+  const { adapter } = gateAdapter({
+    gate: server.gate,
+    respond: async (input) => {
+      await held;
+      return server.respond(input);
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  // A escrita ainda está no ar e a fila já mostra a próxima mensagem.
+  assert.match(dom.root.innerHTML, /data-queue-pending="1"/);
+  assert.ok(!dom.root.innerHTML.includes("Primeira SA"));
+  assert.match(dom.root.innerHTML, /data-write-pending="true"/, "a espera precisa estar visível");
+  assert.ok(dom.root.innerHTML.includes("Registrando a decisão de 1 candidato"));
+  release?.();
+  await settle();
+  assert.doesNotMatch(dom.root.innerHTML, /data-write-pending="true"/);
+  assert.match(dom.root.innerHTML, /data-queue-pending="1"/);
+});
+
+test("uma recusa da API devolve a mensagem para a fila e explica o motivo no card", async () => {
+  reset();
+  const { adapter } = gateAdapter({
+    respond: () => ({
+      ok: false,
+      path: "/x",
+      kind: "nota" as const,
+      message: "o servidor recusou",
+      outcome: "refused",
+      code: "upstream_error",
+      gateAction: "review" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.match(dom.root.innerHTML, /data-queue-pending="1"/, "a mensagem volta a ser trabalho");
+  assert.match(dom.root.innerHTML, /data-queue-state="pendente"/);
+  assert.match(dom.root.innerHTML, /data-write-result="failed"/);
+  assert.match(dom.root.innerHTML, /data-gate-key="review:[^"]*:APPROVE"/, "e pode ser aprovada de novo");
+});
+
+test("um desfecho desconhecido não conta como aprovado: a mensagem fica na fila com o aviso", async () => {
+  reset();
+  const { adapter } = gateAdapter({
+    respond: () => ({
+      ok: false,
+      path: "/x",
+      kind: "nota" as const,
+      message: "sem resposta",
+      outcome: "unknown",
+      code: "human_gate_transport_unknown",
+      gateAction: "review" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.match(dom.root.innerHTML, /data-queue-pending="1"/);
+  assert.match(dom.root.innerHTML, /data-dispatch-outcome="unknown"/);
+});
+
+test("uma releitura que não confirma o efeito devolve a mensagem para a fila", async () => {
+  reset();
+  const { adapter } = gateAdapter({
+    // A releitura devolve o candidato sem revisão nenhuma, então o canal
+    // aceitou e o recurso não mudou. Isso não é aprovado.
+    gate: () => gatePayload(["operators", "admins"], cohort()),
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "APPROVE registrado.",
+      outcome: "executed",
+      gateAction: "review" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.match(dom.root.innerHTML, /data-readback="not_confirmed"/);
+  assert.match(dom.root.innerHTML, /data-queue-pending="1"/, "sem confirmação, continua sendo trabalho");
+});
+
+test("um duplo clique em Aprovar não vira duas aprovações, nem durante a verificação", async () => {
+  reset();
+  const state = validatingGate("VALID");
+  let release: (() => void) | undefined;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const { adapter, seen } = gateAdapter({
+    gate: state.gate,
+    respond: async (input) => {
+      if (input.action === "validate") {
+        await held;
+        state.markValidated();
+      }
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: "ok",
+        outcome: "executed",
+        gateAction: input.action,
+      };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.match(dom.root.innerHTML, /data-write-pending="true"/);
+  // O segundo clique acontece com a verificação ainda no ar.
+  const stillThere = dom.root.querySelectorAll(
+    `[data-gate-key="review:${COHORT_ID}:${CANDIDATE_ID}:APPROVE"]`,
+  );
+  stillThere[0]?.fire();
+  await settle();
+  assert.equal(seen.length, 1, "a segunda intenção não pode alcançar o canal");
+  release?.();
+  await settle();
+  assert.deepEqual(seen.map((call) => call.action), ["validate", "review"]);
+});
+
+test("cinquenta pendências: a fila conta certo, mostra só o que falta e drena uma a uma", async () => {
+  reset();
+  const ids = Array.from(
+    { length: 50 },
+    (_, index) => `55555555-5555-4555-8555-${String(index).padStart(12, "0")}`,
+  );
+  const server = statefulGate(
+    ids.map((id, index) => candidate({ candidate_id: id, company: `Empresa ${index}` })),
+  );
+  const { adapter } = gateAdapter({ gate: server.gate, respond: server.respond });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  assert.match(dom.root.innerHTML, /data-queue-pending="50" data-queue-approved="0"/);
+  for (let index = 0; index < 18; index += 1) {
+    dom.find(`[data-gate-key="review:${COHORT_ID}:${ids[index]}:APPROVE"]`).fire();
+    await settle();
+  }
+  assert.match(dom.root.innerHTML, /data-queue-pending="32" data-queue-approved="18" data-queue-adjust="0" data-queue-total="50"/);
+  const remaining = dom.all("[data-approve-submit]");
+  assert.equal(remaining.length, 32, "só o que falta ocupa a tela");
+  // Nenhuma das aprovadas reaparece, mesmo com o servidor devolvendo o payload
+  // original em toda releitura.
+  for (let index = 0; index < 18; index += 1) {
+    assert.ok(
+      !dom.root.innerHTML.includes(`review:${COHORT_ID}:${ids[index]}:APPROVE`),
+      `a aprovação ${index} não pode voltar para a fila`,
+    );
+  }
+});
+
+test("segurar também tira da fila de pendências, e o motivo continua obrigatório", async () => {
+  reset();
+  const server = statefulGate([candidate()]);
+  const { adapter, seen } = gateAdapter({ gate: server.gate, respond: server.respond });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  const form = dom.find(`[data-gate-key="review:${COHORT_ID}:${CANDIDATE_ID}:HOLD_REJECT"]`);
+  form.set("reason", "endereço genérico demais");
+  form.fire();
+  await settle();
+  assert.equal(seen[0]!.decision, "HOLD");
+  assert.equal(seen[0]!.acknowledged, undefined, "segurar nunca carrega ciência de aprovação");
+  assert.match(dom.root.innerHTML, /data-queue-pending="0" data-queue-approved="0" data-queue-adjust="1"/);
+});
+
+/* ------------------------------------------------------------------ *
+ * Teclado.
+ * ------------------------------------------------------------------ */
+
+test("o atalho de aprovar não dispara com o cursor dentro de um campo", () => {
+  for (const tag of ["INPUT", "TEXTAREA", "SELECT"]) {
+    assert.equal(isEditingTarget({ tagName: tag }), true, `${tag} é escrita, não decisão`);
+    assert.equal(approvalShortcutScope({ key: "a" }, isEditingTarget({ tagName: tag })), null);
+    assert.equal(
+      approvalShortcutScope({ key: "Enter", ctrlKey: true }, isEditingTarget({ tagName: tag })),
+      null,
+    );
+  }
+  assert.equal(isEditingTarget({ tagName: "DIV", isContentEditable: true }), true);
+  assert.equal(isEditingTarget({ tagName: "BUTTON" }), false, "o botão é onde a fila deixa o foco");
+  assert.equal(isEditingTarget(null), false);
+});
+
+test("o atalho é A sozinho ou Ctrl/Cmd+Enter, e nada mais", () => {
+  // A sozinho só alcança o card que já está sob o foco: um "a" digitado por
+  // engano em qualquer outro lugar não autoriza mensagem nenhuma.
+  assert.equal(approvalShortcutScope({ key: "a" }, false), "focused-card");
+  assert.equal(approvalShortcutScope({ key: "A" }, false), "focused-card");
+  assert.equal(approvalShortcutScope({ key: "Enter", ctrlKey: true }, false), "first-pending");
+  assert.equal(approvalShortcutScope({ key: "Enter", metaKey: true }, false), "first-pending");
+  // Ctrl+A continua sendo selecionar tudo, e Enter sozinho continua sendo Enter.
+  assert.equal(approvalShortcutScope({ key: "a", ctrlKey: true }, false), null);
+  assert.equal(approvalShortcutScope({ key: "a", metaKey: true }, false), null);
+  assert.equal(approvalShortcutScope({ key: "a", shiftKey: true }, false), null);
+  assert.equal(approvalShortcutScope({ key: "a", altKey: true }, false), null);
+  assert.equal(approvalShortcutScope({ key: "Enter" }, false), null);
+  assert.equal(approvalShortcutScope({ key: "b" }, false), null);
+  assert.equal(approvalShortcutScope({}, false), null);
+});
+
+test("um canal que morre sem responder devolve a mensagem para a fila como desfecho desconhecido", async () => {
+  reset();
+  const { adapter } = gateAdapter({
+    respond: () => {
+      throw new Error("o canal caiu");
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
+  approve(dom);
+  await settle();
+  assert.match(dom.root.innerHTML, /data-outcome-code="browser_transport"/);
+  assert.match(dom.root.innerHTML, /data-queue-pending="1"/, "sem prova de aplicação, continua sendo trabalho");
+  assert.match(dom.root.innerHTML, /data-gate-key="review:[^"]*:APPROVE"/, "e o controle volta pressionável");
+});
+
+test("reverter uma aprovação com HOLD leva a mensagem para o recorte de ajuste", async () => {
+  reset();
+  const server = statefulGate([candidate({ review: { decision: "APPROVE", effective: true } })]);
+  const { adapter, seen } = gateAdapter({ gate: server.gate, respond: server.respond });
+  const dom = paintingRoot();
+  paintShell(
+    dom.root as never,
+    adapter as never,
+    `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`,
+  );
+  assert.match(dom.root.innerHTML, /data-already-approved="server"/);
+  const form = dom.find(`[data-gate-key="review:${COHORT_ID}:${CANDIDATE_ID}:HOLD_REJECT"]`);
+  form.set("reason", "o edital citado foi revogado");
+  form.fire();
+  await settle();
+  assert.equal(seen[0]!.decision, "HOLD");
+  assert.match(dom.root.innerHTML, /data-queue-approved="0" data-queue-adjust="1"/);
+  assert.match(dom.root.innerHTML, /data-gate-key="review:[^"]*:APPROVE"/, "e aprovar volta a ser oferecido");
 });

--- a/control-center/apps/web-shell/tests/warmbly-human-gate.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-human-gate.test.ts
@@ -5,7 +5,7 @@ import { HttpControlCenterAdapter } from "../src/adapters/http";
 import { warmblyBlock } from "../src/ui/warmbly";
 
 const version="11111111-1111-4111-8111-111111111111";
-const candidate={candidate_id:"22222222-2222-4222-8222-222222222222",company:"Fixture",mailbox:"review@fixture.invalid",route_class:"ROLE_OR_DEPARTMENT",source:"fixture",subject:"Exact fixture subject",body_text:"Exact frozen fixture body",content_hash:"content",evidence_hash:"evidence",validation:{status:"VALID",reason:"sandbox",expires_at:"2026-08-24T12:00:00Z"},review:{decision:"HOLD",effective:false},blocked_by:["approval_missing_or_invalid"]};
+const candidate={candidate_id:"22222222-2222-4222-8222-222222222222",company:"Fixture",mailbox:"review@fixture.invalid",route_class:"ROLE_OR_DEPARTMENT",source:"fixture",subject:"Exact fixture subject",body_text:"Exact frozen fixture body",content_hash:"content",evidence_hash:"evidence",validation:{status:"VALID",reason:"sandbox",expires_at:"2026-08-24T12:00:00Z"},review:null,blocked_by:["approval_missing_or_invalid"]};
 const cohort={id:version,version:3,source:"fixture",as_of:"2026-08-23T12:00:00Z",freshness:"FRESH",policy_version:"bounded-cohort-policy.v1",receipt:`cohort:${version}`,manifest:{preview:{accounts_considered:7,accounts_eligible:2,accounts_excluded:5,recipients_final:2,suppressed:1,opt_out:1,risky_excluded:1}},candidates:[candidate]};
 const input={snapshot:undefined,operator:{kind:"human" as const,id:"operator"},gate:{list:{data:[cohort]},selected:{data:cohort}}};
 
@@ -18,13 +18,13 @@ test("cohort table renders true denominators from Warmbly",()=>{
 });
 
 test("progressive review renders exact preview, validation and proportional confirmations",()=>{
-  const html=warmblyBlock(input,"revisao");assert.match(html,/data-validation-status="VALID"/);assert.match(html,/Exact fixture subject/);assert.match(html,/Exact frozen fixture body/);assert.match(html,/data-human-gate="validate"/);assert.match(html,/APPROVE/);assert.match(html,/REJECT/);assert.match(html,/HOLD/);assert.match(html,/pattern="v3"/);assert.match(html,/GO não envia e-mail/);
+  const html=warmblyBlock({...input,query:"estado=todas"},"revisao");assert.match(html,/data-validation-status="VALID"/);assert.match(html,/Exact fixture subject/);assert.match(html,/Exact frozen fixture body/);assert.doesNotMatch(html,/data-human-gate="validate"/);assert.match(html,/APPROVE/);assert.match(html,/REJECT/);assert.match(html,/HOLD/);assert.match(html,/pattern="v3"/);assert.match(html,/GO não envia e-mail/);
 });
 
 test("review renders every Warmbly validation state without inferring validity",()=>{
   const statuses=["VALID","RISKY","INVALID","UNKNOWN","STALE"];
   const candidates=statuses.map((status,index)=>({...candidate,candidate_id:`22222222-2222-4222-8222-22222222222${index}`,validation:{...candidate.validation,status}}));
-  const html=warmblyBlock({...input,gate:{list:{data:[cohort]},selected:{data:{...cohort,candidates}}}},"revisao");
+  const html=warmblyBlock({...input,query:"estado=todas",gate:{list:{data:[cohort]},selected:{data:{...cohort,candidates}}}},"revisao");
   for(const status of statuses) assert.match(html,new RegExp(`data-validation-status="${status}"`));
 });
 

--- a/control-center/docs/WARMBLY-HUMAN-GATE-FLOW.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-FLOW.md
@@ -11,8 +11,8 @@ account × trigger × offer × decision-unit × route
   -- Warmbly seleciona uma rota preferida e explica exclusões -->
 cohort/version imutável
   -- leitura autenticada --> candidate + preview exato congelado
-  -- escrita idempotente --> validation vinculada à evidência
-  -- escrita humana --> APPROVE | REJECT | HOLD por candidate
+  -- escrita idempotente, disparada pela própria aprovação --> validation
+  -- escrita humana, uma ação --> APPROVE | REJECT | HOLD por candidate
   -- escrita humana de maior privilégio --> GO | NO_GO da versão
   -- somente se GO e todos os gates ao vivo continuarem válidos --> queue
   -- fora do Control Center e desabilitado por padrão --> send
@@ -23,7 +23,7 @@ cohort/version imutável
 | Account/trigger/offer/decision-unit/route | Warmbly + feed canônico | origem, `as_of`, freshness, policy e motivos | nenhuma no frontend | não |
 | Cohort/version | Warmbly | lista, denominadores e relatório de exclusões | criar/reproduzir uma versão imutável, com idempotency key | não |
 | Candidate/preview | snapshot congelado Warmbly | destinatário, provenance, rota, assunto e corpo exatos | nenhuma mutação da mensagem | não |
-| Validation | verificador do Warmbly | VALID/RISKY/INVALID/UNKNOWN/STALE, motivo e validade | solicitar/repetir validação | não |
+| Validation | verificador do Warmbly | VALID/RISKY/INVALID/UNKNOWN/STALE, motivo e validade | solicitar/repetir validação — a aprovação a solicita sozinha quando não há uma vigente | não |
 | Review decision | Warmbly | decisão atual, vínculo e invalidações | APPROVE/REJECT/HOLD com ator Authelia e motivo | não |
 | Cohort decision | Warmbly | prontidão e todos os bloqueios | GO/NO_GO sobre uma versão exata | não |
 | Queue | Warmbly | estado de autorização/preflight/queue | GO materializa somente a autorização exata; Warmbly ainda revalida todos os gates antes da queue | não |
@@ -33,6 +33,26 @@ cohort/version imutável
 
 - O frontend exibe elegibilidade e motivos recebidos do contrato versionado; não
   calcula, completa ou corrige candidatos localmente.
+- A aprovação é uma única ação humana e o Control Center paga o custo técnico
+  dela: quando não há validation vigente, APPROVE dispara a validation, relê o
+  estado no servidor e só registra a decisão se ele devolver VALID. A ordem é
+  sempre validation → releitura → review; um estado que não é VALID interrompe a
+  cadeia sem tentar o APPROVE. Nada disso afrouxa o gate — apenas retira do
+  humano um passo que é determinístico.
+- APPROVE é bloqueado na tela somente onde repetir a verificação não pode ajudar:
+  ausência de destinatário, destinatário sintaticamente inválido, veredito já
+  resolvido como INVALID ou RISKY, e bloqueios materiais que o próprio servidor
+  declarou (`hard_bounce`, suppression, opt-out, duplicidade, copy QA,
+  proveniência ausente). Toda essa classificação lê `validation.status` e
+  `blocked_by` do payload; nenhuma vem de relógio ou heurística local.
+- A ciência do revisor é o próprio clique em Aprovar, e continua viajando como
+  `acknowledged=true`. O adaptador recusa antes do fio qualquer APPROVE sem esse
+  campo, então a remoção da caixa de seleção não abriu caminho de bypass: mudou
+  quem informa o campo, não se ele é exigido.
+- Uma aprovação registrada localmente sai da fila de pendências na hora, e
+  volta para ela em qualquer desfecho que não seja aplicação confirmada —
+  recusa, falha, desconhecido, ou releitura que não confirma o efeito. Nenhuma
+  decisão local sobrevive a um reload: a fila é do servidor.
 - Cada APPROVE fica ligado aos hashes de recipient, content, policy e evidence e
   à expiração da validation. Qualquer drift ou expiração torna a aprovação
   inválida sem apagar a decisão humana original.
@@ -59,9 +79,14 @@ cohort/version imutável
 
 ## Falhas e concorrência
 
-- POSTs exigem `Idempotency-Key`; acknowledgement e confirmação de versão fazem
-  parte da intenção; retry, duas abas e restart devolvem o mesmo
-  receipt, ou 409 se a chave for reutilizada com payload diferente.
+- POSTs exigem `Idempotency-Key`; acknowledgement, motivo e confirmação de versão
+  fazem parte da intenção; retry, duas abas e restart devolvem o mesmo
+  receipt, ou 409 se a chave for reutilizada com payload diferente. Uma
+  aprovação sem comentário tem motivo `approved_by_human_reviewer`, que é
+  estável e portanto mantém a chave estável entre tentativas.
+- Um clique repetido durante a cadeia validation → review não vira segunda
+  intenção: o formulário fica reservado do primeiro clique até o fim da cadeia,
+  e a espera é dita na própria fila, não no card que já saiu dela.
 - Timeout depois de write é mostrado como desfecho desconhecido; a tela relê o
   recurso pelo correlation id/receipt antes de permitir repetição.
 - Payload parcial é 400, ausência de sessão é 401, grupo insuficiente é 403,

--- a/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
@@ -6,20 +6,61 @@
    `admins` registram GO/NO-GO.
 2. Abra **Warmbly → Cohorts**. Confirme source/as_of/freshness e os quatro
    denominadores (considerados, elegíveis, excluídos, finais). Crie no máximo 10.
-3. Abra a versão em **Revisão**. Para cada candidato, revele o preview exato,
-   confira recipient/route/provenance/subject/body e solicite validation.
-4. VALID vigente permite APPROVE depois da ciência explícita. A UI e o Warmbly
-   exigem `acknowledged=true`; RISKY/INVALID/UNKNOWN/STALE ficam bloqueados;
-   registre HOLD ou REJECT com motivo. Se recipient, copy, policy, evidence ou
-   suppression mudar, a aprovação aparece inválida e deve ser refeita.
-5. GO exige todos aprovados, source fresh e a confirmação digitada da versão.
+3. Abra a versão em **Revisão**. A tela abre no recorte **Pendentes** e diz
+   quanto falta (`N pendentes · N aprovadas · N em ajuste · N no total`). Leia o
+   destinatário, o fato observado e a proveniência, e leia o assunto e o corpo
+   exatos — eles ficam abertos por padrão.
+4. Se nada estiver bloqueado, **Aprovar é uma ação só**. Não digite motivo e não
+   marque caixa nenhuma: o clique é a ciência, e a trilha grava ator do Authelia,
+   instante, versão, hash congelado, destinatário e decisão. Sem comentário
+   escrito, o motivo registrado é `approved_by_human_reviewer`; o campo de
+   comentário continua disponível e vence o padrão quando preenchido.
+   - **Verificação do destinatário**: quando não há validação vigente, aprovar
+     pede a verificação ao Warmbly, relê o estado e só então registra o APPROVE.
+     Não acione "Verificar o destinatário agora" antes de aprovar — esse controle
+     existe como escape, e só aparece onde a validação não é VALID.
+   - Se a verificação não voltar VALID, **nada é decidido**: a tela diz o estado
+     observado e que o APPROVE não foi enviado.
+   - A mensagem aprovada sai da fila na hora e a próxima assume a posição, com o
+     foco no botão dela. `A` (com o foco no card) e `Ctrl/Cmd+Enter` aprovam pelo
+     teclado; dentro de qualquer campo de texto o atalho não dispara.
+   - Se a API recusar, falhar, responder desfecho desconhecido ou a releitura não
+     confirmar o efeito, a mensagem **volta para Pendentes** com o motivo no card.
+     Repetir usa a mesma idempotency key.
+5. **APPROVE continua bloqueado** onde verificar de novo não resolve: sem
+   destinatário, destinatário que não é endereço, validação já resolvida como
+   RISKY ou INVALID, hard bounce, suppression, opt-out, duplicidade, reprovação
+   de copy QA ou proveniência ausente marcada pelo servidor. Nesses casos a tela
+   nomeia o bloqueio e o próximo movimento; registre HOLD ou REJECT **com motivo
+   escrito**, que continua obrigatório. Se recipient, copy, policy, evidence ou
+   suppression mudar depois, a aprovação aparece inválida (`effective=false`),
+   volta para Pendentes e deve ser refeita.
+6. GO exige todos aprovados, source fresh e a confirmação digitada da versão.
    O Warmbly compara o valor (por exemplo `v3`) à versão imutável; o proxy não
    consegue remover ou fabricar essa confirmação.
    Use NO_GO para interromper/revogar. GO cria a autoridade bounded exata em
    `READY_FOR_LIVE_PREFLIGHT`; não enfileira, não envia e não liga auto-send.
-6. Em timeout, não repita às cegas. Recarregue a mesma versão e compare receipt
+7. Em timeout, não repita às cegas. Recarregue a mesma versão e compare receipt
    e correlation id. O frontend preserva a idempotency key da intenção incerta;
    só depois repita a mesma intenção.
+
+### O que mudou no gate humano (e o que não mudou)
+
+A fila deixou de ser um formulário e virou uma fila de decisões. O que saiu foi
+custo humano; nenhuma salvaguarda material foi removida.
+
+| Antes | Agora | Por quê |
+|---|---|---|
+| Clicar em "verificar destinatário agora" antes de aprovar | Aprovar obtém a verificação sozinho | Obter validation é chamada determinística, sem julgamento humano |
+| Digitar um motivo para APPROVE | `approved_by_human_reviewer` automático, comentário opcional | O motivo digitado era sempre a mesma palavra; a trilha já tinha ator, instante, versão e hash |
+| Marcar "revisei destinatário" | O clique em Aprovar é a ciência | Um segundo clique declarando o primeiro não acrescenta nada à auditoria |
+| Lista com aprovadas no topo | Recorte **Pendentes** por padrão, com contador | Rolar a própria produção para achar o próximo trabalho não escala |
+
+O que **não** mudou: `acknowledged=true` continua viajando no corpo do APPROVE e
+o adaptador recusa antes do fio um APPROVE sem ele; o Warmbly continua recusando
+APPROVE fora de uma validação VALID vigente; GO continua exigindo `admins` e a
+confirmação digitada da versão; HOLD/REJECT continuam exigindo motivo escrito; e
+o Control Center continua sem qualquer rota de send, dispatch ou queue.
 
 ## Métricas e alertas
 

--- a/control-center/tests/journey/fake-warmbly.mjs
+++ b/control-center/tests/journey/fake-warmbly.mjs
@@ -110,6 +110,33 @@ createServer((req, res) => {
       return v ? send(res, 200, { data: v }) : send(res, 404, { code: "not_found" });
     }
 
+    // Recipient verification. Deterministic on purpose: every mailbox comes
+    // back VALID except empresa-quatro, whose prober identity is refused —
+    // which is what lets the journey prove that an approval which cannot get a
+    // VALID stops before registering anything.
+    const val = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)\/candidates\/([0-9a-f-]+)\/validation$/);
+    if (req.method === "POST" && val) {
+      const v = versions.get(val[1]);
+      if (!v) return send(res, 404, { code: "not_found" });
+      const c = v.candidates.find((x) => x.candidate_id === val[2]);
+      if (!c) return send(res, 404, { code: "candidate_not_found" });
+      const refuses = c.mailbox.includes("empresa-quatro");
+      c.validation = {
+        id: randomUUID(),
+        status: refuses ? "UNKNOWN" : "VALID",
+        reason: refuses ? "identity_rdns_missing: prober identity refused" : "rcpt accepted",
+        provider: "in-house",
+        method: "smtp_rcpt",
+        evidence_hash: `v-${val[2]}`,
+        checked_at: "2026-08-23T18:00:00Z",
+        expires_at: "2026-08-24T18:00:00Z",
+        correlation_id: "corr-validation",
+        receipt: `receipt-validation-${val[2]}`,
+      };
+      c.blocked_by = refuses ? ["validation_not_valid:UNKNOWN"] : [];
+      return send(res, 200, { data: v, receipt: c.validation.receipt, correlation_id: "corr-validation" });
+    }
+
     const rev = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)\/candidates\/([0-9a-f-]+)\/review$/);
     if (req.method === "POST" && rev) {
       const v = versions.get(rev[1]);

--- a/control-center/tests/journey/journey.mjs
+++ b/control-center/tests/journey/journey.mjs
@@ -97,6 +97,25 @@ check("exact subject is visible without opening anything", await subj.isVisible(
 check("exact body is visible without opening anything", await body.isVisible().catch(() => false));
 check("recipient is shown on the card", (await page.locator("[data-candidate-identity]").first().innerText().catch(() => "")).includes("@"));
 check("preview denominators are rendered", await page.locator("[data-preview-denominators]").count() > 0);
+const structure = await page.evaluate(() => {
+  const ids = [...document.querySelectorAll("[id]")].map((node) => node.id);
+  const cards = [...document.querySelectorAll("[data-candidate-id]")];
+  return {
+    duplicateIds: ids.filter((id, index) => id !== "" && ids.indexOf(id) !== index),
+    nestedForms: document.querySelectorAll("form form").length,
+    malformedCards: cards.filter(
+      (card) =>
+        card.querySelectorAll("[data-exact-subject]").length !== 1
+        || card.querySelectorAll("[data-exact-body]").length !== 1
+        || card.querySelectorAll("[data-candidate-identity]").length !== 1,
+    ).length,
+  };
+});
+check("the browser parsed every candidate card as one intact structure",
+  structure.malformedCards === 0 && structure.nestedForms === 0,
+  `malformed=${structure.malformedCards} nested_forms=${structure.nestedForms}`);
+check("the review surface has no duplicate element ids", structure.duplicateIds.length === 0,
+  structure.duplicateIds.join(","));
 
 // ---- 4. The queue opens on pending work and says how much is left
 check("the review surface opens on the pending recorte",
@@ -121,6 +140,29 @@ const cardBefore = await page.locator("[data-candidate-id]").count();
 check("the approve control carries no required motive and no acknowledgement checkbox",
   await page.locator("form.approve-form [name='ack']").count() === 0
   && await page.locator("form.approve-form [name='reason'][required]").count() === 0);
+await firstApprove.focus();
+const pendingBeforeShortcutGuards = await page.locator("[data-queue-progress-text]").first().innerText();
+await page.evaluate(() => {
+  document.dispatchEvent(new KeyboardEvent("keydown", {
+    key: "Enter", ctrlKey: true, repeat: true, bubbles: true, cancelable: true,
+  }));
+});
+await page.waitForTimeout(250);
+check("a repeating keyboard event cannot approve or advance the queue",
+  await page.locator("[data-queue-progress-text]").first().innerText() === pendingBeforeShortcutGuards);
+await page.evaluate(() => {
+  const overlay = document.createElement("div");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("data-journey-overlay", "true");
+  document.body.append(overlay);
+  document.dispatchEvent(new KeyboardEvent("keydown", {
+    key: "Enter", ctrlKey: true, bubbles: true, cancelable: true,
+  }));
+  overlay.remove();
+});
+await page.waitForTimeout(250);
+check("a keyboard shortcut cannot cross an active modal overlay",
+  await page.locator("[data-queue-progress-text]").first().innerText() === pendingBeforeShortcutGuards);
 await firstApprove.click();
 await page.waitForTimeout(1800);
 const cardAfter = await page.locator("[data-candidate-id]").count();

--- a/control-center/tests/journey/journey.mjs
+++ b/control-center/tests/journey/journey.mjs
@@ -98,23 +98,83 @@ check("exact body is visible without opening anything", await body.isVisible().c
 check("recipient is shown on the card", (await page.locator("[data-candidate-identity]").first().innerText().catch(() => "")).includes("@"));
 check("preview denominators are rendered", await page.locator("[data-preview-denominators]").count() > 0);
 
-// ---- 4. APPROVE gating follows the server's verdict
+// ---- 4. The queue opens on pending work and says how much is left
+check("the review surface opens on the pending recorte",
+  await page.locator("[data-review-progress][data-queue-filter='pendentes']").count() > 0);
+const progress = await page.locator("[data-queue-progress-text]").first().innerText().catch(() => "");
+check("the queue states its own progress", /5 pendente/.test(progress), progress.replace(/\s+/g, " "));
+
+// ---- 5. APPROVE gating: only a settled non-VALID verdict blocks a human
 const approveAllowed = await page.locator("[data-approve-allowed='true']").count();
 const approveBlocked = await page.locator("[data-approve-blocked]").count();
-check("APPROVE is offered only for VALID candidates", approveAllowed === 2, `allowed=${approveAllowed}`);
-check("APPROVE is blocked, with a reason, for the rest", approveBlocked === 3, `blocked=${approveBlocked}`);
+const autoValidate = await page.locator("[data-approve-needs-validation='true']").count();
+check("only the settled INVALID candidate blocks APPROVE", approveBlocked === 1, `blocked=${approveBlocked}`);
+check("every other candidate can be approved in one action", approveAllowed === 4, `allowed=${approveAllowed}`);
+check("candidates without a live validation say the approval verifies first", autoValidate === 2,
+  `auto-validate=${autoValidate}`);
 const blockedReason = await page.locator("[data-approve-blocked]").first().innerText().catch(() => "");
 check("the APPROVE block explains itself", blockedReason.trim().length > 0, blockedReason.replace(/\s+/g, " ").slice(0, 70));
 
-// ---- 5. HOLD / REJECT do not inherit the APPROVE acknowledgement
-check("HOLD/REJECT are marked as needing no acknowledgement",
-  await page.locator("[data-no-ack-required]").count() > 0);
+// ---- 6. One action approves: no reason typed, no checkbox ticked
+const firstApprove = page.locator("[data-approve-submit]:not([disabled])").first();
+const cardBefore = await page.locator("[data-candidate-id]").count();
+check("the approve control carries no required motive and no acknowledgement checkbox",
+  await page.locator("form.approve-form [name='ack']").count() === 0
+  && await page.locator("form.approve-form [name='reason'][required]").count() === 0);
+await firstApprove.click();
+await page.waitForTimeout(1800);
+const cardAfter = await page.locator("[data-candidate-id]").count();
+check("one click took the message out of the pending queue", cardAfter === cardBefore - 1,
+  `${cardBefore} -> ${cardAfter}`);
+const progressAfter = await page.locator("[data-queue-progress-text]").first().innerText().catch(() => "");
+check("the queue counted the approval", /1 aprovada/.test(progressAfter), progressAfter.replace(/\s+/g, " "));
+check("the approved message is still readable in its own recorte",
+  await page.locator("[data-review-filter='aprovadas']").count() > 0);
 
-// ---- 6. RBAC is visible
+// ---- 7. Approving a candidate with no live validation verifies it on the way
+//
+// empresa-cinco arrives with no validation at all and the stand-in verifies it
+// as VALID; empresa-quatro is the one whose prober identity is refused and is
+// exercised separately below. Naming them apart matters: picking whichever came
+// first would silently test the same candidate twice.
+const needsCheckBefore = await page.locator("[data-approve-needs-validation='true']").count();
+const verifiable = page
+  .locator("[data-approve-needs-validation='true']")
+  .filter({ hasText: "empresa-cinco" })
+  .locator("[data-approve-submit]:not([disabled])");
+if (await verifiable.count() > 0) {
+  await verifiable.first().click();
+  await page.waitForTimeout(2200);
+  const stillPending = await page.locator("[data-approve-needs-validation='true']").count();
+  check("approving an unverified recipient verified it and registered without a second click",
+    stillPending === needsCheckBefore - 1, `${needsCheckBefore} -> ${stillPending}`);
+  check("and the queue counted that approval too",
+    /2 aprovada/.test(await page.locator("[data-queue-progress-text]").first().innerText().catch(() => "")));
+}
+
+// ---- 8. A verification that cannot come back VALID stops before APPROVE
+const stubborn = page.locator("[data-approve-needs-validation='true'] [data-approve-submit]:not([disabled])");
+if (await stubborn.count() > 0) {
+  await stubborn.first().click();
+  await page.waitForTimeout(2200);
+  check("a recipient that will not verify blocks the approval and says so",
+    await page.locator("[data-outcome-code='approval_validation_not_valid']").count() > 0);
+  const stopText = await page.locator("[data-outcome-recovery]").first().innerText().catch(() => "");
+  check("and it says the APPROVE was not sent", /não foi enviado|não foi tentad/i.test(
+    stopText + (await page.locator("[data-outcome-detail]").first().innerText().catch(() => "")),
+  ), stopText.replace(/\s+/g, " ").slice(0, 80));
+}
+
+// ---- 9. HOLD / REJECT keep their written motive
+check("HOLD/REJECT still demand a written motive",
+  await page.locator("[data-no-ack-required]").count() > 0
+  && await page.locator("form [name='reason'][required]").count() > 0);
+
+// ---- 10. RBAC is visible
 check("effective operator capability is shown", await page.locator("[data-can-review]").count() > 0);
 check("GO authority is stated explicitly", await page.locator("[data-go-authority], [data-can-decide]").count() > 0);
 
-// ---- 7. Adjust: two-step, diff before write, then vN+1
+// ---- 11. Adjust: two-step, diff before write, then vN+1
 const adjustEditor = page.locator("[data-adjust-editor]").first();
 check("an adjust editor exists on the candidate", await adjustEditor.count() > 0);
 let adjusted = false;
@@ -167,20 +227,57 @@ if (adjusted) {
   check("the outcome carries a receipt", /receipt|recibo/i.test(receipt), receipt.replace(/\s+/g, " ").slice(0, 80));
 }
 
-// ---- 8. Reload keeps the operator where they were
+// ---- 12. Reload keeps the operator where they were
 const before = page.url();
 await page.reload({ waitUntil: "networkidle" });
 await page.waitForTimeout(1000);
 check("a reload keeps the same resource", page.url() === before, page.url().split("#")[1] || "");
 
-// ---- 9. A second tab sees the same server truth
+// ---- 12b. A reload of the reviewed version never resurrects an approval
+//
+// The optimistic marks die with the page, so what is asserted here is the
+// server's own record: two approvals registered, neither of them back in the
+// pending queue. This is the failure that would let a message be approved
+// twice, so it is proved against a fresh load rather than against local state.
+const reviewed = await newPage();
+await reviewed.goto(`${BASE}/#/warmbly/revisao?resource=${ORIGINAL_RESOURCE}`, { waitUntil: "networkidle" });
+await reviewed.waitForTimeout(1400);
+const afterReload = await reviewed.locator("[data-queue-progress-text]").first().innerText().catch(() => "");
+check("a reload reads the approvals back from the server, not from this browser",
+  /2 aprovada/.test(afterReload), afterReload.replace(/\s+/g, " "));
+check("and no approved message came back as pending",
+  await reviewed.locator("[data-queue-state='aprovado']").count() === 0
+  && /3 pendente/.test(afterReload), afterReload.replace(/\s+/g, " "));
+await reviewed.goto(`${BASE}/#/warmbly/revisao?resource=${ORIGINAL_RESOURCE}&estado=aprovadas`, { waitUntil: "networkidle" });
+await reviewed.waitForTimeout(1400);
+const approvedCards = await reviewed.locator("[data-queue-state='aprovado']").count();
+check("the approved recorte holds exactly the two decided messages, with no second APPROVE offered",
+  approvedCards === 2 && await reviewed.locator("[data-gate-key$=':APPROVE']").count() === 0,
+  `${approvedCards} approved cards`);
+
+// ---- 12c. The queue works on a phone
+await reviewed.setViewportSize({ width: 390, height: 844 });
+await reviewed.goto(`${BASE}/#/warmbly/revisao?resource=${ORIGINAL_RESOURCE}`, { waitUntil: "networkidle" });
+await reviewed.waitForTimeout(1400);
+const overflow = await reviewed.evaluate(
+  () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+);
+check("the review queue does not scroll sideways on a 390px viewport", overflow <= 1, `overflow=${overflow}px`);
+const tapTarget = await reviewed.locator("[data-approve-submit]:not([disabled])").first().boundingBox();
+check("the approve control is a real tap target on a phone",
+  !!tapTarget && tapTarget.height >= 40, tapTarget ? `${Math.round(tapTarget.height)}px tall` : "absent");
+check("the recortes stay reachable on a phone",
+  await reviewed.locator("[data-review-filters] a").count() === 4);
+await reviewed.close();
+
+// ---- 13. A second tab sees the same server truth
 const tab2 = await newPage();
 await tab2.goto(before, { waitUntil: "networkidle" });
 await tab2.waitForTimeout(1200);
 check("a second tab renders the same cohort", (await tab2.locator("[data-adjust-editor]").count()) === 5,
   `${await tab2.locator("[data-adjust-editor]").count()} candidates in tab 2`);
 
-// ---- 10. Console / network hygiene
+// ---- 14. Console / network hygiene
 check("no application errors in the browser console", consoleErrors.length === 0, consoleErrors.slice(0, 3).join(" | "));
 check("no failed or 5xx requests", failedRequests.length === 0, failedRequests.slice(0, 3).join(" | "));
 


### PR DESCRIPTION
## O problema, em operação real

Aprovar uma mensagem custava seis interações: clicar em "verificar destinatário
agora", esperar, digitar um motivo, marcar uma caixa declarando a revisão que se
estava prestes a fazer, clicar em APPROVE — e depois rolar a página passando pelo
próprio trabalho já concluído para achar a próxima pendência.

## Revisão arquitetural: o que protegia algo, e o que não protegia

| Etapa | Origem | Veredito |
|---|---|---|
| `validate` manual antes de aprovar | Invariante real do Warmbly (recusa APPROVE fora de validation VALID) | O invariante fica; **o clique humano sai** — obter validation é chamada determinística |
| Checkbox "revisei destinatário" | Invenção do frontend (`approval_acknowledgement_required` no adaptador) | **Sai**. `acknowledged=true` continua no fio e o adaptador continua recusando sem ele; o clique em Aprovar é quem informa |
| Motivo obrigatório no APPROVE | `required` no HTML, nada no contrato | **Sai**. Padrão `approved_by_human_reviewer`; comentário opcional vence |
| Lista sem recorte nem contador | Dívida de UX | **Sai**. Fila com `pendentes` por padrão |

## O que mudou

**Aprovar é uma ação.** Sem motivo digitado, sem caixa, sem verificação prévia.
Quando não há validação vigente, a própria aprovação pede a verificação ao
Warmbly, relê o estado no servidor e só registra o APPROVE se voltar `VALID`.
Se não voltar, **nada é decidido** e a tela diz o estado observado e que o
APPROVE não foi enviado.

**Revisão virou fila.** Abre em Pendentes, diz `N pendentes · N aprovadas · N em
ajuste · N no total`, e os recortes `aprovadas`/`ajuste`/`todas` são links que
carregam a versão selecionada. A aprovação sai da fila na hora e a próxima
assume a posição, com o foco no botão dela.

**Rollback honesto.** A marca otimista cai em qualquer desfecho que não seja
aplicação confirmada — recusa, falha, `unknown`, e releitura que não confirma o
efeito. Nada é durável: um reload lê a fila do servidor. Um candidato já
aprovado não emite controle de APPROVE nenhum.

**Gates materiais preservados — e um deles mais apertado.** APPROVE fica
bloqueado sem destinatário, com destinatário que não é endereço, com veredito já
resolvido como `INVALID`/`RISKY`, e com bloqueio material declarado pelo servidor
(hard bounce, suppression, opt-out, duplicidade, copy QA, proveniência ausente).
Cada um nomeia o próximo movimento. HOLD/REJECT continuam exigindo motivo escrito.

**Teclado.** `A` aprova o card já sob o foco e nunca outro; `Ctrl/Cmd+Enter`
aprova a primeira pendência. Nenhum dispara com o cursor dentro de campo de
texto — o editor de ajuste vive na mesma página.

## Métrica

| | Antes | Agora |
|---|---|---|
| Cliques por aprovação normal | 5 (verificar, motivo, checkbox, approve, + scroll) | **1** |
| Digitação obrigatória | 1 campo livre | **nenhuma** |
| Scroll para achar a próxima | sim, crescente com o cohort | **nenhum** (foco automático) |
| Requisições no caminho feliz | 2 escritas | 1 escrita (2 quando falta validation) |

## Prova

- `apps/web-shell`: **391 testes**, incluindo 50 pendências, duplo clique durante
  a cadeia validation→review, erro de API, desfecho desconhecido, releitura
  divergente, destinatário ausente/inválido, bloqueio material, reversão por HOLD
  e os predicados do atalho.
- Workspace completo: **23 pacotes, 0 falhas**; convergência: 66/66; typecheck limpo.
- **Jornada em navegador real** (Context Service real + conector de gate real,
  stand-in fiel do Warmbly): **43/43**, incluindo aprovação em um clique, a
  auto-verificação, um destinatário que não verifica interrompendo antes do
  APPROVE, um reload que lê as duas aprovações do servidor **sem nenhuma voltar
  como pendente**, e a fila em viewport de 390px.

## Documentação

`docs/WARMBLY-HUMAN-GATE-RUNBOOK.md` (passo a passo novo + tabela "o que mudou e
o que não mudou"), `docs/WARMBLY-HUMAN-GATE-FLOW.md` (invariantes da cadeia) e
`apps/web-shell/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
