### PR TITLE
docs(control-center): corrige dois comentários que ainda prometiam não existir rota de dispatch

### DIFF
--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -6,6 +6,11 @@
  * control here and there must never be one — this surface can stop outbound and
  * let it flow again, and that is the whole of its authority.
  *
+ * The cohort dispatch that hands a GO'd cohort to Warmbly's queue lives in the
+ * Revisão surface further down this module, behind a registered GO, the
+ * `admins` group and a typed version confirmation. It enqueues; it does not
+ * send, and it is deliberately not one of the three controls above.
+ *
  * Everything an operator needs to decide is rendered *before* the controls:
  * dispatch state, why it is in that state, the commercial window, the approved
  * queue, the hourly cap, and who last touched the switch. Every reading is

--- a/control-center/connectors/warmbly/src/human-gate/http.ts
+++ b/control-center/connectors/warmbly/src/human-gate/http.ts
@@ -171,7 +171,11 @@ export interface HumanGateHttpOptions {
   logger?: Logger;
 }
 
-/** Fixed-route authenticated proxy. It has no dispatch/send route by construction. */
+/**
+ * Fixed-route authenticated proxy. It has no `send`, `queue` or `resume` route
+ * by construction, and its one dispatch route hands an already-GO'd cohort to
+ * Warmbly's queue rather than sending anything.
+ */
 export function createHumanGateHttpHandler(options: HumanGateHttpOptions) {
   const fetchImpl = options.fetchImpl ?? fetch;
   const timeoutMs = options.timeoutMs ?? 12_000;


### PR DESCRIPTION
Dois comentários ficaram mentindo depois do PR #117, ambos exatamente em cima do código que ganhou a capacidade que eles negavam:

- `connectors/warmbly/src/human-gate/http.ts`: "It has no dispatch/send route by construction" — logo acima da tabela de rotas que agora tem uma.
- `apps/web-shell/src/ui/warmbly.ts`: o docstring do módulo dizia que não há controle de envio, sem dizer onde o disparo da cohort passou a viver.

Numa fronteira de segurança, o comentário em que o leitor confia é o que está ao lado do código. Só comentários; nenhuma mudança de comportamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)