### PR TITLE
feat(control-center): entregar a cohort aprovada à fila — o passo que faltava entre GO e o envio

### DIFF
--- a/control-center/apps/web-shell/README.md
+++ b/control-center/apps/web-shell/README.md
@@ -17,7 +17,7 @@ Chrome navigation exposes exactly these ten areas:
 9. Memória/Decisões
 10. Agentes
 
-“Operação Warmbly” is the safe-operation cockpit for the outbound kill switch: dispatch state, pause reason, commercial window, approved queue, hourly cap and the recent audit trail are rendered **before** the three controls (pause in one step, resume in two, acknowledge an inbound alert). There is no send control there and there must never be one.
+“Operação Warmbly” is the safe-operation cockpit for the outbound kill switch: dispatch state, pause reason, commercial window, approved queue, hourly cap and the recent audit trail are rendered **before** the three controls (pause in one step, resume in two, acknowledge an inbound alert). There is no send control there and there must never be one — the cohort dispatch that hands a GO’d cohort to Warmbly’s queue lives in Revisão, behind GO and `admins`, and it enqueues rather than sends.
 
 ### Rotas do gate humano de cohorts
 
@@ -65,6 +65,27 @@ validação não é VALID.
 Teclado: `A` aprova o card que já está sob o foco (nunca outro), `Ctrl/Cmd+Enter`
 aprova a primeira pendência. Nenhum dos dois dispara com o cursor dentro de um
 campo de texto — o editor de ajuste vive na mesma página.
+
+#### Entregar a cohort à fila
+
+GO autoriza e **não** enfileira. O controle “Entregar esta cohort à fila de
+envio” aparece na Revisão **somente depois de um GO registrado pelo servidor**,
+exige o grupo `admins` e a versão digitada, e é o que coloca as mensagens
+aprovadas na fila do Warmbly. Sem GO não existe formulário nenhum — não um
+desabilitado — e a tela diz por quê.
+
+Ele enfileira; quem envia é o worker do Warmbly, dentro da janela comercial e sob
+o teto por hora. Os contadores exibidos depois (tentados, aceitos, falharam,
+duplicados, bloqueados) são os do servidor e são de enfileiramento, não de
+entrega; um contador que o servidor não mandou aparece como ausente, nunca como
+zero. Repetir o disparo é seguro — o Warmbly pula os já enfileirados.
+
+Nenhum portão do disparo mora aqui: o Warmbly recusa sozinho se o GO foi
+revogado ou venceu, se auto-send ou autorun estão ligados, se o disparo está
+pausado ou se o kill switch está acionado, e limita o lote a dez. A rota nova é
+uma só (`POST …/cohorts/{id}/dispatch`, `admins`); `send`, `queue`, `resume` e
+`payment` continuam impossíveis de construir, com teste negativo enumerando cada
+forma.
 
 `#/comercial/cohorts` (“Comercial → Coortes”) é **outra coisa**: são coortes de
 aquisição e métricas por período. Nenhum runbook do gate humano deve apontar para

--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -92,6 +92,24 @@ export interface GateReadback {
   detail: string;
 }
 
+/**
+ * What a bounded dispatch actually did, as Warmbly reported it.
+ *
+ * Every field is optional because an absent counter is not a zero: the operator
+ * must be able to tell "o servidor disse que zero foram bloqueados" from "o
+ * servidor não disse quantos foram bloqueados".
+ */
+export interface GateDispatchCounts {
+  attempted?: number;
+  accepted?: number;
+  failed?: number;
+  skippedDuplicate?: number;
+  blocked?: number;
+  maxDaily?: number;
+  killSwitchAvailable?: boolean;
+  failures?: readonly { mailbox: string; reason: string }[];
+}
+
 export interface AdapterWriteResult {
   ok: boolean;
   path: string;
@@ -154,6 +172,8 @@ export interface AdapterWriteResult {
   receiptId?: string;
   /** Field-level diff the server returned for an accepted adjust. */
   diff?: readonly GateDiffEntry[];
+  /** Counters Warmbly returned for an accepted cohort dispatch. */
+  dispatch?: GateDispatchCounts;
   /** Result of the GET readback performed after a definitive response. */
   readback?: GateReadback;
 }
@@ -212,6 +232,10 @@ export const WARMBLY_GATE_ACTIONS = [
   "review",
   "decide",
   "adjust",
+  // Hands an already-GO'd cohort to Warmbly's queue. It is not a send: Warmbly
+  // enqueues each member and its own worker delivers inside the send window,
+  // under the rolling-hour governor, with the kill switch still in front.
+  "dispatch",
 ] as const;
 export type WarmblyGateAction = (typeof WARMBLY_GATE_ACTIONS)[number];
 

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -156,7 +156,45 @@ function gateFallbackMessage(input: WarmblyGateInput, version: number | undefine
         : "NO-GO registrado.";
     case "adjust":
       return `Ajuste aceito. O servidor criou a nova versão${v}.`;
+    case "dispatch":
+      return "Cohort entregue à fila do Warmbly. O envio acontece na janela comercial, sob o teto por hora.";
   }
+}
+
+/**
+ * The counters Warmbly returns for a bounded dispatch.
+ *
+ * Read out of the response rather than summarised into a sentence: "10
+ * enfileirados" and "3 enfileirados, 7 bloqueados" are different outcomes and
+ * the operator has to see which one happened. Anything the server did not send
+ * stays absent instead of becoming a zero.
+ */
+export function gateDispatchOf(body: Record<string, unknown>): AdapterWriteResult["dispatch"] {
+  const data = asRecord(body.data) ?? body;
+  const num = (key: string): number | undefined => gateNumber(data[key]);
+  const counts = {
+    ...(num("attempted") !== undefined ? { attempted: num("attempted")! } : {}),
+    ...(num("provider_accepted") !== undefined ? { accepted: num("provider_accepted")! } : {}),
+    ...(num("failed") !== undefined ? { failed: num("failed")! } : {}),
+    ...(num("skipped_duplicate") !== undefined ? { skippedDuplicate: num("skipped_duplicate")! } : {}),
+    ...(num("blocked") !== undefined ? { blocked: num("blocked")! } : {}),
+    ...(num("max_daily") !== undefined ? { maxDaily: num("max_daily")! } : {}),
+    ...(typeof data.kill_switch_available === "boolean"
+      ? { killSwitchAvailable: data.kill_switch_available }
+      : {}),
+  };
+  const failures = Array.isArray(data.failures)
+    ? data.failures
+        .map((entry) => asRecord(entry))
+        .filter((entry): entry is Record<string, unknown> => entry !== null)
+        .map((entry) => ({
+          mailbox: typeof entry.mailbox === "string" ? entry.mailbox : "",
+          reason: typeof entry.reason === "string" ? entry.reason : "",
+        }))
+        .filter((entry) => entry.mailbox !== "" || entry.reason !== "")
+    : [];
+  if (Object.keys(counts).length === 0 && failures.length === 0) return undefined;
+  return { ...counts, ...(failures.length > 0 ? { failures } : {}) };
 }
 
 export function gateResult(
@@ -226,6 +264,11 @@ export function gateResult(
     ...(receipt ? { receiptId: receipt } : {}),
     ...(correlation ? { correlationId: correlation } : {}),
     ...(diff ? { diff } : {}),
+    ...(() => {
+      if (input.action !== "dispatch" || !ok) return {};
+      const dispatch = gateDispatchOf(body);
+      return dispatch ? { dispatch } : {};
+    })(),
   };
 }
 
@@ -406,6 +449,7 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       : input.action === "validate" ? `${base}/${version}/candidates/${candidate}/validation`
       : input.action === "review" ? `${base}/${version}/candidates/${candidate}/review`
       : input.action === "adjust" ? `${base}/${version}/candidates/${candidate}/adjust`
+      : input.action === "dispatch" ? `${base}/${version}/dispatch`
       : `${base}/${version}/decision`;
     // Every refusal below happens before the wire, so "nada foi aplicado" is a
     // fact this adapter can prove rather than a hope.
@@ -455,6 +499,16 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     if (input.action === "decide" && !input.confirmation?.trim()) {
       return refuse(
         "GO/NO-GO exige a confirmação digitada da versão imutável",
+        "cohort_version_confirmation_required",
+      );
+    }
+    // Dispatch is the one call in this gate whose effect leaves the building:
+    // Warmbly enqueues real messages to real companies and its worker delivers
+    // them. It therefore carries the same typed confirmation GO does, refused
+    // here before the wire rather than after.
+    if (input.action === "dispatch" && !input.confirmation?.trim()) {
+      return refuse(
+        "Disparar a cohort exige a confirmação digitada da versão imutável",
         "cohort_version_confirmation_required",
       );
     }

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -637,7 +637,12 @@ function bindWarmblyHumanGate(
         // to the trail: actor, instant, version, frozen hash and recipient are
         // all recorded already.
         ...(isApprove ? { acknowledged: true } : {}),
-        ...((raw === "decide" || raw === "adjust") && confirmation ? { confirmation } : {}),
+        // GO, adjust and dispatch each cost a typed version confirmation. The
+        // adapter refuses all three before the wire without it, so a missing
+        // one here would be a refusal the operator never asked for.
+        ...((raw === "decide" || raw === "adjust" || raw === "dispatch") && confirmation
+          ? { confirmation }
+          : {}),
         ...(raw === "adjust"
           ? {
               subject: form.querySelector('[name="subject"]')?.value ?? "",
@@ -1191,6 +1196,23 @@ async function gateReadback(
         : {
             status: "not_confirmed",
             detail: `O servidor ainda registra "${String(recorded ?? "nada")}" como decisão final.`,
+          };
+    }
+    case "dispatch": {
+      // There is nothing on the cohort resource that proves a queue depth, so
+      // this readback deliberately does not claim one. What it can say is that
+      // the version still reads GO — i.e. the authority the dispatch consumed
+      // is the one the operator was looking at. The counters Warmbly returned
+      // are the evidence of what was queued, and they are rendered verbatim.
+      const recorded = gateRecord(cohort.decision).decision;
+      return recorded === "GO"
+        ? {
+            status: "confirmed",
+            detail: "O servidor devolve esta versão ainda com GO registrado; os números enfileirados vêm da resposta do disparo.",
+          }
+        : {
+            status: "not_confirmed",
+            detail: `O servidor registra "${String(recorded ?? "nada")}" como decisão final desta versão, não GO.`,
           };
     }
     case "validate": {

--- a/control-center/apps/web-shell/src/human-gate-idempotency.ts
+++ b/control-center/apps/web-shell/src/human-gate-idempotency.ts
@@ -5,7 +5,7 @@
  */
 
 export interface HumanGateIntent {
-  action: "create" | "reproduce" | "validate" | "review" | "decide" | "adjust";
+  action: "create" | "reproduce" | "validate" | "review" | "decide" | "adjust" | "dispatch";
   version_id?: string;
   candidate_id?: string;
   limit?: number;

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -339,6 +339,53 @@ const OUTCOME_BY_CODE: Record<string, OutcomeRule> = {
     recovery:
       "A verificação foi feita nesta ação e o APPROVE não foi enviado, então nada foi decidido. O Warmbly recusa aprovação fora de uma validação VALID: registre HOLD ou REJECT, ou corrija a origem do contato e recomponha.",
   },
+  /* ---------------------------------------------------------------- *
+   * Entrega da cohort à fila do Warmbly. Os códigos abaixo são os do
+   * próprio Warmbly: cada um é um portão diferente e manda o operador
+   * para um lugar diferente.
+   * ---------------------------------------------------------------- */
+  auto_send_forbidden: {
+    kind: "refused",
+    title: "Recusada: auto-send está ligado no Warmbly",
+    recovery:
+      "O Warmbly recusa entregar uma cohort controlada enquanto auto-send estiver ligado, e nada foi enfileirado. Isto é configuração do Warmbly, não do operador: desligue auto-send lá antes de disparar por aqui.",
+  },
+  green_autorun_forbidden: {
+    kind: "refused",
+    title: "Recusada: green autorun está ligado no Warmbly",
+    recovery:
+      "Nada foi enfileirado. Autorun e cohort controlada são excludentes: desligue o autorun no Warmbly antes de disparar por aqui.",
+  },
+  sending_paused: {
+    kind: "refused",
+    title: "Recusada: o disparo de saída está pausado",
+    recovery:
+      "Nada foi enfileirado. Retome o disparo em Operação segura — a retomada é de dois passos e mostra o resumo de impacto — e dispare a cohort em seguida.",
+  },
+  kill_switch_engaged: {
+    kind: "refused",
+    title: "Recusada: o kill switch de arquivo está acionado",
+    recovery:
+      `Nada foi enfileirado. O kill switch fica fora deste canal por construção: remova-o na VPS (${OUT_OF_BAND_PAUSE_FALLBACK} documenta o caminho) e dispare de novo depois.`,
+  },
+  cohort_grant_revoked: {
+    kind: "refused",
+    title: "Recusada: a autoridade desta cohort foi revogada",
+    recovery:
+      "Um NO_GO revogou a autoridade bounded desta versão e nada foi enfileirado. Registre GO de novo, ou prepare uma versão nova, antes de disparar.",
+  },
+  cohort_grant_expired: {
+    kind: "refused",
+    title: "Recusada: a autoridade desta cohort venceu",
+    recovery:
+      "A autoridade bounded tem prazo e o dela passou; nada foi enfileirado. Registre GO de novo nesta versão para obter uma autoridade vigente.",
+  },
+  cohort_grant_missing: {
+    kind: "refused",
+    title: "Recusada: esta versão não tem autoridade bounded",
+    recovery:
+      "Disparar exige um GO registrado nesta versão exata. Nada foi enfileirado: registre GO e dispare em seguida.",
+  },
   adjust_route_unavailable: {
     kind: "refused",
     title: "Ajuste ainda não disponível nesta instalação",
@@ -475,6 +522,7 @@ const GATE_ACTION_LABELS: Record<string, string> = {
   review: "registrar decisão de revisão",
   decide: "registrar GO/NO-GO",
   adjust: "ajustar assunto e corpo",
+  dispatch: "entregar a cohort à fila de envio",
 };
 
 const READBACK_LABELS: Record<string, string> = {
@@ -554,6 +602,7 @@ export function writeResultBlock(result: AdapterWriteResult | undefined): string
           ? `<dl class="facts" data-server-diff="true">${diffRows}</dl>`
           : ""
       }
+      ${dispatchCounters(result.dispatch)}
       ${technicalDetails(
         [
           { term: "path", value: result.path },
@@ -569,6 +618,45 @@ export function writeResultBlock(result: AdapterWriteResult | undefined): string
         "warmbly-operator-result",
       )}
     </article>`;
+}
+
+/**
+ * What a bounded dispatch actually queued, straight from Warmbly's counters.
+ *
+ * "Executada" is not an answer here: ten attempted with ten accepted and ten
+ * attempted with nine blocked are the same HTTP 200 and completely different
+ * operational facts. A counter the server did not send renders as absent rather
+ * than as zero, and every per-mailbox failure the server named is listed.
+ */
+function dispatchCounters(counts: AdapterWriteResult["dispatch"]): string {
+  if (!counts) return "";
+  const row = (label: string, value: number | undefined): string =>
+    value === undefined ? fact(label, NOT_IN_PAYLOAD) : fact(label, String(value));
+  const failures = (counts.failures ?? [])
+    .map(
+      (entry) =>
+        `<div data-dispatch-failure="${escapeHtml(entry.reason)}"><dt>${escapeHtml(entry.mailbox || "destinatário não nomeado")}</dt><dd>${escapeHtml(entry.reason || "motivo não informado pelo servidor")}</dd></div>`,
+    )
+    .join("");
+  return `
+      <dl class="facts" data-dispatch-counts="true">
+        ${row("Tentados", counts.attempted)}
+        ${row("Aceitos pelo provedor", counts.accepted)}
+        ${row("Falharam", counts.failed)}
+        ${row("Pulados por duplicidade", counts.skippedDuplicate)}
+        ${row("Bloqueados", counts.blocked)}
+        ${row("Teto diário da autoridade", counts.maxDaily)}
+        ${
+          counts.killSwitchAvailable === undefined
+            ? ""
+            : fact(
+                "Kill switch disponível",
+                counts.killSwitchAvailable ? "sim" : "não — pare o outbound fora de banda se precisar",
+              )
+        }
+      </dl>
+      <p class="constraint" data-dispatch-not-sent="true">Estes números são de enfileiramento, não de entrega. O envio acontece depois, pelo worker do Warmbly, dentro da janela comercial.</p>
+      ${failures ? `<dl class="facts" data-dispatch-failures="true">${failures}</dl>` : ""}`;
 }
 
 /** The "enviando…" state. A control with no pending state invites a second click. */
@@ -1973,6 +2061,62 @@ function emptyQueueBlock(
   </article>`;
 }
 
+/**
+ * Entregar a cohort à fila do Warmbly.
+ *
+ * The last control on the page, and the only one on this surface whose effect
+ * leaves the building. Four things make it what it is:
+ *
+ * 1. **It only exists after GO.** The server's own `decision` is what gates it,
+ *    not anything this screen inferred. Without a registered GO there is no
+ *    form at all — not a disabled one — so there is nothing for devtools to
+ *    re-enable, exactly as with a historical version.
+ * 2. **It says what it does and what it does not do.** It hands the authorised
+ *    cohort to Warmbly's queue. It does not send: the worker delivers inside
+ *    the commercial window, under the rolling-hour cap, and the pause switch in
+ *    Operação segura still stops everything.
+ * 3. **It costs a typed confirmation**, like GO. One click that queues real mail
+ *    to real companies is the one place on this surface where a second,
+ *    deliberate act is worth its cost.
+ * 4. **It never claims a number.** How many messages Warmbly accepted comes back
+ *    in the response and is rendered from it; this block only states the ceiling
+ *    the server enforces.
+ */
+function dispatchBlock(args: {
+  cohortId: string;
+  version: string;
+  decisionValue: string;
+  counts: ReturnType<typeof reviewQueueCounts>;
+  authority: OperatorAuthority;
+  actionable: boolean;
+}): string {
+  const { cohortId, version, decisionValue, counts, authority, actionable } = args;
+  if (!actionable) return "";
+  const dispatchKey = `dispatch:${cohortId}::`;
+  const pending = gateInFlight(dispatchKey);
+  if (decisionValue !== "GO") {
+    return `<p class="constraint" data-dispatch-gate="no-go">Entregar esta cohort à fila só é oferecido depois de um GO registrado nesta versão. A decisão final lida agora é ${escapeHtml(decisionValue)}.</p>`;
+  }
+  return `
+  ${pending ? pendingBlock("Entregando a cohort à fila do Warmbly") : ""}
+  <article class="card" data-cohort-dispatch="${escapeHtml(cohortId)}">
+    <p class="kicker"><span class="pill">GO REGISTRADO</span></p>
+    <h3>Entregar esta cohort à fila de envio</h3>
+    <p data-dispatch-meaning="true">Isto entrega ao Warmbly os ${counts.aprovadas} candidato(s) aprovado(s) desta versão. O Warmbly enfileira cada um e o worker dele envia dentro da janela comercial, no máximo 10 por hora e no máximo 10 por disparo. Esta tela não envia e-mail e não tem controle de send.</p>
+    <p class="constraint" data-dispatch-gates="true">O Warmbly recusa o disparo por conta própria se o GO tiver sido revogado ou vencido, se auto-send ou autorun estiverem ligados, se o disparo estiver pausado ou se o kill switch estiver acionado. Nenhum desses portões é contornável a partir daqui.</p>
+    <p class="constraint" data-dispatch-repeat="true">Disparar de novo é seguro: o Warmbly pula os candidatos já enfileirados desta versão e os conta como duplicados na resposta. Repetir não reenvia o que já saiu.</p>
+    <form class="operator-form" data-human-gate="dispatch" data-gate-key="${escapeHtml(dispatchKey)}" data-version="${escapeHtml(cohortId)}">
+      <label>Confirme digitando <code>v${escapeHtml(version)}</code><input name="confirmation" required pattern="v${escapeHtml(version)}"></label>
+      <button type="submit" data-dispatch-submit="true"${authority.canDecide && !pending ? "" : " disabled"}>${pending ? "Enviando…" : `Entregar v${escapeHtml(version)} à fila do Warmbly`}</button>
+      ${
+        authority.canDecide
+          ? ""
+          : `<p class="constraint" data-dispatch-authority="absent">Entregar a cohort à fila exige o grupo <code>admins</code> no Authelia, a mesma autoridade do GO. Revisar continua permitido com <code>operators</code>.</p>`
+      }
+    </form>
+  </article>`;
+}
+
 function reviewSurface(input: WarmblySurfaceInput): string {
   const selected = gateSection(input, "selected");
   const list = gateSection(input, "list");
@@ -2047,6 +2191,14 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   <form class="operator-form" data-human-gate="reproduce" data-gate-key="${escapeHtml(reproduceKey)}" data-version="${escapeHtml(cohortId)}"><button type="submit"${gateInFlight(reproduceKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(reproduceKey) ? "Enviando…" : "Reproduzir versão imutável"}</button></form>
 `
     : "";
+  const dispatchControl = dispatchBlock({
+    cohortId,
+    version,
+    decisionValue,
+    counts,
+    authority,
+    actionable: editorial.actionable,
+  });
   const decideControl = editorial.actionable
     ? `
   ${gateInFlight(decideKey) ? pendingBlock("Registrando GO/NO-GO") : ""}
@@ -2084,7 +2236,8 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   }
   ${decideControl}
   <dl class="facts"><div><dt>Decisão final registrada</dt><dd>${escapeHtml(decisionValue)}</dd></div></dl>
-  <p class="constraint">GO não envia e-mail. O Control Center não expõe dispatch, queue ou send neste gate.</p></section>`;
+  ${dispatchControl}
+  <p class="constraint">GO autoriza e não envia. Entregar a cohort à fila é o passo seguinte e separado; o envio em si é do worker do Warmbly, dentro da janela comercial e sob o teto por hora. Esta tela continua sem qualquer controle de send, queue ou resume.</p></section>`;
 }
 
 function warmblySubnav(current: WarmblySurface, resource: string | null | undefined): string {

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -26,7 +26,7 @@ import {
   decidedReviewState,
   resetReviewQueue,
 } from "../src/review-queue";
-import { warmblyBlock } from "../src/ui/warmbly";
+import { warmblyBlock, writeResultBlock } from "../src/ui/warmbly";
 import { clearPendingResumeConfirmation } from "../src/warmbly-confirmation";
 
 /* ------------------------------------------------------------------ *
@@ -1330,12 +1330,15 @@ test("no gate write ever carries a browser-set actor header", async () => {
   }
 });
 
-test("the gate never exposes a queue, dispatch, send, resume or payment control", () => {
+test("the gate never exposes a queue, send, resume or payment control, with or without GO", () => {
   reset();
+  const withGo = gatePayload(["operators", "admins"], cohort({ decision: { decision: "GO" } }));
   for (const surface of ["cohorts", "revisao"] as const) {
-    const html = warmblyBlock(surfaceInput(), surface);
-    assert.doesNotMatch(html, /data-human-gate="(queue|dispatch|send|resume|payment)"/);
-    assert.doesNotMatch(html, /enviar agora|disparar|SEND_CAMPAIGN|cobran[çc]a|checkout/i);
+    for (const input of [surfaceInput(), surfaceInput({ gate: withGo })]) {
+      const html = warmblyBlock(input, surface);
+      assert.doesNotMatch(html, /data-human-gate="(queue|send|resume|payment)"/);
+      assert.doesNotMatch(html, /enviar agora|SEND_CAMPAIGN|cobran[çc]a|checkout/i);
+    }
   }
 });
 
@@ -2569,4 +2572,320 @@ test("toda tag aberta nesta superfície é fechada antes da próxima começar", 
       );
     }
   }
+});
+
+/* ------------------------------------------------------------------ *
+ * Entregar a cohort à fila.
+ *
+ * The one control on this surface whose effect leaves the building. Every test
+ * here holds a line that, if it moved, would let real mail reach real companies
+ * without the act that authorises it.
+ * ------------------------------------------------------------------ */
+
+/** A version the server itself reports as GO. Nothing here is inferred locally. */
+function goCohort(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return cohort({
+    decision: { decision: "GO" },
+    candidates: [candidate({ review: { decision: "APPROVE", effective: true } })],
+    ...overrides,
+  });
+}
+
+test("sem GO registrado não existe forma nenhuma de disparo, nem desabilitada", () => {
+  reset();
+  for (const decision of [undefined, { decision: "NO_GO" }, {}]) {
+    const html = warmblyBlock(
+      surfaceInput({
+        gate: gatePayload(["operators", "admins"], cohort({ decision })),
+        query: ALL_STATES,
+      }),
+      "revisao",
+    );
+    assert.doesNotMatch(html, /data-human-gate="dispatch"/, "não pode haver formulário de disparo");
+    assert.doesNotMatch(html, /data-dispatch-submit/);
+    assert.match(html, /data-dispatch-gate="no-go"/, "e a tela precisa dizer por que não há");
+  }
+});
+
+test("com GO registrado o disparo aparece uma vez, exige a versão digitada e diz o que faz", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], goCohort()), query: ALL_STATES }),
+    "revisao",
+  );
+  const forms = [...html.matchAll(/data-human-gate="dispatch"/g)];
+  assert.equal(forms.length, 1, "exatamente um controle de disparo");
+  const form = html.match(/data-gate-key="dispatch:[^"]*"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.match(form, /name="confirmation" required pattern="v1"/, "exige a versão digitada, como o GO");
+  assert.match(form, /data-dispatch-submit="true"/);
+  assert.doesNotMatch(form, /disabled/, "com admins o controle fica pressionável");
+  // O que ele faz e o que ele não faz precisam estar escritos antes do botão.
+  assert.match(html, /data-dispatch-meaning="true"/);
+  assert.ok(html.includes("O Warmbly enfileira cada um"), "precisa dizer que enfileira");
+  assert.ok(html.includes("Esta tela não envia e-mail"), "e que esta tela não envia");
+  assert.match(html, /data-dispatch-gates="true"/);
+  assert.ok(html.includes("kill switch"), "os portões do Warmbly precisam estar nomeados");
+});
+
+test("disparar exige admins: operators vê o motivo e o controle desabilitado", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators"], goCohort()), query: ALL_STATES }),
+    "revisao",
+  );
+  const form = html.match(/data-gate-key="dispatch:[^"]*"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.match(form, /<button type="submit" data-dispatch-submit="true" disabled>/);
+  assert.match(html, /data-dispatch-authority="absent"/);
+  assert.ok(html.includes("admins"), "precisa nomear o grupo que falta");
+});
+
+test("uma versão histórica não oferece disparo mesmo com GO registrado", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: gatePayload(
+        ["operators", "admins"],
+        goCohort({ editorial_state: "LEGACY", actionable: false }),
+      ),
+      query: ALL_STATES,
+    }),
+    "revisao",
+  );
+  assert.doesNotMatch(html, /data-human-gate="dispatch"/);
+  assert.doesNotMatch(html, /data-dispatch-gate=/, "nem o aviso: nada é decidível numa versão histórica");
+});
+
+test("o adaptador recusa um disparo sem a confirmação digitada, antes do fio", async () => {
+  reset();
+  const calls: string[] = [];
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://cc.fixture",
+    fetchImpl: (async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch,
+  });
+  const refused = await adapter.warmblyGate({
+    action: "dispatch",
+    version_id: COHORT_ID,
+    idempotency_key: "idem-dispatch-fixture",
+  });
+  assert.equal(refused.code, "cohort_version_confirmation_required");
+  assert.equal(refused.ok, false);
+  assert.equal(calls.length, 0, "nada pode sair do navegador sem a confirmação");
+
+  await adapter.warmblyGate({
+    action: "dispatch",
+    version_id: COHORT_ID,
+    confirmation: " V1 ",
+    idempotency_key: "idem-dispatch-fixture",
+  });
+  assert.deepEqual(calls, [`http://cc.fixture/v1/warmbly/operator/cohorts/${COHORT_ID}/dispatch`]);
+});
+
+test("o disparo viaja para a rota do cohort e nunca para uma rota de candidato", async () => {
+  reset();
+  const seen: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://cc.fixture",
+    fetchImpl: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push({ url: String(input), body: JSON.parse(String(init?.body ?? "{}")) });
+      return new Response(JSON.stringify({ data: { attempted: 4, provider_accepted: 4 } }), { status: 200 });
+    }) as typeof fetch,
+  });
+  await adapter.warmblyGate({
+    action: "dispatch",
+    version_id: COHORT_ID,
+    candidate_id: CANDIDATE_ID,
+    confirmation: "v1",
+    idempotency_key: "idem-dispatch-route",
+  });
+  assert.equal(seen.length, 1);
+  assert.ok(!seen[0]!.url.includes("candidates"), "não existe disparo por candidato");
+  assert.match(seen[0]!.url, /\/cohorts\/[0-9a-f-]{36}\/dispatch$/);
+  assert.equal(seen[0]!.body.confirmation, "v1");
+});
+
+test("os números do disparo são os do servidor, e ausência não vira zero", async () => {
+  reset();
+  const adapter = new HttpControlCenterAdapter({
+    baseUrl: "http://cc.fixture",
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            attempted: 10,
+            provider_accepted: 7,
+            failed: 1,
+            blocked: 2,
+            max_daily: 10,
+            kill_switch_available: true,
+            failures: [{ mailbox: "contato@empresa.invalid", reason: "risky_outside_default_pilot" }],
+          },
+        }),
+        { status: 200 },
+      )) as typeof fetch,
+  });
+  const result = await adapter.warmblyGate({
+    action: "dispatch",
+    version_id: COHORT_ID,
+    confirmation: "v1",
+    idempotency_key: "idem-dispatch-counts",
+  });
+  assert.deepEqual(result.dispatch, {
+    attempted: 10,
+    accepted: 7,
+    failed: 1,
+    blocked: 2,
+    maxDaily: 10,
+    killSwitchAvailable: true,
+    failures: [{ mailbox: "contato@empresa.invalid", reason: "risky_outside_default_pilot" }],
+  });
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(result.dispatch ?? {}, "skippedDuplicate"),
+    "o servidor não mandou skipped_duplicate; não pode virar zero",
+  );
+
+  const html = writeResultBlock({ ...result, gateAction: "dispatch" });
+  assert.match(html, /data-dispatch-counts="true"/);
+  assert.ok(html.includes("<dt>Tentados</dt><dd>10</dd>"));
+  assert.ok(html.includes("<dt>Aceitos pelo provedor</dt><dd>7</dd>"));
+  assert.ok(
+    html.includes("<dt>Pulados por duplicidade</dt><dd>não informado pelo servidor</dd>"),
+    "um contador ausente é dito como ausente",
+  );
+  assert.match(html, /data-dispatch-failure="risky_outside_default_pilot"/);
+  assert.match(html, /data-dispatch-not-sent="true"/);
+  assert.ok(html.includes("não de entrega"), "enfileirar não é entregar");
+});
+
+test("cada recusa do Warmbly no disparo tem a sua própria frase acionável", () => {
+  reset();
+  const expectations: Record<string, RegExp> = {
+    auto_send_forbidden: /auto-send está ligado/i,
+    green_autorun_forbidden: /autorun está ligado/i,
+    sending_paused: /disparo de saída está pausado/i,
+    kill_switch_engaged: /kill switch de arquivo está acionado/i,
+    cohort_grant_revoked: /autoridade desta cohort foi revogada/i,
+    cohort_grant_expired: /autoridade desta cohort venceu/i,
+    cohort_grant_missing: /não tem autoridade bounded/i,
+  };
+  for (const [code, sentence] of Object.entries(expectations)) {
+    const html = writeResultBlock({
+      ok: false,
+      path: "/x",
+      kind: "nota",
+      message: code,
+      outcome: "refused",
+      code,
+      gateAction: "dispatch",
+    });
+    assert.match(html, sentence, `${code} precisa da própria frase`);
+    assert.match(html, /data-outcome-recovery="true"/);
+    assert.ok(
+      /nada foi enfileirado/i.test(html) || /Nada foi enfileirado/.test(html),
+      `${code} precisa dizer que nada foi enfileirado`,
+    );
+  }
+});
+
+test("um clique duplo durante o disparo não vira dois disparos", async () => {
+  reset();
+  let release: (() => void) | undefined;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const { adapter, seen } = gateAdapter({
+    gate: () => gatePayload(["operators", "admins"], goCohort()),
+    respond: async () => {
+      await held;
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: "enfileirado",
+        outcome: "executed",
+        gateAction: "dispatch" as const,
+      };
+    },
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`);
+  const form = dom.find(`[data-gate-key="dispatch:${COHORT_ID}::"]`);
+  form.set("confirmation", "v1");
+  form.fire();
+  await settle();
+  assert.match(dom.root.innerHTML, /data-write-pending="true"/, "a espera precisa estar visível");
+  // Segundo clique com a escrita ainda no ar.
+  dom.root.querySelectorAll(`[data-gate-key="dispatch:${COHORT_ID}::"]`)[0]?.fire();
+  await settle();
+  assert.equal(seen.length, 1, "um disparo é um disparo");
+  assert.equal(seen[0]!.action, "dispatch");
+  assert.equal(seen[0]!.version_id, COHORT_ID);
+  assert.equal(seen[0]!.candidate_id, undefined, "o disparo é da cohort, não de um candidato");
+  assert.equal(seen[0]!.confirmation, "v1");
+  assert.ok(seen[0]!.idempotency_key, "toda escrita do gate viaja com chave");
+  release?.();
+  await settle();
+  assert.doesNotMatch(dom.root.innerHTML, /data-write-pending="true"/);
+});
+
+test("repetir um disparo já concluído é uma intenção nova, e o Warmbly é quem pula os já enviados", async () => {
+  reset();
+  const { adapter, seen } = gateAdapter({
+    gate: () => gatePayload(["operators", "admins"], goCohort()),
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "enfileirado",
+      outcome: "executed",
+      gateAction: "dispatch" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`);
+  for (let i = 0; i < 2; i += 1) {
+    const form = dom.find(`[data-gate-key="dispatch:${COHORT_ID}::"]`);
+    form.set("confirmation", "v1");
+    form.fire();
+    await settle();
+  }
+  assert.equal(seen.length, 2, "um disparo concluído não trava o controle para sempre");
+  assert.notEqual(
+    seen[0]!.idempotency_key,
+    seen[1]!.idempotency_key,
+    "um desfecho definitivo avança a geração: o segundo disparo é uma intenção nova, não um retry",
+  );
+  // E a tela diz que repetir não reenvia o que já saiu.
+  assert.ok(
+    dom.root.innerHTML.includes("já enfileirados"),
+    "a tela precisa dizer o que acontece ao repetir",
+  );
+});
+
+test("o disparo nunca é tratado como aplicado quando a releitura não confirma o GO", async () => {
+  reset();
+  const { adapter } = gateAdapter({
+    // A releitura devolve a versão sem GO: a autoridade que o disparo diz ter
+    // consumido não é a que o servidor mostra agora.
+    gate: () => gatePayload(["operators", "admins"], cohort({ decision: { decision: "NO_GO" } })),
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "enfileirado",
+      outcome: "executed",
+      gateAction: "dispatch" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`);
+  // Pinta uma vez com GO para o controle existir, depois a releitura discorda.
+  const html = warmblyBlock(
+    surfaceInput({ gate: gatePayload(["operators", "admins"], goCohort()), query: ALL_STATES }),
+    "revisao",
+  );
+  assert.match(html, /data-human-gate="dispatch"/);
+  assert.doesNotMatch(dom.root.innerHTML, /data-human-gate="dispatch"/, "sem GO na leitura, sem controle");
 });

--- a/control-center/apps/web-shell/tests/warmbly-human-gate.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-human-gate.test.ts
@@ -18,7 +18,7 @@ test("cohort table renders true denominators from Warmbly",()=>{
 });
 
 test("progressive review renders exact preview, validation and proportional confirmations",()=>{
-  const html=warmblyBlock({...input,query:"estado=todas"},"revisao");assert.match(html,/data-validation-status="VALID"/);assert.match(html,/Exact fixture subject/);assert.match(html,/Exact frozen fixture body/);assert.doesNotMatch(html,/data-human-gate="validate"/);assert.match(html,/APPROVE/);assert.match(html,/REJECT/);assert.match(html,/HOLD/);assert.match(html,/pattern="v3"/);assert.match(html,/GO não envia e-mail/);
+  const html=warmblyBlock({...input,query:"estado=todas"},"revisao");assert.match(html,/data-validation-status="VALID"/);assert.match(html,/Exact fixture subject/);assert.match(html,/Exact frozen fixture body/);assert.doesNotMatch(html,/data-human-gate="validate"/);assert.match(html,/APPROVE/);assert.match(html,/REJECT/);assert.match(html,/HOLD/);assert.match(html,/pattern="v3"/);assert.match(html,/GO autoriza e não envia/);
 });
 
 test("review renders every Warmbly validation state without inferring validity",()=>{

--- a/control-center/connectors/warmbly/src/human-gate/contract.ts
+++ b/control-center/connectors/warmbly/src/human-gate/contract.ts
@@ -23,8 +23,18 @@ export const WARMBLY_COHORTS_PREFIX = "/v1/confenge/cohorts";
 
 /**
  * Every operation the human gate can name. There is deliberately no generic
- * proxy entry and no `send`, `dispatch`, `queue`, `resume` or `payment` member:
- * the type itself is part of the security boundary.
+ * proxy entry and no `send`, `queue`, `resume` or `payment` member: the type
+ * itself is part of the security boundary.
+ *
+ * `dispatch` is the one deliberate widening, and it is narrow on purpose. It
+ * names exactly one upstream route — `POST {prefix}/{cohortId}/dispatch` — which
+ * is the call that hands an already-GO'd cohort to Warmbly's own queue. It does
+ * not send: Warmbly enqueues each member and its worker delivers inside the
+ * send window under the rolling-hour governor. Every gate that matters stays
+ * upstream and none of them is expressible from here: Warmbly re-checks the
+ * durable human-gate GO, the grant's revocation and expiry, `auto_send` and
+ * `green_autorun` being off, the pause state and the file kill switch, and caps
+ * the batch at ten regardless of what this connector asks for.
  */
 export const HUMAN_GATE_OPERATIONS = [
   "list_cohorts",
@@ -36,6 +46,7 @@ export const HUMAN_GATE_OPERATIONS = [
   "review",
   "adjust",
   "decision",
+  "dispatch",
 ] as const;
 export type HumanGateOperation = (typeof HUMAN_GATE_OPERATIONS)[number];
 
@@ -47,16 +58,22 @@ export const HUMAN_GATE_WRITE_OPERATIONS = [
   "review",
   "adjust",
   "decision",
+  "dispatch",
 ] as const;
 
 /**
  * Route classes this connector must never be able to construct, at any prefix.
  * Kept as data so `tests/human-gate-negative-allowlist.test.ts` can enumerate
  * them instead of a reviewer having to remember the list.
+ *
+ * `dispatch` left this list when the cockpit gained the control that hands a
+ * GO'd cohort to Warmbly's queue. Nothing else did, and the removal buys exactly
+ * one fixed route: the negative tests still prove that `dispatch` is
+ * unreachable at every other shape — under `/candidates/`, at the bare prefix,
+ * through traversal, and on every method except POST.
  */
 export const FORBIDDEN_HUMAN_GATE_SEGMENTS = [
   "send",
-  "dispatch",
   "queue",
   "resume",
   "auto-send",

--- a/control-center/connectors/warmbly/src/human-gate/http.ts
+++ b/control-center/connectors/warmbly/src/human-gate/http.ts
@@ -48,6 +48,12 @@ const routes: readonly HumanGateRoute[] = [
   // it is not a GO, so it is deliberately NOT behind the admins gate.
   { method: "POST", operation: "adjust", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/candidates/(${UUID})/adjust$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/candidates/${m[2]}/adjust`, role: "operators", validate: validateAdjustRequest },
   { method: "POST", operation: "decision", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/decision$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/decision`, role: "admins" },
+  // Hands a cohort that already carries a durable GO to Warmbly's own queue.
+  // `admins`, like the GO it depends on: authorising the send and performing it
+  // are the same authority, and neither is `operators`. There is no candidate
+  // form of this route — a dispatch is of the whole authorised cohort or of
+  // nothing — and Warmbly caps the batch at ten whatever arrives here.
+  { method: "POST", operation: "dispatch", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/dispatch$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/dispatch`, role: "admins" },
 ];
 
 /** Exposed for tests and for the cockpit: the complete reachable surface. */

--- a/control-center/connectors/warmbly/tests/human-gate-adjust-contract.test.ts
+++ b/control-center/connectors/warmbly/tests/human-gate-adjust-contract.test.ts
@@ -60,9 +60,15 @@ test("adjust is one POST route under the operators role and nothing else", () =>
   assert.deepEqual(
     HUMAN_GATE_ROUTES.filter((r) => r.method === "POST").map((r) => r.operation).sort(),
     [...HUMAN_GATE_WRITE_OPERATIONS].sort(),
-    "the write surface is exactly the six declared operations",
+    "the write surface is exactly the seven declared operations",
   );
-  assert.equal(HUMAN_GATE_OPERATIONS.length, 9, "three reads plus six writes; nothing else exists");
+  assert.equal(HUMAN_GATE_OPERATIONS.length, 10, "three reads plus seven writes; nothing else exists");
+  // Dispatch hands a GO'd cohort to Warmbly's queue, so it carries the same
+  // authority as the GO it depends on and never the reviewer's.
+  const dispatch = HUMAN_GATE_ROUTES.filter((route) => route.operation === "dispatch");
+  assert.equal(dispatch.length, 1, "dispatch must have exactly one route");
+  assert.equal(dispatch[0]?.method, "POST");
+  assert.equal(dispatch[0]?.role, "admins", "dispatch is admins-only, like GO");
 });
 
 test("the adjust request shape is exactly the five contract fields", () => {

--- a/control-center/connectors/warmbly/tests/human-gate-negative-allowlist.test.ts
+++ b/control-center/connectors/warmbly/tests/human-gate-negative-allowlist.test.ts
@@ -125,11 +125,105 @@ describe("the human gate cannot construct an outbound-send route", () => {
         `${forbidden} must never become an operation`,
       );
     }
-    // Exactly the five pre-existing writes plus adjust, plus three reads.
+    // Exactly the six writes plus dispatch, plus three reads.
     assert.deepEqual([...declared].sort(), [
-      "adjust", "create", "decision", "list_cohorts", "read_candidate",
+      "adjust", "create", "decision", "dispatch", "list_cohorts", "read_candidate",
       "read_cohort", "reproduce", "review", "validation",
     ]);
+  });
+});
+
+/**
+ * `dispatch` is the only segment ever taken off the forbidden list, so it gets
+ * the same adversarial treatment the list itself provides: reachable at exactly
+ * one shape, by exactly one method, for exactly one role, and nowhere else.
+ */
+describe("dispatch is reachable at exactly one shape and nowhere else", () => {
+  const only = `${HUMAN_GATE_PREFIX}/${COHORT}/dispatch`;
+
+  it("forwards the cohort dispatch and nothing else about it", async () => {
+    const { attempts, handler } = trap();
+    const res = await handler(request("POST", only, "admins,operators", WRITE_BODY));
+    assert.equal(res.status, 200);
+    assert.deepEqual(attempts, [`https://warmbly.invalid/v1/confenge/cohorts/${COHORT}/dispatch`]);
+  });
+
+  it("has no candidate-level dispatch, and no dispatch at the bare prefix", async () => {
+    const { attempts, handler } = trap();
+    for (const path of [
+      `${HUMAN_GATE_PREFIX}/dispatch`,
+      `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/dispatch`,
+      `${HUMAN_GATE_PREFIX}/${COHORT}/dispatch/${CANDIDATE}`,
+      `${HUMAN_GATE_PREFIX}/${COHORT}/dispatch/all`,
+      `/v1/warmbly/operator/dispatch`,
+      `/v1/confenge/dispatch`,
+    ]) {
+      const res = await handler(request("POST", path, "admins,operators", WRITE_BODY));
+      assert.equal(res.status, 404, `${path} must be outside the allowlist`);
+      assert.equal(res.body.code, "human_gate_route_not_allowed");
+    }
+    assert.deepEqual(attempts, [], "no dispatch shape but the one may reach Warmbly");
+  });
+
+  it("refuses every method on dispatch except POST", async () => {
+    const { attempts, handler } = trap();
+    for (const method of ["GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]) {
+      const res = await handler(request(method, only, "admins,operators", WRITE_BODY));
+      assert.equal(res.status, 404, method);
+    }
+    assert.deepEqual(attempts, []);
+  });
+
+  it("requires admins: operators alone cannot dispatch, and the refusal never reaches Warmbly", async () => {
+    const { attempts, handler } = trap();
+    const res = await handler(request("POST", only, "operators", WRITE_BODY));
+    assert.equal(res.status, 403);
+    assert.equal(res.body.code, "insufficient_human_gate_role");
+    assert.deepEqual(attempts, []);
+  });
+
+  it("refuses a dispatch whose cohort id is not a canonical UUID or tries to traverse", async () => {
+    const { attempts, handler } = trap();
+    for (const id of [
+      "..",
+      "../send",
+      `${COHORT}%2F..%2Fsend`,
+      "%2e%2e%2fqueue",
+      "https://evil.invalid",
+      "-".repeat(36),
+      "all",
+    ]) {
+      const res = await handler(
+        request("POST", `${HUMAN_GATE_PREFIX}/${id}/dispatch`, "admins,operators", WRITE_BODY),
+      );
+      assert.equal(res.status, 404, id);
+    }
+    assert.deepEqual(attempts, []);
+  });
+
+  it("still cannot reach send or queue, which is what dispatch is not", async () => {
+    const { attempts, handler } = trap();
+    for (const path of [
+      `${HUMAN_GATE_PREFIX}/${COHORT}/send`,
+      `${HUMAN_GATE_PREFIX}/${COHORT}/queue`,
+      `${HUMAN_GATE_PREFIX}/${COHORT}/dispatch/send`,
+      `${HUMAN_GATE_PREFIX}/${COHORT}/dispatch/queue`,
+    ]) {
+      const res = await handler(request("POST", path, "admins,operators", WRITE_BODY));
+      assert.equal(res.status, 404, path);
+    }
+    assert.deepEqual(attempts, []);
+  });
+
+  it("drops a query string that tries to raise the batch beyond the upstream cap", async () => {
+    const { attempts, handler } = trap();
+    const res = await handler(
+      request("POST", `${only}?limit=5000`, "admins,operators", WRITE_BODY),
+    );
+    assert.equal(res.status, 200);
+    // Writes never carry `url.search` upstream, so the batch size is whatever
+    // Warmbly decides — and Warmbly caps it at ten.
+    assert.deepEqual(attempts, [`https://warmbly.invalid/v1/confenge/cohorts/${COHORT}/dispatch`]);
   });
 });
 

--- a/control-center/docs/WARMBLY-HUMAN-GATE-FLOW.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-FLOW.md
@@ -14,8 +14,9 @@ cohort/version imutável
   -- escrita idempotente, disparada pela própria aprovação --> validation
   -- escrita humana, uma ação --> APPROVE | REJECT | HOLD por candidate
   -- escrita humana de maior privilégio --> GO | NO_GO da versão
+  -- escrita humana de maior privilégio, separada do GO --> dispatch da cohort
   -- somente se GO e todos os gates ao vivo continuarem válidos --> queue
-  -- fora do Control Center e desabilitado por padrão --> send
+  -- worker do Warmbly, na janela comercial e sob o teto por hora --> send
 ```
 
 | Etapa | Autoridade | Leitura no Control Center | Escrita permitida | Pode enviar? |
@@ -26,8 +27,8 @@ cohort/version imutável
 | Validation | verificador do Warmbly | VALID/RISKY/INVALID/UNKNOWN/STALE, motivo e validade | solicitar/repetir validação — a aprovação a solicita sozinha quando não há uma vigente | não |
 | Review decision | Warmbly | decisão atual, vínculo e invalidações | APPROVE/REJECT/HOLD com ator Authelia e motivo | não |
 | Cohort decision | Warmbly | prontidão e todos os bloqueios | GO/NO_GO sobre uma versão exata | não |
-| Queue | Warmbly | estado de autorização/preflight/queue | GO materializa somente a autorização exata; Warmbly ainda revalida todos os gates antes da queue | não |
-| Send | runtime Warmbly | métricas/read model | não existe ação de envio no Control Center | sim, mas `auto_send=false` e fora deste gate |
+| Queue | Warmbly | estado de autorização/preflight/queue | entregar a cohort com GO à fila, `admins` e confirmação digitada; Warmbly revalida todos os gates e limita o lote a 10 | não |
+| Send | runtime Warmbly | métricas/read model | não existe ação de envio no Control Center | sim, pelo worker, com `auto_send=false` e fora deste gate |
 
 ## Invariantes de segurança
 
@@ -60,7 +61,24 @@ cohort/version imutável
   Cohort vazia ou candidato sem APPROVE efetivo e VALID vigente falha fechado.
 - Retomar dispatch não cria approval e não ignora suppression, opt-out, bounce,
   cap, janela, kill switch, validation ou TTL. O scheduler não adota cohort
-  controlada automaticamente.
+  controlada automaticamente: **não existe disparo agendado**. Uma cohort só
+  entra na fila quando um humano com `admins` pede, e nunca como efeito de
+  aprovar ou de registrar GO.
+- `dispatch` **enfileira, não envia**. Ele entrega ao Warmbly a cohort que já
+  tem GO durável; o worker do Warmbly é quem entrega, dentro da janela comercial
+  e sob o governador de taxa por hora. Os números que o Control Center mostra
+  depois de um disparo são de enfileiramento.
+- O Control Center não pode contornar nenhum portão do disparo, porque não os
+  implementa: o próprio Warmbly recusa se o GO durável não existir, se a
+  autoridade bounded tiver sido revogada ou vencida, se `auto_send` ou
+  `green_autorun` estiverem ligados, se o disparo estiver pausado, se o kill
+  switch de arquivo estiver acionado, e limita o lote a dez independentemente do
+  que a borda pedir. A borda também descarta a query string em escritas, então
+  nem o tamanho do lote é influenciável daqui.
+- A rota de disparo é uma só — `POST {prefix}/{cohortId}/dispatch` — exigindo
+  `admins`. Não existe disparo por candidato, e `send`, `queue`, `resume` e
+  `payment` continuam impossíveis de construir neste conector, com teste
+  negativo enumerando cada um.
 - A identidade humana nasce somente dos headers ForwardAuth entregues por hop
   confiável. O navegador não declara ator. Auditoria registra ids opacos,
   hashes, estados e reason codes; recipient, subject e body não entram em logs.

--- a/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
@@ -35,12 +35,27 @@
    escrito**, que continua obrigatório. Se recipient, copy, policy, evidence ou
    suppression mudar depois, a aprovação aparece inválida (`effective=false`),
    volta para Pendentes e deve ser refeita.
-6. GO exige todos aprovados, source fresh e a confirmação digitada da versão.
+6. GO exige todos decididos, source fresh e a confirmação digitada da versão.
    O Warmbly compara o valor (por exemplo `v3`) à versão imutável; o proxy não
    consegue remover ou fabricar essa confirmação.
    Use NO_GO para interromper/revogar. GO cria a autoridade bounded exata em
    `READY_FOR_LIVE_PREFLIGHT`; não enfileira, não envia e não liga auto-send.
-7. Em timeout, não repita às cegas. Recarregue a mesma versão e compare receipt
+7. **Entregar a cohort à fila.** GO autoriza e não enfileira: o controle
+   "Entregar esta cohort à fila de envio" aparece na Revisão **somente depois de
+   um GO registrado**, exige `admins` e a versão digitada, e é o passo que
+   coloca as mensagens aprovadas na fila do Warmbly. O envio em si é do worker
+   do Warmbly, dentro da janela comercial (`09:00–18:00 America/Sao_Paulo`, dias
+   úteis) e sob o teto de 10/hora; no máximo 10 por disparo.
+   - A tela mostra os números que o Warmbly devolveu — tentados, aceitos,
+     falharam, duplicados, bloqueados. São números de **enfileiramento**, não de
+     entrega.
+   - Repetir o disparo é seguro: o Warmbly pula os já enfileirados e os conta
+     como duplicados.
+   - O Warmbly recusa por conta própria, e a tela nomeia cada caso: GO revogado
+     ou vencido, auto-send ou autorun ligados, disparo pausado, kill switch
+     acionado. Nenhum desses portões é contornável pelo Control Center.
+   - Não existe disparo agendado e nenhuma aprovação enfileira nada sozinha.
+8. Em timeout, não repita às cegas. Recarregue a mesma versão e compare receipt
    e correlation id. O frontend preserva a idempotency key da intenção incerta;
    só depois repita a mesma intenção.
 
@@ -55,12 +70,21 @@ custo humano; nenhuma salvaguarda material foi removida.
 | Digitar um motivo para APPROVE | `approved_by_human_reviewer` automático, comentário opcional | O motivo digitado era sempre a mesma palavra; a trilha já tinha ator, instante, versão e hash |
 | Marcar "revisei destinatário" | O clique em Aprovar é a ciência | Um segundo clique declarando o primeiro não acrescenta nada à auditoria |
 | Lista com aprovadas no topo | Recorte **Pendentes** por padrão, com contador | Rolar a própria produção para achar o próximo trabalho não escala |
+| Disparo só por API/CLI do Warmbly | Controle "Entregar à fila" na Revisão, após GO, `admins` + versão digitada | GO autorizava e nada acontecia depois; a cohort aprovada nunca chegava à fila |
 
 O que **não** mudou: `acknowledged=true` continua viajando no corpo do APPROVE e
 o adaptador recusa antes do fio um APPROVE sem ele; o Warmbly continua recusando
 APPROVE fora de uma validação VALID vigente; GO continua exigindo `admins` e a
 confirmação digitada da versão; HOLD/REJECT continuam exigindo motivo escrito; e
-o Control Center continua sem qualquer rota de send, dispatch ou queue.
+o Control Center continua sem qualquer rota de **send**, **queue** ou **resume**
+de cohort — a única rota nova é `POST {prefix}/{cohortId}/dispatch`, que
+enfileira e não envia.
+
+**Auto-send continua proibido por construção.** `CONFENGE_AUTO_SEND_ENABLED=true`
+derruba o boot do Warmbly (invariante testada, não é flag para ligar), e o
+próprio endpoint de disparo recusa quando auto-send ou green autorun estão
+ligados. Não existe, e não deve passar a existir, disparo agendado: a cohort
+entra na fila porque um humano com `admins` pediu.
 
 ## Métricas e alertas
 
@@ -79,7 +103,9 @@ denominadores, ou qualquer indício de auto-send/green autorun habilitado.
 
 - Produção: somente GET de lista/detalhe com conta autorizada; não execute POST.
 - Escritas: sandbox/fixtures, mailbox `.invalid`/Mailpit e kill switch ativo.
-- Nunca use o endpoint de dispatch para validar esta entrega e nunca envie mail.
+- Nunca use o endpoint de dispatch para validar uma entrega e nunca envie mail
+  como parte de um smoke: o disparo é uma decisão comercial do fundador, não um
+  passo de verificação. Exercite-o em sandbox/Mailpit.
 - Rollback app: reverta primeiro Governance, depois Warmbly; versões persistidas
   continuam inertes e legíveis.
 - Rollback schema: somente após rollback dos dois apps, execute a migration

--- a/control-center/services/context/test/warmbly-human-gate-adjust-mount.test.ts
+++ b/control-center/services/context/test/warmbly-human-gate-adjust-mount.test.ts
@@ -346,7 +346,7 @@ test("adjust accepts no client-settable actor and no identity from an untrusted 
   }
 });
 
-test("the mount adds no send, dispatch or queue cohort route alongside adjust", async () => {
+test("the mount adds no send or queue cohort route, and dispatch only as one admins-only route", async () => {
   const upstream = await stubWarmbly();
   const { dir, path } = credentialFile();
   try {
@@ -360,9 +360,9 @@ test("the mount adds no send, dispatch or queue cohort route alongside adjust", 
       async (base) => {
         const hostile = [
           `/v1/warmbly/operator/cohorts/${COHORT}/send`,
-          `/v1/warmbly/operator/cohorts/${COHORT}/dispatch`,
           `/v1/warmbly/operator/cohorts/${COHORT}/queue`,
           `/v1/warmbly/operator/cohorts/${COHORT}/candidates/${CANDIDATE}/send`,
+          `/v1/warmbly/operator/cohorts/${COHORT}/candidates/${CANDIDATE}/dispatch`,
           `/v1/warmbly/operator/cohorts/${COHORT}/candidates/${CANDIDATE}/adjust/send`,
         ];
         for (const route of hostile) {
@@ -374,6 +374,18 @@ test("the mount adds no send, dispatch or queue cohort route alongside adjust", 
           assert.ok(res.status === 404, `${route} answered ${res.status}`);
           await res.text();
         }
+
+        // Cohort dispatch exists, and only at the cohort level, and only for
+        // admins. `operators` — the group these headers carry — is refused
+        // before anything reaches Warmbly.
+        const asOperators = await fetch(`${base}/v1/warmbly/operator/cohorts/${COHORT}/dispatch`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...AUTHELIA },
+          body: adjustBody(),
+        });
+        assert.equal(asOperators.status, 403, "dispatch is admins-only at the mount");
+        const refusal = (await asOperators.json()) as Record<string, unknown>;
+        assert.equal(refusal.code, "insufficient_human_gate_role");
 
         // `fetch` collapses `..` before the request line is written, so a raw
         // socket is the only way to make the server itself see the traversal.

--- a/control-center/tests/journey/fake-warmbly.mjs
+++ b/control-center/tests/journey/fake-warmbly.mjs
@@ -146,8 +146,64 @@ createServer((req, res) => {
       if (body.decision === "APPROVE" && c.validation?.status !== "VALID") {
         return send(res, 422, { code: "validation_not_valid", message: "APPROVE requires a current VALID validation" });
       }
-      c.review = { id: randomUUID(), decision: body.decision, reason: body.reason ?? "", effective: true, invalidated_by: [], actor_id: "00000000-0000-4000-8000-00000000000a", created_at: new Date(0).toISOString(), correlation_id: "corr-review", receipt: `receipt-review-${body.decision}` };
+      c.review = { id: randomUUID(), decision: body.decision, reason: body.reason ?? "", effective: body.decision === "APPROVE", invalidated_by: [], actor_id: "00000000-0000-4000-8000-00000000000a", created_at: new Date(0).toISOString(), correlation_id: "corr-review", receipt: `receipt-review-${body.decision}` };
       return send(res, 200, { data: v, receipt: c.review.receipt, correlation_id: "corr-review" });
+    }
+
+    // GO/NO-GO, so the journey can reach the state where a dispatch is offered.
+    const dec = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)\/decision$/);
+    if (req.method === "POST" && dec) {
+      const v = versions.get(dec[1]);
+      if (!v) return send(res, 404, { code: "not_found" });
+      if (body.confirmation !== `v${v.version}`) return send(res, 409, { code: "confirmation_mismatch", message: "confirmation must name the current version" });
+      // GO fails closed on anything still undecided, and on a cohort with
+      // nothing approved: an authority over zero sendable messages is not an
+      // authority. A candidate the founder held or rejected is decided.
+      const undecided = v.candidates.filter((c) => !c.review?.decision);
+      const approved = v.candidates.filter((c) => c.review?.decision === "APPROVE" && c.review?.effective === true);
+      if (body.decision === "GO" && undecided.length > 0) {
+        return send(res, 409, { code: "approval_missing_or_invalid", message: `${undecided.length} candidate(s) still undecided` });
+      }
+      if (body.decision === "GO" && approved.length === 0) {
+        return send(res, 409, { code: "approval_missing_or_invalid", message: "no effective APPROVE in this version" });
+      }
+      v.decision = { decision: body.decision, reason: body.reason ?? "", actor_id: "00000000-0000-4000-8000-00000000000a", receipt: `receipt-decision-${body.decision}` };
+      return send(res, 200, { data: v, receipt: v.decision.receipt, correlation_id: "corr-decision" });
+    }
+
+    // Bounded dispatch: hands the GO'd cohort to the queue. It never sends —
+    // exactly like the real one, which enqueues and lets the worker deliver.
+    const dis = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)\/dispatch$/);
+    if (req.method === "POST" && dis) {
+      const v = versions.get(dis[1]);
+      if (!v) return send(res, 404, { code: "not_found" });
+      if (v.decision?.decision !== "GO") return send(res, 409, { code: "cohort_grant_missing", message: "no bounded authority for this version" });
+      const eligible = v.candidates.filter((c) => c.review?.decision === "APPROVE" && c.review?.effective === true);
+      let attempted = 0;
+      let skipped = 0;
+      for (const c of eligible) {
+        if (c.queued_at) { skipped += 1; continue; }
+        c.queued_at = "2026-08-23T18:30:00Z";
+        attempted += 1;
+      }
+      return send(res, 200, {
+        data: {
+          authorization_id: "00000000-0000-4000-8000-0000000000a1",
+          cohort_id: v.cohort_id,
+          attempted,
+          provider_accepted: attempted,
+          failed: 0,
+          skipped_duplicate: skipped,
+          blocked: 0,
+          real_email_sent: false,
+          auto_send_enabled: false,
+          green_autorun_enabled: false,
+          kill_switch_available: true,
+          max_daily: 10,
+        },
+        receipt: "receipt-dispatch-1",
+        correlation_id: "corr-dispatch",
+      });
     }
 
     const adj = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)\/candidates\/([0-9a-f-]+)\/adjust$/);

--- a/control-center/tests/journey/journey.mjs
+++ b/control-center/tests/journey/journey.mjs
@@ -44,6 +44,8 @@ async function loadChromium() {
 const chromium = await loadChromium();
 
 const BASE = process.argv[2];
+// Same stack, forward-auth identity carrying `admins`. GO and dispatch live there.
+const ADMIN_BASE = process.argv[3] ?? BASE;
 const exe = process.env.CC_CHROMIUM ?? (process.env.HOME + "/.cache/ms-playwright/chromium-1237/chrome-linux64/chrome");
 
 const results = [];
@@ -275,6 +277,110 @@ await page.reload({ waitUntil: "networkidle" });
 await page.waitForTimeout(1000);
 check("a reload keeps the same resource", page.url() === before, page.url().split("#")[1] || "");
 
+// ---- 11b. On the new version: decide everything, GO, then hand it to the queue
+//
+// This is where the founder actually ends. v2 was frozen with every validation
+// reset, so approving here also exercises the auto-verification path, and the
+// one recipient that never verifies has to be held by hand before GO is
+// possible at all. GO and dispatch are admins-only, so this runs against the
+// forward-auth identity that carries that group — and the operators-only page
+// is checked first, to prove the refusal is real and not merely cosmetic.
+if (adjusted) {
+  const v2 = (page.url().split("resource=")[1] || "").slice(0, 36);
+
+  // The operators-only identity must not be able to decide or dispatch.
+  check("an operators-only session cannot register GO", 
+    await page.locator("form[data-human-gate='decide'] button[disabled]").count() > 0);
+  check("and is told which group it is missing",
+    await page.locator("[data-go-authority='absent']").count() > 0);
+
+  const admin = await newPage();
+  await admin.goto(`${ADMIN_BASE}/#/warmbly/revisao?resource=${v2}&estado=todas`, { waitUntil: "networkidle" });
+  await admin.waitForTimeout(1400);
+  const title = await admin.locator("#review-title").innerText().catch(() => "");
+  check("the admins session opens the same version", /v2/i.test(title), title);
+
+  // Approve everything except the mailbox the stand-in refuses to verify.
+  // Always taking `.first()` would spend every round re-clicking that one: its
+  // approval correctly stops before APPROVE, so it never leaves the queue.
+  for (let round = 0; round < 6; round += 1) {
+    const btn = admin
+      .locator("[data-candidate-id]")
+      .filter({ hasNotText: "empresa-quatro" })
+      .locator("[data-approve-submit]:not([disabled])")
+      .first();
+    if (await btn.count() === 0) break;
+    await btn.click();
+    await admin.waitForTimeout(2200);
+  }
+  const stillPending = await admin.locator("[data-queue-pending]").first().getAttribute("data-queue-pending");
+  check("approving drains v2 down to the recipient that cannot be verified", stillPending === "1",
+    `${stillPending} pending`);
+
+  // The stubborn one is held by hand, with a written motive.
+  // Scoped to the card that is actually stuck. `.first()` on the whole page
+  // would land on an already-approved candidate and flip it out of Aprovadas —
+  // which is exactly what it did the first time this journey ran.
+  const hold = admin
+    .locator("[data-candidate-id]")
+    .filter({ hasText: "empresa-quatro" })
+    .locator("form[data-human-gate='review'][data-gate-key$=':HOLD_REJECT']")
+    .first();
+  if (await hold.count() > 0) {
+    await hold.locator("[name='reason']").first().fill("verificacao do destinatario nao conclui nesta caixa");
+    await hold.locator("button[type=submit]").first().click();
+    await admin.waitForTimeout(2000);
+  }
+  const progress2 = await admin.locator("[data-queue-progress-text]").first().innerText().catch(() => "");
+  check("nothing is left pending on v2", /0 pendente/.test(progress2), progress2.replace(/\s+/g, " "));
+
+  // Dispatch must not be on the page before GO.
+  check("no dispatch control exists before GO", await admin.locator("form[data-human-gate='dispatch']").count() === 0);
+  check("and the page says why", await admin.locator("[data-dispatch-gate='no-go']").count() > 0);
+
+  // GO.
+  const go = admin.locator("form[data-human-gate='decide']").first();
+  await go.locator("select[name='decision']").selectOption("GO");
+  await go.locator("[name='reason']").first().fill("cohort revisada e aprovada pelo fundador");
+  await go.locator("[name='confirmation']").first().fill("v2");
+  await go.locator("button[type=submit]").first().click();
+  await admin.waitForTimeout(2200);
+  const goOutcome = await admin.locator("[data-write-result]").first().innerText().catch(() => "");
+  check("GO is registered on the version", /EXECUTADA/.test(goOutcome), goOutcome.replace(/\s+/g, " ").slice(0, 70));
+
+  // Only now does the dispatch control exist.
+  const dispatchForm = admin.locator("form[data-human-gate='dispatch']");
+  const hasDispatch = await dispatchForm.count() === 1;
+  check("the dispatch control appears only after GO", hasDispatch);
+  if (!hasDispatch) { await admin.close(); throw new Error("dispatch control absent after GO"); }
+  check("it states that it queues and does not send",
+    (await admin.locator("[data-dispatch-meaning]").first().innerText().catch(() => "")).includes("não envia e-mail"));
+  check("it names the gates Warmbly still enforces",
+    (await admin.locator("[data-dispatch-gates]").first().innerText().catch(() => "")).includes("kill switch"));
+
+  // The cohort reaches the queue only with the typed version.
+  await dispatchForm.locator("[name='confirmation']").first().fill("v2");
+  await dispatchForm.locator("button[type=submit]").first().click();
+  await admin.waitForTimeout(2600);
+  const counts = await admin.locator("[data-dispatch-counts]").first().innerText().catch(() => "");
+  check("the cohort reached the queue and the numbers come from the server",
+    /Tentados/.test(counts) && /Aceitos pelo provedor/.test(counts), counts.replace(/\s+/g, " ").slice(0, 90));
+  check("the outcome says queued, not delivered",
+    (await admin.locator("[data-dispatch-not-sent]").first().innerText().catch(() => "")).includes("não de entrega"));
+  check("the dispatch carried a receipt",
+    /receipt|recibo/i.test(await admin.locator("[data-write-evidence]").first().innerText().catch(() => "")));
+
+  // Repeating is safe, and the server is what says so.
+  await admin.locator("form[data-human-gate='dispatch'] [name='confirmation']").first().fill("v2");
+  await admin.locator("form[data-human-gate='dispatch'] button[type=submit]").first().click();
+  await admin.waitForTimeout(2600);
+  const again = await admin.locator("[data-dispatch-counts]").first().innerText().catch(() => "");
+  const dup = (again.match(/Pulados por duplicidade\s*(\d+)/) || [])[1];
+  check("a repeated dispatch queues nothing new and counts the duplicates", dup !== undefined && Number(dup) > 0,
+    again.replace(/\s+/g, " ").slice(0, 90));
+  await admin.close();
+}
+
 // ---- 12b. A reload of the reviewed version never resurrects an approval
 //
 // The optimistic marks die with the page, so what is asserted here is the
@@ -314,10 +420,16 @@ await reviewed.close();
 
 // ---- 13. A second tab sees the same server truth
 const tab2 = await newPage();
-await tab2.goto(before, { waitUntil: "networkidle" });
+// Explicitly the "todas" recorte: by now every candidate of this version is
+// decided, so the default Pendentes is legitimately empty and counting cards
+// there would measure the filter, not the second tab's view of server truth.
+await tab2.goto(`${before}${before.includes("?") ? "&" : "?"}estado=todas`, { waitUntil: "networkidle" });
 await tab2.waitForTimeout(1200);
 check("a second tab renders the same cohort", (await tab2.locator("[data-adjust-editor]").count()) === 5,
   `${await tab2.locator("[data-adjust-editor]").count()} candidates in tab 2`);
+const tab2Progress = await tab2.locator("[data-queue-progress-text]").first().innerText().catch(() => "");
+check("and the second tab reads the same decisions from the server",
+  /0 pendente/.test(tab2Progress) && /4 aprovada/.test(tab2Progress), tab2Progress.replace(/\s+/g, " "));
 
 // ---- 14. Console / network hygiene
 check("no application errors in the browser console", consoleErrors.length === 0, consoleErrors.slice(0, 3).join(" | "));

--- a/control-center/tests/journey/run.sh
+++ b/control-center/tests/journey/run.sh
@@ -14,6 +14,11 @@ APP="$CC/apps/web-shell"
 WORK="$(mktemp -d)"
 
 WPORT=${WPORT:-8099}; CPORT=${CPORT:-8098}; SPORT=${SPORT:-8097}; EPORT=${EPORT:-8096}
+# A second edge+shell pair whose forward-auth identity carries `admins`.
+# GO and cohort dispatch are admins-only, so proving both the refusal (on the
+# operators-only pair) and the happy path needs two identities, and the fake
+# edge fixes its groups at startup.
+EPORT2=${EPORT2:-8095}; SPORT2=${SPORT2:-8094}
 TOKEN=stub-operator-token
 TOKFILE="$WORK/token"; printf %s "$TOKEN" > "$TOKFILE"
 
@@ -23,7 +28,7 @@ PIDS=()
 # Sweep the ports we own as well.
 cleanup() {
   for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null; done
-  for port in $WPORT $CPORT $SPORT $EPORT; do
+  for port in $WPORT $CPORT $SPORT $EPORT $EPORT2 $SPORT2; do
     for pid in $(lsof -t -i ":$port" -sTCP:LISTEN 2>/dev/null); do kill "$pid" 2>/dev/null; done
   done
   rm -rf "$WORK"
@@ -58,8 +63,16 @@ PORT=$EPORT UPSTREAM_PORT=$CPORT EDGE_GROUPS="${EDGE_GROUPS:-operators}" \
   CC_ACTOR_ID=founder-local CC_ACTOR_KIND=human \
   node scripts/serve-prod.mjs > "$WORK/web.log" 2>&1 ) & PIDS+=($!)
 
+PORT=$EPORT2 UPSTREAM_PORT=$CPORT EDGE_GROUPS="operators,admins" \
+  node "$HERE/fake-edge.mjs" > "$WORK/edge-admin.log" 2>&1 & PIDS+=($!)
+
+( cd "$APP" && HOST=127.0.0.1 PORT=$SPORT2 CC_CONTEXT_UPSTREAM=http://127.0.0.1:$EPORT2 \
+  CC_ACTOR_ID=founder-local CC_ACTOR_KIND=human \
+  node scripts/serve-prod.mjs > "$WORK/web-admin.log" 2>&1 ) & PIDS+=($!)
+
 for i in $(seq 1 80); do curl -fsS "http://127.0.0.1:$CPORT/healthz" >/dev/null 2>&1 && break; sleep 0.5; done
 for i in $(seq 1 60); do curl -fsS "http://127.0.0.1:$SPORT/healthz" >/dev/null 2>&1 && break; sleep 0.5; done
+for i in $(seq 1 60); do curl -fsS "http://127.0.0.1:$SPORT2/healthz" >/dev/null 2>&1 && break; sleep 0.5; done
 
 gate=$(curl -s -o /dev/null -w '%{http_code}' -H 'x-actor-id: founder-local' -H 'x-actor-kind: human' "http://127.0.0.1:$SPORT/v1/warmbly/operator/cohorts")
 echo "gate through the shell: $gate"
@@ -68,4 +81,4 @@ if [ "$gate" != "200" ]; then
   tail -20 "$WORK/context.log"; exit 1
 fi
 
-( cd "$APP" && node "$HERE/journey.mjs" "http://127.0.0.1:$SPORT" )
+( cd "$APP" && node "$HERE/journey.mjs" "http://127.0.0.1:$SPORT" "http://127.0.0.1:$SPORT2" )


### PR DESCRIPTION
## O que estava quebrado

Aprovar não enfileirava nada. **GO também não** — ele cria a autoridade bounded e para, exatamente como está documentado. O passo que alcança a fila do Warmbly é `POST /v1/confenge/cohorts/{id}/dispatch`, e **ninguém chamava**: nenhum cron, nenhum systemd timer, nenhum worker, e nem o Control Center — cujo conector recusava por construção montar qualquer URL contendo `dispatch`.

Resultado: o fundador aprovava, dava GO, e a cohort ficava parada.

## O que mudou

`dispatch` sai de `FORBIDDEN_HUMAN_GATE_SEGMENTS` e vira **exatamente uma rota**: `POST {prefix}/{cohortId}/dispatch`, `admins`-only — a mesma autoridade do GO de que depende. `send`, `queue`, `resume` e `payment` continuam proibidos, e o teste negativo continua enumerando cada forma de cada um.

O controle aparece na Revisão **só depois de o servidor reportar GO**. Sem GO não existe formulário nenhum (não um desabilitado) e a tela diz por quê. Custa a versão digitada, como o GO, recusada antes do fio sem ela.

**Ele enfileira, não envia.** O worker do Warmbly entrega dentro da janela comercial (09:00–18:00 `America/Sao_Paulo`, dias úteis) sob o teto de 10/hora.

## Por que isso não afrouxa nada

Todo portão continua no Warmbly, onde este conector não consegue expressá-lo:

| Portão | Onde vive |
|---|---|
| GO durável do human gate | `requireDurableHumanGateGO` |
| Autoridade revogada / vencida | `auth.RevokedAt`, `EffectiveExpiry()` |
| `auto_send` / `green_autorun` ligados | recusa explícita no dispatch |
| Disparo pausado | `SendingAllowed()` |
| Kill switch de arquivo | `FileKillSwitchActive()` |
| Teto do lote | ≤10, independente do que a borda pedir |

A borda descarta a query string em escritas, então **nem o tamanho do lote é influenciável daqui**. Cada uma dessas recusas ganhou frase própria e próximo movimento próprio, em vez de uma "recusada" genérica.

**Auto-send segue impossível**: `CONFENGE_AUTO_SEND_ENABLED=true` derruba o boot do Warmbly por invariante testada, e o endpoint recusa quando auto-send ou autorun estão ligados. Continua não existindo disparo agendado.

Nenhuma mudança no Warmbly e nenhuma credencial nova: a máscara 196 já contém `WRITE_CONTACTS` (128), que é o que a rota exige.

## Honestidade dos números

A tela mostra os contadores do próprio Warmbly — tentados, aceitos, falharam, duplicados, bloqueados — rotulados como **enfileiramento, não entrega**. Um contador que o servidor não mandou aparece como ausente, nunca como zero. Repetir é seguro e a tela diz: o Warmbly pula os já enfileirados e os conta como duplicados.

## Prova

- **Jornada em navegador real: 63/63**, agora com **duas identidades forward-auth**. A sessão `operators` é recusada no GO e não recebe controle de disparo; a sessão `admins` dirige aprovar → segurar o destinatário que não verifica → GO → disparar → **4 enfileirados**, e um repeat que enfileira **0** e conta **4 duplicados**.
- 23 workspaces, 0 falhas; convergência 66/66; typecheck limpo.
- Conector: 165 testes, incluindo o novo bloco adversarial que prova que `dispatch` é alcançável em **uma** forma e em nenhuma outra — sem forma por candidato, sem forma no prefixo nu, só POST, só `admins`, e imune a traversal e a URL absoluta smuggled como id.
- Mount do Context Service: `dispatch` por candidato continua 404, e o cohort dispatch responde **403 `insufficient_human_gate_role`** para `operators`.

## Docs

`WARMBLY-HUMAN-GATE-FLOW.md` (cadeia e invariantes), `WARMBLY-HUMAN-GATE-RUNBOOK.md` (passo 7 novo) e `apps/web-shell/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
