### PR TITLE
feat(control-center): queue reviewed candidates on approve

### DIFF
--- a/control-center/apps/web-shell/README.md
+++ b/control-center/apps/web-shell/README.md
@@ -17,7 +17,7 @@ Chrome navigation exposes exactly these ten areas:
 9. Memória/Decisões
 10. Agentes
 
-“Operação Warmbly” is the safe-operation cockpit for the outbound kill switch: dispatch state, pause reason, commercial window, approved queue, hourly cap and the recent audit trail are rendered **before** the three controls (pause in one step, resume in two, acknowledge an inbound alert). There is no send control there and there must never be one. In the current human-gate contract an effective APPROVE schedules only its exact reviewed message; the Warmbly worker remains governed by pause, window and hourly cap.
+“Operação Warmbly” is the safe-operation cockpit for the outbound kill switch: dispatch state, pause reason, commercial window, approved queue, hourly cap and the recent audit trail are rendered **before** the three controls (pause in one step, resume in two, acknowledge an inbound alert). There is no immediate-send or cohort-dispatch control. In Revisão, candidate APPROVE is the complete per-message scheduling authority: it writes `auto_send=true`, `QUEUED` and `due_at`; the Warmbly worker transports later.
 
 ### Rotas do gate humano de cohorts
 
@@ -25,13 +25,18 @@ O gate humano vive **inteiramente** sob “Operação Warmbly”, em três sub-r
 
 | Rota | O que é |
 | --- | --- |
-| `#/warmbly` (`operacao`) | Resumo do piloto — Fonte → Cohort → Validação → Revisão/APPROVE → Fila — mais a versão recente e o acesso à revisão. |
-| `#/warmbly/cohorts` | Lista de cohorts versionadas, denominadores, recuperação, próxima seleção sem repetição e reconciliação administrativa de aprovações antigas. |
-| `#/warmbly/revisao?resource=<id>` | Revisão candidato a candidato; APPROVE efetivo agenda a mensagem exata para a próxima janela elegível. |
+| `#/warmbly` (`operacao`) | Resumo do piloto — Fonte → Cohort → Validação → Revisão → Agendamento — mais a versão mais recente, o botão “Abrir revisão” e os controles seguros de pausa/retomada/reconhecimento. |
+| `#/warmbly/cohorts` | Lista de cohorts versionadas, denominadores, recuperação e próxima seleção sem repetição (1–10). |
+| `#/warmbly/revisao?resource=<id>` | Revisão candidato a candidato; APPROVE agenda a mensagem e o reparo administrativo reprocessa aprovações antigas. |
 
 O `resource` viaja na subnav: abrir “Revisão” a partir de “Cohorts” **não** perde a
 versão selecionada, e uma Revisão sem `resource` oferece a lista de versões em vez
 de uma página vazia.
+
+Criar usa `NEXT_UNCLAIMED`: claims transacionais por conta, fonte, fornecedor e
+destinatário formam cohorts disjuntas sem offset controlável pelo navegador.
+`RECOVER_PRIOR` relê os fornecedores de versões vencidas na fonte atual e cria
+texto, evidência e hashes novos; não herda APPROVE ou agendamento antigos.
 
 #### Revisão é uma fila de decisões, não um formulário
 
@@ -41,18 +46,20 @@ padrão e por isso não aparece na URL) e diz quanto falta:
 `aprovadas`, `ajuste` e `todas` continuam legíveis e preservam `resource` e o
 estado de expansão das mensagens.
 
-No caminho feliz, **uma mensagem válida é aprovada com uma única ação**: sem
+No caminho feliz, **uma mensagem válida é aprovada e enfileirada com uma única ação**: sem
 motivo digitado, sem caixa de ciência e sem acionar a verificação do destinatário
 antes. O clique em Aprovar é a ciência e viaja como `acknowledged=true`; um
 APPROVE sem comentário registra `approved_by_human_reviewer` e o comentário
 opcional vence esse padrão. Quando o candidato não tem validação vigente, a
 própria aprovação pede a verificação ao Warmbly, relê o estado e só registra o
 APPROVE se ele voltar `VALID` — caso contrário nada é decidido e a tela diz o
-estado observado.
+estado observado. O botão é “Aprovar e enfileirar para envio”: a mesma operação
+deixa a mensagem com `auto_send=true`, `QUEUED` e `due_at`. Não há GO ou handoff.
 
-A aprovação sai da fila na hora (otimista) e volta para ela em qualquer desfecho
+A aprovação sai da fila de revisão na hora (otimista) e volta para ela em qualquer desfecho
 que não seja aplicação confirmada: recusa, falha, desconhecido, ou releitura que
-não confirma o efeito. Nada disso é durável — um reload lê a fila do servidor.
+não confirma APPROVE efetivo e o agendamento. Nada disso é durável — um reload
+lê a fila do servidor.
 
 APPROVE continua bloqueado onde verificar de novo não resolve: sem destinatário,
 destinatário que não é endereço, veredito já resolvido como `INVALID`/`RISKY`, e
@@ -66,22 +73,28 @@ Teclado: `A` aprova o card que já está sob o foco (nunca outro), `Ctrl/Cmd+Ent
 aprova a primeira pendência. Nenhum dos dois dispara com o cursor dentro de um
 campo de texto — o editor de ajuste vive na mesma página.
 
-#### Agendamento e reconciliação
+#### Agendamento e reparo
 
-APPROVE registra a decisão e cria ou confirma o touchpoint da mensagem exata na
-mesma operação. Não existe GO nem entrega manual da cohort no contrato vigente.
-Agendar não envia imediatamente: somente o worker do Warmbly entrega, quando a
-pausa operacional permitir, na janela comercial e sob o teto por hora.
+A Revisão lê o status outbound do servidor e mostra kill switch/pausa antes de
+qualquer trabalho. Com bloqueio ativo, APPROVE continua criando `QUEUED` e
+`due_at`, mas a tela diz que nada sairá.
 
-Antes de ampliar o backlog, `admins` executa “Reconciliar aprovações antigas com
-a fila”. A chamada é global, idempotente e não recebe cohort ou candidato do
-navegador. Os contadores de registros APPROVE, bindings vigentes, candidatos
-únicos, agendados, já agendados e falhas são os do servidor; ausência nunca vira
-zero. Qualquer falha deve ser classificada antes de criar novas cohorts.
+GO/NO-GO e “Entregar à fila” foram removidos do fluxo vivo. Registros antigos
+aparecem somente em um disclosure de auditoria, sem efeito operacional. O worker
+é quem envia, dentro da janela comercial e sob o teto por hora; o Control Center
+não oferece `send`, `dispatch`, `queue` ou `resume` de cohort.
 
-O auto-send global continua proibido. O `auto_send=true` de um agendamento é por
-mensagem e só nasce de um APPROVE humano efetivo. `send`, `queue`, `resume`, GO,
-cohort dispatch e `payment` continuam impossíveis de construir no proxy do gate.
+“Reprocessar aprovações já registradas” é um reparo global de `admins`, não um
+próximo passo. Ele chama a rota fixa `POST …/cohorts/reconcile-approved`, usa o
+mesmo agendador do APPROVE, deduplica candidatos e é idempotente. Os contadores
+são os do servidor; campo ausente aparece como ausente, nunca zero. A borda
+descarta query string e envia corpo upstream vazio. O teste negativo continua
+enumerando `send`, `dispatch`, `queue`, `resume`, `payment`, `charge`, `enroll`
+e `deliver` em todas as formas.
+
+A automação global permanece desligada: `CONFENGE_AUTO_SEND_ENABLED=false` e
+`GREEN_AUTORUN=false`. O `auto_send=true` mostrado no card pertence somente à
+mensagem aprovada.
 
 `#/comercial/cohorts` (“Comercial → Coortes”) é **outra coisa**: são coortes de
 aquisição e métricas por período. Nenhum runbook do gate humano deve apontar para
@@ -89,10 +102,11 @@ lá — o caminho correto é **Operação Warmbly → Cohorts**. Pausar, retomar
 reconhecer também já não vivem em Comercial; a aba de lá só carrega o ponteiro
 para `#/warmbly`.
 
-Autoridade: `operators` cria, reproduz, pede verificação, ajusta e registra
-APPROVE/HOLD/REJECT. `admins` é exigido somente para reconciliar as aprovações
-antigas em lote. A identidade é resolvida pelo Authelia na borda; esta tela não
-envia cabeçalho de ator em nenhuma escrita do gate.
+Autoridade deliberada: `operators` cria, reproduz, pede verificação, ajusta e
+registra APPROVE/HOLD/REJECT; APPROVE pode provocar envio futuro e o botão diz
+que enfileira. `admins` executa somente o reparo de aprovações já registradas —
+sem esse grupo o controle aparece desabilitado e a borda devolve 403 antes do
+upstream. A identidade é resolvida pelo Authelia; o navegador não envia ator.
 
 Ajustar assunto/corpo cria uma **nova versão** (`POST …/candidates/{id}/adjust`).
 Enquanto essa rota não estiver implantada, a UI trata o 404 como estado esperado,

--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -92,24 +92,6 @@ export interface GateReadback {
   detail: string;
 }
 
-/**
- * What a bounded dispatch actually did, as Warmbly reported it.
- *
- * Every field is optional because an absent counter is not a zero: the operator
- * must be able to tell "o servidor disse que zero foram bloqueados" from "o
- * servidor não disse quantos foram bloqueados".
- */
-export interface GateDispatchCounts {
-  attempted?: number;
-  accepted?: number;
-  failed?: number;
-  skippedDuplicate?: number;
-  blocked?: number;
-  maxDaily?: number;
-  killSwitchAvailable?: boolean;
-  failures?: readonly { mailbox: string; reason: string }[];
-}
-
 /** Backend reconciliation of durable APPROVEs into scheduled queue work. */
 export interface GateReconcileCounts {
   approvalRecords?: number;
@@ -118,7 +100,7 @@ export interface GateReconcileCounts {
   scheduled?: number;
   alreadyScheduled?: number;
   failed?: number;
-  failures?: readonly { cohortVersionId: string; candidateId: string; reason: string }[];
+  failures?: readonly { cohortId?: string; candidateId?: string; reason: string }[];
 }
 
 export interface AdapterWriteResult {
@@ -183,9 +165,7 @@ export interface AdapterWriteResult {
   receiptId?: string;
   /** Field-level diff the server returned for an accepted adjust. */
   diff?: readonly GateDiffEntry[];
-  /** Counters Warmbly returned for an accepted cohort dispatch. */
-  dispatch?: GateDispatchCounts;
-  /** Counters Warmbly returned while reconciling approvals that predate scheduling. */
+  /** Counters Warmbly returned for an accepted approval reconciliation. */
   reconcile?: GateReconcileCounts;
   /** Result of the GET readback performed after a definitive response. */
   readback?: GateReadback;
@@ -243,13 +223,9 @@ export const WARMBLY_GATE_ACTIONS = [
   "reproduce",
   "validate",
   "review",
-  "reconcile",
-  "decide",
   "adjust",
-  // Hands an already-GO'd cohort to Warmbly's queue. It is not a send: Warmbly
-  // enqueues each member and its own worker delivers inside the send window,
-  // under the rolling-hour governor, with the kill switch still in front.
-  "dispatch",
+  // Admin repair only. Ordinary APPROVE already queues through the same path.
+  "reconcile",
 ] as const;
 export type WarmblyGateAction = (typeof WARMBLY_GATE_ACTIONS)[number];
 
@@ -277,7 +253,7 @@ export interface WarmblyGateInput {
   limit?: number;
   selection_mode?: "NEXT_UNCLAIMED" | "RECOVER_PRIOR";
   recover_version_ids?: string[];
-  decision?: "APPROVE" | "REJECT" | "HOLD" | "GO" | "NO_GO";
+  decision?: "APPROVE" | "REJECT" | "HOLD";
   reason?: string;
   acknowledged?: boolean;
   confirmation?: string;

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -146,60 +146,23 @@ function gateFallbackMessage(input: WarmblyGateInput, version: number | undefine
       return "Verificação do destinatário solicitada ao Warmbly.";
     case "review":
       return input.decision === "APPROVE"
-        ? "Aprovação registrada e mensagem agendada para a próxima janela comercial elegível."
+        ? "Aprovação registrada e mensagem agendada para a próxima janela comercial."
         : input.decision === "HOLD"
           ? "HOLD registrado para este candidato."
           : "Rejeição registrada para este candidato.";
-    case "reconcile":
-      return "Aprovações duráveis reconciliadas com a fila do Warmbly.";
-    case "decide":
-      return input.decision === "GO"
-        ? "GO registrado. Nenhum e-mail foi enfileirado nem enviado."
-        : "NO-GO registrado.";
     case "adjust":
       return `Ajuste aceito. O servidor criou a nova versão${v}.`;
-    case "dispatch":
-      return "Cohort entregue à fila do Warmbly. O envio acontece na janela comercial, sob o teto por hora.";
+    case "reconcile":
+      return "Reconciliação concluída pelo mesmo caminho de agendamento do APPROVE.";
   }
 }
 
 /**
- * The counters Warmbly returns for a bounded dispatch.
+ * The counters Warmbly returns for approval reconciliation.
  *
- * Read out of the response rather than summarised into a sentence: "10
- * enfileirados" and "3 enfileirados, 7 bloqueados" are different outcomes and
- * the operator has to see which one happened. Anything the server did not send
- * stays absent instead of becoming a zero.
+ * Read out of the response rather than guessed from the approval history.
+ * Anything the server did not send stays absent instead of becoming a zero.
  */
-export function gateDispatchOf(body: Record<string, unknown>): AdapterWriteResult["dispatch"] {
-  const data = asRecord(body.data) ?? body;
-  const num = (key: string): number | undefined => gateNumber(data[key]);
-  const counts = {
-    ...(num("attempted") !== undefined ? { attempted: num("attempted")! } : {}),
-    ...(num("provider_accepted") !== undefined ? { accepted: num("provider_accepted")! } : {}),
-    ...(num("failed") !== undefined ? { failed: num("failed")! } : {}),
-    ...(num("skipped_duplicate") !== undefined ? { skippedDuplicate: num("skipped_duplicate")! } : {}),
-    ...(num("blocked") !== undefined ? { blocked: num("blocked")! } : {}),
-    ...(num("max_daily") !== undefined ? { maxDaily: num("max_daily")! } : {}),
-    ...(typeof data.kill_switch_available === "boolean"
-      ? { killSwitchAvailable: data.kill_switch_available }
-      : {}),
-  };
-  const failures = Array.isArray(data.failures)
-    ? data.failures
-        .map((entry) => asRecord(entry))
-        .filter((entry): entry is Record<string, unknown> => entry !== null)
-        .map((entry) => ({
-          mailbox: typeof entry.mailbox === "string" ? entry.mailbox : "",
-          reason: typeof entry.reason === "string" ? entry.reason : "",
-        }))
-        .filter((entry) => entry.mailbox !== "" || entry.reason !== "")
-    : [];
-  if (Object.keys(counts).length === 0 && failures.length === 0) return undefined;
-  return { ...counts, ...(failures.length > 0 ? { failures } : {}) };
-}
-
-/** Read the backend's naturally idempotent approval-reconciliation report. */
 export function gateReconcileOf(body: Record<string, unknown>): AdapterWriteResult["reconcile"] {
   const data = asRecord(body.data) ?? body;
   const num = (key: string): number | undefined => gateNumber(data[key]);
@@ -212,7 +175,9 @@ export function gateReconcileOf(body: Record<string, unknown>): AdapterWriteResu
       ? { uniqueApprovedCandidates: num("unique_approved_candidates")! }
       : {}),
     ...(num("scheduled") !== undefined ? { scheduled: num("scheduled")! } : {}),
-    ...(num("already_scheduled") !== undefined ? { alreadyScheduled: num("already_scheduled")! } : {}),
+    ...(num("already_scheduled") !== undefined
+      ? { alreadyScheduled: num("already_scheduled")! }
+      : {}),
     ...(num("failed") !== undefined ? { failed: num("failed")! } : {}),
   };
   const failures = Array.isArray(data.failures)
@@ -220,11 +185,11 @@ export function gateReconcileOf(body: Record<string, unknown>): AdapterWriteResu
         .map((entry) => asRecord(entry))
         .filter((entry): entry is Record<string, unknown> => entry !== null)
         .map((entry) => ({
-          cohortVersionId: typeof entry.cohort_version_id === "string" ? entry.cohort_version_id : "",
-          candidateId: typeof entry.candidate_id === "string" ? entry.candidate_id : "",
+          ...(typeof entry.cohort_version_id === "string" ? { cohortId: entry.cohort_version_id } : {}),
+          ...(typeof entry.candidate_id === "string" ? { candidateId: entry.candidate_id } : {}),
           reason: typeof entry.reason === "string" ? entry.reason : "",
         }))
-        .filter((entry) => entry.cohortVersionId !== "" || entry.candidateId !== "" || entry.reason !== "")
+        .filter((entry) => entry.cohortId !== undefined || entry.candidateId !== undefined || entry.reason !== "")
     : [];
   if (Object.keys(counts).length === 0 && failures.length === 0) return undefined;
   return { ...counts, ...(failures.length > 0 ? { failures } : {}) };
@@ -269,16 +234,28 @@ export function gateResult(
     gateText(adjustment ?? {}, "correlation_id")
     ?? gateText(body, "correlation_id")
     ?? gateText(body, "edge_correlation_id");
+  const upstreamOutcome = gateText(body, "outcome")?.toUpperCase();
+  const outcome = upstreamOutcome === "UNKNOWN"
+    ? "unknown"
+    : upstreamOutcome === "REFUSED"
+      ? "refused"
+      : upstreamOutcome === "APPLIED"
+        ? "executed"
+        : ok
+          ? "executed"
+          : status >= 500
+            ? "unknown"
+            : "refused";
   return {
     ok,
     path,
     kind: "nota",
     status,
-    outcome: ok ? "executed" : status === 503 ? "unknown" : "refused",
+    outcome,
     message: serverMessage ?? gateFallbackMessage(input, version),
     gateAction: input.action,
     ...(code ? { code } : {}),
-    ...(input.version_id || input.candidate_id
+    ...(input.action !== "reconcile" && (input.version_id || input.candidate_id)
       ? {
           gateTarget: {
             ...(input.version_id ? { cohort_id: input.version_id } : {}),
@@ -297,11 +274,6 @@ export function gateResult(
     ...(receipt ? { receiptId: receipt } : {}),
     ...(correlation ? { correlationId: correlation } : {}),
     ...(diff ? { diff } : {}),
-    ...(() => {
-      if (input.action !== "dispatch" || !ok) return {};
-      const dispatch = gateDispatchOf(body);
-      return dispatch ? { dispatch } : {};
-    })(),
     ...(() => {
       if (input.action !== "reconcile" || !ok) return {};
       const reconcile = gateReconcileOf(body);
@@ -487,15 +459,15 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       : input.action === "reproduce" ? `${base}/${version}/reproduce`
       : input.action === "validate" ? `${base}/${version}/candidates/${candidate}/validation`
       : input.action === "review" ? `${base}/${version}/candidates/${candidate}/review`
-      : input.action === "adjust" ? `${base}/${version}/candidates/${candidate}/adjust`
-      : input.action === "dispatch" ? `${base}/${version}/dispatch`
-      : `${base}/${version}/decision`;
+      : `${base}/${version}/candidates/${candidate}/adjust`;
     // Every refusal below happens before the wire, so "nada foi aplicado" is a
     // fact this adapter can prove rather than a hope.
-    const target = {
-      ...(version ? { cohort_id: version } : {}),
-      ...(candidate ? { candidate_id: candidate } : {}),
-    };
+    const target = input.action === "reconcile"
+      ? {}
+      : {
+          ...(version ? { cohort_id: version } : {}),
+          ...(candidate ? { candidate_id: candidate } : {}),
+        };
     const refuse = (message: string, code: string): AdapterWriteResult => {
       const refusal: AdapterWriteResult = {
         ok: false,
@@ -541,22 +513,6 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       && !input.reason?.trim()
     ) {
       return refuse("HOLD/REJECT exige motivo escrito", "gate_precondition");
-    }
-    if (input.action === "decide" && !input.confirmation?.trim()) {
-      return refuse(
-        "GO/NO-GO exige a confirmação digitada da versão imutável",
-        "cohort_version_confirmation_required",
-      );
-    }
-    // Dispatch is the one call in this gate whose effect leaves the building:
-    // Warmbly enqueues real messages to real companies and its worker delivers
-    // them. It therefore carries the same typed confirmation GO does, refused
-    // here before the wire rather than after.
-    if (input.action === "dispatch" && !input.confirmation?.trim()) {
-      return refuse(
-        "Disparar a cohort exige a confirmação digitada da versão imutável",
-        "cohort_version_confirmation_required",
-      );
     }
     if (input.action === "adjust") {
       // The three editable fields plus the two anti-clobber tokens. An adjust
@@ -1034,7 +990,10 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       // opens on a stepper that has to say where the pilot actually stands. A
       // gate the channel cannot serve must not take the whole destination down
       // with it, so these reads are soft and report their own status.
-      const list = await this.readGate("/v1/warmbly/operator/cohorts?limit=50");
+      const [list, outboundStatus] = await Promise.all([
+        this.readGate("/v1/warmbly/operator/cohorts?limit=50"),
+        this.readGate("/v1/warmbly/operator/outbound-status"),
+      ]);
       const selected = parsed.resource
         ? await this.readGate(`/v1/warmbly/operator/cohorts/${encodeURIComponent(parsed.resource)}`)
         : undefined;
@@ -1042,6 +1001,9 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
         list: list.data ?? {},
         list_status: list.status,
         ...(list.detail ? { list_detail: list.detail } : {}),
+        outbound_status: outboundStatus.data ?? {},
+        outbound_status_status: outboundStatus.status,
+        ...(outboundStatus.detail ? { outbound_status_detail: outboundStatus.detail } : {}),
         ...(selected
           ? {
               selected: selected.data ?? {},

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -638,7 +638,7 @@ function bindWarmblyHumanGate(
           ? { selection_mode: selectionMode }
           : {}),
         ...(recoverVersionIds.length > 0 ? { recover_version_ids: recoverVersionIds } : {}),
-        ...(decision === "APPROVE" || decision === "REJECT" || decision === "HOLD" || decision === "GO" || decision === "NO_GO" ? { decision } : {}),
+        ...(decision === "APPROVE" || decision === "REJECT" || decision === "HOLD" ? { decision } : {}),
         // An ordinary approval types nothing, and the trail must still say what
         // happened. The default is folded in here, not only at the wire, so the
         // idempotency identity and the recorded motive are the same string.
@@ -652,10 +652,9 @@ function bindWarmblyHumanGate(
         // to the trail: actor, instant, version, frozen hash and recipient are
         // all recorded already.
         ...(isApprove ? { acknowledged: true } : {}),
-        // GO, adjust and dispatch each cost a typed version confirmation. The
-        // adapter refuses all three before the wire without it, so a missing
-        // one here would be a refusal the operator never asked for.
-        ...((raw === "decide" || raw === "adjust" || raw === "dispatch") && confirmation
+        // Adjust costs a typed version confirmation so an edit cannot clobber
+        // a version the operator was not looking at.
+        ...(raw === "adjust" && confirmation
           ? { confirmation }
           : {}),
         ...(raw === "adjust"
@@ -794,14 +793,17 @@ async function settleGateIntent(
   // definitive after the resource readback confirms it. If that GET fails or
   // disagrees, retaining the same idempotency key is what lets a later retry
   // reconcile the original write instead of creating a second intent.
-  const settledOutcome =
-    result.outcome === "refused"
-      ? "refused"
-      : result.outcome === "executed" && readback.status === "confirmed"
-        ? "executed"
-        : undefined;
+  const settledOutcome = result.outcome === "refused"
+    ? "refused"
+    : readback.status === "confirmed"
+      ? "executed"
+      : undefined;
   settleHumanGateIntent(intent, settledOutcome);
-  const settled: AdapterWriteResult = { ...result, readback };
+  const settled: AdapterWriteResult = {
+    ...result,
+    ...(settledOutcome === "executed" ? { ok: true, outcome: "executed" } : {}),
+    readback,
+  };
   adapter.lastOperatorResult = settled;
   return settled;
 }
@@ -1139,19 +1141,66 @@ async function gateReadback(
   intent: HumanGateIntent,
   result: AdapterWriteResult,
 ): Promise<GateReadback> {
-  if (result.outcome !== "executed" || !result.ok) {
+  if (result.outcome === "refused") {
     return {
       status: "skipped",
       detail: "Nenhuma releitura é devida: o canal não relatou uma escrita aplicada.",
     };
   }
   if (intent.action === "reconcile") {
-    return {
-      status: "confirmed",
-      detail: result.reconcile
-        ? "A resposta trouxe os denominadores da reconciliação; nenhuma mensagem foi enviada por esta ação."
-        : "A reconciliação foi aceita, mas a resposta não trouxe denominadores.",
-    };
+    let reconcileRead: import("./adapters/contract").AdapterReadResult;
+    try {
+      reconcileRead = await Promise.resolve(adapter.readDestination("warmbly", "#/warmbly/cohorts"));
+    } catch {
+      return { status: "unavailable", detail: "A releitura das cohorts não completou." };
+    }
+    if (!reconcileRead.ok || reconcileRead.loading || !reconcileRead.page) {
+      return { status: "unavailable", detail: "A releitura das cohorts não completou." };
+    }
+    const rows = Array.isArray(gateRecord(gateRecord(reconcileRead.page.warmbly_gate).list).data)
+      ? (gateRecord(gateRecord(reconcileRead.page.warmbly_gate).list).data as unknown[]).map(gateRecord)
+      : [];
+    const effectiveApprovals = rows.flatMap((row) =>
+      (Array.isArray(row.candidates) ? row.candidates : []).map(gateRecord),
+    ).filter((row) => {
+      const review = gateRecord(row.review);
+      return review.decision === "APPROVE" && review.effective === true;
+    });
+    const unscheduled = effectiveApprovals.filter((row) => {
+      const scheduling = gateRecord(row.scheduling);
+      return scheduling.auto_send !== true
+        || !["QUEUED", "SENT"].includes(String(scheduling.state ?? ""))
+        || !scheduling.due_at;
+    });
+    const latestApprovedBindings = result.reconcile?.latestApprovedBindings;
+    const failed = result.reconcile?.failed;
+    if (latestApprovedBindings === undefined || failed === undefined) {
+      return {
+        status: "not_confirmed",
+        detail: "A resposta não informou os totais de vínculos aprovados e falhas; ausência não é zero e o reparo não pode ser confirmado.",
+      };
+    }
+    if (failed > 0) {
+      return {
+        status: "not_confirmed",
+        detail: `A resposta registra ${failed} falha(s) de reconciliação.`,
+      };
+    }
+    if (effectiveApprovals.length !== latestApprovedBindings) {
+      return {
+        status: "not_confirmed",
+        detail: `A resposta contou ${latestApprovedBindings} vínculo(s) aprovado(s), mas a releitura devolveu ${effectiveApprovals.length}; o conjunto completo não foi confirmado.`,
+      };
+    }
+    return unscheduled.length === 0
+      ? {
+          status: "confirmed",
+          detail: `A releitura confirma ${effectiveApprovals.length} vínculo(s) aprovado(s) com auto_send por mensagem e estado QUEUED ou SENT.`,
+        }
+      : {
+          status: "not_confirmed",
+          detail: `A releitura ainda mostra ${unscheduled.length} aprovação(ões) efetiva(s) sem agendamento confirmado.`,
+        };
   }
   const cohortId = result.gateResource?.cohort_id ?? intent.version_id;
   if (!cohortId) {
@@ -1210,49 +1259,22 @@ async function gateReadback(
             "O servidor registra APPROVE, mas não confirma que a aprovação está efetiva para o destinatário, conteúdo, policy e evidência atuais.",
         };
       }
-      if (
-        intent.decision === "APPROVE"
-        && Object.prototype.hasOwnProperty.call(candidate, "scheduling")
-      ) {
+      if (intent.decision === "APPROVE") {
         const scheduling = gateRecord(candidate.scheduling);
-        if (
-          typeof scheduling.touchpoint_id !== "string"
-          || scheduling.auto_send !== true
-          || scheduling.invalidated_at
-        ) {
+        const state = String(scheduling.state ?? "");
+        if (scheduling.auto_send !== true || !["QUEUED", "SENT"].includes(state) || !scheduling.due_at) {
           return {
             status: "not_confirmed",
-            detail: "O APPROVE está registrado, mas o servidor não confirmou um agendamento efetivo para esta mensagem.",
+            detail:
+              "O servidor confirma APPROVE efetivo, mas não confirma auto_send por mensagem, estado QUEUED/SENT e due_at. Aprovação sem agendamento é defeito e continua visível.",
           };
         }
+        return {
+          status: "confirmed",
+          detail: `O servidor registra APPROVE efetivo e ${state} para ${String(scheduling.due_at)}.`,
+        };
       }
       return { status: "confirmed", detail: `O servidor registra ${String(recorded)} neste candidato.` };
-    }
-    case "decide": {
-      const recorded = gateRecord(cohort.decision).decision;
-      return recorded === intent.decision
-        ? { status: "confirmed", detail: `O servidor registra a decisão final ${String(recorded)}.` }
-        : {
-            status: "not_confirmed",
-            detail: `O servidor ainda registra "${String(recorded ?? "nada")}" como decisão final.`,
-          };
-    }
-    case "dispatch": {
-      // There is nothing on the cohort resource that proves a queue depth, so
-      // this readback deliberately does not claim one. What it can say is that
-      // the version still reads GO — i.e. the authority the dispatch consumed
-      // is the one the operator was looking at. The counters Warmbly returned
-      // are the evidence of what was queued, and they are rendered verbatim.
-      const recorded = gateRecord(cohort.decision).decision;
-      return recorded === "GO"
-        ? {
-            status: "confirmed",
-            detail: "O servidor devolve esta versão ainda com GO registrado; os números enfileirados vêm da resposta do disparo.",
-          }
-        : {
-            status: "not_confirmed",
-            detail: `O servidor registra "${String(recorded ?? "nada")}" como decisão final desta versão, não GO.`,
-          };
     }
     case "validate": {
       if (!candidate) {

--- a/control-center/apps/web-shell/src/human-gate-idempotency.ts
+++ b/control-center/apps/web-shell/src/human-gate-idempotency.ts
@@ -5,13 +5,13 @@
  */
 
 export interface HumanGateIntent {
-  action: "create" | "reproduce" | "validate" | "review" | "reconcile" | "decide" | "adjust" | "dispatch";
+  action: "create" | "reproduce" | "validate" | "review" | "adjust" | "reconcile";
   version_id?: string;
   candidate_id?: string;
   limit?: number;
   selection_mode?: "NEXT_UNCLAIMED" | "RECOVER_PRIOR";
   recover_version_ids?: string[];
-  decision?: "GO" | "NO_GO" | "APPROVE" | "REJECT" | "HOLD";
+  decision?: "APPROVE" | "REJECT" | "HOLD";
   reason?: string;
   acknowledged?: boolean;
   confirmation?: string;

--- a/control-center/apps/web-shell/src/review-queue.ts
+++ b/control-center/apps/web-shell/src/review-queue.ts
@@ -88,7 +88,7 @@ function idOf(value: unknown): string {
  * An APPROVE the server itself marks `effective: false` was invalidated by
  * drift — recipient, copy, policy or evidence moved under it — so it is work
  * again, and hiding it from the pending recorte would hide exactly the message
- * that has to be re-decided before GO. HOLD and REJECT carry no `effective`
+ * that has to be reviewed again before it can be scheduled. HOLD and REJECT carry no `effective`
  * flag of their own: they are decisions, not authorisations.
  */
 export function serverReviewState(candidate: Record<string, unknown>): ReviewQueueState {

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -1320,7 +1320,7 @@ details.alert-why > summary {
 
 [data-approve-blocked],
 [data-blocked-reason],
-[data-go-authority="absent"] {
+[data-reconcile-authority="absent"] {
   border-left: 3px solid var(--high);
   padding-left: 0.6rem;
 }

--- a/control-center/apps/web-shell/src/ui/editorial-state.ts
+++ b/control-center/apps/web-shell/src/ui/editorial-state.ts
@@ -3,8 +3,8 @@
  *
  * A version composed by a superseded composer still has to be readable for
  * audit, but it is not sendable. The founder saw defective legacy copy offered
- * with APPROVE and GO beside it, so this reading exists to tell the surface
- * which of the two it is looking at.
+ * with live approval controls beside it, so this reading exists to tell the
+ * surface which of the two it is looking at.
  *
  * Defaulting rule: an absent `editorial_state` is an older backend, not a
  * legacy version. Absent reads as CURRENT and actionable so the working flow

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -6,10 +6,9 @@
  * control here and there must never be one — this surface can stop outbound and
  * let it flow again, and that is the whole of its authority.
  *
- * The cohort dispatch that hands a GO'd cohort to Warmbly's queue lives in the
- * Revisão surface further down this module, behind a registered GO, the
- * `admins` group and a typed version confirmation. It enqueues; it does not
- * send, and it is deliberately not one of the three controls above.
+ * Candidate APPROVE lives in Revisão and is the complete per-message scheduling
+ * authority. It queues with auto_send=true for that message; only Warmbly's
+ * worker transports later, under the controls shown here.
  *
  * Everything an operator needs to decide is rendered *before* the controls:
  * dispatch state, why it is in that state, the commercial window, the approved
@@ -244,21 +243,15 @@ const OUTCOME_BY_CODE: Record<string, OutcomeRule> = {
   },
   approval_acknowledgement_required: {
     kind: "refused",
-    title: "Recusada: APPROVE exige a ciência marcada",
+    title: "Recusada: APPROVE chegou sem a ciência obrigatória",
     recovery:
-      "Aprovar é assumir que você leu destinatário, mensagem exata, policy e evidência desta versão. Marque a ciência e aprove de novo. HOLD e REJECT não pedem essa marcação.",
-  },
-  cohort_version_confirmation_required: {
-    kind: "refused",
-    title: "Recusada: falta a confirmação digitada da versão",
-    recovery:
-      "GO/NO-GO exige digitar a versão imutável (por exemplo v1). Nada foi decidido.",
+      "O clique em “Aprovar e enfileirar” é a ciência sobre destinatário, mensagem exata, policy e evidência, e deve carregar acknowledged=true. Recarregue a tela; se persistir, é defeito do Control Center. HOLD e REJECT não carregam essa ciência.",
   },
   insufficient_human_gate_role: {
     kind: "refused",
     title: "Recusada: sua sessão não tem a autoridade necessária",
     recovery:
-      "Revisar exige o grupo operators; registrar GO/NO-GO exige admins. Nada foi aplicado. Peça a inclusão no grupo no Authelia e reautentique antes de repetir.",
+      "Aprovar e enfileirar exige operators; reprocessar aprovações antigas exige admins. Nada foi aplicado. Peça a inclusão no grupo no Authelia e reautentique antes de repetir.",
   },
   idempotency_key_required: {
     kind: "refused",
@@ -306,7 +299,7 @@ const OUTCOME_BY_CODE: Record<string, OutcomeRule> = {
     kind: "refused",
     title: "Recusada: há autoridade bounded ativa para esta cohort",
     recovery:
-      "Uma cohort com GO ativo não pode ter conteúdo ajustado. Registre NO-GO para revogar a autoridade e só então ajuste. Nada foi alterado.",
+      "Esta versão ainda carrega uma autoridade histórica ativa. O endpoint antigo de GO/NO-GO não existe mais: trate a revogação operacional no Warmbly antes de ajustar. Nada foi alterado.",
   },
   immutable_field: {
     kind: "refused",
@@ -343,53 +336,6 @@ const OUTCOME_BY_CODE: Record<string, OutcomeRule> = {
     title: "Recusada: o destinatário foi verificado agora e não voltou VALID",
     recovery:
       "A verificação foi feita nesta ação e o APPROVE não foi enviado, então nada foi decidido. O Warmbly recusa aprovação fora de uma validação VALID: registre HOLD ou REJECT, ou corrija a origem do contato e recomponha.",
-  },
-  /* ---------------------------------------------------------------- *
-   * Entrega da cohort à fila do Warmbly. Os códigos abaixo são os do
-   * próprio Warmbly: cada um é um portão diferente e manda o operador
-   * para um lugar diferente.
-   * ---------------------------------------------------------------- */
-  auto_send_forbidden: {
-    kind: "refused",
-    title: "Recusada: auto-send está ligado no Warmbly",
-    recovery:
-      "O Warmbly recusa entregar uma cohort controlada enquanto auto-send estiver ligado, e nada foi enfileirado. Isto é configuração do Warmbly, não do operador: desligue auto-send lá antes de disparar por aqui.",
-  },
-  green_autorun_forbidden: {
-    kind: "refused",
-    title: "Recusada: green autorun está ligado no Warmbly",
-    recovery:
-      "Nada foi enfileirado. Autorun e cohort controlada são excludentes: desligue o autorun no Warmbly antes de disparar por aqui.",
-  },
-  sending_paused: {
-    kind: "refused",
-    title: "Recusada: o disparo de saída está pausado",
-    recovery:
-      "Nada foi enfileirado. Retome o disparo em Operação segura — a retomada é de dois passos e mostra o resumo de impacto — e dispare a cohort em seguida.",
-  },
-  kill_switch_engaged: {
-    kind: "refused",
-    title: "Recusada: o kill switch de arquivo está acionado",
-    recovery:
-      `Nada foi enfileirado. O kill switch fica fora deste canal por construção: remova-o na VPS (${OUT_OF_BAND_PAUSE_FALLBACK} documenta o caminho) e dispare de novo depois.`,
-  },
-  cohort_grant_revoked: {
-    kind: "refused",
-    title: "Recusada: a autoridade desta cohort foi revogada",
-    recovery:
-      "Um NO_GO revogou a autoridade bounded desta versão e nada foi enfileirado. Registre GO de novo, ou prepare uma versão nova, antes de disparar.",
-  },
-  cohort_grant_expired: {
-    kind: "refused",
-    title: "Recusada: a autoridade desta cohort venceu",
-    recovery:
-      "A autoridade bounded tem prazo e o dela passou; nada foi enfileirado. Registre GO de novo nesta versão para obter uma autoridade vigente.",
-  },
-  cohort_grant_missing: {
-    kind: "refused",
-    title: "Recusada: esta versão não tem autoridade bounded",
-    recovery:
-      "Disparar exige um GO registrado nesta versão exata. Nada foi enfileirado: registre GO e dispare em seguida.",
   },
   adjust_route_unavailable: {
     kind: "refused",
@@ -525,10 +471,8 @@ const GATE_ACTION_LABELS: Record<string, string> = {
   reproduce: "reproduzir versão imutável",
   validate: "verificar destinatário",
   review: "registrar decisão de revisão",
-  reconcile: "reconciliar aprovações com a fila",
-  decide: "registrar GO/NO-GO",
   adjust: "ajustar assunto e corpo",
-  dispatch: "entregar a cohort à fila de envio",
+  reconcile: "reprocessar aprovações já registradas",
 };
 
 const READBACK_LABELS: Record<string, string> = {
@@ -546,7 +490,7 @@ const READBACK_LABELS: Record<string, string> = {
  * Operation, Cohorts and Revisão share it deliberately. Three copies of this
  * block would drift, and the surfaces that never had one — Cohorts and Revisão —
  * are exactly where an operator was left with no success, no refusal, no code
- * and no next move after every create, review and GO.
+ * and no next move after every create, review and reconciliation.
  */
 export function writeResultBlock(result: AdapterWriteResult | undefined): string {
   if (!result) return "";
@@ -608,7 +552,6 @@ export function writeResultBlock(result: AdapterWriteResult | undefined): string
           ? `<dl class="facts" data-server-diff="true">${diffRows}</dl>`
           : ""
       }
-      ${dispatchCounters(result.dispatch)}
       ${reconcileCounters(result.reconcile)}
       ${technicalDetails(
         [
@@ -627,60 +570,35 @@ export function writeResultBlock(result: AdapterWriteResult | undefined): string
     </article>`;
 }
 
-function reconcileCounters(counts: AdapterWriteResult["reconcile"]): string {
-  if (!counts) return "";
-  const row = (label: string, value: number | undefined): string =>
-    value === undefined ? fact(label, NOT_IN_PAYLOAD) : fact(label, String(value));
-  const failures = (counts.failures ?? [])
-    .map((entry) => `<div data-reconcile-failure="${escapeHtml(entry.reason)}"><dt>${escapeHtml(entry.cohortVersionId || entry.candidateId || "registro não identificado")}</dt><dd>${escapeHtml(entry.reason || "motivo não informado pelo servidor")}</dd></div>`)
-    .join("");
-  return `<dl class="facts" data-reconcile-counts="true">
-    ${row("Registros APPROVE", counts.approvalRecords)}
-    ${row("Bindings APPROVE vigentes", counts.latestApprovedBindings)}
-    ${row("Candidatos aprovados únicos", counts.uniqueApprovedCandidates)}
-    ${row("Agendados agora", counts.scheduled)}
-    ${row("Já agendados", counts.alreadyScheduled)}
-    ${row("Falharam", counts.failed)}
-  </dl><p class="constraint" data-reconcile-not-sent="true">Reconciliação cria ou confirma trabalho na fila; não envia e não retoma o disparo.</p>${failures ? `<dl class="facts" data-reconcile-failures="true">${failures}</dl>` : ""}`;
-}
-
 /**
- * What a bounded dispatch actually queued, straight from Warmbly's counters.
+ * What approval reconciliation actually repaired, straight from Warmbly.
  *
- * "Executada" is not an answer here: ten attempted with ten accepted and ten
- * attempted with nine blocked are the same HTTP 200 and completely different
- * operational facts. A counter the server did not send renders as absent rather
- * than as zero, and every per-mailbox failure the server named is listed.
+ * "Executada" is not an answer here: six historical review rows, five latest
+ * approved bindings and three deduplicated messages are different facts. A
+ * counter the server did not send renders as absent rather than as zero, and
+ * every candidate failure the server named is listed.
  */
-function dispatchCounters(counts: AdapterWriteResult["dispatch"]): string {
+function reconcileCounters(counts: AdapterWriteResult["reconcile"]): string {
   if (!counts) return "";
   const row = (label: string, value: number | undefined): string =>
     value === undefined ? fact(label, NOT_IN_PAYLOAD) : fact(label, String(value));
   const failures = (counts.failures ?? [])
     .map(
       (entry) =>
-        `<div data-dispatch-failure="${escapeHtml(entry.reason)}"><dt>${escapeHtml(entry.mailbox || "destinatário não nomeado")}</dt><dd>${escapeHtml(entry.reason || "motivo não informado pelo servidor")}</dd></div>`,
+        `<div data-reconcile-failure="${escapeHtml(entry.reason)}"><dt>${escapeHtml(entry.cohortId || entry.candidateId || "registro não identificado")}</dt><dd>${escapeHtml(entry.reason || "motivo não informado pelo servidor")}</dd></div>`,
     )
     .join("");
   return `
-      <dl class="facts" data-dispatch-counts="true">
-        ${row("Tentados", counts.attempted)}
-        ${row("Aceitos pelo provedor", counts.accepted)}
+      <dl class="facts" data-reconcile-counts="true">
+        ${row("Registros APPROVE no histórico", counts.approvalRecords)}
+        ${row("Vínculos com APPROVE mais recente", counts.latestApprovedBindings)}
+        ${row("Candidatos únicos aprovados", counts.uniqueApprovedCandidates)}
+        ${row("Agendados agora", counts.scheduled)}
+        ${row("Já agendados", counts.alreadyScheduled)}
         ${row("Falharam", counts.failed)}
-        ${row("Pulados por duplicidade", counts.skippedDuplicate)}
-        ${row("Bloqueados", counts.blocked)}
-        ${row("Teto diário da autoridade", counts.maxDaily)}
-        ${
-          counts.killSwitchAvailable === undefined
-            ? ""
-            : fact(
-                "Kill switch disponível",
-                counts.killSwitchAvailable ? "sim" : "não — pare o outbound fora de banda se precisar",
-              )
-        }
       </dl>
-      <p class="constraint" data-dispatch-not-sent="true">Estes números são de enfileiramento, não de entrega. O envio acontece depois, pelo worker do Warmbly, dentro da janela comercial.</p>
-      ${failures ? `<dl class="facts" data-dispatch-failures="true">${failures}</dl>` : ""}`;
+      <p class="constraint" data-reconcile-not-sent="true">Reconciliação cria ou confirma trabalho na fila; não envia nem transporta e-mail. Ela usa o mesmo agendamento do APPROVE, e o worker decide a saída depois.</p>
+      ${failures ? `<dl class="facts" data-reconcile-failures="true">${failures}</dl>` : ""}`;
 }
 
 /** The "enviando…" state. A control with no pending state invites a second click. */
@@ -1005,6 +923,50 @@ function gateSection(input: WarmblySurfaceInput, key: "list" | "selected"): Gate
   };
 }
 
+/** Server-owned outbound block, rendered before any review work. */
+function outboundStatusBlock(input: WarmblySurfaceInput): string {
+  const gate = record(input.gate);
+  const status = typeof gate.outbound_status_status === "string"
+    ? gate.outbound_status_status
+    : Object.keys(record(gate.outbound_status)).length > 0
+      ? "read"
+      : "absent";
+  const detail = typeof gate.outbound_status_detail === "string" ? gate.outbound_status_detail : "";
+  const data = record(gate.outbound_status);
+  if (status !== "read") {
+    return `<article class="card banner error" role="alert" data-outbound-status="${escapeHtml(status)}">
+      <h3>Bloqueio de outbound não pôde ser lido antes da revisão</h3>
+      <p>${escapeHtml(detail || "O servidor não devolveu o status neste carregamento.")} Aprovar ainda pode enfileirar; esta tela não afirma que a mensagem poderá sair.</p>
+    </article>`;
+  }
+  const killSwitch = typeof data.kill_switch === "boolean" ? data.kill_switch : undefined;
+  const sendingAllowed = typeof data.sending_allowed === "boolean" ? data.sending_allowed : undefined;
+  const globalAutoSend = typeof data.auto_send_enabled === "boolean" ? data.auto_send_enabled : undefined;
+  const blocked = killSwitch === true || sendingAllowed === false || globalAutoSend === true;
+  if (blocked) {
+    return `<article class="card banner error" role="alert" data-outbound-status="blocked" data-kill-switch="${killSwitch === undefined ? "unknown" : String(killSwitch)}">
+      <p class="kicker"><span class="pill error">OUTBOUND BLOQUEADO</span></p>
+      <h3>APPROVE enfileira, mas nenhuma mensagem sai enquanto este bloqueio durar</h3>
+      <p>O Warmbly reporta um bloqueio ou configuração global incompatível antes desta revisão. Aprovar grava <code>auto_send=true</code> na mensagem e agenda a próxima janela comercial; o worker continuará impedido de transportá-la.</p>
+      <dl class="facts">
+        ${fact("Kill switch reportado", killSwitch === undefined ? NOT_IN_PAYLOAD : killSwitch ? "acionado" : "não acionado")}
+        ${fact("Envio permitido pelo servidor", sendingAllowed === undefined ? NOT_IN_PAYLOAD : sendingAllowed ? "sim" : "não")}
+        ${fact("Auto-send global", globalAutoSend === undefined ? NOT_IN_PAYLOAD : globalAutoSend ? "ligado — configuração inválida" : "desligado (esperado)")}
+      </dl>
+    </article>`;
+  }
+  if (killSwitch === undefined || sendingAllowed === undefined) {
+    return `<article class="card banner stale" role="alert" data-outbound-status="unknown">
+      <h3>Servidor não informou todo o estado de outbound</h3>
+      <p>Ausência não é zero nem “liberado”. APPROVE enfileira com auto_send por mensagem, mas confira o status do Warmbly antes de esperar transporte.</p>
+    </article>`;
+  }
+  return `<article class="card banner ok" role="status" data-outbound-status="allowed">
+    <h3>Outbound liberado pelo servidor neste instante</h3>
+    <p>APPROVE enfileira com auto_send por mensagem. O worker ainda decide janela comercial, teto por hora e todos os gates de última milha.</p>
+  </article>`;
+}
+
 function cohortRows(input: WarmblySurfaceInput): Record<string, unknown>[] {
   return array(gateSection(input, "list").data.data);
 }
@@ -1042,8 +1004,8 @@ function gateUnreadableBanner(section: GateSection, what: string): string {
  * ------------------------------------------------------------------ */
 
 const CAPABILITY_LABELS: Record<string, string> = {
-  operators: "revisar candidatos, criar e reproduzir cohorts, pedir verificação",
-  admins: "registrar GO/NO-GO (autoridade bounded)",
+  operators: "revisar candidatos; APPROVE enfileira com auto_send por mensagem",
+  admins: "reprocessar aprovações já registradas (reparo idempotente)",
 };
 
 export interface OperatorAuthority {
@@ -1051,7 +1013,7 @@ export interface OperatorAuthority {
   known: boolean;
   groups: readonly string[];
   canReview: boolean;
-  canDecide: boolean;
+  canReconcile: boolean;
 }
 
 /**
@@ -1066,7 +1028,9 @@ export function operatorAuthority(input: WarmblySurfaceInput): OperatorAuthority
   const actor =
     record(record(gate.list).edge_actor).groups !== undefined
       ? record(record(gate.list).edge_actor)
-      : record(record(gate.selected).edge_actor);
+      : record(record(gate.selected).edge_actor).groups !== undefined
+        ? record(record(gate.selected).edge_actor)
+        : record(record(gate.outbound_status).edge_actor);
   const groups = Array.isArray(actor.groups)
     ? actor.groups.filter((group): group is string => typeof group === "string")
     : [];
@@ -1075,7 +1039,7 @@ export function operatorAuthority(input: WarmblySurfaceInput): OperatorAuthority
     known,
     groups,
     canReview: groups.includes("operators"),
-    canDecide: groups.includes("admins"),
+    canReconcile: groups.includes("admins"),
   };
 }
 
@@ -1095,7 +1059,7 @@ function identityBlock(input: WarmblySurfaceInput, directScheduling = false): st
           .map((group) => {
             const currentLabel = directScheduling
               ? group === "operators"
-                ? "revisar e aprovar candidatos, criar e reproduzir cohorts, pedir verificação"
+                ? "revisar candidatos — APPROVE enfileira para envio futuro —, criar e reproduzir cohorts, pedir verificação"
                 : group === "admins"
                   ? "reconciliar aprovações antigas com a fila"
                   : undefined
@@ -1106,8 +1070,8 @@ function identityBlock(input: WarmblySurfaceInput, directScheduling = false): st
       : "nenhum grupo efetivo — esta sessão não pode escrever no gate"
     : NOT_IN_PAYLOAD;
   return `
-    <article class="card" data-operator-identity="true" data-can-review="${authority.canReview ? "true" : "false"}" data-can-decide="${authority.canDecide ? "true" : "false"}">
-      <p class="kicker"><span class="pill">${escapeHtml(authority.canDecide ? "admins" : authority.canReview ? "operators" : "sem autoridade de escrita")}</span></p>
+    <article class="card" data-operator-identity="true" data-can-review="${authority.canReview ? "true" : "false"}" data-can-reconcile="${authority.canReconcile ? "true" : "false"}">
+      <p class="kicker"><span class="pill">${escapeHtml(authority.canReview ? "operators" : authority.canReconcile ? "admins (somente reparo)" : "sem autoridade de escrita")}</span></p>
       <h3>Quem você é nesta tela</h3>
       <dl class="facts">
         ${fact("Operador", name)}
@@ -1160,8 +1124,16 @@ export function pilotSteps(input: WarmblySurfaceInput): StepView[] {
   const readable = list.status === "read";
   const candidates = array(cohort?.candidates);
   const validations = candidates.map((candidate) => show(record(candidate.validation).status));
-  const reviews = candidates.map((candidate) => show(record(candidate.review).decision));
-  const decision = show(record(cohort?.decision).decision);
+  const approved = candidates.filter((candidate) => {
+    const review = record(candidate.review);
+    return review.decision === "APPROVE" && review.effective === true;
+  });
+  const scheduled = approved.filter((candidate) => {
+    const scheduling = record(candidate.scheduling);
+    return scheduling.auto_send === true
+      && ["QUEUED", "SENT"].includes(show(scheduling.state))
+      && Boolean(scheduling.due_at);
+  });
   const unknownStep = (id: string, label: string, detail: string): StepView => ({
     id,
     label,
@@ -1174,69 +1146,14 @@ export function pilotSteps(input: WarmblySurfaceInput): StepView[] {
       unknownStep("cohort", "Cohort", "O gate não pôde ser lido neste carregamento."),
       unknownStep("validacao", "Validação", "O gate não pôde ser lido neste carregamento."),
       unknownStep("revisao", "Revisão", "O gate não pôde ser lido neste carregamento."),
-      unknownStep("go", "GO", "O gate não pôde ser lido neste carregamento."),
-      unknownStep("handoff", "Handoff", "O gate não pôde ser lido neste carregamento."),
+      unknownStep("agendamento", "Agendamento", "O gate não pôde ser lido neste carregamento."),
     ];
   }
   const hasCohort = cohort !== undefined && Object.keys(cohort).length > 0;
   const source = hasCohort ? show(cohort.source) : "—";
   const freshness = hasCohort ? show(cohort.freshness) : "—";
-  const decided = decision === "GO" || decision === "NO_GO";
   const validationPending = validations.filter((status) => status !== "VALID").length;
-  const reviewPending = reviews.filter((decisionValue) => decisionValue !== "APPROVE").length;
-  const directScheduling = candidates.some((candidate) =>
-    Object.prototype.hasOwnProperty.call(candidate, "scheduling"),
-  );
-  const scheduled = candidates.filter((candidate) => {
-    const scheduling = record(candidate.scheduling);
-    return typeof scheduling.touchpoint_id === "string"
-      && scheduling.auto_send === true
-      && !scheduling.invalidated_at;
-  }).length;
-  if (directScheduling) {
-    return [
-      {
-        id: "fonte",
-        label: "Fonte",
-        state: hasCohort ? "done" : "pending",
-        detail: hasCohort
-          ? `Origem ${source}, freshness ${freshness}, as_of ${show(cohort.as_of)}.`
-          : "Nenhuma cohort listada pelo servidor.",
-      },
-      {
-        id: "cohort",
-        label: "Cohort",
-        state: hasCohort ? "done" : "current",
-        detail: hasCohort
-          ? `v${show(cohort.version)} congelada com ${candidates.length} candidato(s) no payload.`
-          : "Crie uma cohort pequena (1–10) em Cohorts para começar.",
-      },
-      {
-        id: "validacao",
-        label: "Validação",
-        state: candidates.length === 0 ? "unknown" : validationPending === 0 ? "done" : "current",
-        detail: candidates.length === 0
-          ? "O payload desta versão não trouxe candidatos."
-          : `${validations.filter((status) => status === "VALID").length} de ${candidates.length} com validação VALID segundo o servidor.`,
-      },
-      {
-        id: "revisao",
-        label: "Revisão e agendamento",
-        state: candidates.length === 0 ? "unknown" : reviewPending === 0 ? "done" : "current",
-        detail: candidates.length === 0
-          ? "O payload desta versão não trouxe candidatos."
-          : `${reviews.filter((value) => value === "APPROVE").length} de ${candidates.length} aprovados; ${scheduled} com agendamento efetivo segundo o servidor.`,
-      },
-      {
-        id: "fila",
-        label: "Fila do Warmbly",
-        state: candidates.length === 0 ? "unknown" : scheduled === candidates.length ? "done" : "pending",
-        detail: candidates.length === 0
-          ? "O payload desta versão não trouxe candidatos."
-          : `${scheduled} de ${candidates.length} estão na fila. O worker respeita pausa, janela comercial e teto por hora.`,
-      },
-    ];
-  }
+  const reviewPending = candidates.length - approved.length;
   return [
     {
       id: "fonte",
@@ -1282,26 +1199,21 @@ export function pilotSteps(input: WarmblySurfaceInput): StepView[] {
       detail:
         !hasCohort || candidates.length === 0
           ? "O payload desta versão não trouxe candidatos."
-          : `${reviews.filter((value) => value === "APPROVE").length} de ${candidates.length} aprovados segundo o servidor.`,
+          : `${approved.length} de ${candidates.length} com APPROVE efetivo segundo o servidor. Aprovar é autoridade para enfileirar.`,
     },
     {
-      id: "go",
-      label: "GO",
-      state: decided ? "done" : hasCohort ? "pending" : "pending",
-      detail: decided
-        ? `Decisão final registrada: ${decision}.`
-        : hasCohort
-          ? "Nenhuma decisão final registrada nesta versão."
-          : "Sem cohort não existe GO.",
-    },
-    {
-      id: "handoff",
-      label: "Handoff",
-      state: decision === "GO" ? "current" : "pending",
-      detail:
-        decision === "GO"
-          ? "GO cria a autoridade bounded. Ele não enfileira, não envia e não liga auto-send."
-          : "O handoff só existe depois de um GO registrado.",
+      id: "agendamento",
+      label: "Agendamento",
+      state: !hasCohort
+        ? "pending"
+        : approved.length === 0
+          ? "pending"
+          : scheduled.length === approved.length
+            ? "done"
+            : "current",
+      detail: !hasCohort
+        ? "Sem cohort não há mensagens para agendar."
+        : `${scheduled.length} de ${approved.length} aprovação(ões) efetiva(s) têm auto_send por mensagem, due_at e estado QUEUED/SENT.`,
     },
   ];
 }
@@ -1329,18 +1241,15 @@ function pilotSummary(input: WarmblySurfaceInput): string {
   const list = gateSection(input, "list");
   const latest = latestCohort(input);
   const authority = operatorAuthority(input);
-  const directScheduling = array(latest?.candidates).some((candidate) =>
-    Object.prototype.hasOwnProperty.call(candidate, "scheduling"),
-  );
   const open = latest
     ? `<p><a class="button" data-open-review="true" href="#/warmbly/revisao?resource=${escapeHtml(show(latest.id))}">Abrir revisão da v${escapeHtml(show(latest.version))}</a></p>`
     : `<p><a class="button" data-open-cohorts="true" href="#/warmbly/cohorts">Abrir Cohorts para criar a primeira versão</a></p>`;
   return `
     <section class="stack" aria-labelledby="warmbly-piloto" data-pilot-summary="true">
       <h2 id="warmbly-piloto">Onde o piloto está</h2>
-      <p class="constraint">${directScheduling ? "Fonte → Cohort → Validação → APPROVE → fila. O APPROVE agenda a mensagem; o worker respeita pausa, janela comercial e teto por hora." : "Fonte → Cohort → Validação → Revisão → GO → Handoff. Cada passo abaixo repete o que o servidor devolveu; nada é recontado nesta tela. GO não envia e-mail e auto-send permanece desligado."}</p>
+      <p class="constraint">Fonte → Cohort → Validação → Revisão → Agendamento. APPROVE já enfileira a mensagem com auto_send=true para ela; a automação global continua desligada. Cada passo abaixo repete o servidor.</p>
       ${gateUnreadableBanner(list, "a lista de cohorts")}
-      ${identityBlock(input, directScheduling)}
+      ${identityBlock(input, true)}
       ${stepperBlock(input)}
       ${
         latest
@@ -1350,21 +1259,21 @@ function pilotSummary(input: WarmblySurfaceInput): string {
               <dl class="facts">
                 ${fact("Identificador da versão", show(latest.id))}
                 ${fact("as_of", show(latest.as_of))}
-                ${directScheduling ? "" : fact("Decisão final", fromPayload(record(latest.decision).decision))}
+                ${fact("GO/NO-GO histórico", fromPayload(record(latest.decision).decision))}
                 ${fact("Destinatários finais no preview", fromPayload(record(record(latest.manifest).preview).recipients_final))}
               </dl>
               ${open}
             </article>`
           : list.status === "read"
-            ? `<article class="card" data-latest-cohort="none"><h3>Nenhuma cohort listada</h3><p>O servidor respondeu e não listou nenhuma versão. Uma cohort vazia nunca pode receber GO.</p>${open}</article>`
+            ? `<article class="card" data-latest-cohort="none"><h3>Nenhuma cohort listada</h3><p>O servidor respondeu e não listou nenhuma versão para revisão.</p>${open}</article>`
             : open
       }
       ${
-        authority.canDecide || directScheduling
+        authority.canReconcile
           ? ""
-          : `<p class="constraint" data-go-authority="absent">Registrar GO/NO-GO exige o grupo <code>admins</code> no Authelia. Sua sessão ${
+          : `<p class="constraint" data-reconcile-authority="absent">O reparo “Reprocessar aprovações” exige <code>admins</code>. Sua sessão ${
               authority.known ? "não tem esse grupo" : "não teve os grupos confirmados pelo canal"
-            }: revisar continua permitido, e o controle de GO aparece desabilitado com o motivo na Revisão.</p>`
+            }: o fluxo normal continua sendo APPROVE por <code>operators</code>, sem passo extra.</p>`
       }
     </section>`;
 }
@@ -1581,26 +1490,17 @@ export function approvalGate(candidate: Record<string, unknown>): ApprovalGate {
 function cohortSurface(input: WarmblySurfaceInput): string {
   const params = new URLSearchParams(input.query ?? "");
   const freshness = params.get("freshness") ?? "all";
-  const decisionFilter = params.get("decision") ?? "all";
   const list = gateSection(input, "list");
   const authority = operatorAuthority(input);
   const feedback = feedbackRouter(input.operatorResult);
   const allCohorts = cohortRows(input);
-  const directScheduling = allCohorts.some((cohort) =>
-    array(cohort.candidates).some((candidate) =>
-      Object.prototype.hasOwnProperty.call(candidate, "scheduling"),
-    ),
+  const cohorts = allCohorts.filter(
+    (cohort) => freshness === "all" || show(cohort.freshness) === freshness,
   );
-  const cohorts = allCohorts.filter((cohort) => {
-    const decision = show(record(cohort.decision).decision);
-    return (freshness === "all" || show(cohort.freshness) === freshness)
-      && (decisionFilter === "all" || decision === decisionFilter);
-  });
   const rows = cohorts.map((cohort) => {
     const preview = record(record(cohort.manifest).preview);
-    const decision = record(cohort.decision);
     const id = show(cohort.id);
-    return `<tr data-cohort-row="${escapeHtml(id)}"><td><a href="#/warmbly/revisao?resource=${escapeHtml(id)}">v${escapeHtml(show(cohort.version))}</a></td><td>${escapeHtml(show(cohort.freshness))}</td><td>${escapeHtml(fromPayload(preview.accounts_considered))}</td><td>${escapeHtml(fromPayload(preview.accounts_eligible))}</td><td>${escapeHtml(fromPayload(preview.accounts_excluded))}</td><td>${escapeHtml(fromPayload(preview.recipients_final))}</td><td>${escapeHtml(fromPayload(decision.decision))}</td><td><a class="button" data-open-review="true" href="#/warmbly/revisao?resource=${escapeHtml(id)}">Abrir revisão</a></td></tr>`;
+    return `<tr data-cohort-row="${escapeHtml(id)}"><td><a href="#/warmbly/revisao?resource=${escapeHtml(id)}">v${escapeHtml(show(cohort.version))}</a></td><td>${escapeHtml(show(cohort.freshness))}</td><td>${escapeHtml(fromPayload(preview.accounts_considered))}</td><td>${escapeHtml(fromPayload(preview.accounts_eligible))}</td><td>${escapeHtml(fromPayload(preview.accounts_excluded))}</td><td>${escapeHtml(fromPayload(preview.recipients_final))}</td><td><a class="button" data-open-review="true" href="#/warmbly/revisao?resource=${escapeHtml(id)}">Abrir revisão</a></td></tr>`;
   }).join("");
   const currentSelection = record(allCohorts[0]?.selection);
   const selectionProgress = Object.keys(currentSelection).length > 0
@@ -1619,22 +1519,14 @@ function cohortSurface(input: WarmblySurfaceInput): string {
   }).join("");
   const createKey = "create:next-unclaimed";
   const recoverKey = "create:recover-prior";
-  const reconcileKey = "reconcile:approved";
   const createPending = gateInFlight(createKey);
   const recoverPending = gateInFlight(recoverKey);
-  const reconcilePending = gateInFlight(reconcileKey);
-  return `<section class="stack" aria-labelledby="cohorts-title"><h2 id="cohorts-title">Cohorts versionadas</h2><p class="constraint">Denominadores vêm do preview Warmbly: considerados = elegíveis + excluídos e destinatários finais nunca são recalculados nesta tela. O auto-send global permanece OFF; somente uma aprovação humana efetiva pode agendar o próprio touchpoint.</p>
+  return `<section class="stack" aria-labelledby="cohorts-title"><h2 id="cohorts-title">Cohorts versionadas</h2><p class="constraint">Denominadores vêm do preview Warmbly: considerados = elegíveis + excluídos e destinatários finais nunca são recalculados nesta tela. A automação global permanece desligada; cada APPROVE agenda somente sua mensagem com <code>auto_send=true</code>.</p>
   ${gateUnreadableBanner(list, "a lista de cohorts")}
   ${feedback.remainder()}
-  ${identityBlock(input, directScheduling)}
+  ${identityBlock(input, true)}
   ${selectionProgress}
-  ${reconcilePending ? pendingBlock("Reconciliando aprovações já registradas") : ""}
-  <form class="operator-form" data-human-gate="reconcile" data-gate-key="${escapeHtml(reconcileKey)}"><button type="submit"${reconcilePending || !authority.canDecide ? " disabled" : ""}>${reconcilePending ? "Enviando…" : "Reconciliar aprovações antigas com a fila"}</button><p class="constraint">Execute antes de ampliar o backlog. O Warmbly agenda de forma idempotente os APPROVEs duráveis ainda sem fila; não envia nada e não retoma o disparo.</p>${
-    authority.canDecide
-      ? ""
-      : `<p class="constraint" data-blocked-reason="reconcile">Reconciliar em lote exige o grupo <code>admins</code> no Authelia.</p>`
-  }</form>
-  <form class="filters" data-human-gate-filters="cohorts"><label>Freshness<select name="freshness"><option value="all">Todos</option><option value="FRESH"${freshness === "FRESH" ? " selected" : ""}>FRESH</option><option value="STALE"${freshness === "STALE" ? " selected" : ""}>STALE</option></select></label><label>Decisão<select name="decision"><option value="all">Todas</option><option value="GO"${decisionFilter === "GO" ? " selected" : ""}>GO</option><option value="NO_GO"${decisionFilter === "NO_GO" ? " selected" : ""}>NO_GO</option></select></label></form>
+  <form class="filters" data-human-gate-filters="cohorts"><label>Freshness<select name="freshness"><option value="all">Todos</option><option value="FRESH"${freshness === "FRESH" ? " selected" : ""}>FRESH</option><option value="STALE"${freshness === "STALE" ? " selected" : ""}>STALE</option></select></label></form>
   ${createPending ? pendingBlock("Criando a cohort congelada") : ""}
   <form class="operator-form" data-human-gate="create" data-gate-key="${escapeHtml(createKey)}"><input type="hidden" name="selection_mode" value="NEXT_UNCLAIMED"><label>Próxima cohort (1–10)<input name="limit" type="number" min="1" max="10" value="10" required></label><button type="submit"${createPending || !authority.canReview ? " disabled" : ""}>${createPending ? "Enviando…" : "Criar próxima cohort sem repetição"}</button>${
     authority.canReview
@@ -1642,7 +1534,7 @@ function cohortSurface(input: WarmblySurfaceInput): string {
       : `<p class="constraint" data-blocked-reason="create">Criar cohort exige o grupo <code>operators</code> no Authelia.</p>`
   }</form>
   ${recoverable.length > 0 ? `${recoverPending ? pendingBlock("Recuperando fornecedores anteriores na fonte atual") : ""}<form class="operator-form" data-human-gate="create" data-gate-key="${escapeHtml(recoverKey)}"><input type="hidden" name="selection_mode" value="RECOVER_PRIOR"><input type="hidden" name="limit" value="10"><fieldset><legend>Recuperar versões anteriores</legend>${recoveryChoices}</fieldset><button type="submit"${recoverPending || !authority.canReview ? " disabled" : ""}>${recoverPending ? "Enviando…" : "Recompor fornecedores selecionados com a fonte atual"}</button><p class="constraint">A recuperação deduplica fornecedores, relê a fonte vigente e cria textos e hashes novos. Aprovação ou agendamento anteriores não são herdados.</p></form>` : ""}
-  <div class="table-wrap"><table><thead><tr><th>Versão</th><th>Freshness</th><th>Considerados</th><th>Elegíveis</th><th>Excluídos</th><th>Finais</th><th>Decisão</th><th>Revisão</th></tr></thead><tbody>${rows || `<tr><td colspan="8">Nenhuma cohort ${list.status === "read" ? "listada pelo servidor" : "pôde ser lida"}. Uma cohort vazia nunca pode receber GO.</td></tr>`}</tbody></table></div></section>`;
+  <div class="table-wrap"><table><thead><tr><th>Versão</th><th>Freshness</th><th>Considerados</th><th>Elegíveis</th><th>Excluídos</th><th>Finais</th><th>Revisão</th></tr></thead><tbody>${rows || `<tr><td colspan="7">Nenhuma cohort ${list.status === "read" ? "listada pelo servidor" : "pôde ser lida"}.</td></tr>`}</tbody></table></div></section>`;
 }
 
 /* ------------------------------------------------------------------ *
@@ -1768,8 +1660,15 @@ function candidateCard(
   const review = record(candidate.review);
   const schedulingKnown = Object.prototype.hasOwnProperty.call(candidate, "scheduling");
   const scheduling = record(candidate.scheduling);
+  const reviewApproved = review.decision === "APPROVE" && review.effective === true;
   const schedulingState = textOf(scheduling.state);
+  const schedulingDueAt = textOf(scheduling.due_at);
   const schedulingInvalidated = textOf(scheduling.invalidated_at);
+  const schedulingConfirmed =
+    reviewApproved
+    && scheduling.auto_send === true
+    && schedulingDueAt !== null
+    && (schedulingState === "QUEUED" || schedulingState === "SENT");
   // Produção manda `observed_fact` e `fact_source` como texto simples. Ler o
   // texto como objeto fazia o fato real sair como "não informado pelo servidor"
   // embaixo de uma mensagem que afirmava exatamente esse fato. O formato objeto
@@ -1887,20 +1786,22 @@ function candidateCard(
     <p class="banner ok" role="status" data-already-approved="${escapeHtml(queue.optimistic ? "local" : "server")}">${
       queue.optimistic
         ? "Aprovação registrada nesta sessão. A releitura do servidor ainda não voltou; se ela discordar, este candidato volta para a fila."
-        : "Este candidato já está aprovado nesta versão. Para reverter, registre HOLD ou REJECT abaixo."
+        : schedulingConfirmed
+          ? "Este candidato já está aprovado e agendado pelo servidor. Para cancelar antes do envio, registre HOLD ou REJECT abaixo."
+          : "Este candidato já está aprovado, mas o agendamento não foi confirmado. Um admin deve usar o reparo idempotente desta página; não reaprove o candidato."
     }</p>
 `
       : `
     ${gateInFlight(approveKey) ? pendingBlock("Registrando a aprovação") : ""}
     <form class="operator-form approve-form" data-human-gate="review" data-gate-key="${escapeHtml(approveKey)}" data-decision="APPROVE" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}"${gate.needsValidation ? ` data-auto-validate="true"` : ""}>
-      <h4>Aprovar este candidato</h4>
-      <p class="constraint" data-approve-meaning="true">Clicar em Aprovar é a ciência: a trilha grava sua identidade do Authelia, o instante, esta versão v${escapeHtml(version)}, o hash congelado, o destinatário exato e a decisão. Não há segunda caixa a marcar.</p>
+      <h4>Aprovar e enfileirar este candidato</h4>
+      <p class="constraint" data-approve-meaning="true">Clicar em Aprovar e enfileirar é a ciência e a autoridade de agendamento: a trilha grava sua identidade do Authelia, o instante, esta versão v${escapeHtml(version)}, o hash congelado, o destinatário exato e a decisão; a mesma operação cria a mensagem com <code>auto_send=true</code> e <code>due_at</code> na próxima janela comercial. Não há GO, segunda caixa ou passo de entrega.</p>
       ${
         gate.needsValidation
           ? `<p class="constraint" data-approve-autovalidate="true">Este destinatário ainda não tem verificação vigente. Aprovar pede a verificação ao Warmbly primeiro e só registra o APPROVE se ela voltar VALID — você não precisa acionar nada antes.</p>`
           : ""
       }
-      <button type="submit" data-approve-submit="true"${gate.allowed && authority.canReview && !gateInFlight(approveKey) ? "" : " disabled"}>${gateInFlight(approveKey) ? "Enviando…" : "Aprovar"}</button>
+      <button type="submit" data-approve-submit="true"${gate.allowed && authority.canReview && !gateInFlight(approveKey) ? "" : " disabled"}>${gateInFlight(approveKey) ? "Enviando…" : "Aprovar e enfileirar para envio"}</button>
       <details data-approve-comment="true">
         <summary>Comentário para a trilha (opcional)</summary>
         <label>Observação<input name="reason" maxlength="200"></label>
@@ -1918,6 +1819,20 @@ function candidateCard(
       }
     </form>
 `;
+
+  const schedulingBlock = reviewApproved
+    ? schedulingConfirmed
+      ? `<article class="banner ok" role="status" data-approval-scheduling="true" data-scheduling-confirmed="true" data-scheduling-state="${escapeHtml(schedulingState ?? "")}">
+          <h4>Agendamento confirmado pelo servidor</h4>
+          <p>APPROVE agenda a mensagem: ela está ${schedulingState === "SENT" ? "marcada como enviada" : "na fila do worker"}, com <code>auto_send=true</code>${schedulingState === "QUEUED" ? " e saída prevista para a próxima janela permitida" : ""}. Pausa, kill switch, janela comercial, teto por hora e validação de última milha ainda governam o transporte.</p>
+          <dl class="facts">${fact("Estado", schedulingState ?? NOT_IN_PAYLOAD)}${fact("due_at", schedulingDueAt === null ? NOT_IN_PAYLOAD : stamp(schedulingDueAt))}${fact("auto_send da mensagem", "true")}</dl>
+        </article>`
+      : `<article class="banner error" role="alert" data-approval-scheduling="true" data-scheduling-confirmed="false">
+          <h4>Defeito: APPROVE efetivo sem agendamento confirmado</h4>
+          <p>Uma aprovação válida deve sair da mesma operação em <code>QUEUED</code>, com <code>due_at</code> e <code>auto_send=true</code>. Não reaprove. Um admin deve executar “Reprocessar aprovações já registradas” e reler este candidato.</p>
+          <dl class="facts">${fact("Estado", schedulingState ?? NOT_IN_PAYLOAD)}${fact("due_at", schedulingDueAt === null ? NOT_IN_PAYLOAD : stamp(schedulingDueAt))}${fact("auto_send da mensagem", scheduling.auto_send === undefined ? NOT_IN_PAYLOAD : String(scheduling.auto_send))}</dl>
+        </article>`
+    : "";
 
   // Not merely disabled: a historical version emits no decision markup at all,
   // so there is nothing for devtools to re-enable.
@@ -1982,6 +1897,7 @@ ${validateControl}
       ${factWhenPresent("Excluído do preview por", flagText(candidate.exclusion_reason ?? candidate.excluded_reason))}
     </dl>
 
+    ${schedulingBlock}
     ${controls}
     ${technicalDetails(
       [
@@ -2005,7 +1921,7 @@ ${validateControl}
         { term: "review_decision", value: techValue(review.decision) },
         { term: "review_effective", value: techValue(review.effective) },
         { term: "scheduling_state", value: techValue(scheduling.state) },
-        { term: "scheduling_due_at", value: scheduling.due_at ? stamp(scheduling.due_at) : "" },
+        { term: "scheduling_due_at", value: techValue(scheduling.due_at) },
         { term: "scheduling_auto_send", value: techValue(scheduling.auto_send) },
         { term: "scheduling_invalidated_at", value: techValue(scheduling.invalidated_at) },
         { term: "scheduling_invalidation_reason", value: techValue(scheduling.invalidation_reason) },
@@ -2056,7 +1972,7 @@ function adjustBlock(args: {
           <div data-diff-field="body_text"><dt>Corpo</dt><dd><del><pre class="message-preview">${escapeHtml(draft.before_body_text)}</pre></del><ins><pre class="message-preview">${escapeHtml(draft.body_text)}</pre></ins></dd></div>
           <div data-diff-field="reason"><dt>Motivo</dt><dd>${escapeHtml(draft.reason)}</dd></div>
         </dl>
-        <p class="constraint">Confirmar cria a versão seguinte. A versão v${escapeHtml(version)} continua existindo e legível; validação, revisão e agendamento da nova versão começam pendentes.</p>
+        <p class="constraint">Confirmar cria a versão seguinte. A versão v${escapeHtml(version)} continua existindo e legível; validação e revisão da nova versão começam pendentes. Cada APPROVE nela fará o próprio agendamento.</p>
       </div>`
     : "";
   return `
@@ -2099,7 +2015,7 @@ function legacyBanner(editorial: EditorialReading, cohortId: string): string {
   const linkable = editorial.currentVersionId !== "" && editorial.currentVersionId !== cohortId;
   return `<section class="banner error" role="alert" data-legacy-banner="true" data-editorial-state="${escapeHtml(editorial.state)}">
     <h3>Versão histórica. Não enviar.</h3>
-    <p data-legacy-summary="true">Esta é uma versão antiga desta cohort, mantida legível só para auditoria. A mensagem abaixo não é enviável: aprovar, ajustar, verificar e registrar GO não são oferecidos nesta tela.</p>
+    <p data-legacy-summary="true">Esta é uma versão antiga desta cohort, mantida legível só para auditoria. A mensagem abaixo não é enviável: aprovar, ajustar e verificar não são oferecidos nesta tela.</p>
     ${reasons ? `<p data-legacy-reasons="true">Por que ficou histórica: ${escapeHtml(reasons)}.</p>` : ""}
     ${editorial.notice ? `<p data-editorial-notice="true">${escapeHtml(editorial.notice)}</p>` : ""}
     ${
@@ -2164,7 +2080,7 @@ function queueBlock(
     <p class="kicker"><span class="pill">FILA</span></p>
     <h3 data-queue-progress-text="true">${counts.pendentes} pendente(s) · ${counts.aprovadas} aprovada(s) · ${counts.ajuste} em ajuste · ${counts.total} no total</h3>
     <nav class="subnav queue-filters" data-review-filters="true" aria-label="Estado da revisão">${tabs}</nav>
-    <p class="constraint">A fila abre em Pendentes. Uma mensagem aprovada sai daqui na hora e a próxima assume a posição; as concluídas continuam legíveis nos outros recortes.</p>
+    <p class="constraint">A fila abre em Pendentes. Uma mensagem aprovada sai deste recorte e, na mesma operação, entra na fila do worker com <code>auto_send=true</code>; as concluídas continuam legíveis nos outros recortes.</p>
   </article>`;
 }
 
@@ -2180,17 +2096,11 @@ function emptyQueueBlock(
   filter: ReviewQueueFilter,
   params: URLSearchParams,
   actionable: boolean,
-  directScheduling: boolean,
 ): string {
   const everything = `<p><a class="button" data-queue-see-all="true" href="${escapeHtml(queueFilterHref(params, "todas"))}">Ver todas as ${counts.total}</a></p>`;
   if (filter === "pendentes") {
-    // A historical version offers no GO control at all, so naming GO as the
-    // next step there would point the founder at a button this screen refuses
-    // to render.
     const next = actionable
-      ? directScheduling
-        ? "Os APPROVEs efetivos já criaram ou confirmaram seus agendamentos na fila do Warmbly."
-        : "O próximo passo é o GO/NO-GO logo abaixo, e ele continua exigindo a confirmação digitada da versão."
+      ? "Não há GO nem entrega manual: cada APPROVE efetivo já deve estar agendado. Confira o estado de agendamento nas mensagens aprovadas."
       : "Esta versão é histórica e não é enviável, então não há próximo passo aqui: decida na versão corrente.";
     return `<article class="card banner ok" role="status" data-queue-empty="pendentes">
       <h3>Fila vazia: nada pendente nesta versão.</h3>
@@ -2205,57 +2115,24 @@ function emptyQueueBlock(
   </article>`;
 }
 
-/**
- * Entregar a cohort à fila do Warmbly.
- *
- * The last control on the page, and the only one on this surface whose effect
- * leaves the building. Four things make it what it is:
- *
- * 1. **It only exists after GO.** The server's own `decision` is what gates it,
- *    not anything this screen inferred. Without a registered GO there is no
- *    form at all — not a disabled one — so there is nothing for devtools to
- *    re-enable, exactly as with a historical version.
- * 2. **It says what it does and what it does not do.** It hands the authorised
- *    cohort to Warmbly's queue. It does not send: the worker delivers inside
- *    the commercial window, under the rolling-hour cap, and the pause switch in
- *    Operação segura still stops everything.
- * 3. **It costs a typed confirmation**, like GO. One click that queues real mail
- *    to real companies is the one place on this surface where a second,
- *    deliberate act is worth its cost.
- * 4. **It never claims a number.** How many messages Warmbly accepted comes back
- *    in the response and is rendered from it; this block only states the ceiling
- *    the server enforces.
- */
-function dispatchBlock(args: {
-  cohortId: string;
-  version: string;
-  decisionValue: string;
-  counts: ReturnType<typeof reviewQueueCounts>;
-  authority: OperatorAuthority;
-  actionable: boolean;
-}): string {
-  const { cohortId, version, decisionValue, counts, authority, actionable } = args;
-  if (!actionable) return "";
-  const dispatchKey = `dispatch:${cohortId}::`;
-  const pending = gateInFlight(dispatchKey);
-  if (decisionValue !== "GO") {
-    return `<p class="constraint" data-dispatch-gate="no-go">Entregar esta cohort à fila só é oferecido depois de um GO registrado nesta versão. A decisão final lida agora é ${escapeHtml(decisionValue)}.</p>`;
-  }
+/** Admin-only repair for approvals that predate or missed atomic scheduling. */
+function reconcileBlock(authority: OperatorAuthority): string {
+  const reconcileKey = "reconcile::::";
+  const pending = gateInFlight(reconcileKey);
   return `
-  ${pending ? pendingBlock("Entregando a cohort à fila do Warmbly") : ""}
-  <article class="card" data-cohort-dispatch="${escapeHtml(cohortId)}">
-    <p class="kicker"><span class="pill">GO REGISTRADO</span></p>
-    <h3>Entregar esta cohort à fila de envio</h3>
-    <p data-dispatch-meaning="true">Isto entrega ao Warmbly os ${counts.aprovadas} candidato(s) aprovado(s) desta versão. O Warmbly enfileira cada um e o worker dele envia dentro da janela comercial, no máximo 10 por hora e no máximo 10 por disparo. Esta tela não envia e-mail e não tem controle de send.</p>
-    <p class="constraint" data-dispatch-gates="true">O Warmbly recusa o disparo por conta própria se o GO tiver sido revogado ou vencido, se auto-send ou autorun estiverem ligados, se o disparo estiver pausado ou se o kill switch estiver acionado. Nenhum desses portões é contornável a partir daqui.</p>
-    <p class="constraint" data-dispatch-repeat="true">Disparar de novo é seguro: o Warmbly pula os candidatos já enfileirados desta versão e os conta como duplicados na resposta. Repetir não reenvia o que já saiu.</p>
-    <form class="operator-form" data-human-gate="dispatch" data-gate-key="${escapeHtml(dispatchKey)}" data-version="${escapeHtml(cohortId)}">
-      <label>Confirme digitando <code>v${escapeHtml(version)}</code><input name="confirmation" required pattern="v${escapeHtml(version)}"></label>
-      <button type="submit" data-dispatch-submit="true"${authority.canDecide && !pending ? "" : " disabled"}>${pending ? "Enviando…" : `Entregar v${escapeHtml(version)} à fila do Warmbly`}</button>
+  ${pending ? pendingBlock("Reprocessando aprovações já registradas") : ""}
+  <article class="card" data-approval-reconcile="true">
+    <p class="kicker"><span class="pill">REPARO · ADMINS</span></p>
+    <h3>Reprocessar aprovações já registradas</h3>
+    <p data-reconcile-meaning="true">Este não é um passo normal depois da revisão. APPROVE já agenda sozinho. Use o reparo somente para aprovações antigas ou para um APPROVE cujo card mostre “sem agendamento confirmado”.</p>
+    <p class="constraint" data-reconcile-repeat="true">A operação percorre o histórico pelo mesmo caminho de código do APPROVE, deduplica candidatos repetidos entre cohorts e é idempotente: executar de novo não cria outra mensagem nem reenvia o que já saiu.</p>
+    <p class="constraint">O resultado mostra quantos registros, vínculos e candidatos únicos foram encontrados e quantos ficaram agendados. Isto não transporta e-mail; o worker continua sob janela comercial, teto por hora, pausa e kill switch.</p>
+    <form class="operator-form" data-human-gate="reconcile" data-gate-key="${escapeHtml(reconcileKey)}">
+      <button type="submit" data-reconcile-submit="true"${authority.canReconcile && !pending ? "" : " disabled"}>${pending ? "Enviando…" : "Reprocessar aprovações já registradas"}</button>
       ${
-        authority.canDecide
+        authority.canReconcile
           ? ""
-          : `<p class="constraint" data-dispatch-authority="absent">Entregar a cohort à fila exige o grupo <code>admins</code> no Authelia, a mesma autoridade do GO. Revisar continua permitido com <code>operators</code>.</p>`
+          : `<p class="constraint" data-reconcile-authority="absent">Este reparo exige o grupo <code>admins</code> no Authelia. O fluxo normal continua disponível a <code>operators</code>: “Aprovar e enfileirar para envio”, sem passo extra.</p>`
       }
     </form>
   </article>`;
@@ -2274,10 +2151,11 @@ function reviewSurface(input: WarmblySurfaceInput): string {
     const options = cohortRows(input)
       .map(
         (row) =>
-          `<li class="card" data-cohort-option="${escapeHtml(show(row.id))}"><h3>v${escapeHtml(show(row.version))} · ${escapeHtml(show(row.freshness))}</h3><dl class="facts">${fact("Origem", show(row.source))}${fact("as_of", show(row.as_of))}${fact("Decisão final", fromPayload(record(row.decision).decision))}</dl><p><a class="button" data-open-review="true" href="#/warmbly/revisao?resource=${escapeHtml(show(row.id))}">Abrir revisão</a></p></li>`,
+          `<li class="card" data-cohort-option="${escapeHtml(show(row.id))}"><h3>v${escapeHtml(show(row.version))} · ${escapeHtml(show(row.freshness))}</h3><dl class="facts">${fact("Origem", show(row.source))}${fact("as_of", show(row.as_of))}${fact("GO/NO-GO histórico (sem efeito operacional)", fromPayload(record(row.decision).decision))}</dl><p><a class="button" data-open-review="true" href="#/warmbly/revisao?resource=${escapeHtml(show(row.id))}">Abrir revisão</a></p></li>`,
       )
       .join("");
     return `<section class="stack" data-review-empty="true"><h2>Revisão</h2>
+      ${outboundStatusBlock(input)}
       ${feedback.remainder()}
       ${input.resource ? gateUnreadableBanner(selected, "a versão selecionada") : ""}
       ${gateUnreadableBanner(list, "a lista de cohorts")}
@@ -2292,15 +2170,11 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   const manifest = record(cohort.manifest);
   const preview = record(manifest.preview);
   const candidates = array(cohort.candidates);
-  const directScheduling = candidates.some((candidate) =>
-    Object.prototype.hasOwnProperty.call(candidate, "scheduling"),
-  );
   const params = new URLSearchParams(input.query ?? "");
   const expandAll = params.get("mensagens") !== "recolhidas";
   const cohortId = show(cohort.id);
   const version = show(cohort.version);
   const reproduceKey = `reproduce:${cohortId}::`;
-  const decideKey = `decide:${cohortId}::`;
   // The recorte links are built from the route's own query, and the selected
   // version is restated into it when the route did not carry it. A filter that
   // drops `resource` lands the reviewer on an empty Revisão, which is the exact
@@ -2328,44 +2202,21 @@ function reviewSurface(input: WarmblySurfaceInput): string {
     .join("");
   const cohortFeedback = feedback.forCohort(cohortId);
   const leftover = feedback.remainder();
-  const decisionValue = fromPayload(record(cohort.decision).decision);
+  const historicalDecision = fromPayload(record(cohort.decision).decision);
   const editorial = readEditorialState(cohort);
-  // A historical version emits neither the GO/NO-GO form nor the reproduce
-  // form. The facts below them stay: this removes decisions, not information.
   const reproduceControl = editorial.actionable
     ? `
   ${gateInFlight(reproduceKey) ? pendingBlock("Reproduzindo a versão imutável") : ""}
   <form class="operator-form" data-human-gate="reproduce" data-gate-key="${escapeHtml(reproduceKey)}" data-version="${escapeHtml(cohortId)}"><button type="submit"${gateInFlight(reproduceKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(reproduceKey) ? "Enviando…" : "Reproduzir versão imutável"}</button></form>
 `
     : "";
-  const dispatchControl = directScheduling ? "" : dispatchBlock({
-    cohortId,
-    version,
-    decisionValue,
-    counts,
-    authority,
-    actionable: editorial.actionable,
-  });
-  const decideControl = directScheduling
-    ? editorial.actionable
-      ? `<article class="card" data-approval-scheduling="true"><h3>APPROVE agenda a mensagem</h3><p>Cada APPROVE efetivo cria ou confirma o trabalho na fila do Warmbly para a próxima janela comercial elegível. Não existe GO nem entrega manual da cohort neste contrato.</p><p class="constraint">O worker continua submetido à pausa operacional, ao kill switch, à janela de dias úteis e ao teto por hora.</p></article>`
-      : `<p class="constraint" data-non-actionable-surface="true">Versão histórica, não enviável. Revisão, agendamento e reprodução não são oferecidos aqui. Decida na versão corrente.</p>`
-    : editorial.actionable
-    ? `
-  ${gateInFlight(decideKey) ? pendingBlock("Registrando GO/NO-GO") : ""}
-  <form class="operator-form" data-human-gate="decide" data-gate-key="${escapeHtml(decideKey)}" data-version="${escapeHtml(cohortId)}"><label>Decisão final<select name="decision"><option value="NO_GO">NO_GO</option><option value="GO">GO</option></select></label><label>Motivo<input name="reason" required minlength="3"></label><label>Confirme digitando <code>v${escapeHtml(version)}</code><input name="confirmation" required pattern="v${escapeHtml(version)}"></label><button type="submit"${authority.canDecide && !gateInFlight(decideKey) ? "" : " disabled"}>${gateInFlight(decideKey) ? "Enviando…" : "Registrar GO/NO-GO"}</button>${
-    authority.canDecide
-      ? ""
-      : `<p class="constraint" data-go-authority="absent">GO/NO-GO está desabilitado nesta sessão: ele exige o grupo <code>admins</code> no Authelia. Peça a inclusão nesse grupo e reautentique; revisar candidatos continua permitido com <code>operators</code>.</p>`
-  }</form>
-`
-    : `<p class="constraint" data-non-actionable-surface="true">Versão histórica, não enviável. GO/NO-GO e a reprodução da versão imutável não são oferecidos aqui. Decida na versão corrente.</p>`;
   return `<section class="stack" aria-labelledby="review-title" data-review-cohort="${escapeHtml(cohortId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}"><h2 id="review-title">Revisão v${escapeHtml(version)}</h2>
+  ${outboundStatusBlock(input)}
   ${legacyBanner(editorial, cohortId)}
   ${leftover}${cohortFeedback}
   ${gateUnreadableBanner(selected, "a versão selecionada")}
   <p class="constraint">${escapeHtml(show(cohort.source))}, as_of ${escapeHtml(show(cohort.as_of))}, ${escapeHtml(show(cohort.freshness))}, policy ${escapeHtml(show(cohort.policy_version))}. Receipt ${escapeHtml(show(cohort.receipt))}.</p>
-  ${identityBlock(input, directScheduling)}
+  ${identityBlock(input, true)}
   ${previewBlock(preview)}
   <p><button type="button" data-toggle-messages="true" aria-expanded="${expandAll ? "true" : "false"}">${expandAll ? "Recolher todas as mensagens" : "Expandir todas as mensagens"}</button></p>
   ${reproduceControl}
@@ -2382,13 +2233,12 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   ${
     candidateCards
       || (candidates.length === 0
-        ? `<p class="banner error">${directScheduling ? "Cohort vazia: nenhuma mensagem pode ser revisada ou agendada." : "Cohort vazia: GO bloqueado."}</p>`
-        : emptyQueueBlock(counts, queueFilter, queueParams, editorial.actionable, directScheduling))
+        ? `<p class="banner error">Cohort vazia: nenhum candidato para revisar ou agendar.</p>`
+        : emptyQueueBlock(counts, queueFilter, queueParams, editorial.actionable))
   }
-  ${decideControl}
-  ${directScheduling ? "" : `<dl class="facts"><div><dt>Decisão final registrada</dt><dd>${escapeHtml(decisionValue)}</dd></div></dl>`}
-  ${dispatchControl}
-  <p class="constraint">${directScheduling ? "Aprovar agenda; não envia imediatamente. O envio é do worker do Warmbly na janela comercial e sob o teto por hora. Esta tela não retoma o disparo." : "GO autoriza e não envia. Entregar a cohort à fila é o passo seguinte e separado; o envio em si é do worker do Warmbly, dentro da janela comercial e sob o teto por hora. Esta tela continua sem qualquer controle de send, queue ou resume."}</p></section>`;
+  <details class="card" data-historical-go-audit="true"><summary>Auditoria histórica de GO/NO-GO (sem efeito operacional)</summary><dl class="facts"><div><dt>Último valor histórico</dt><dd>${escapeHtml(historicalDecision)}</dd></div></dl><p class="constraint">O controle foi removido da Revisão. Este dado antigo permanece apenas para auditoria: não autoriza, bloqueia, enfileira nem desenfileira mensagens.</p></details>
+  ${reconcileBlock(authority)}
+  <p class="constraint">APPROVE é o único ato humano necessário para agendar a mensagem. O envio em si continua sendo do worker do Warmbly, na janela comercial e sob o teto por hora; esta tela não expõe send, queue ou resume.</p></section>`;
 }
 
 function warmblySubnav(current: WarmblySurface, resource: string | null | undefined): string {

--- a/control-center/apps/web-shell/tests/human-gate-idempotency.test.ts
+++ b/control-center/apps/web-shell/tests/human-gate-idempotency.test.ts
@@ -40,8 +40,10 @@ test("a definitive response advances the generation but changed payload has anot
   const second = humanGateIdempotencyKey(intent, shared);
   assert.notEqual(first, second);
   assert.notEqual(humanGateIdempotencyKey({ ...intent, limit: 4 }, shared), second);
-  const decision: HumanGateIntent = { action: "decide", version_id: "v-id", decision: "NO_GO", reason: "fixture", confirmation: "v3" };
-  assert.notEqual(humanGateIdempotencyKey(decision, shared), humanGateIdempotencyKey({ ...decision, confirmation: "v4" }, shared));
+  const hold: HumanGateIntent = { action: "review", version_id: "v-id", candidate_id: "candidate-id", decision: "HOLD", reason: "fixture" };
+  assert.notEqual(humanGateIdempotencyKey(hold, shared), humanGateIdempotencyKey({ ...hold, reason: "fixture changed" }, shared));
+  const repair: HumanGateIntent = { action: "reconcile" };
+  assert.equal(humanGateIdempotencyKey(repair, shared), humanGateIdempotencyKey({ ...repair }, shared));
 });
 
 test("selection mode and recovery set are part of the create intent", () => {

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -112,8 +112,15 @@ function gatePayload(
   selected: Record<string, unknown> | null = cohort(),
 ): Record<string, unknown> {
   return {
-    list: { data: [cohort()], edge_actor: { id: "fixture-user", groups } },
+    list: { data: [selected ?? cohort()], edge_actor: { id: "fixture-user", groups } },
     list_status: "read",
+    outbound_status: {
+      kill_switch: true,
+      sending_allowed: false,
+      auto_send_enabled: false,
+      edge_actor: { id: "fixture-user", groups },
+    },
+    outbound_status_status: "read",
     ...(selected ? { selected: { data: selected }, selected_status: "read" } : {}),
   };
 }
@@ -403,7 +410,7 @@ test("#/warmbly opens on the pilot stepper with the latest cohort and a way into
   reset();
   const html = warmblyBlock(surfaceInput(), "operacao");
   assert.match(html, /data-pilot-summary="true"/);
-  for (const step of ["fonte", "cohort", "validacao", "revisao", "go", "handoff"]) {
+  for (const step of ["fonte", "cohort", "validacao", "revisao", "agendamento"]) {
     assert.match(html, new RegExp(`data-step="${step}"`), `step ${step} is missing`);
   }
   assert.match(html, new RegExp(`data-latest-cohort="${COHORT_ID}"`));
@@ -772,7 +779,7 @@ test("a settled non-VALID verdict blocks APPROVE; an unresolved one is verified 
     assert.match(html, /data-approve-allowed="false"/, `${status} must not offer APPROVE`);
     assert.match(html, /data-approve-blocked="true"/, `${status} must explain the refusal`);
     const approveForm = html.match(/data-gate-key="review:[^"]*:APPROVE"[\s\S]*?<\/form>/)?.[0] ?? "";
-    assert.match(approveForm, /Aprovar<\/button>/);
+    assert.match(approveForm, /Aprovar e enfileirar para envio<\/button>/);
     assert.match(approveForm, /<button type="submit" data-approve-submit="true" disabled>/);
   }
 
@@ -1079,7 +1086,7 @@ test("a confirmed adjust sends the contract body and lands on the new version th
   assert.deepEqual(navigations, [`#/warmbly/revisao?resource=${NEXT_COHORT_ID}`]);
 });
 
-test("the new version opens with validation, review and GO all pending", () => {
+test("the new version opens with validation, review and scheduling pending", () => {
   reset();
   const fresh = cohort({
     id: NEXT_COHORT_ID,
@@ -1109,7 +1116,8 @@ test("the new version opens with validation, review and GO all pending", () => {
   // decisão não vira "não informado pelo servidor" na cara do fundador.
   assert.ok(!html.includes("Revisão registrada"));
   assert.match(html, /<dt>Validação<\/dt><dd>UNKNOWN<\/dd>/);
-  assert.match(html, /<dt>Decisão final registrada<\/dt><dd>não informado pelo servidor<\/dd>/);
+  assert.doesNotMatch(html, /data-human-gate="decide"|data-human-gate="dispatch"/);
+  assert.match(html, /data-step="agendamento"|APPROVE é o único ato humano necessário/);
 });
 
 test("every adjust refusal code renders its own actionable sentence", () => {
@@ -1295,22 +1303,25 @@ test("the surface names the operator and the environment without a raw identifie
   assert.match(identity, /identificador_auditavel/);
 });
 
-test("GO is disabled without admins and says how to obtain the authority", () => {
+test("APPROVE stays with operators while repair is disabled without admins", () => {
   reset();
   const operatorsOnly = warmblyBlock(
     surfaceInput({ gate: gatePayload(["operators"]) }),
     "revisao",
   );
-  assert.match(operatorsOnly, /data-can-decide="false"/);
-  assert.match(operatorsOnly, /data-go-authority="absent"/);
-  assert.match(operatorsOnly, /exige o grupo <code>admins<\/code> no Authelia/);
-  const decideForm = operatorsOnly.match(/data-human-gate="decide"[\s\S]*?<\/form>/)?.[0] ?? "";
-  assert.match(decideForm, /<button type="submit" disabled>/);
+  assert.match(operatorsOnly, /data-can-review="true"/);
+  assert.match(operatorsOnly, /data-can-reconcile="false"/);
+  assert.match(operatorsOnly, /data-reconcile-authority="absent"/);
+  const approveForm = operatorsOnly.match(/data-human-gate="review"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.doesNotMatch(approveForm, /data-approve-submit="true" disabled/);
+  const repairForm = operatorsOnly.match(/data-human-gate="reconcile"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.match(repairForm, /data-reconcile-submit="true" disabled/);
 
   const admins = warmblyBlock(surfaceInput(), "revisao");
-  assert.match(admins, /data-can-decide="true"/);
-  const enabled = admins.match(/data-human-gate="decide"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.match(admins, /data-can-reconcile="true"/);
+  const enabled = admins.match(/data-human-gate="reconcile"[\s\S]*?<\/form>/)?.[0] ?? "";
   assert.doesNotMatch(enabled, /<button type="submit" disabled>/);
+  assert.doesNotMatch(admins, /data-human-gate="decide"|data-human-gate="dispatch"/);
 });
 
 test("capabilities the channel never reported are rendered as unknown, never as granted", () => {
@@ -1326,7 +1337,7 @@ test("capabilities the channel never reported are rendered as unknown, never as 
     }),
     "revisao",
   );
-  assert.match(html, /data-can-decide="false"/);
+  assert.match(html, /data-can-reconcile="false"/);
   assert.match(html, /não informado pelo servidor/);
   assert.match(html, /não teve os grupos confirmados pelo canal|não devolveu os grupos efetivos/);
 });
@@ -1436,15 +1447,16 @@ test("admins can reconcile old approvals and the UI renders the server denominat
   assert.match(rendered, /Agendados agora/);
   assert.match(rendered, /Reconciliação cria ou confirma trabalho na fila; não envia/);
 
-  const admin = warmblyBlock(surfaceInput(), "cohorts");
+  const admin = warmblyBlock(surfaceInput(), "revisao");
   const adminForm = admin.match(/data-human-gate="reconcile"[\s\S]*?<\/form>/)?.[0] ?? "";
-  assert.doesNotMatch(adminForm, /<button type="submit" disabled>/);
+  assert.match(adminForm, /data-reconcile-submit="true"/);
+  assert.doesNotMatch(adminForm, /<button type="submit"[^>]* disabled>/);
   const operator = warmblyBlock(
     surfaceInput({ gate: gatePayload(["operators"]) }),
-    "cohorts",
+    "revisao",
   );
   const operatorForm = operator.match(/data-human-gate="reconcile"[\s\S]*?<\/form>/)?.[0] ?? "";
-  assert.match(operatorForm, /<button type="submit" disabled>/);
+  assert.match(operatorForm, /<button type="submit"[^>]* disabled>/);
 });
 
 test("the current scheduling contract hides obsolete GO and dispatch controls", () => {
@@ -1476,7 +1488,7 @@ test("the current scheduling contract hides obsolete GO and dispatch controls", 
   assert.doesNotMatch(html, /data-human-gate="dispatch"/);
   assert.doesNotMatch(html, /data-dispatch-gate=/);
   assert.deepEqual(pilotSteps(surfaceInput({ gate: gatePayload(["operators", "admins"], current) })).map((step) => step.id), [
-    "fonte", "cohort", "validacao", "revisao", "fila",
+    "fonte", "cohort", "validacao", "revisao", "agendamento",
   ]);
 });
 
@@ -1640,7 +1652,7 @@ test("without a current_version_id the banner says so instead of inventing a lin
   assert.match(html, /data-open-current="absent"/);
 });
 
-test("a historical version emits no approve, hold, validate, adjust, reproduce or GO markup at all", () => {
+test("a historical version emits no candidate decisions or reproduction; only global admin repair remains", () => {
   reset();
   const html = warmblyBlock(legacyInput(), "revisao");
   for (const gate of ["validate", "review", "adjust", "reproduce", "decide"]) {
@@ -1653,7 +1665,8 @@ test("a historical version emits no approve, hold, validate, adjust, reproduce o
   assert.doesNotMatch(html, /data-adjust-editor=/);
   assert.doesNotMatch(html, /Registrar APPROVE|Registrar HOLD\/REJECT|Registrar GO\/NO-GO/);
   assert.match(html, /data-non-actionable-notice="true"/);
-  assert.match(html, /data-non-actionable-surface="true"/);
+  assert.match(html, /data-human-gate="reconcile"/);
+  assert.doesNotMatch(html, /data-human-gate="decide"|data-human-gate="dispatch"/);
 });
 
 test("a historical version stays fully readable: message, facts and hashes all render", () => {
@@ -1696,10 +1709,10 @@ test("a historical card is marked as such and carries a non-actionable chip", ()
   assert.match(html, /data-approve-allowed="false"/);
 });
 
-test("a current version keeps every control exactly as before", () => {
+test("a current version keeps review, adjust and reproduce plus explicit admin repair", () => {
   reset();
   const html = warmblyBlock(surfaceInput(), "revisao");
-  for (const gate of ["review", "adjust", "reproduce", "decide"]) {
+  for (const gate of ["review", "adjust", "reproduce", "reconcile"]) {
     assert.match(html, new RegExp(`data-human-gate="${gate}"`), `${gate} must still be offered on a current version`);
   }
   // `validate` is the one control that moved: on a candidate the server already
@@ -1715,7 +1728,7 @@ test("a current version keeps every control exactly as before", () => {
   assert.match(html, /data-review-cohort="[^"]*" data-editorial-state="CURRENT" data-actionable="true"/);
   assert.doesNotMatch(html, /data-legacy-banner="true"/);
   assert.doesNotMatch(html, /data-non-actionable-notice="true"/);
-  assert.doesNotMatch(html, /data-non-actionable-surface="true"/);
+  assert.doesNotMatch(html, /data-human-gate="decide"|data-human-gate="dispatch"/);
 });
 
 test("an absent editorial_state is an older backend, not a historical version", () => {
@@ -1723,8 +1736,9 @@ test("an absent editorial_state is an older backend, not a historical version", 
   const html = warmblyBlock(surfaceInput(), "revisao");
   assert.match(html, /data-editorial-state="CURRENT"/);
   assert.doesNotMatch(html, /data-legacy-banner="true"/);
-  assert.match(html, /data-human-gate="decide"/);
   assert.match(html, /data-human-gate="review"/);
+  assert.match(html, /data-human-gate="reconcile"/);
+  assert.doesNotMatch(html, /data-human-gate="decide"|data-human-gate="dispatch"/);
 });
 
 test("actionable:false alone is enough to withdraw the controls", () => {
@@ -1758,7 +1772,8 @@ test("a non-actionable candidate loses its controls even inside a current versio
   assert.match(html, /data-editorial-state="LEGACY_SUPERSEDED"/, "the card carries the candidate's own state");
   assert.doesNotMatch(html, /data-human-gate="review"/);
   assert.doesNotMatch(html, /data-adjust-editor=/);
-  assert.match(html, /data-human-gate="decide"/, "the version itself is still decidable");
+  assert.match(html, /data-human-gate="reconcile"/, "global admin repair stays available");
+  assert.doesNotMatch(html, /data-human-gate="decide"|data-human-gate="dispatch"/);
   assert.ok(html.includes("sem carimbo de redator"));
 });
 
@@ -1904,14 +1919,15 @@ test("um link de recorte nunca larga a versão selecionada nem o estado das mens
   assert.ok(!pendentes[1]!.includes(REVIEW_QUEUE_PARAM));
 });
 
-test("com tudo decidido a fila diz que acabou e aponta o GO, em vez de uma tela vazia", () => {
+test("com tudo decidido a fila diz que APPROVE já agendou, em vez de inventar um passo extra", () => {
   reset();
   const done = cohort({
     candidates: [
-      candidate({ review: { decision: "APPROVE", effective: true } }),
+      candidate({ review: { decision: "APPROVE", effective: true }, scheduling: { state: "QUEUED", due_at: "2026-08-25T12:00:00Z", auto_send: true } }),
       candidate({
         candidate_id: SECOND_CANDIDATE,
         review: { decision: "APPROVE", effective: true },
+        scheduling: { state: "QUEUED", due_at: "2026-08-25T12:00:00Z", auto_send: true },
       }),
     ],
   });
@@ -1921,14 +1937,14 @@ test("com tudo decidido a fila diz que acabou e aponta o GO, em vez de uma tela 
   );
   assert.match(html, /data-queue-empty="pendentes"/);
   assert.ok(html.includes("Fila vazia"));
-  assert.ok(html.includes("GO/NO-GO"), "o próximo passo precisa estar nomeado");
+  assert.ok(html.includes("Não há GO nem entrega manual"));
   assert.match(html, /data-queue-see-all="true"/);
-  // A cohort vazia continua sendo outra coisa: ali GO está bloqueado.
+  // A cohort vazia continua sendo outra coisa: não há candidato para revisar.
   const empty = warmblyBlock(
     surfaceInput({ gate: gatePayload(["operators", "admins"], cohort({ candidates: [] })) }),
     "revisao",
   );
-  assert.ok(empty.includes("Cohort vazia: GO bloqueado."));
+  assert.ok(empty.includes("Cohort vazia: nenhum candidato para revisar ou agendar."));
 });
 
 test("um recorte vazio que não é pendentes diz que só o recorte está vazio", () => {
@@ -1988,6 +2004,9 @@ function statefulGate(initial: Record<string, unknown>[]): {
         const row = rows.find((entry) => String(entry.candidate_id) === input.candidate_id);
         if (row) {
           row.review = { decision: input.decision, effective: input.decision === "APPROVE" };
+          row.scheduling = input.decision === "APPROVE"
+            ? { state: "QUEUED", due_at: "2026-08-25T12:00:00Z", auto_send: true }
+            : { state: "CANCELLED", due_at: null, auto_send: false };
         }
       }
       if (input.action === "validate") {
@@ -2725,317 +2744,353 @@ test("toda tag aberta nesta superfície é fechada antes da próxima começar", 
 });
 
 /* ------------------------------------------------------------------ *
- * Entregar a cohort à fila.
+ * Reparo idempotente de aprovações.
  *
- * The one control on this surface whose effect leaves the building. Every test
- * here holds a line that, if it moved, would let real mail reach real companies
- * without the act that authorises it.
+ * APPROVE é o caminho normal e já agenda. A única escrita administrativa é
+ * uma reconciliação global, reexecutável, que usa o mesmo caminho de código.
  * ------------------------------------------------------------------ */
 
-/** A version the server itself reports as GO. Nothing here is inferred locally. */
-function goCohort(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return cohort({
-    decision: { decision: "GO" },
-    candidates: [candidate({ review: { decision: "APPROVE", effective: true } })],
+function scheduledApprovedCandidate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return candidate({
+    review: { decision: "APPROVE", effective: true },
+    scheduling: {
+      state: "QUEUED",
+      due_at: "2026-08-25T12:00:00Z",
+      auto_send: true,
+    },
     ...overrides,
   });
 }
 
-test("sem GO registrado não existe forma nenhuma de disparo, nem desabilitada", () => {
+test("GO e dispatch desapareceram da Revisão, mesmo quando existem no histórico", () => {
   reset();
-  for (const decision of [undefined, { decision: "NO_GO" }, {}]) {
+  for (const decision of [undefined, {}, { decision: "GO" }, { decision: "NO_GO" }]) {
     const html = warmblyBlock(
       surfaceInput({
-        gate: gatePayload(["operators", "admins"], cohort({ decision })),
+        gate: gatePayload(
+          ["operators", "admins"],
+          cohort({ decision, candidates: [scheduledApprovedCandidate()] }),
+        ),
         query: ALL_STATES,
       }),
       "revisao",
     );
-    assert.doesNotMatch(html, /data-human-gate="dispatch"/, "não pode haver formulário de disparo");
-    assert.doesNotMatch(html, /data-dispatch-submit/);
-    assert.match(html, /data-dispatch-gate="no-go"/, "e a tela precisa dizer por que não há");
+    assert.doesNotMatch(html, /data-human-gate="decide"|data-human-gate="dispatch"/);
+    assert.doesNotMatch(html, /Entregar .*fila|Registrar GO\/NO-GO/);
+    assert.match(html, /data-historical-go-audit="true"/);
+    assert.match(html, /sem efeito operacional/);
   }
 });
 
-test("com GO registrado o disparo aparece uma vez, exige a versão digitada e diz o que faz", () => {
+test("o reparo aparece uma vez, sem confirmação de versão, e diz que não é passo normal", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  assert.equal((html.match(/data-human-gate="reconcile"/g) ?? []).length, 1);
+  const form = html.match(/data-human-gate="reconcile"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.match(form, /data-gate-key="reconcile::::"/);
+  assert.match(form, /data-reconcile-submit="true"/);
+  assert.doesNotMatch(form, /name="confirmation"|data-version=/);
+  assert.doesNotMatch(form, /disabled/);
+  assert.ok(html.includes("Este não é um passo normal depois da revisão"));
+  assert.ok(html.includes("deduplica candidatos repetidos entre cohorts"));
+});
+
+test("operators aprova e enfileira, mas não executa o reparo administrativo", () => {
   reset();
   const html = warmblyBlock(
-    surfaceInput({ gate: gatePayload(["operators", "admins"], goCohort()), query: ALL_STATES }),
+    surfaceInput({ gate: gatePayload(["operators"]) }),
     "revisao",
   );
-  const forms = [...html.matchAll(/data-human-gate="dispatch"/g)];
-  assert.equal(forms.length, 1, "exatamente um controle de disparo");
-  const form = html.match(/data-gate-key="dispatch:[^"]*"[\s\S]*?<\/form>/)?.[0] ?? "";
-  assert.match(form, /name="confirmation" required pattern="v1"/, "exige a versão digitada, como o GO");
-  assert.match(form, /data-dispatch-submit="true"/);
-  assert.doesNotMatch(form, /disabled/, "com admins o controle fica pressionável");
-  // O que ele faz e o que ele não faz precisam estar escritos antes do botão.
-  assert.match(html, /data-dispatch-meaning="true"/);
-  assert.ok(html.includes("O Warmbly enfileira cada um"), "precisa dizer que enfileira");
-  assert.ok(html.includes("Esta tela não envia e-mail"), "e que esta tela não envia");
-  assert.match(html, /data-dispatch-gates="true"/);
-  assert.ok(html.includes("kill switch"), "os portões do Warmbly precisam estar nomeados");
+  const approve = html.match(/data-human-gate="review"[\s\S]*?<\/form>/)?.[0] ?? "";
+  const repair = html.match(/data-human-gate="reconcile"[\s\S]*?<\/form>/)?.[0] ?? "";
+  assert.doesNotMatch(approve, /data-approve-submit="true" disabled/);
+  assert.match(approve, /Aprovar e enfileirar para envio/);
+  assert.match(repair, /data-reconcile-submit="true" disabled/);
+  assert.match(html, /data-reconcile-authority="absent"/);
 });
 
-test("disparar exige admins: operators vê o motivo e o controle desabilitado", () => {
-  reset();
-  const html = warmblyBlock(
-    surfaceInput({ gate: gatePayload(["operators"], goCohort()), query: ALL_STATES }),
-    "revisao",
-  );
-  const form = html.match(/data-gate-key="dispatch:[^"]*"[\s\S]*?<\/form>/)?.[0] ?? "";
-  assert.match(form, /<button type="submit" data-dispatch-submit="true" disabled>/);
-  assert.match(html, /data-dispatch-authority="absent"/);
-  assert.ok(html.includes("admins"), "precisa nomear o grupo que falta");
-});
-
-test("uma versão histórica não oferece disparo mesmo com GO registrado", () => {
-  reset();
-  const html = warmblyBlock(
-    surfaceInput({
-      gate: gatePayload(
-        ["operators", "admins"],
-        goCohort({ editorial_state: "LEGACY", actionable: false }),
-      ),
-      query: ALL_STATES,
-    }),
-    "revisao",
-  );
-  assert.doesNotMatch(html, /data-human-gate="dispatch"/);
-  assert.doesNotMatch(html, /data-dispatch-gate=/, "nem o aviso: nada é decidível numa versão histórica");
-});
-
-test("o adaptador recusa um disparo sem a confirmação digitada, antes do fio", async () => {
-  reset();
-  const calls: string[] = [];
-  const adapter = new HttpControlCenterAdapter({
-    baseUrl: "http://cc.fixture",
-    fetchImpl: (async (input: RequestInfo | URL) => {
-      calls.push(String(input));
-      return new Response("{}", { status: 200 });
-    }) as typeof fetch,
-  });
-  const refused = await adapter.warmblyGate({
-    action: "dispatch",
-    version_id: COHORT_ID,
-    idempotency_key: "idem-dispatch-fixture",
-  });
-  assert.equal(refused.code, "cohort_version_confirmation_required");
-  assert.equal(refused.ok, false);
-  assert.equal(calls.length, 0, "nada pode sair do navegador sem a confirmação");
-
-  await adapter.warmblyGate({
-    action: "dispatch",
-    version_id: COHORT_ID,
-    confirmation: " V1 ",
-    idempotency_key: "idem-dispatch-fixture",
-  });
-  assert.deepEqual(calls, [`http://cc.fixture/v1/warmbly/operator/cohorts/${COHORT_ID}/dispatch`]);
-});
-
-test("o disparo viaja para a rota do cohort e nunca para uma rota de candidato", async () => {
+test("o adaptador envia a reconciliação à única rota global e não aceita alvo de cohort", async () => {
   reset();
   const seen: Array<{ url: string; body: Record<string, unknown> }> = [];
   const adapter = new HttpControlCenterAdapter({
     baseUrl: "http://cc.fixture",
     fetchImpl: (async (input: RequestInfo | URL, init?: RequestInit) => {
-      seen.push({ url: String(input), body: JSON.parse(String(init?.body ?? "{}")) });
-      return new Response(JSON.stringify({ data: { attempted: 4, provider_accepted: 4 } }), { status: 200 });
+      seen.push({ url: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      return new Response(JSON.stringify({
+        outcome: "APPLIED",
+        data: {
+          approval_records: 6,
+          latest_approved_bindings: 5,
+          unique_approved_candidates: 3,
+          scheduled: 3,
+          already_scheduled: 0,
+          failed: 0,
+        },
+      }), { status: 200 });
     }) as typeof fetch,
   });
-  await adapter.warmblyGate({
-    action: "dispatch",
+  const result = await adapter.warmblyGate({
+    action: "reconcile",
     version_id: COHORT_ID,
     candidate_id: CANDIDATE_ID,
-    confirmation: "v1",
-    idempotency_key: "idem-dispatch-route",
+    idempotency_key: "idem-reconcile-route",
   });
   assert.equal(seen.length, 1);
-  assert.ok(!seen[0]!.url.includes("candidates"), "não existe disparo por candidato");
-  assert.match(seen[0]!.url, /\/cohorts\/[0-9a-f-]{36}\/dispatch$/);
-  assert.equal(seen[0]!.body.confirmation, "v1");
+  assert.equal(seen[0]!.url, "http://cc.fixture/v1/warmbly/operator/cohorts/reconcile-approved");
+  assert.deepEqual(seen[0]!.body, { idempotency_key: "idem-reconcile-route" });
+  assert.equal(result.gateTarget, undefined);
+  assert.equal(result.reconcile?.uniqueApprovedCandidates, 3);
 });
 
-test("os números do disparo são os do servidor, e ausência não vira zero", async () => {
+test("os números do reparo vêm do servidor e ausência nunca vira zero", async () => {
   reset();
   const adapter = new HttpControlCenterAdapter({
     baseUrl: "http://cc.fixture",
     fetchImpl: (async () =>
-      new Response(
-        JSON.stringify({
-          data: {
-            attempted: 10,
-            provider_accepted: 7,
-            failed: 1,
-            blocked: 2,
-            max_daily: 10,
-            kill_switch_available: true,
-            failures: [{ mailbox: "contato@empresa.invalid", reason: "risky_outside_default_pilot" }],
-          },
-        }),
-        { status: 200 },
-      )) as typeof fetch,
+      new Response(JSON.stringify({
+        outcome: "APPLIED",
+        data: {
+          approval_records: 6,
+          latest_approved_bindings: 5,
+          unique_approved_candidates: 3,
+          scheduled: 2,
+          already_scheduled: 1,
+          failures: [{
+            cohort_version_id: COHORT_ID,
+            candidate_id: CANDIDATE_ID,
+            reason: "validation_drift",
+          }],
+        },
+      }), { status: 200 })) as typeof fetch,
   });
   const result = await adapter.warmblyGate({
-    action: "dispatch",
-    version_id: COHORT_ID,
-    confirmation: "v1",
-    idempotency_key: "idem-dispatch-counts",
+    action: "reconcile",
+    idempotency_key: "idem-reconcile-counts",
   });
-  assert.deepEqual(result.dispatch, {
-    attempted: 10,
-    accepted: 7,
-    failed: 1,
-    blocked: 2,
-    maxDaily: 10,
-    killSwitchAvailable: true,
-    failures: [{ mailbox: "contato@empresa.invalid", reason: "risky_outside_default_pilot" }],
+  assert.deepEqual(result.reconcile, {
+    approvalRecords: 6,
+    latestApprovedBindings: 5,
+    uniqueApprovedCandidates: 3,
+    scheduled: 2,
+    alreadyScheduled: 1,
+    failures: [{ cohortId: COHORT_ID, candidateId: CANDIDATE_ID, reason: "validation_drift" }],
   });
-  assert.ok(
-    !Object.prototype.hasOwnProperty.call(result.dispatch ?? {}, "skippedDuplicate"),
-    "o servidor não mandou skipped_duplicate; não pode virar zero",
-  );
-
-  const html = writeResultBlock({ ...result, gateAction: "dispatch" });
-  assert.match(html, /data-dispatch-counts="true"/);
-  assert.ok(html.includes("<dt>Tentados</dt><dd>10</dd>"));
-  assert.ok(html.includes("<dt>Aceitos pelo provedor</dt><dd>7</dd>"));
-  assert.ok(
-    html.includes("<dt>Pulados por duplicidade</dt><dd>não informado pelo servidor</dd>"),
-    "um contador ausente é dito como ausente",
-  );
-  assert.match(html, /data-dispatch-failure="risky_outside_default_pilot"/);
-  assert.match(html, /data-dispatch-not-sent="true"/);
-  assert.ok(html.includes("não de entrega"), "enfileirar não é entregar");
+  assert.equal(Object.prototype.hasOwnProperty.call(result.reconcile ?? {}, "failed"), false);
+  const html = writeResultBlock(result);
+  assert.match(html, /data-reconcile-counts="true"/);
+  assert.ok(html.includes("<dt>Candidatos únicos aprovados</dt><dd>3</dd>"));
+  assert.ok(html.includes("<dt>Falharam</dt><dd>não informado pelo servidor</dd>"));
+  assert.match(html, /data-reconcile-failure="validation_drift"/);
+  assert.match(html, /data-reconcile-not-sent="true"/);
 });
 
-test("cada recusa do Warmbly no disparo tem a sua própria frase acionável", () => {
-  reset();
-  const expectations: Record<string, RegExp> = {
-    auto_send_forbidden: /auto-send está ligado/i,
-    green_autorun_forbidden: /autorun está ligado/i,
-    sending_paused: /disparo de saída está pausado/i,
-    kill_switch_engaged: /kill switch de arquivo está acionado/i,
-    cohort_grant_revoked: /autoridade desta cohort foi revogada/i,
-    cohort_grant_expired: /autoridade desta cohort venceu/i,
-    cohort_grant_missing: /não tem autoridade bounded/i,
-  };
-  for (const [code, sentence] of Object.entries(expectations)) {
-    const html = writeResultBlock({
-      ok: false,
-      path: "/x",
-      kind: "nota",
-      message: code,
-      outcome: "refused",
-      code,
-      gateAction: "dispatch",
-    });
-    assert.match(html, sentence, `${code} precisa da própria frase`);
-    assert.match(html, /data-outcome-recovery="true"/);
-    assert.ok(
-      /nada foi enfileirado/i.test(html) || /Nada foi enfileirado/.test(html),
-      `${code} precisa dizer que nada foi enfileirado`,
-    );
-  }
-});
-
-test("um clique duplo durante o disparo não vira dois disparos", async () => {
+test("duplo clique durante o reparo faz uma só chamada", async () => {
   reset();
   let release: (() => void) | undefined;
-  const held = new Promise<void>((resolve) => {
-    release = resolve;
-  });
+  const held = new Promise<void>((resolve) => { release = resolve; });
   const { adapter, seen } = gateAdapter({
-    gate: () => gatePayload(["operators", "admins"], goCohort()),
+    gate: () => gatePayload(["operators", "admins"], cohort({ candidates: [scheduledApprovedCandidate()] })),
     respond: async () => {
       await held;
       return {
         ok: true,
         path: "/x",
         kind: "nota" as const,
-        message: "enfileirado",
+        message: "reconciliado",
         outcome: "executed",
-        gateAction: "dispatch" as const,
+        gateAction: "reconcile" as const,
+        reconcile: {
+          approvalRecords: 1,
+          latestApprovedBindings: 1,
+          uniqueApprovedCandidates: 1,
+          scheduled: 0,
+          alreadyScheduled: 1,
+          failed: 0,
+        },
       };
     },
   });
   const dom = paintingRoot();
   paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`);
-  const form = dom.find(`[data-gate-key="dispatch:${COHORT_ID}::"]`);
-  form.set("confirmation", "v1");
+  const form = dom.find('[data-gate-key="reconcile::::"]');
   form.fire();
   await settle();
-  assert.match(dom.root.innerHTML, /data-write-pending="true"/, "a espera precisa estar visível");
-  // Segundo clique com a escrita ainda no ar.
-  dom.root.querySelectorAll(`[data-gate-key="dispatch:${COHORT_ID}::"]`)[0]?.fire();
+  assert.match(dom.root.innerHTML, /data-write-pending="true"/);
+  dom.root.querySelectorAll('[data-gate-key="reconcile::::"]')[0]?.fire();
   await settle();
-  assert.equal(seen.length, 1, "um disparo é um disparo");
-  assert.equal(seen[0]!.action, "dispatch");
-  assert.equal(seen[0]!.version_id, COHORT_ID);
-  assert.equal(seen[0]!.candidate_id, undefined, "o disparo é da cohort, não de um candidato");
-  assert.equal(seen[0]!.confirmation, "v1");
-  assert.ok(seen[0]!.idempotency_key, "toda escrita do gate viaja com chave");
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0]!.action, "reconcile");
   release?.();
   await settle();
   assert.doesNotMatch(dom.root.innerHTML, /data-write-pending="true"/);
 });
 
-test("repetir um disparo já concluído é uma intenção nova, e o Warmbly é quem pula os já enviados", async () => {
+test("reexecutar o reparo usa nova intenção, e o servidor relata tudo como já agendado", async () => {
   reset();
+  let attempt = 0;
   const { adapter, seen } = gateAdapter({
-    gate: () => gatePayload(["operators", "admins"], goCohort()),
-    respond: () => ({
-      ok: true,
-      path: "/x",
-      kind: "nota" as const,
-      message: "enfileirado",
-      outcome: "executed",
-      gateAction: "dispatch" as const,
-    }),
+    gate: () => gatePayload(["operators", "admins"], cohort({ candidates: [scheduledApprovedCandidate()] })),
+    respond: () => {
+      attempt += 1;
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        message: "reconciliado",
+        outcome: "executed",
+        gateAction: "reconcile" as const,
+        reconcile: {
+          approvalRecords: 1,
+          latestApprovedBindings: 1,
+          uniqueApprovedCandidates: 1,
+          scheduled: attempt === 1 ? 1 : 0,
+          alreadyScheduled: attempt === 1 ? 0 : 1,
+          failed: 0,
+        },
+      };
+    },
   });
   const dom = paintingRoot();
-  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`);
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}`);
   for (let i = 0; i < 2; i += 1) {
-    const form = dom.find(`[data-gate-key="dispatch:${COHORT_ID}::"]`);
-    form.set("confirmation", "v1");
-    form.fire();
+    dom.find('[data-gate-key="reconcile::::"]').fire();
     await settle();
   }
-  assert.equal(seen.length, 2, "um disparo concluído não trava o controle para sempre");
-  assert.notEqual(
-    seen[0]!.idempotency_key,
-    seen[1]!.idempotency_key,
-    "um desfecho definitivo avança a geração: o segundo disparo é uma intenção nova, não um retry",
-  );
-  // E a tela diz que repetir não reenvia o que já saiu.
-  assert.ok(
-    dom.root.innerHTML.includes("já enfileirados"),
-    "a tela precisa dizer o que acontece ao repetir",
-  );
+  assert.equal(seen.length, 2);
+  assert.notEqual(seen[0]!.idempotency_key, seen[1]!.idempotency_key);
+  assert.match(dom.root.innerHTML, /<dt>Agendados agora<\/dt><dd>0<\/dd>/);
+  assert.match(dom.root.innerHTML, /<dt>Já agendados<\/dt><dd>1<\/dd>/);
 });
 
-test("o disparo nunca é tratado como aplicado quando a releitura não confirma o GO", async () => {
+test("a releitura divergente não deixa um reparo parecer confirmado", async () => {
   reset();
+  const broken = cohort({
+    candidates: [candidate({
+      review: { decision: "APPROVE", effective: true },
+      scheduling: { state: "APPROVED", auto_send: true },
+    })],
+  });
   const { adapter } = gateAdapter({
-    // A releitura devolve a versão sem GO: a autoridade que o disparo diz ter
-    // consumido não é a que o servidor mostra agora.
-    gate: () => gatePayload(["operators", "admins"], cohort({ decision: { decision: "NO_GO" } })),
+    gate: () => gatePayload(["operators", "admins"], broken),
     respond: () => ({
       ok: true,
       path: "/x",
       kind: "nota" as const,
-      message: "enfileirado",
+      message: "reconciliado",
       outcome: "executed",
-      gateAction: "dispatch" as const,
+      gateAction: "reconcile" as const,
+      reconcile: {
+        approvalRecords: 1,
+        latestApprovedBindings: 1,
+        uniqueApprovedCandidates: 1,
+        scheduled: 1,
+        alreadyScheduled: 0,
+        failed: 0,
+      },
     }),
   });
   const dom = paintingRoot();
   paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`);
-  // Pinta uma vez com GO para o controle existir, depois a releitura discorda.
+  dom.find('[data-gate-key="reconcile::::"]').fire();
+  await settle();
+  assert.match(dom.root.innerHTML, /data-readback="not_confirmed"/);
+  assert.match(dom.root.innerHTML, /sem agendamento confirmado/);
+});
+
+test("reparo com contadores ausentes não infere zero nem confirma pela lista", async () => {
+  reset();
+  const { adapter } = gateAdapter({
+    gate: () => gatePayload(["operators", "admins"], cohort({ candidates: [scheduledApprovedCandidate()] })),
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "resposta parcial",
+      outcome: "executed",
+      gateAction: "reconcile" as const,
+      reconcile: { approvalRecords: 1, scheduled: 1 },
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`);
+  dom.find('[data-gate-key="reconcile::::"]').fire();
+  await settle();
+  assert.match(dom.root.innerHTML, /data-readback="not_confirmed"/);
+  assert.match(dom.root.innerHTML, /ausência não é zero/);
+});
+
+test("reparo não confirma quando a releitura não contém todos os vínculos contados", async () => {
+  reset();
+  const { adapter } = gateAdapter({
+    gate: () => gatePayload(["operators", "admins"], cohort({ candidates: [scheduledApprovedCandidate()] })),
+    respond: () => ({
+      ok: true,
+      path: "/x",
+      kind: "nota" as const,
+      message: "reconciliado",
+      outcome: "executed",
+      gateAction: "reconcile" as const,
+      reconcile: {
+        approvalRecords: 2,
+        latestApprovedBindings: 2,
+        uniqueApprovedCandidates: 2,
+        scheduled: 2,
+        alreadyScheduled: 0,
+        failed: 0,
+      },
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, `#/warmbly/revisao?resource=${COHORT_ID}&${REVIEW_QUEUE_PARAM}=todas`);
+  dom.find('[data-gate-key="reconcile::::"]').fire();
+  await settle();
+  assert.match(dom.root.innerHTML, /data-readback="not_confirmed"/);
+  assert.match(dom.root.innerHTML, /conjunto completo não foi confirmado/);
+});
+
+test("o bloqueio outbound aparece antes de qualquer trabalho e APPROVE ainda agenda", () => {
+  reset();
+  const html = warmblyBlock(surfaceInput(), "revisao");
+  const status = html.indexOf('data-outbound-status="blocked"');
+  const preview = html.indexOf('data-preview-denominators="true"');
+  const approve = html.indexOf('data-approve-submit="true"');
+  assert.ok(status > 0 && status < preview && status < approve);
+  assert.match(html, /OUTBOUND BLOQUEADO/);
+  assert.match(html, /APPROVE enfileira, mas nenhuma mensagem sai/);
+  assert.match(html, /auto_send=true/);
+  assert.match(html, /Kill switch reportado<\/dt><dd>acionado/);
+});
+
+test("APPROVE efetivo sem scheduling é mostrado como defeito, nunca como agendado", () => {
+  reset();
   const html = warmblyBlock(
-    surfaceInput({ gate: gatePayload(["operators", "admins"], goCohort()), query: ALL_STATES }),
+    surfaceInput({
+      gate: gatePayload(
+        ["operators", "admins"],
+        cohort({ candidates: [candidate({ review: { decision: "APPROVE", effective: true } })] }),
+      ),
+      query: ALL_STATES,
+    }),
     "revisao",
   );
-  assert.match(html, /data-human-gate="dispatch"/);
-  assert.doesNotMatch(dom.root.innerHTML, /data-human-gate="dispatch"/, "sem GO na leitura, sem controle");
+  assert.match(html, /data-scheduling-confirmed="false"/);
+  assert.match(html, /Defeito: APPROVE efetivo sem agendamento confirmado/);
+  assert.doesNotMatch(html, /data-scheduling-confirmed="true"/);
+  assert.ok(html.includes("Não reaprove"));
+});
+
+test("APPROVE confirmado mostra QUEUED, due_at e auto_send por mensagem", () => {
+  reset();
+  const html = warmblyBlock(
+    surfaceInput({
+      gate: gatePayload(["operators", "admins"], cohort({ candidates: [scheduledApprovedCandidate()] })),
+      query: ALL_STATES,
+    }),
+    "revisao",
+  );
+  assert.match(html, /data-scheduling-confirmed="true" data-scheduling-state="QUEUED"/);
+  assert.match(html, /<dt>Estado<\/dt><dd>QUEUED<\/dd>/);
+  assert.match(html, /<dt>due_at<\/dt><dd>/);
+  assert.match(html, /<dt>auto_send da mensagem<\/dt><dd>true<\/dd>/);
+  assert.doesNotMatch(html, /data-gate-key="review:[^"]*:APPROVE"/);
 });

--- a/control-center/apps/web-shell/tests/warmbly-human-gate.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-human-gate.test.ts
@@ -4,67 +4,157 @@ import { parseHash, WARMBLY_SURFACES } from "../src/destinations";
 import { HttpControlCenterAdapter } from "../src/adapters/http";
 import { warmblyBlock } from "../src/ui/warmbly";
 
-const version="11111111-1111-4111-8111-111111111111";
-const candidate={candidate_id:"22222222-2222-4222-8222-222222222222",company:"Fixture",mailbox:"review@fixture.invalid",route_class:"ROLE_OR_DEPARTMENT",source:"fixture",subject:"Exact fixture subject",body_text:"Exact frozen fixture body",content_hash:"content",evidence_hash:"evidence",validation:{status:"VALID",reason:"sandbox",expires_at:"2026-08-24T12:00:00Z"},review:null,blocked_by:["approval_missing_or_invalid"]};
-const cohort={id:version,version:3,source:"fixture",as_of:"2026-08-23T12:00:00Z",freshness:"FRESH",policy_version:"bounded-cohort-policy.v1",receipt:`cohort:${version}`,manifest:{preview:{accounts_considered:7,accounts_eligible:2,accounts_excluded:5,recipients_final:2,suppressed:1,opt_out:1,risky_excluded:1}},candidates:[candidate]};
-const input={snapshot:undefined,operator:{kind:"human" as const,id:"operator"},gate:{list:{data:[cohort]},selected:{data:cohort}}};
+const version = "11111111-1111-4111-8111-111111111111";
+const candidate = {
+  candidate_id: "22222222-2222-4222-8222-222222222222",
+  company: "Fixture",
+  mailbox: "review@fixture.invalid",
+  route_class: "ROLE_OR_DEPARTMENT",
+  source: "fixture",
+  subject: "Exact fixture subject",
+  body_text: "Exact frozen fixture body",
+  observed_fact: "Fixture fact",
+  fact_source: "fixture://source",
+  content_hash: "content",
+  evidence_hash: "evidence",
+  validation: { status: "VALID", reason: "sandbox", expires_at: "2026-08-24T12:00:00Z" },
+  review: null,
+  blocked_by: ["approval_missing_or_invalid"],
+};
+const cohort = {
+  id: version,
+  version: 3,
+  source: "fixture",
+  as_of: "2026-08-23T12:00:00Z",
+  freshness: "FRESH",
+  policy_version: "bounded-cohort-policy.v1",
+  receipt: `cohort:${version}`,
+  manifest: { preview: { accounts_considered: 7, accounts_eligible: 2, accounts_excluded: 5, recipients_final: 2, suppressed: 1, opt_out: 1, risky_excluded: 1 } },
+  candidates: [candidate],
+};
+const actor = { id: "fixture-user", groups: ["operators", "admins"] };
+const input = {
+  snapshot: undefined,
+  operator: { kind: "human" as const, id: "operator" },
+  gate: {
+    list: { data: [cohort], edge_actor: actor },
+    list_status: "read",
+    selected: { data: cohort },
+    selected_status: "read",
+    outbound_status: { kill_switch: true, sending_allowed: false, auto_send_enabled: false, edge_actor: actor },
+    outbound_status_status: "read",
+  },
+};
 
-test("Warmbly exposes accessible Cohorts and Revisão routes",()=>{
-  assert.deepEqual(WARMBLY_SURFACES,["operacao","cohorts","revisao"]);assert.equal(parseHash("#/warmbly/revisao?resource="+version).surface,"revisao");assert.equal(parseHash("#/warmbly/revisao?resource="+version).resource,version);
+test("Warmbly exposes accessible Cohorts and Revisão routes", () => {
+  assert.deepEqual(WARMBLY_SURFACES, ["operacao", "cohorts", "revisao"]);
+  assert.equal(parseHash(`#/warmbly/revisao?resource=${version}`).surface, "revisao");
+  assert.equal(parseHash(`#/warmbly/revisao?resource=${version}`).resource, version);
 });
 
-test("cohort table renders true denominators from Warmbly",()=>{
-  const html=warmblyBlock(input,"cohorts");for(const value of ["Considerados","Elegíveis","Excluídos","Finais",">7<",">2<",">5<"]){assert.match(html,new RegExp(value))};assert.match(html,/data-human-gate="create"/);assert.doesNotMatch(html,/send email|dispatch cohort/i);
+test("cohort table renders true denominators from Warmbly", () => {
+  const html = warmblyBlock(input, "cohorts");
+  for (const value of ["Considerados", "Elegíveis", "Excluídos", "Finais", ">7<", ">2<", ">5<"]) {
+    assert.match(html, new RegExp(value));
+  }
+  assert.match(html, /data-human-gate="create"/);
+  assert.doesNotMatch(html, /send email|dispatch cohort/i);
 });
 
-test("progressive review renders exact preview, validation and proportional confirmations",()=>{
-  const html=warmblyBlock({...input,query:"estado=todas"},"revisao");assert.match(html,/data-validation-status="VALID"/);assert.match(html,/Exact fixture subject/);assert.match(html,/Exact frozen fixture body/);assert.doesNotMatch(html,/data-human-gate="validate"/);assert.match(html,/APPROVE/);assert.match(html,/REJECT/);assert.match(html,/HOLD/);assert.match(html,/pattern="v3"/);assert.match(html,/GO autoriza e não envia/);
+test("progressive review tells the new approve-and-queue truth before the button", () => {
+  const html = warmblyBlock({ ...input, query: "estado=todas" }, "revisao");
+  assert.match(html, /data-outbound-status="blocked"/);
+  assert.match(html, /data-validation-status="VALID"/);
+  assert.match(html, /Exact fixture subject/);
+  assert.match(html, /Exact frozen fixture body/);
+  assert.doesNotMatch(html, /data-human-gate="validate"/);
+  assert.match(html, /Aprovar e enfileirar para envio/);
+  assert.match(html, /auto_send=true/);
+  assert.match(html, /pattern="v3"/, "adjust still requires immutable-version confirmation");
+  assert.doesNotMatch(html, /data-human-gate="decide"|data-human-gate="dispatch"/);
 });
 
-test("review renders every Warmbly validation state without inferring validity",()=>{
-  const statuses=["VALID","RISKY","INVALID","UNKNOWN","STALE"];
-  const candidates=statuses.map((status,index)=>({...candidate,candidate_id:`22222222-2222-4222-8222-22222222222${index}`,validation:{...candidate.validation,status}}));
-  const html=warmblyBlock({...input,query:"estado=todas",gate:{list:{data:[cohort]},selected:{data:{...cohort,candidates}}}},"revisao");
-  for(const status of statuses) assert.match(html,new RegExp(`data-validation-status="${status}"`));
+test("global auto-send true is shown as an incompatible outbound block", () => {
+  const html = warmblyBlock({
+    ...input,
+    query: "estado=todas",
+    gate: {
+      ...input.gate,
+      outbound_status: {
+        kill_switch: false,
+        sending_allowed: true,
+        auto_send_enabled: true,
+        edge_actor: actor,
+      },
+    },
+  }, "revisao");
+  assert.match(html, /data-outbound-status="blocked"/);
+  assert.match(html, /Auto-send global<\/dt><dd>ligado — configuração inválida/);
+  assert.doesNotMatch(html, /data-outbound-status="allowed"/);
 });
 
-test("cohort filters select observed freshness and decisions",()=>{
-  const stale={...cohort,id:"33333333-3333-4333-8333-333333333333",freshness:"STALE",decision:{decision:"GO"}};
-  const html=warmblyBlock({...input,query:"freshness=STALE&decision=GO",gate:{list:{data:[cohort,stale]}}},"cohorts");
-  assert.match(html,/33333333-3333-4333-8333-333333333333/);
-  assert.doesNotMatch(html,/11111111-1111-4111-8111-111111111111/);
+test("review renders every Warmbly validation state without inferring validity", () => {
+  const statuses = ["VALID", "RISKY", "INVALID", "UNKNOWN", "STALE"];
+  const candidates = statuses.map((status, index) => ({
+    ...candidate,
+    candidate_id: `22222222-2222-4222-8222-22222222222${index}`,
+    validation: { ...candidate.validation, status },
+  }));
+  const html = warmblyBlock({
+    ...input,
+    query: "estado=todas",
+    gate: { ...input.gate, selected: { data: { ...cohort, candidates } } },
+  }, "revisao");
+  for (const status of statuses) assert.match(html, new RegExp(`data-validation-status="${status}"`));
 });
 
-test("HTTP adapter enforces and forwards human confirmations", async () => {
-  const calls: Array<Record<string, unknown>> = [];
+test("cohort filters select observed freshness; GO is not a live filter", () => {
+  const stale = { ...cohort, id: "33333333-3333-4333-8333-333333333333", freshness: "STALE", decision: { decision: "GO" } };
+  const html = warmblyBlock({
+    ...input,
+    query: "freshness=STALE&decision=GO",
+    gate: { ...input.gate, list: { data: [cohort, stale], edge_actor: actor } },
+  }, "cohorts");
+  assert.match(html, /33333333-3333-4333-8333-333333333333/);
+  assert.doesNotMatch(html, /11111111-1111-4111-8111-111111111111/);
+  assert.doesNotMatch(html, /name="decision"/);
+});
+
+test("HTTP adapter enforces APPROVE acknowledgement and forwards reconciliation without GO confirmation", async () => {
+  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
   const adapter = new HttpControlCenterAdapter({
     baseUrl: "http://control-center.fixture",
-    fetchImpl: (async (_input: RequestInfo | URL, init?: RequestInit) => {
-      calls.push(JSON.parse(String(init?.body)));
-      return new Response(JSON.stringify({ receipt: "fixture:r1" }), { status: 200 });
+    fetchImpl: (async (wire: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(wire), body: JSON.parse(String(init?.body)) as Record<string, unknown> });
+      return new Response(JSON.stringify({ outcome: "APPLIED", receipt: "fixture:r1" }), { status: 200 });
     }) as typeof fetch,
   });
   const missingAck = await adapter.warmblyGate({
-    action: "review", version_id: version, candidate_id: candidate.candidate_id,
-    decision: "APPROVE", reason: "fixture", idempotency_key: "idem-review-fixture",
+    action: "review",
+    version_id: version,
+    candidate_id: candidate.candidate_id,
+    decision: "APPROVE",
+    reason: "fixture",
+    idempotency_key: "idem-review-fixture",
   });
   assert.equal(missingAck.code, "approval_acknowledgement_required");
   assert.equal(calls.length, 0);
   await adapter.warmblyGate({
-    action: "review", version_id: version, candidate_id: candidate.candidate_id,
-    decision: "APPROVE", reason: "fixture", acknowledged: true, idempotency_key: "idem-review-fixture",
+    action: "review",
+    version_id: version,
+    candidate_id: candidate.candidate_id,
+    decision: "APPROVE",
+    reason: "fixture",
+    acknowledged: true,
+    idempotency_key: "idem-review-fixture",
   });
-  const missingVersion = await adapter.warmblyGate({
-    action: "decide", version_id: version, decision: "NO_GO", reason: "fixture",
-    idempotency_key: "idem-decision-fixture",
-  });
-  assert.equal(missingVersion.code, "cohort_version_confirmation_required");
-  await adapter.warmblyGate({
-    action: "decide", version_id: version, decision: "NO_GO", reason: "fixture",
-    confirmation: " V3 ", idempotency_key: "idem-decision-fixture",
-  });
-  assert.deepEqual(calls.map((body) => ({ acknowledged: body.acknowledged, confirmation: body.confirmation })), [
+  await adapter.warmblyGate({ action: "reconcile", idempotency_key: "idem-reconcile-fixture" });
+  assert.deepEqual(calls.map((call) => call.url), [
+    `http://control-center.fixture/v1/warmbly/operator/cohorts/${version}/candidates/${candidate.candidate_id}/review`,
+    "http://control-center.fixture/v1/warmbly/operator/cohorts/reconcile-approved",
+  ]);
+  assert.deepEqual(calls.map((call) => ({ acknowledged: call.body.acknowledged, confirmation: call.body.confirmation })), [
     { acknowledged: true, confirmation: undefined },
-    { acknowledged: undefined, confirmation: "v3" },
+    { acknowledged: undefined, confirmation: undefined },
   ]);
 });

--- a/control-center/connectors/warmbly/src/human-gate/contract.ts
+++ b/control-center/connectors/warmbly/src/human-gate/contract.ts
@@ -23,10 +23,10 @@ export const WARMBLY_COHORTS_PREFIX = "/v1/confenge/cohorts";
 
 /**
  * Every operation the human gate can name. There is deliberately no generic
- * proxy entry and no `send`, `queue`, `resume` or `payment` member: the type
+ * proxy entry and no `send`, `dispatch`, `queue`, `resume` or `payment` member: the type
  * itself is part of the security boundary.
  *
- * `reconcile_approved` is the admin-only bridge for approvals that predate
+ * `reconcile` is the admin-only bridge for approvals that predate
  * approval-time scheduling. It names exactly one fixed route and does not
  * accept a caller-selected cohort or candidate. On the current contract
  * APPROVE itself asks Warmbly to create the queued touchpoint, and the worker
@@ -34,6 +34,7 @@ export const WARMBLY_COHORTS_PREFIX = "/v1/confenge/cohorts";
  * remains paused. There is no GO or cohort-dispatch operation in this surface.
  */
 export const HUMAN_GATE_OPERATIONS = [
+  "read_status",
   "list_cohorts",
   "read_cohort",
   "read_candidate",
@@ -42,7 +43,7 @@ export const HUMAN_GATE_OPERATIONS = [
   "validation",
   "review",
   "adjust",
-  "reconcile_approved",
+  "reconcile",
 ] as const;
 export type HumanGateOperation = (typeof HUMAN_GATE_OPERATIONS)[number];
 
@@ -53,7 +54,7 @@ export const HUMAN_GATE_WRITE_OPERATIONS = [
   "validation",
   "review",
   "adjust",
-  "reconcile_approved",
+  "reconcile",
 ] as const;
 
 /**
@@ -61,12 +62,13 @@ export const HUMAN_GATE_WRITE_OPERATIONS = [
  * Kept as data so `tests/human-gate-negative-allowlist.test.ts` can enumerate
  * them instead of a reviewer having to remember the list.
  *
- * Approval-time scheduling is the only way the current gate can put reviewed
- * content into Warmbly's queue. GO and cohort dispatch are intentionally
- * unconstructable here.
+ * `APPROVE` is the only ordinary path to queue work. Reconciliation is a fixed
+ * admin repair route that replays that same server path; it is not a generic
+ * dispatch capability.
  */
 export const FORBIDDEN_HUMAN_GATE_SEGMENTS = [
   "send",
+  "dispatch",
   "queue",
   "resume",
   "auto-send",
@@ -77,7 +79,6 @@ export const FORBIDDEN_HUMAN_GATE_SEGMENTS = [
   "enroll",
   "deliver",
   "decision",
-  "dispatch",
 ] as const;
 
 /** How a call ended. `UNKNOWN` is never collapsed into `REFUSED`. */

--- a/control-center/connectors/warmbly/src/human-gate/http.ts
+++ b/control-center/connectors/warmbly/src/human-gate/http.ts
@@ -15,6 +15,7 @@ import {
 
 export { HUMAN_GATE_CONTRACT };
 export const HUMAN_GATE_PREFIX = "/v1/warmbly/operator/cohorts";
+export const HUMAN_GATE_STATUS_PATH = "/v1/warmbly/operator/outbound-status";
 
 const UUID = UUID_PATTERN_SOURCE;
 
@@ -36,6 +37,7 @@ interface HumanGateRoute {
 }
 
 const routes: readonly HumanGateRoute[] = [
+  { method: "GET", operation: "read_status", local: new RegExp(`^${HUMAN_GATE_STATUS_PATH}$`), upstream: () => "/v1/confenge/status", role: "operators" },
   { method: "GET", operation: "list_cohorts", local: new RegExp(`^${HUMAN_GATE_PREFIX}$`), upstream: () => WARMBLY_COHORTS_PREFIX, role: "operators" },
   { method: "POST", operation: "create", local: new RegExp(`^${HUMAN_GATE_PREFIX}$`), upstream: () => WARMBLY_COHORTS_PREFIX, role: "operators" },
   { method: "GET", operation: "read_cohort", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}`, role: "operators" },
@@ -47,10 +49,10 @@ const routes: readonly HumanGateRoute[] = [
   // a new immutable version and revokes the authorization bound to the old one;
   // it is not a GO, so it is deliberately NOT behind the admins gate.
   { method: "POST", operation: "adjust", local: new RegExp(`^${HUMAN_GATE_PREFIX}/(${UUID})/candidates/(${UUID})/adjust$`), upstream: (m) => `${WARMBLY_COHORTS_PREFIX}/${m[1]}/candidates/${m[2]}/adjust`, role: "operators", validate: validateAdjustRequest },
-  // Replays the backend's idempotent scheduler for durable APPROVEs created
-  // before scheduling landed. It does not send or resume anything; admins use
-  // it once while dispatch remains paused, then inspect the returned counts.
-  { method: "POST", operation: "reconcile_approved", local: new RegExp(`^${HUMAN_GATE_PREFIX}/reconcile-approved$`), upstream: () => `${WARMBLY_COHORTS_PREFIX}/reconcile-approved`, role: "admins" },
+  // Repair-only replay of the same scheduling path an APPROVE already runs.
+  // It is global, payload-free and naturally idempotent upstream; admins own
+  // repair while operators own the ordinary approve-and-queue decision.
+  { method: "POST", operation: "reconcile", local: new RegExp(`^${HUMAN_GATE_PREFIX}/reconcile-approved$`), upstream: () => `${WARMBLY_COHORTS_PREFIX}/reconcile-approved`, role: "admins" },
 ];
 
 /** Exposed for tests and for the cockpit: the complete reachable surface. */
@@ -144,7 +146,17 @@ function edgeEnvelope(
     reason,
     correlation_id: typeof meta.correlation_id === "string" ? meta.correlation_id : ctx.correlation,
     receipt: upstreamReceipt(payload) ?? `edge:${ctx.correlation}`,
-    auto_send_enabled: false,
+    // Human-gate envelopes retain their canonical global-off assertion. The
+    // dedicated status read is different: it is server telemetry, so preserve
+    // a real boolean and let absence remain absence instead of stamping false.
+    ...(ctx.operation === "read_status"
+      ? {
+          auto_send_enabled:
+            typeof payload.auto_send_enabled === "boolean"
+              ? payload.auto_send_enabled
+              : undefined,
+        }
+      : { auto_send_enabled: false }),
     edge_correlation_id: ctx.correlation,
     // Distinct write results used to arrive as one indistinguishable body. These
     // three say which call this was, how it ended, and what it produced.
@@ -169,9 +181,9 @@ export interface HumanGateHttpOptions {
 }
 
 /**
- * Fixed-route authenticated proxy. It has no `send`, `queue`, `resume`, GO or
- * cohort-dispatch route by construction. Only an effective APPROVE may ask the
- * current Warmbly contract to schedule its exact reviewed message.
+ * Fixed-route authenticated proxy. It has no `send`, `dispatch`, `queue` or
+ * `resume` route by construction. APPROVE and repair reconciliation are the
+ * only ways this surface can cause durable scheduling.
  */
 export function createHumanGateHttpHandler(options: HumanGateHttpOptions) {
   const fetchImpl = options.fetchImpl ?? fetch;
@@ -247,7 +259,7 @@ export function createHumanGateHttpHandler(options: HumanGateHttpOptions) {
         };
       }
       body = { ...validated.value };
-    } else {
+    } else if (route.operation !== "reconcile") {
       for (const field of ["limit", "source_run_id", "selection_mode", "recover_version_ids", "decision", "reason", "acknowledged", "confirmation"] as const) {
         if (submitted[field] !== undefined) body[field] = submitted[field];
       }

--- a/control-center/connectors/warmbly/src/index.ts
+++ b/control-center/connectors/warmbly/src/index.ts
@@ -50,6 +50,7 @@ export * from "./operator/index.ts";
 export {
   HUMAN_GATE_CONTRACT,
   HUMAN_GATE_PREFIX,
+  HUMAN_GATE_STATUS_PATH,
   HUMAN_GATE_ROUTES,
   createHumanGateHttpHandler,
 } from "./human-gate/http.ts";

--- a/control-center/connectors/warmbly/tests/human-gate-adjust-contract.test.ts
+++ b/control-center/connectors/warmbly/tests/human-gate-adjust-contract.test.ts
@@ -53,20 +53,24 @@ test("adjust is one POST route under the operators role and nothing else", () =>
   assert.equal(
     adjust[0]?.role,
     "operators",
-    "adjust carries the same permission as review, never the admins-only GO permission",
+    "adjust carries the same permission as review, never the admins-only repair permission",
   );
+  const reconcile = HUMAN_GATE_ROUTES.filter((route) => route.operation === "reconcile");
+  assert.equal(reconcile.length, 1, "reconciliation must have exactly one route");
+  assert.equal(reconcile[0]?.method, "POST");
+  assert.equal(reconcile[0]?.role, "admins", "repair stays admins-only");
+  const status = HUMAN_GATE_ROUTES.filter((route) => route.operation === "read_status");
+  assert.equal(status.length, 1, "outbound status must have exactly one route");
+  assert.equal(status[0]?.method, "GET");
+  assert.equal(status[0]?.role, "operators");
   assert.deepEqual(
     HUMAN_GATE_ROUTES.filter((r) => r.method === "POST").map((r) => r.operation).sort(),
     [...HUMAN_GATE_WRITE_OPERATIONS].sort(),
     "the write surface is exactly the six declared operations",
   );
-  assert.equal(HUMAN_GATE_OPERATIONS.length, 9, "three reads plus six writes; nothing else exists");
-  const reconcile = HUMAN_GATE_ROUTES.filter((route) => route.operation === "reconcile_approved");
-  assert.equal(reconcile.length, 1, "approval reconciliation must have exactly one route");
-  assert.equal(reconcile[0]?.method, "POST");
-  assert.equal(reconcile[0]?.role, "admins", "approval reconciliation is admins-only");
-  assert.equal(HUMAN_GATE_ROUTES.some((route) => (route.operation as string) === "decision"), false);
-  assert.equal(HUMAN_GATE_ROUTES.some((route) => (route.operation as string) === "dispatch"), false);
+  assert.equal(HUMAN_GATE_OPERATIONS.length, 10, "four reads plus six writes; nothing else exists");
+  assert.equal(HUMAN_GATE_ROUTES.some((route) => route.operation === ("decision" as never)), false);
+  assert.equal(HUMAN_GATE_ROUTES.some((route) => route.operation === ("dispatch" as never)), false);
 });
 
 test("the adjust request shape is exactly the five contract fields", () => {

--- a/control-center/connectors/warmbly/tests/human-gate-adjust.test.ts
+++ b/control-center/connectors/warmbly/tests/human-gate-adjust.test.ts
@@ -2,9 +2,9 @@
  * The cohort `adjust` control-plane operation.
  *
  * Adjust mints a new immutable cohort version from edited copy and revokes the
- * authorization bound to the version it supersedes. It is the sixth and only
- * new member of the fixed human-gate allowlist; everything asserted here is
- * about keeping it exactly that narrow.
+ * historical authority bound to the version it supersedes. It remains one
+ * member of the fixed human-gate allowlist; everything asserted here is about
+ * keeping it exactly that narrow.
  *
  * No real mailbox, token or PII appears in this file. Hosts are `.invalid`,
  * hashes are obvious fixtures, and copy is neutral Portuguese.
@@ -118,26 +118,26 @@ describe("human gate adjust — the request that reaches Warmbly", () => {
     assert.match(String(seen.headers?.get("x-correlation-id")), /^cc:human-gate:/);
   });
 
-  it("runs under operators, while approval reconciliation remains admins-only", async () => {
+  it("runs under operators, like review and unlike admin-only reconciliation", async () => {
     let hits = 0;
     const handler = handlerWith(async () => {
       hits += 1;
       return new Response(JSON.stringify(createdPayload()), { status: 201 });
     });
-    // One identity, operators only. Adjust is reachable for it; bulk approval
-    // reconciliation is not. That difference is the whole RBAC claim.
+    // One identity, operators only. Adjust is reachable; repair is not.
     const ok = await handler(request("POST", ADJUST_PATH, "operators", adjustBody()));
     assert.equal(ok.status, 201, "operators must be sufficient for adjust");
     assert.equal(hits, 1);
 
-    const denied = await handler(
-      request("POST", `${HUMAN_GATE_PREFIX}/reconcile-approved`, "operators", {
-        idempotency_key: "idem-reconcile-0002",
-      }),
-    );
+    const denied = await handler(request(
+      "POST",
+      `${HUMAN_GATE_PREFIX}/reconcile-approved`,
+      "operators",
+      { idempotency_key: "idem-reconcile-0002" },
+    ));
     assert.equal(denied.status, 403);
     assert.equal(denied.body.code, "insufficient_human_gate_role");
-    assert.equal(denied.body.operation, "reconcile_approved");
+    assert.equal(denied.body.operation, "reconcile");
     assert.equal(hits, 1, "a role refusal must never reach Warmbly");
   });
 
@@ -290,7 +290,7 @@ describe("human gate adjust — response fidelity", () => {
     assert.equal(res.body.receipt, "review:r1");
   });
 
-  it("labels every one of the six writes with its own operation name", async () => {
+  it("labels every fixed human-gate operation with its own name", async () => {
     const handler = handlerWith(async () => new Response(JSON.stringify({ receipt: "r" }), { status: 200 }));
     const cases: [string, string, Record<string, unknown>, string][] = [
       ["POST", HUMAN_GATE_PREFIX, { limit: 2, idempotency_key: "idem-create-0001" }, "create"],
@@ -299,17 +299,19 @@ describe("human gate adjust — response fidelity", () => {
       ["POST", `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/review`, { decision: "HOLD", reason: "x", idempotency_key: "idem-review-0002" }, "review"],
       ["POST", ADJUST_PATH, adjustBody(), "adjust"],
       ["GET", HUMAN_GATE_PREFIX, {}, "list_cohorts"],
+      ["GET", "/v1/warmbly/operator/outbound-status", {}, "read_status"],
     ];
     for (const [method, path, body, operation] of cases) {
       const res = await handler(request(method, path, "operators", body));
       assert.equal(res.body.operation, operation, `${method} ${path}`);
     }
-    const reconcile = await handler(
-      request("POST", `${HUMAN_GATE_PREFIX}/reconcile-approved`, "admins,operators", {
-        idempotency_key: "idem-reconcile-0001",
-      }),
-    );
-    assert.equal(reconcile.body.operation, "reconcile_approved");
+    const reconcile = await handler(request(
+      "POST",
+      `${HUMAN_GATE_PREFIX}/reconcile-approved`,
+      "admins,operators",
+      { idempotency_key: "idem-reconcile-0001" },
+    ));
+    assert.equal(reconcile.body.operation, "reconcile");
   });
 
   it("preserves the server's own refusal codes for every adjust conflict", async () => {

--- a/control-center/connectors/warmbly/tests/human-gate-negative-allowlist.test.ts
+++ b/control-center/connectors/warmbly/tests/human-gate-negative-allowlist.test.ts
@@ -2,7 +2,7 @@
  * What the human gate must never be able to construct.
  *
  * The load-bearing property of this connector is negative: there is no generic
- * proxy route, and no route that can send, dispatch, decide, queue, resume, auto-send or
+ * proxy route, and no route that can send, dispatch, queue, resume, auto-send or
  * charge. Adding `adjust` is the first widening of this surface in a while, so
  * these tests hold the boundary from the outside — by enumerating the routes an
  * attacker would want and proving each one is unreachable, at every prefix and
@@ -125,11 +125,82 @@ describe("the human gate cannot construct an outbound-send route", () => {
         `${forbidden} must never become an operation`,
       );
     }
-    // Exactly the six typed writes, plus three reads.
+    // Exactly six fixed writes and four fixed reads. Dispatch is forbidden.
     assert.deepEqual([...declared].sort(), [
-      "adjust", "create", "list_cohorts", "read_candidate",
-      "read_cohort", "reconcile_approved", "reproduce", "review", "validation",
+      "adjust", "create", "list_cohorts", "read_candidate", "read_cohort", "read_status",
+      "reconcile", "reproduce", "review", "validation",
     ]);
+  });
+});
+
+/**
+ * Reconciliation repairs already-recorded approvals. It is reachable at one
+ * exact admin-only path and cannot be shaped into a dispatch or generic proxy.
+ */
+describe("reconciliation is reachable at exactly one shape and nowhere else", () => {
+  const only = `${HUMAN_GATE_PREFIX}/reconcile-approved`;
+
+  it("forwards the global approval reconciliation and no caller payload", async () => {
+    const { attempts, handler } = trap();
+    const res = await handler(request("POST", only, "admins,operators", WRITE_BODY));
+    assert.equal(res.status, 200);
+    assert.deepEqual(attempts, ["https://warmbly.invalid/v1/confenge/cohorts/reconcile-approved"]);
+  });
+
+  it("has no cohort-level, candidate-level or alternate reconciliation route", async () => {
+    const { attempts, handler } = trap();
+    for (const path of [
+      `${HUMAN_GATE_PREFIX}/${COHORT}/reconcile-approved`,
+      `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/reconcile-approved`,
+      `${HUMAN_GATE_PREFIX}/reconcile`,
+      "/v1/warmbly/operator/reconcile-approved",
+      "/v1/confenge/cohorts/reconcile-approved",
+    ]) {
+      const res = await handler(request("POST", path, "admins,operators", WRITE_BODY));
+      assert.equal(res.status, 404, `${path} must be outside the allowlist`);
+      assert.equal(res.body.code, "human_gate_route_not_allowed");
+    }
+    assert.deepEqual(attempts, []);
+  });
+
+  it("refuses every method on reconciliation except POST", async () => {
+    const { attempts, handler } = trap();
+    for (const method of ["GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]) {
+      const res = await handler(request(method, only, "admins,operators", WRITE_BODY));
+      assert.equal(res.status, 404, method);
+    }
+    assert.deepEqual(attempts, []);
+  });
+
+  it("requires admins: operators alone cannot reconcile, and the refusal never reaches Warmbly", async () => {
+    const { attempts, handler } = trap();
+    const res = await handler(request("POST", only, "operators", WRITE_BODY));
+    assert.equal(res.status, 403);
+    assert.equal(res.body.code, "insufficient_human_gate_role");
+    assert.deepEqual(attempts, []);
+  });
+
+  it("cannot reach send, queue or dispatch through reconciliation", async () => {
+    const { attempts, handler } = trap();
+    for (const path of [
+      `${only}/send`,
+      `${only}/queue`,
+      `${only}/dispatch`,
+      `${only}%2Fsend`,
+    ]) {
+      const res = await handler(request("POST", path, "admins,operators", WRITE_BODY));
+      assert.equal(res.status, 404, path);
+    }
+    assert.deepEqual(attempts, []);
+  });
+
+  it("drops every query string on the reconciliation write", async () => {
+    const { attempts, handler } = trap();
+    const res = await handler(
+      request("POST", `${only}?limit=5000&redirect=/v1/confenge/send`, "admins,operators", WRITE_BODY),
+    );
+    assert.equal(res.status, 200);
+    assert.deepEqual(attempts, ["https://warmbly.invalid/v1/confenge/cohorts/reconcile-approved"]);
   });
 });
 

--- a/control-center/connectors/warmbly/tests/human-gate.test.ts
+++ b/control-center/connectors/warmbly/tests/human-gate.test.ts
@@ -1,56 +1,118 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { createHumanGateHttpHandler, HUMAN_GATE_PREFIX } from "../src/human-gate/http.ts";
+import {
+  createHumanGateHttpHandler,
+  HUMAN_GATE_PREFIX,
+  HUMAN_GATE_STATUS_PATH,
+} from "../src/human-gate/http.ts";
 import { defaultOperatorIdentityPolicy } from "../src/operator/identity.ts";
 
 const hop = "10.89.0.2";
+const COHORT = "11111111-1111-4111-8111-111111111111";
+const CANDIDATE = "22222222-2222-4222-8222-222222222222";
+
 function request(method: string, url: string, groups = "operators", body: unknown = {}) {
-  return { method, url, remoteAddress: hop, headers: { "Remote-User":"founder", "Remote-Groups":groups, "Remote-Name":"Founder", "Remote-Email":"founder@confenge.invalid" }, body };
+  return {
+    method,
+    url,
+    remoteAddress: hop,
+    headers: {
+      "Remote-User": "founder",
+      "Remote-Groups": groups,
+      "Remote-Name": "Founder",
+      "Remote-Email": "founder@confenge.invalid",
+    },
+    body,
+  };
+}
+
+function makeHandler(fetchImpl: typeof fetch) {
+  return createHumanGateHttpHandler({
+    baseUrl: "https://warmbly.invalid",
+    token: "wmbly_secret_12345678",
+    identityPolicy: defaultOperatorIdentityPolicy([hop]),
+    fetchImpl,
+  });
 }
 
 describe("Warmbly human gate fixed proxy", () => {
   it("denies missing identity before touching Warmbly", async () => {
-    let hits=0; const handler=createHumanGateHttpHandler({baseUrl:"https://warmbly.invalid",token:"wmbly_secret_12345678",identityPolicy:defaultOperatorIdentityPolicy([hop]),fetchImpl:async()=>{hits++;return new Response("{}")}});
-    const res=await handler({method:"GET",url:HUMAN_GATE_PREFIX,remoteAddress:hop,headers:{},body:{}});
-    assert.equal(res.status,401); assert.equal(hits,0);
+    let hits = 0;
+    const handler = makeHandler(async () => { hits += 1; return new Response("{}"); });
+    const res = await handler({ method: "GET", url: HUMAN_GATE_PREFIX, remoteAddress: hop, headers: {}, body: {} });
+    assert.equal(res.status, 401);
+    assert.equal(hits, 0);
     assert.equal(res.body.contract_version, "confenge.human-gate.v1");
     assert.equal(res.body.freshness, "UNKNOWN");
     assert.equal(res.body.auto_send_enabled, false);
     assert.match(String(res.body.receipt), /^edge:cc:human-gate:/);
   });
 
-  it("exposes neither legacy GO/NO-GO nor cohort dispatch", async () => {
-    let hits=0; const handler=createHumanGateHttpHandler({baseUrl:"https://warmbly.invalid",token:"wmbly_secret_12345678",identityPolicy:defaultOperatorIdentityPolicy([hop]),fetchImpl:async()=>{hits++;return new Response("{}")}});
-    const id="11111111-1111-4111-8111-111111111111";
-    for (const path of [`${HUMAN_GATE_PREFIX}/${id}/decision`, `${HUMAN_GATE_PREFIX}/${id}/dispatch`]) {
-      const denied=await handler(request("POST",path,"admins,operators",{decision:"GO",reason:"ok",idempotency_key:"idem-12345678"}));
-      assert.equal(denied.status,404); assert.equal(hits,0);
-    }
+  it("keeps APPROVE with operators; admins without operators are refused before upstream", async () => {
+    let hits = 0;
+    const handler = makeHandler(async () => { hits += 1; return new Response("{}"); });
+    const path = `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/review`;
+    const denied = await handler(request("POST", path, "admins", {
+      decision: "APPROVE", reason: "fixture", acknowledged: true, idempotency_key: "idem-review-admin",
+    }));
+    assert.equal(denied.status, 401);
+    assert.equal(denied.body.operation, "review");
+    assert.equal(hits, 0);
   });
 
-  it("forwards only fixed routes, strips browser actor and preserves idempotency", async () => {
-    let seen: {url?:string;body?:Record<string,unknown>;headers?:Headers}|undefined;
-    const handler=createHumanGateHttpHandler({baseUrl:"https://warmbly.invalid",token:"wmbly_secret_12345678",identityPolicy:defaultOperatorIdentityPolicy([hop]),fetchImpl:async(input,init)=>{seen={url:String(input),body:JSON.parse(String(init?.body)),headers:new Headers(init?.headers)};return new Response(JSON.stringify({receipt:"review:r1"}),{status:200,headers:{"content-type":"application/json"}})}});
-    const version="11111111-1111-4111-8111-111111111111",candidate="22222222-2222-4222-8222-222222222222";
-    const res=await handler(request("POST",`${HUMAN_GATE_PREFIX}/${version}/candidates/${candidate}/review`,"operators",{decision:"APPROVE",reason:"evidência válida",acknowledged:true,actor_id:"attacker",idempotency_key:"idem-12345678"}));
-    assert.equal(res.status,200); assert.equal(seen?.url,`https://warmbly.invalid/v1/confenge/cohorts/${version}/candidates/${candidate}/review`);assert.equal(seen?.headers?.get("idempotency-key"),"idem-12345678");assert.equal(seen?.body?.actor_id,undefined);
-    assert.equal(seen?.body?.acknowledged, true);
-    // Warmbly ignores actor fields: its authenticated service user is the only upstream actor.
-    assert.equal(seen?.headers?.has("x-actor-id"),false);
+  it("keeps reconciliation with admins; operators are refused before upstream", async () => {
+    let hits = 0;
+    const handler = makeHandler(async () => { hits += 1; return new Response("{}"); });
+    const denied = await handler(request("POST", `${HUMAN_GATE_PREFIX}/reconcile-approved`, "operators", {
+      idempotency_key: "idem-reconcile-denied",
+    }));
+    assert.equal(denied.status, 403);
+    assert.equal(denied.body.operation, "reconcile");
+    assert.equal(hits, 0);
+  });
+
+  it("forwards APPROVE only on the fixed route, strips browser actor and preserves acknowledgement and idempotency", async () => {
+    let seen: { url?: string; body?: Record<string, unknown>; headers?: Headers } = {};
+    const handler = makeHandler(async (input, init) => {
+      seen = {
+        url: String(input),
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+        headers: new Headers(init?.headers),
+      };
+      return new Response(JSON.stringify({ receipt: "review:r1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const res = await handler(request(
+      "POST",
+      `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/review`,
+      "operators",
+      {
+        decision: "APPROVE",
+        reason: "evidência válida",
+        acknowledged: true,
+        actor_id: "attacker",
+        idempotency_key: "idem-12345678",
+      },
+    ));
+    assert.equal(res.status, 200);
+    assert.equal(seen.url, `https://warmbly.invalid/v1/confenge/cohorts/${COHORT}/candidates/${CANDIDATE}/review`);
+    assert.equal(seen.headers?.get("idempotency-key"), "idem-12345678");
+    assert.equal(seen.body?.actor_id, undefined);
+    assert.equal(seen.body?.acknowledged, true);
+    assert.equal(seen.headers?.has("x-actor-id"), false);
   });
 
   it("forwards server-managed next-page and recovery selection without exposing an offset", async () => {
     const bodies: Record<string, unknown>[] = [];
-    const handler = createHumanGateHttpHandler({
-      baseUrl: "https://warmbly.invalid",
-      token: "wmbly_secret_12345678",
-      identityPolicy: defaultOperatorIdentityPolicy([hop]),
-      fetchImpl: async (_input, init) => {
-        bodies.push(JSON.parse(String(init?.body)));
-        return new Response(JSON.stringify({ receipt: "cohort:r1" }), { status: 201 });
-      },
+    const handler = makeHandler(async (_input, init) => {
+      bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response(JSON.stringify({ receipt: "cohort:r1" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
     });
-    const prior = "11111111-1111-4111-8111-111111111111";
     await handler(request("POST", HUMAN_GATE_PREFIX, "operators", {
       limit: 10,
       selection_mode: "NEXT_UNCLAIMED",
@@ -60,29 +122,29 @@ describe("Warmbly human gate fixed proxy", () => {
     await handler(request("POST", HUMAN_GATE_PREFIX, "operators", {
       limit: 10,
       selection_mode: "RECOVER_PRIOR",
-      recover_version_ids: [prior],
+      recover_version_ids: [COHORT],
       idempotency_key: "idem-recover-prior",
     }));
     assert.deepEqual(bodies[0], { limit: 10, selection_mode: "NEXT_UNCLAIMED" });
-    assert.deepEqual(bodies[1], { limit: 10, selection_mode: "RECOVER_PRIOR", recover_version_ids: [prior] });
+    assert.deepEqual(bodies[1], {
+      limit: 10,
+      selection_mode: "RECOVER_PRIOR",
+      recover_version_ids: [COHORT],
+    });
   });
 
   it("lets only admins reconcile durable approvals and forwards no caller target", async () => {
     let hits = 0;
     let seenUrl = "";
     let seenBody: Record<string, unknown> = { unexpected: true };
-    let seenKey = "";
-    const handler = createHumanGateHttpHandler({
-      baseUrl: "https://warmbly.invalid",
-      token: "wmbly_secret_12345678",
-      identityPolicy: defaultOperatorIdentityPolicy([hop]),
-      fetchImpl: async (input, init) => {
-        hits += 1;
-        seenUrl = String(input);
-        seenBody = JSON.parse(String(init?.body));
-        seenKey = new Headers(init?.headers).get("idempotency-key") ?? "";
-        return new Response(JSON.stringify({ data: { scheduled: 4, already_scheduled: 7, failed: 0 } }), { status: 200 });
-      },
+    const handler = makeHandler(async (input, init) => {
+      hits += 1;
+      seenUrl = String(input);
+      seenBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({ data: { scheduled: 4, already_scheduled: 7, failed: 0 } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     });
     const denied = await handler(request("POST", `${HUMAN_GATE_PREFIX}/reconcile-approved`, "operators", {
       idempotency_key: "idem-reconcile-approvals",
@@ -98,24 +160,49 @@ describe("Warmbly human gate fixed proxy", () => {
     assert.equal(hits, 1);
     assert.equal(seenUrl, "https://warmbly.invalid/v1/confenge/cohorts/reconcile-approved");
     assert.deepEqual(seenBody, {});
-    assert.equal(seenKey, "idem-reconcile-approvals");
   });
 
-  it("allows the exact candidate/message-preview read and nothing below it", async () => {
+  it("forwards the server-owned outbound status through one fixed read route", async () => {
     let seen = "";
-    const handler = createHumanGateHttpHandler({
-      baseUrl: "https://warmbly.invalid",
-      token: "wmbly_secret_12345678",
-      identityPolicy: defaultOperatorIdentityPolicy([hop]),
-      fetchImpl: async (input) => { seen = String(input); return new Response(JSON.stringify({ data: {} }), { status: 200 }); },
+    const handler = makeHandler(async (input) => {
+      seen = String(input);
+      return new Response(JSON.stringify({
+        kill_switch: false,
+        sending_allowed: true,
+        auto_send_enabled: true,
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     });
-    const version = "11111111-1111-4111-8111-111111111111";
-    const candidate = "22222222-2222-4222-8222-222222222222";
-    const res = await handler(request("GET", `${HUMAN_GATE_PREFIX}/${version}/candidates/${candidate}`));
+    const res = await handler(request("GET", HUMAN_GATE_STATUS_PATH));
     assert.equal(res.status, 200);
-    assert.equal(seen, `https://warmbly.invalid/v1/confenge/cohorts/${version}/candidates/${candidate}`);
-    const denied = await handler(request("GET", `${HUMAN_GATE_PREFIX}/${version}/candidates/${candidate}/raw`));
-    assert.equal(denied.status, 404);
+    assert.equal(seen, "https://warmbly.invalid/v1/confenge/status");
+    assert.equal(res.body.kill_switch, false);
+    assert.equal(res.body.sending_allowed, true);
+    assert.equal(res.body.auto_send_enabled, true, "status telemetry must not be overwritten by the edge");
+  });
+
+  it("keeps absent auto-send absent on the outbound status read", async () => {
+    const handler = makeHandler(async () => new Response(JSON.stringify({
+      kill_switch: true,
+      sending_allowed: false,
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    const res = await handler(request("GET", HUMAN_GATE_STATUS_PATH));
+    assert.equal(res.status, 200);
+    assert.equal(res.body.auto_send_enabled, undefined);
+  });
+
+  it("allows the exact candidate read and nothing below it", async () => {
+    let seen = "";
+    const handler = makeHandler(async (input) => {
+      seen = String(input);
+      return new Response(JSON.stringify({ data: {} }), { status: 200 });
+    });
+    const path = `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}`;
+    assert.equal((await handler(request("GET", path))).status, 200);
+    assert.equal(seen, `https://warmbly.invalid/v1/confenge/cohorts/${COHORT}/candidates/${CANDIDATE}`);
+    assert.equal((await handler(request("GET", `${path}/raw`))).status, 404);
   });
 
   it("audits the Authelia actor as an opaque reference without logging PII", async () => {
@@ -135,50 +222,68 @@ describe("Warmbly human gate fixed proxy", () => {
   });
 
   it("reports timeout after write as unknown and never retries", async () => {
-    let hits=0;const handler=createHumanGateHttpHandler({baseUrl:"https://warmbly.invalid",token:"wmbly_secret_12345678",identityPolicy:defaultOperatorIdentityPolicy([hop]),timeoutMs:1,fetchImpl:async(_input,init)=>{hits++;await new Promise((_r,reject)=>init?.signal?.addEventListener("abort",()=>reject(new Error("aborted"))));return new Response("{}")}});
-    const res=await handler(request("POST",HUMAN_GATE_PREFIX,"operators",{limit:2,idempotency_key:"idem-timeout-123"}));assert.equal(res.status,503);assert.equal(res.body.code,"human_gate_transport_unknown");assert.equal(res.body.source,"warmbly.controlled-outbound");assert.equal(res.body.auto_send_enabled,false);assert.equal(hits,1);
-  });
-
-  it("rejects a partial write without a caller-stable idempotency key before upstream", async () => {
     let hits = 0;
     const handler = createHumanGateHttpHandler({
       baseUrl: "https://warmbly.invalid",
       token: "wmbly_secret_12345678",
       identityPolicy: defaultOperatorIdentityPolicy([hop]),
-      fetchImpl: async () => { hits += 1; return new Response("{}"); },
+      timeoutMs: 1,
+      fetchImpl: async (_input, init) => {
+        hits += 1;
+        await new Promise((_resolve, reject) => init?.signal?.addEventListener("abort", () => reject(new Error("aborted"))));
+        return new Response("{}");
+      },
     });
-    const res = await handler(request("POST", HUMAN_GATE_PREFIX, "operators", { limit: 10 }));
+    const res = await handler(request("POST", HUMAN_GATE_PREFIX, "operators", { limit: 2, idempotency_key: "idem-timeout-123" }));
+    assert.equal(res.status, 503);
+    assert.equal(res.body.code, "human_gate_transport_unknown");
+    assert.equal(res.body.source, "warmbly.controlled-outbound");
+    assert.equal(res.body.auto_send_enabled, false);
+    assert.equal(hits, 1);
+  });
+
+  it("rejects reconciliation without a caller-stable idempotency key before upstream", async () => {
+    let hits = 0;
+    const handler = makeHandler(async () => { hits += 1; return new Response("{}"); });
+    const res = await handler(request("POST", `${HUMAN_GATE_PREFIX}/reconcile-approved`, "admins,operators", {}));
     assert.equal(res.status, 400);
     assert.equal(res.body.code, "idempotency_key_required");
     assert.equal(hits, 0);
   });
 
-  it("preserves upstream partial-payload, unauthorized, forbidden, conflict and write-denied failures without retry", async () => {
+  it("preserves upstream determinate failures without retry", async () => {
     for (const [status, code] of [[400, "invalid_payload"], [401, "unauthorized"], [403, "write_denied"], [409, "idempotency_payload_conflict"]] as const) {
       let hits = 0;
-      const handler = createHumanGateHttpHandler({
-        baseUrl: "https://warmbly.invalid",
-        token: "wmbly_secret_12345678",
-        identityPolicy: defaultOperatorIdentityPolicy([hop]),
-        fetchImpl: async () => {
-          hits += 1;
-          return new Response(JSON.stringify({ ok: false, code, reason: "fixture refusal" }), {
-            status,
-            headers: { "content-type": "application/json" },
-          });
-        },
+      const handler = makeHandler(async () => {
+        hits += 1;
+        return new Response(JSON.stringify({ ok: false, code, reason: "fixture refusal" }), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
       });
-      const res = await handler(request("POST", HUMAN_GATE_PREFIX, "operators", {
-        limit: 10, selection_mode: "NEXT_UNCLAIMED", idempotency_key: `idem-${status}-fixture`,
-      }));
+      const res = await handler(request(
+        "POST",
+        `${HUMAN_GATE_PREFIX}/${COHORT}/candidates/${CANDIDATE}/review`,
+        "operators",
+        { decision: "APPROVE", reason: "fixture", acknowledged: true, idempotency_key: `idem-${status}-fixture` },
+      ));
       assert.equal(res.status, status);
       assert.equal(res.body.code, code);
       assert.equal(hits, 1, `${status} must never be retried by the edge`);
     }
   });
 
-  it("rejects raw dispatch and arbitrary paths", async () => {
-    let hits=0;const handler=createHumanGateHttpHandler({baseUrl:"https://warmbly.invalid",token:"wmbly_secret_12345678",identityPolicy:defaultOperatorIdentityPolicy([hop]),fetchImpl:async()=>{hits++;return new Response("{}")}});
-    const res=await handler(request("POST",`${HUMAN_GATE_PREFIX}/dispatch`,"admins,operators",{}));assert.equal(res.status,404);assert.equal(hits,0);
+  it("rejects removed GO and cohort-dispatch routes before upstream", async () => {
+    let hits = 0;
+    const handler = makeHandler(async () => { hits += 1; return new Response("{}"); });
+    for (const path of [
+      `${HUMAN_GATE_PREFIX}/${COHORT}/decision`,
+      `${HUMAN_GATE_PREFIX}/${COHORT}/dispatch`,
+      `${HUMAN_GATE_PREFIX}/dispatch`,
+    ]) {
+      const res = await handler(request("POST", path, "admins,operators", { idempotency_key: "idem-old-route" }));
+      assert.equal(res.status, 404, path);
+    }
+    assert.equal(hits, 0);
   });
 });

--- a/control-center/deploy/PRODUCTION-RUNBOOK.md
+++ b/control-center/deploy/PRODUCTION-RUNBOOK.md
@@ -104,17 +104,21 @@ value and does not touch any other secret. Remove the one-time source after
 the Context container can read the mount and `/v1/me` proves `permissions=196` and
 the absence of `send_campaigns`. Never reuse the collector's broader read key.
 
-On an upgraded installation, preserve the current password hash and add `admins`
-to the authorized operator's existing `users.yml` groups beside `operators`.
-Back up the file first, validate YAML and restart only Authelia. Never regenerate
-the secret pack to make this group change.
+On an upgraded installation, preserve the current password hash and group
+membership. The boundary is deliberate: `operators` may APPROVE and therefore
+queue a message; `admins` may run the explicit reconciliation repair. If a
+future release changes either group, back up `users.yml`, validate YAML and
+restart only Authelia. Never regenerate the secret pack to make a group change.
 
 ## Ordered Warmbly prerequisite
 
-Merge and deploy the backward-compatible Warmbly human-gate and editorial-review
-APIs before the Control Center release. Apply migrations through
-`000122_confenge_cohort_selection` with the normal Warmbly deploy path; verify
-schema is `122`, `/ready` is ready, and all of
+Merge and deploy the Warmbly approval-scheduling API before the Control Center
+release. Apply migrations through `000122_confenge_cohort_selection` (including
+`000121_confenge_human_gate_scheduling`) with the normal Warmbly deploy path;
+verify schema is `122`, `/ready` is ready,
+`POST /v1/confenge/cohorts/{cohort}/candidates/{candidate}/review`
+schedules an APPROVE, and `POST /v1/confenge/cohorts/reconcile-approved` exists.
+Verify all of
 these remain false/true as shown:
 
 ```
@@ -124,31 +128,44 @@ CONFENGE_REQUIRE_HUMAN_APPROVAL=true
 ```
 
 Keep the dispatch kill switch engaged for deployment and sandbox verification.
-The migrations are additive. Do not expose the Control Center override until
-this prerequisite passes. The same least-privilege human-gate credential and
-private Context-to-Warmbly network path serve draft review: mask `196` already
-contains the required contact read/write permissions and still contains no send
-permission. Do not create a browser token or expose the credential to `web`.
-
-Before creating any additional backlog, an authenticated `admins` operator must
-run approval reconciliation once and inspect every reported failure. On the
-current contract an effective APPROVE creates or confirms its own queued
-touchpoint for the next eligible business window; there is no live cohort GO or
-manual cohort dispatch step. Reconciliation covers durable approvals created
-before that scheduling behavior. Neither operation sends immediately or resumes
-the dispatch kill switch.
+The migration is additive. Do not expose the Control Center contract until this
+prerequisite passes. The same least-privilege human-gate credential and private
+Context-to-Warmbly network path serve review: mask `196` already contains the
+required contact read/write permissions and still contains no send permission.
+Do not create a browser token or expose the credential to `web`.
 
 ## Deploy (production-edge)
 
-Checkout the certified `RELEASE_SHA` at `/opt/confenge-control-center`.
+Before every release, record the current Git SHA and image IDs for `context`,
+`web` and `mcp`; those are the rollback point. Then fast-forward the certified
+release at `/opt/confenge-control-center`. The Warmbly connector is compiled
+inside the Context image, so every connector change must rebuild `context`.
 
 ```bash
+git -C /opt/confenge-control-center pull --ff-only
 cd /opt/confenge-control-center/control-center/deploy/overlays/production-edge
 set -a
 source /etc/confenge/control-center/secrets/.env
 set +a
 export CC_SECRET_DIR=/etc/confenge/control-center/secrets
+export CC_RELEASE_SHA=<certified-git-sha>
 
+# Build and replace both artifacts touched by the release. The connector travels
+# in Context; updating only web leaves the old server contract in production.
+docker compose -p confenge-control-center \
+  -f docker-compose.production-edge.yml \
+  -f docker-compose.warmbly-human-gate.override.yml \
+  build context web
+docker compose -p confenge-control-center \
+  -f docker-compose.production-edge.yml \
+  -f docker-compose.warmbly-human-gate.override.yml \
+  up -d context web
+```
+
+For a first installation only, use the full bootstrap sequence instead of the
+two-service replacement above:
+
+```bash
 # 1. datastores
 docker compose -f docker-compose.production-edge.yml up -d postgres redis nats
 # confirm alias cc-postgres on cc_internal
@@ -183,6 +200,41 @@ curl -sS -o /dev/null -w '%{http_code}\n' -H 'Host: ops.confenge.com.br' http://
 Public cockpit: `https://ops.confenge.com.br/` → Authelia 302 until authenticated + 2FA.
 
 Do not treat `/healthz` 200 as authenticated cockpit access.
+
+## Approval reconciliation after this release
+
+Take the database counts below before the write. With the kill switch still
+engaged, an authenticated `admins` identity runs **Reprocessar aprovações já
+registradas** once. This is the only production POST in this rollout. It calls
+the same Warmbly scheduling function used synchronously by APPROVE; it is not a
+cohort dispatch and it cannot transport mail. Run it a second time to prove
+idempotency, then repeat the SELECTs and record every `due_at`.
+
+```sql
+SELECT decision, count(*)
+FROM confenge_cohort_candidate_reviews
+GROUP BY decision ORDER BY decision;
+
+SELECT count(*) AS dispatch_bindings
+FROM confenge_cohort_candidate_dispatches;
+
+SELECT t.state, d.auto_send, count(*)
+FROM confenge_cohort_candidate_dispatches d
+JOIN outreach_touchpoints t ON t.id = d.touchpoint_id
+GROUP BY t.state, d.auto_send ORDER BY t.state, d.auto_send;
+
+SELECT t.id, t.state, t.due_at, d.auto_send, d.cohort_version_id,
+       d.candidate_id, d.invalidated_at
+FROM confenge_cohort_candidate_dispatches d
+JOIN outreach_touchpoints t ON t.id = d.touchpoint_id
+ORDER BY t.due_at, t.id;
+```
+
+An absent row is reported as absent, never as zero inferred by the UI. Repeating
+reconciliation must create neither a second dispatch binding for the same
+`(cohort_id, candidate_id)` nor a second live touchpoint for duplicate frozen
+content. Do not remove `/data/confenge-ops/kill-switch`; do not POST a separate
+smoke; do not change global auto-send or autorun.
 
 ## Governance bootstrap
 
@@ -247,7 +299,7 @@ Mechanical requirement: `same_content=true` (SHA-256 of restored dump equals pla
 4. Revoke the `control-center-human-gate` API key. Do not alter the collector key,
    host PostgreSQL, or extra-cli.
 5. Roll back Warmbly only after Control Center no longer calls the new contract.
-   Keep migration 122 data for evidence; run down migrations only after export and
+   Keep migration 121/122 data for evidence; run down migrations only after export and
    only if schema rollback is explicitly required.
 6. Prove `https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health`
    remains READY and `auto_send_enabled=false`.
@@ -271,11 +323,14 @@ Backup `/etc/nginx` first. Install only `ops.confenge.com.br` and `auth.ops.conf
 - `api.confenge.com.br` inbound READY
 - Warmbly `/ready` live=true ready=true, `CONFENGE_AUTO_SEND_ENABLED=false`
 - Human-gate credential `/v1/me`: exact mask `196`, no `SEND_CAMPAIGNS`; do not log its value
-- authenticated `operators` can GET/list/review and APPROVE schedules only the
-  exact reviewed message; only `admins` can reconcile old durable approvals
-- production smoke is GET-only; all POST verification uses fixtures/sandbox and `.invalid` recipients
-- review list and reconciliation report reachable from `context`, with dispatch
-  paused throughout rollout
+- authenticated `operators` can GET/list/review and APPROVE; the button says that
+  APPROVE enqueues. A group without `operators` receives 403 at the edge before upstream.
+- only `admins` can run reconciliation; a group without `admins` receives 403 at
+  the edge before upstream. There is no live GO/NO-GO or cohort-dispatch route.
+- production smoke is GET-only except for the planned reconciliation above; all
+  other POST verification uses fixtures/sandbox and `.invalid` recipients
+- review list and outbound status are reachable from `context`; the kill switch
+  warning renders before review work and remains engaged throughout rollout
 - GitHub collector FRESH when token+allowlist are set; otherwise honest ERROR/UNKNOWN
 
 ## `/intranet`

--- a/control-center/docs/WARMBLY-HUMAN-GATE-EVIDENCE.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-EVIDENCE.md
@@ -8,30 +8,19 @@
 | VALID/RISKY/INVALID/UNKNOWN/STALE | `TestNormalizeHumanGateValidationStatus`; UI `data-validation-status` |
 | Invalidation recipient/message/policy/evidence/expiry | `TestHumanGateApprovalInvalidatesEveryBoundDimension` |
 | suppression tardia/opt-out/bounce/removal | `GetHumanGateCohort` relê candidato canônico e invalida fail-closed |
-| APPROVE/REJECT/HOLD e agendamento | `TestHumanGateValidApprovalRemainsEffectiveAndHoldNeverDoes`; testes de approval-time scheduling; adapter e proxy preservam `acknowledged` e expõem `scheduling` |
-| Seleção disjunta de fornecedores | teste PostgreSQL concorrente 10×10 prova 100 CNPJs-raiz e destinatários únicos; replay idempotente devolve a mesma cohort |
-| Recuperação de versão stale | testes de `RECOVER_PRIOR` provam releitura da fonte atual e ausência de approval/agendamento herdado |
+| APPROVE agenda; HOLD/REJECT cancelam | testes PostgreSQL Warmbly `human_gate_scheduling_pg_test.go`; adapter e proxy preservam `acknowledged=true`; UI exige releitura com `effective=true`, `auto_send=true`, `QUEUED|SENT` e `due_at` |
+| GO/NO-GO removido do fluxo vivo | rotas antigas não são registradas no Warmbly nem construíveis no conector; UI mostra somente auditoria histórica sem efeito |
 | MX ausente/risky/invalid/unknown | verificador existente + normalização/teste; somente VALID permite APPROVE |
-| Authelia, 401/403 e least privilege | `human-gate.test.ts`: identidade ausente não chega ao upstream; reconciliação exige admins; GO/dispatch não existem no allowlist atual |
+| Authelia, 401/403 e least privilege | `human-gate.test.ts`: identidade ausente não chega ao upstream; `operators` aprovam/enfileiram e `admins` reconciliam; grupo incorreto falha antes do upstream |
 | timeout/payload parcial/conflito/write denied | proxy retorna UNKNOWN sem retry e envelope completo; handler 400; request-hash 409; RBAC 403 |
 | sem PII nos logs | proxy loga somente actor/id/path/status/receipt; Warmbly audit usa ids/hashes/status |
-| pausa e last-mile gates | worker Warmbly revalida pause/kill switch/janela/teto/suppression; UI não oferece GO/queue/dispatch/send no contrato atual |
-| auto-send global OFF / nenhum e-mail real | boot fail-closed fixa global false; `auto_send=true` é somente por touchpoint aprovado; testes usam `.invalid` |
+| pausa/kill switch/janela/cap e last-mile gates | o worker Warmbly continua como único transportador; revalidação invalida e cancela trabalho não enviado; UI não oferece queue/dispatch/send |
+| auto-send por mensagem; automação global OFF | scheduling persiste `auto_send=true`; snapshots fixam flags globais false; testes usam `.invalid`; runbook permite somente a reconciliação planejada em produção |
 
-Evidência executada em 2026-08-24 para esta revisão:
-
-- Web-shell: 415/415 — PASS, incluindo contrato de scheduling, ocultação de
-  GO/dispatch, reconciliação e cohorts sem repetição.
-- Connector Warmbly: 161/161 + 1 canário ignorado — PASS, incluindo
-  reconciliação `admins`, fixed allowlist sem GO/dispatch e exclusão de ator
-  controlável pelo navegador.
-- TypeScript typecheck: connector e web-shell — PASS.
-- Warmbly PostgreSQL 16: migration até 122 e integração 10×10 — PASS, com 100
-  fornecedores CNPJ-raiz e 100 destinatários distintos, além de replay
-  idempotente.
-- Nenhum POST de envio foi executado; dispatch permaneceu pausado.
-
-Evidência histórica executada em 2026-08-23:
+Evidência abaixo executada em 2026-08-23 para a entrega anterior; os números não
+descrevem a mudança de agendamento por APPROVE. A evidência atual fica nos testes
+e no runbook desta entrega, incluindo jornada real, reconciliação duas vezes e
+SELECT antes/depois em produção:
 
 - TypeScript typecheck: connector, Context Service e web-shell — PASS.
 - Contract cross-repo: 1/1 — PASS; cópia Governance idêntica ao schema Warmbly.

--- a/control-center/docs/WARMBLY-HUMAN-GATE-FLOW.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-FLOW.md
@@ -1,99 +1,115 @@
-# Gate humano de outbound — mapa de autoridade
+# Gate humano Warmbly — APPROVE agenda a mensagem
 
-Status: contrato de implementação para `ops.confenge.com.br`
-Fontes: `confenge.human-gate.v1`, `confenge.frozen_cohort.v1`,
-`bounded-cohort-policy.v1` e ADR-CC-001.
+Status: contrato implantável de `ops.confenge.com.br`.
 
 ## Fluxo canônico
 
 ```text
-fonte canônica de contratos públicos
-  -- somente fornecedor/contratada; órgão contratante é excluído -->
-fornecedor_cnpj_raiz × destinatário único
-  -- claims transacionais, sem repetição entre cohorts -->
-cohort/version imutável (máximo 10)
-  -- leitura autenticada --> candidate + preview exato congelado
-  -- escrita idempotente, disparada pela própria aprovação --> validation
-  -- escrita humana, uma ação --> APPROVE | REJECT | HOLD por candidate
-  -- APPROVE efetivo cria/confirma o touchpoint --> queue
-  -- worker do Warmbly, quando a pausa permitir, na janela e sob o teto --> send
+cohort/version imutável
+  → leitura autenticada do candidate + preview congelado
+  → validation vigente e VALID no Warmbly
+  → APPROVE por operators, com acknowledged=true
+  → na mesma transação lógica: touchpoint + auto_send=true + QUEUED + due_at
+  → worker Warmbly, quando todos os gates permitirem
+  → envio em dia útil, 09:00–18:00 America/Sao_Paulo, ≤10/hora
 ```
 
-| Etapa | Autoridade | Leitura no Control Center | Escrita permitida | Pode enviar? |
-|---|---|---|---|---|
-| Fonte/seleção | Warmbly + feed canônico | origem, `as_of`, freshness, progresso e exclusões | nenhuma seleção no frontend | não |
-| Cohort/version | Warmbly | lista, denominadores e relatório de exclusões | criar a próxima cohort sem repetição ou recuperar fornecedores de versões vencidas | não |
-| Candidate/preview | snapshot congelado Warmbly | fornecedor, destinatário, provenance, rota, assunto e corpo exatos | ajustar texto dentro do contrato tipado | não |
-| Validation | verificador do Warmbly | VALID/RISKY/INVALID/UNKNOWN/STALE, motivo e validade | solicitar/repetir; APPROVE a solicita sozinho quando necessário | não |
-| Review decision | Warmbly | decisão atual, vínculo, invalidações e agendamento | APPROVE/REJECT/HOLD com ator Authelia e motivo | APPROVE agenda; não entrega imediatamente |
-| Reconciliação | Warmbly | denominadores e falhas do relatório | `admins` conciliam APPROVEs duráveis anteriores ao agendamento | não |
-| Queue/send | runtime Warmbly | estado do touchpoint e métricas | não existe ação de send no gate | sim, somente pelo worker, com pausa liberada, janela e teto válidos |
+APPROVE é a autoridade humana completa para uma mensagem. Não há GO, handoff,
+“Entregar à fila” nem segunda tela. O clique não transporta e-mail: ele deixa a
+mensagem agendada, e somente o worker pode transportá-la depois.
+
+`NEXT_UNCLAIMED` usa claims transacionais por conta, fonte, fornecedor e
+destinatário. Não existe offset controlável pelo navegador: cohorts sucessivas
+ficam disjuntas mesmo com duas abas ou operadores concorrentes. Para versões
+vencidas, `RECOVER_PRIOR` relê os mesmos fornecedores na fonte atual e gera
+texto, evidência e hashes novos; decisões e agendamentos antigos não são
+herdados.
+
+| Etapa | Autoridade | Efeito |
+|---|---|---|
+| Cohort/version | Warmbly | congela seleção, denominadores, copy, hashes e policy |
+| Validation | Warmbly | precisa estar vigente e `VALID`; a ação de aprovar pode obtê-la antes da escrita |
+| APPROVE | `operators` | grava a revisão e converge a mensagem para `QUEUED`, `due_at`, `auto_send=true` |
+| HOLD/REJECT | `operators` | exige motivo e cancela/desenfileira a mensagem ainda não enviada |
+| Reconciliação | `admins` | reprocessa APPROVEs já gravados pelo mesmo agendador; é reparo global e idempotente |
+| Transporte | worker Warmbly | revalida drift e gates operacionais; envia somente na janela e sob o teto |
+
+## Auto-send: dois conceitos diferentes
+
+- `scheduling.auto_send=true` é por mensagem aprovada. É o efeito esperado de
+  APPROVE e permite que o worker a recolha na janela comercial.
+- `CONFENGE_AUTO_SEND_ENABLED=true` e `GREEN_AUTORUN=true` continuam proibidos e
+  derrubam o boot. As flags globais permanecem `false`.
+
+Não existe job de dispatch de cohort. A única criação de trabalho outbound
+controlado nasce de uma aprovação individual ou da reconciliação dessa mesma
+aprovação preexistente.
+
+## GO/NO-GO histórico
+
+Os endpoints de decisão da cohort e de dispatch foram removidos do contrato
+vivo. Registros antigos de GO/NO-GO continuam legíveis somente para auditoria:
+não autorizam, bloqueiam, enfileiram nem desenfileiram.
+
+O equivalente operacional de impedir uma mensagem ainda não enviada é
+HOLD/REJECT no candidato. O Warmbly invalida o vínculo, cancela a fila e preserva
+o histórico. Depois de `SENT`, o histórico é imutável.
+
+## Reconciliação e backfill
+
+`POST /v1/confenge/cohorts/reconcile-approved` percorre as decisões duráveis,
+seleciona a decisão mais recente de cada `(cohort_version_id, candidate_id)` e
+chama exatamente o agendador usado por APPROVE. Aprovações duplicadas da mesma
+mensagem convergem em um touchpoint. A resposta distingue:
+
+- `approval_records` — histórico bruto;
+- `latest_approved_bindings` — vínculos cuja decisão mais recente é APPROVE;
+- `unique_approved_candidates` — mensagens distintas após deduplicação;
+- `scheduled`, `already_scheduled`, `failed` e falhas nomeadas.
+
+Reexecutar é seguro: a chave persistida em
+`confenge_cohort_candidate_dispatches` e os invariantes do touchpoint impedem
+duplicação. No Control Center essa rota aparece como “Reprocessar aprovações já
+registradas”, explicitamente como reparo de `admins`, nunca como próximo passo.
+
+## Bloqueio visível antes da revisão
+
+Toda carga de Warmbly lê `GET /v1/warmbly/operator/outbound-status`, que o
+conector fixa em `GET /v1/confenge/status`. A Revisão renderiza o resultado logo
+após o título, antes de preview, identidade ou botões. Kill switch, pausa ou
+leitura incompleta nunca viram “liberado” por inferência.
+
+Com kill switch acionado, a mensagem ainda fica `QUEUED` com `due_at` e
+`auto_send=true`, mas a tela diz que nada sairá até o bloqueio ser removido fora
+deste fluxo.
 
 ## Invariantes de segurança
 
-- Leads são empresas fornecedoras/contratadas. A identidade canônica usa
-  `fornecedor_cnpj`/`ni_fornecedor`, reduzida ao CNPJ-raiz; `orgao_cnpj` e demais
-  entidades contratantes nunca são leads.
-- O frontend exibe elegibilidade e motivos recebidos do contrato versionado; não
-  calcula, completa ou corrige candidatos localmente.
-- `NEXT_UNCLAIMED` usa claims transacionais por conta, fonte, fornecedor e
-  destinatário. Dez requisições de dez formam até 100 leads disjuntos, sem
-  offset controlável pelo navegador. Replay da mesma idempotency key devolve a
-  mesma cohort.
-- `RECOVER_PRIOR` relê os mesmos fornecedores na fonte atual e gera texto,
-  evidência e hashes novos. Aprovação e agendamento antigos não são herdados.
-- Quando não há validation vigente, APPROVE dispara validation, relê o estado e
-  só registra a decisão se o Warmbly devolver VALID. Um estado não VALID encerra
-  a cadeia sem tentar o APPROVE.
-- APPROVE é bloqueado onde verificar de novo não ajuda: destinatário ausente ou
-  inválido, INVALID/RISKY resolvido, hard bounce, suppression, opt-out,
-  duplicidade, copy QA reprovada ou proveniência ausente declarada pelo servidor.
-- A ciência do revisor é o clique em Aprovar e viaja como `acknowledged=true`.
-  O adaptador recusa antes do fio qualquer APPROVE sem esse campo.
-- Cada APPROVE fica ligado aos hashes de recipient, content, policy e evidence e
-  à validation vigente. Drift, expiração, HOLD ou REJECT invalidam o agendamento
-  correspondente sem apagar a decisão humana original.
-- Um APPROVE efetivo cria ou confirma, na mesma operação, um touchpoint com
-  `auto_send=true` para a próxima janela elegível. Esse valor é por mensagem e
-  não habilita o auto-send global nem o green autorun.
-- Não existe GO nem entrega manual da cohort no contrato vigente. As rotas
-  legadas podem permanecer pinadas durante rollout, mas a interface atual não
-  apresenta seus controles.
-- A reconciliação chama somente `POST {prefix}/reconcile-approved`, sem cohort,
-  destinatário ou conteúdo escolhidos pelo navegador. Ela é `admins`,
-  idempotente, atende primeiro aprovações duráveis antigas e não envia nem
-  retoma o disparo.
-- Pausa, kill switch, dias úteis, janela comercial, teto por hora, suppression,
-  opt-out e bounce continuam sendo reavaliados pelo Warmbly. Agendado não
-  significa enviado.
-- A identidade humana nasce somente dos headers ForwardAuth entregues por hop
-  confiável. O navegador não declara ator. Auditoria registra ids opacos,
-  hashes, estados e reason codes; recipient, subject e body não entram em logs.
-- O Control Center não expõe `send`, `queue`, `resume`, `payment` nem proxy
-  genérico no human gate. O controle operacional de pausa/retomada continua uma
-  superfície separada e mais restrita.
+- O frontend não calcula elegibilidade nem destinatários.
+- APPROVE continua exigindo validation vigente e `VALID` no servidor.
+- O clique continua produzindo `acknowledged=true`; o adaptador recusa antes do
+  fio quando ele falta.
+- HOLD/REJECT continuam exigindo motivo escrito.
+- Drift de recipient, content, evidence, policy, validation ou suppression
+  invalida/cancela antes do transporte.
+- Janela, dias úteis, cap 10/hora, pausa e kill switch permanecem no Warmbly.
+- Writes têm idempotency key e a borda descarta query string.
+- O conector não possui proxy genérico. `send`, `dispatch`, `queue`, `resume`,
+  `payment`, `charge`, `enroll` e `deliver` são segmentos proibidos e testados
+  em todas as formas. A reconciliação é uma rota fixa, global e sem payload
+  upstream.
+- Ausência é ausência, nunca zero; `effective` ausente nunca é APPROVE efetivo.
+- Uma marca otimista só sobrevive quando a releitura confirma APPROVE efetivo,
+  `auto_send=true`, `QUEUED`/`SENT` e `due_at`.
+- Timeout ou 5xx de write é `UNKNOWN`; retry reutiliza a mesma idempotency key.
 
-## Fronteiras de RBAC
+## RBAC deliberado
 
-- `operators`: listar, detalhar, criar/reproduzir cohort pequena, solicitar
-  validation, ajustar texto e registrar APPROVE/REJECT/HOLD.
-- `admins`: tudo acima e reconciliar aprovações duráveis antigas com a fila.
-- Serviço Control Center → Warmbly usa credencial própria de menor escopo, sem
-  permissão de send. O ator humano e seus grupos vêm da borda autenticada, nunca
-  de headers controláveis pelo browser.
-
-## Falhas e concorrência
-
-- POSTs exigem `Idempotency-Key`; acknowledgement e motivo fazem parte da
-  intenção. Retry, duas abas e restart devolvem o mesmo receipt, ou 409 se a
-  chave for reutilizada com payload diferente.
-- Um clique repetido durante validation → review não vira segunda intenção: o
-  formulário fica reservado até o fim da cadeia.
-- Timeout depois de write é desfecho desconhecido. A tela relê o recurso antes
-  de permitir repetição e preserva a idempotency key da intenção incerta.
-- A reconciliação relata registros APPROVE, bindings vigentes, candidatos
-  únicos, agendados agora, já agendados e falhas. Qualquer falha interrompe a
-  ampliação do backlog até classificação do motivo.
-- Payload parcial é 400, ausência de sessão é 401, grupo insuficiente é 403,
-  conflito/version drift é 409 e indisponibilidade upstream é 502/503. Nenhum
-  desses casos promove candidato, fila ou envio.
+- `operators`: listar, criar/reproduzir, validar, ajustar e registrar
+  APPROVE/HOLD/REJECT. Portanto `operators` podem provocar saída futura de
+  e-mail; o botão diz “Aprovar e enfileirar para envio”.
+- `admins`: reparo global de aprovações já registradas. Na instalação atual a
+  identidade administrativa também pertence a `operators`.
+- Uma identidade sem o grupo da rota é recusada na borda antes do upstream.
+- A identidade vem de ForwardAuth em hop confiável; o navegador nunca declara o
+  ator e PII/copy não entra em logs.

--- a/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
@@ -1,139 +1,162 @@
 # Runbook — gate humano Warmbly
 
-## Operação segura
+## Revisão normal
 
 1. Autentique em `ops.confenge.com.br` pelo Authelia. `operators` revisam e
-   aprovam mensagens; `admins` podem reconciliar aprovações antigas em lote.
-2. Abra **Warmbly → Cohorts**. Confirme source/as_of/freshness e os quatro
-   denominadores (considerados, elegíveis, excluídos, finais). Crie no máximo 10.
-   - Leads são empresas contratadas/fornecedoras. A identidade canônica vem de
-     `fornecedor_cnpj`/`ni_fornecedor`, reduzida a um CNPJ-raiz. Nunca trate
-     `orgao_cnpj` ou outra entidade contratante como lead.
-   - Antes de gerar novas mensagens, selecione as versões vencidas em
-     **Recuperar versões anteriores**. A recuperação relê a fonte atual,
-     deduplica fornecedores e cria texto e hashes novos; não carrega APPROVE ou
-     agendamento antigos.
+   aprovam; `admins` somente reprocessam aprovações já registradas.
+2. Abra **Warmbly → Cohorts**, confira source, `as_of`, freshness e os
+   denominadores do servidor.
+   - Antes de gerar novas mensagens, selecione versões vencidas em **Recuperar
+     versões anteriores**. A recuperação relê a fonte atual e cria texto,
+     evidência e hashes novos; não carrega APPROVE ou agendamento antigos.
    - Para ampliar o backlog, use **Criar próxima cohort sem repetição**. Cada
-     clique reserva até dez CNPJs-raiz e destinatários ainda não usados. Confira
-     `fornecedores únicos reservados` e pare no total adicional pretendido.
+     clique reserva até dez fornecedores e destinatários ainda não usados.
    - Não existe offset digitável. Paginação e claims pertencem ao servidor para
      que duas abas ou dois operadores não escolham a mesma empresa.
-3. Abra a versão em **Revisão**. A tela abre no recorte **Pendentes** e diz
-   quanto falta (`N pendentes · N aprovadas · N em ajuste · N no total`). Leia o
-   destinatário, o fato observado e a proveniência, e leia o assunto e o corpo
-   exatos — eles ficam abertos por padrão.
-4. Se nada estiver bloqueado, **Aprovar é uma ação só**. Não digite motivo e não
-   marque caixa nenhuma: o clique é a ciência, e a trilha grava ator do Authelia,
-   instante, versão, hash congelado, destinatário e decisão. Sem comentário
-   escrito, o motivo registrado é `approved_by_human_reviewer`; o campo de
-   comentário continua disponível e vence o padrão quando preenchido.
-   - **Verificação do destinatário**: quando não há validação vigente, aprovar
-     pede a verificação ao Warmbly, relê o estado e só então registra o APPROVE.
-     Não acione "Verificar o destinatário agora" antes de aprovar — esse controle
-     existe como escape, e só aparece onde a validação não é VALID.
-   - Se a verificação não voltar VALID, **nada é decidido**: a tela diz o estado
-     observado e que o APPROVE não foi enviado.
-   - A mensagem aprovada sai da fila na hora e a próxima assume a posição, com o
-     foco no botão dela. `A` (com o foco no card) e `Ctrl/Cmd+Enter` aprovam pelo
-     teclado; dentro de qualquer campo de texto o atalho não dispara.
-   - Se a API recusar, falhar, responder desfecho desconhecido ou a releitura não
-     confirmar o efeito, a mensagem **volta para Pendentes** com o motivo no card.
-     Repetir usa a mesma idempotency key.
-5. **APPROVE continua bloqueado** onde verificar de novo não resolve: sem
-   destinatário, destinatário que não é endereço, validação já resolvida como
-   RISKY ou INVALID, hard bounce, suppression, opt-out, duplicidade, reprovação
-   de copy QA ou proveniência ausente marcada pelo servidor. Nesses casos a tela
-   nomeia o bloqueio e o próximo movimento; registre HOLD ou REJECT **com motivo
-   escrito**, que continua obrigatório. Se recipient, copy, policy, evidence ou
-   suppression mudar depois, a aprovação aparece inválida (`effective=false`),
-   volta para Pendentes e deve ser refeita.
-6. Um `APPROVE` efetivo registra a decisão e agenda a mensagem exata para a
-   próxima janela comercial elegível na mesma operação. Não existe GO nem
-   entrega manual da cohort no contrato vigente. Agendar não é enviar: o worker
-   continua sob pausa, kill switch, janela útil (`09:00–18:00
-   America/Sao_Paulo`) e teto de 10/hora.
-7. **Antes de ampliar o backlog**, um `admin` executa **Reconciliar aprovações
-   antigas com a fila**. A operação é naturalmente idempotente e mostra:
-   registros APPROVE, bindings vigentes, candidatos únicos, agendados agora, já
-   agendados e falhas. Ela existe para que aprovações anteriores à implantação
-   do agendamento sejam atendidas primeiro. Ela não envia e não retoma o
-   disparo. Se houver falhas, não crie as 100 novas mensagens até classificar
-   cada motivo.
-8. Em timeout, não repita às cegas. Recarregue a mesma versão e compare receipt
-   e correlation id. O frontend preserva a idempotency key da intenção incerta;
-   só depois repita a mesma intenção.
+   Abra a versão escolhida em **Revisão**.
+3. Antes de qualquer trabalho, leia o banner de outbound no topo. Se o kill
+   switch ou a pausa estiver ativo, APPROVE ainda agenda, mas nenhuma mensagem
+   sairá enquanto o bloqueio durar. Estado ausente/desconhecido não é liberado.
+4. Leia destinatário, fato/proveniência, assunto e corpo exatos. O botão
+   **Aprovar e enfileirar para envio** é o único ato humano do caminho feliz.
+   Ele:
+   - obtém uma validation quando necessário e só continua se voltar `VALID`;
+   - envia `acknowledged=true` e um comentário opcional (ou
+     `approved_by_human_reviewer`);
+   - grava APPROVE e agenda a mensagem pelo mesmo caminho;
+   - só é considerado concluído quando a releitura confirma APPROVE efetivo,
+     `auto_send=true`, `state=QUEUED|SENT` e `due_at`.
+5. Confira no card “Agendamento confirmado pelo servidor”, estado e `due_at`.
+   Não há GO nem “Entregar à fila”. O worker envia em dias úteis,
+   `09:00–18:00 America/Sao_Paulo`, no máximo 10/hora, quando pausa, kill switch
+   e revalidação de última milha permitirem.
+6. HOLD/REJECT exigem motivo. Quando aplicados antes de `SENT`, invalidam o
+   agendamento e cancelam a fila; não há NO_GO operacional.
 
-### O que mudou no gate humano (e o que não mudou)
+Se API, transporte ou releitura divergir, trate como não confirmado. O card
+volta para Pendentes e o retry mantém a idempotency key. Não reaprove uma decisão
+que o servidor já mostra como APPROVE; use o reparo administrativo.
 
-A fila deixou de ser um formulário e virou uma fila de decisões. O que saiu foi
-custo humano; nenhuma salvaguarda material foi removida.
+## Reparo/backfill de APPROVEs existentes
 
-| Antes | Agora | Por quê |
-|---|---|---|
-| Clicar em "verificar destinatário agora" antes de aprovar | Aprovar obtém a verificação sozinho | Obter validation é chamada determinística, sem julgamento humano |
-| Digitar um motivo para APPROVE | `approved_by_human_reviewer` automático, comentário opcional | O motivo digitado era sempre a mesma palavra; a trilha já tinha ator, instante, versão e hash |
-| Marcar "revisei destinatário" | O clique em Aprovar é a ciência | Um segundo clique declarando o primeiro não acrescenta nada à auditoria |
-| Lista com aprovadas no topo | Recorte **Pendentes** por padrão, com contador | Rolar a própria produção para achar o próximo trabalho não escala |
-| Criar repetia os primeiros fornecedores | Próxima cohort usa claims transacionais por fornecedor e destinatário | Dez cohorts formam um backlog disjunto sem relaxar o limite de dez por autorização |
-| Versões vencidas eram apenas históricas | Recuperação relê os mesmos fornecedores na fonte atual | Fatos, texto e hashes vencidos não podem ser reaproveitados como se fossem atuais |
-| APPROVE antigo podia ficar sem fila | APPROVE agenda a mensagem; reconciliação cobre o histórico | A decisão humana e o efeito operacional ficam convergentes e idempotentes |
+O card **Reprocessar aprovações já registradas** é global, exige `admins` e não é
+um passo normal. Ele chama `POST /v1/confenge/cohorts/reconcile-approved` pelo
+conector fixo. A operação usa o mesmo agendador de APPROVE, deduplica mensagens e
+é reexecutável.
 
-O que **não** mudou: `acknowledged=true` continua viajando no corpo do APPROVE e
-o adaptador recusa antes do fio um APPROVE sem ele; o Warmbly continua recusando
-APPROVE fora de uma validação VALID vigente; HOLD/REJECT continuam exigindo
-motivo escrito; e o Control Center continua sem qualquer rota de **send**. A
-reconciliação chama somente `POST {prefix}/reconcile-approved`, sem destinatário
-ou conteúdo controlável pelo navegador.
+Antes da execução planejada, capture no PostgreSQL Warmbly:
 
-**Auto-send global continua proibido por construção.**
-`CONFENGE_AUTO_SEND_ENABLED=true` derruba o boot do Warmbly (invariante testada,
-não é flag para ligar). O `auto_send=true` do agendamento é por mensagem e nasce
-somente de um APPROVE humano efetivo; não habilita autorun global.
+```sql
+SELECT count(*) AS approval_records
+FROM confenge_cohort_candidate_reviews
+WHERE decision = 'APPROVE';
+
+WITH latest AS (
+  SELECT DISTINCT ON (cohort_version_id, candidate_id)
+    cohort_version_id, candidate_id, decision
+  FROM confenge_cohort_candidate_reviews
+  ORDER BY cohort_version_id, candidate_id, created_at DESC, id DESC
+)
+SELECT count(*) FILTER (WHERE decision = 'APPROVE') AS latest_approved_bindings
+FROM latest;
+
+SELECT count(*) AS mapping_rows,
+       count(DISTINCT touchpoint_id) AS unique_messages
+FROM confenge_cohort_candidate_dispatches;
+
+SELECT state, count(*)
+FROM outreach_touchpoints
+GROUP BY state
+ORDER BY state;
+```
+
+Execute o reparo uma vez pelo Control Center administrativo durante a janela de
+release. Registre todos os contadores da resposta e releia o banco:
+
+```sql
+SELECT d.cohort_version_id, d.candidate_id, d.touchpoint_id,
+       d.auto_send, d.due_at, d.invalidated_at,
+       t.state, t.sent_at
+FROM confenge_cohort_candidate_dispatches d
+JOIN outreach_touchpoints t ON t.id = d.touchpoint_id
+ORDER BY d.due_at, d.cohort_version_id, d.candidate_id;
+```
+
+Execute o mesmo reparo uma segunda vez. A segunda resposta deve ter
+`scheduled=0`, aumentar/confirmar `already_scheduled` e não alterar contagem de
+mapping nem touchpoints únicos. Qualquer `failed>0`, APPROVE efetivo sem mapping,
+mapping com `auto_send<>true`, estado diferente de `QUEUED|SENT` ou `due_at`
+ausente bloqueia a conclusão do rollout.
+
+Não use SQL para criar a fila. SQL é somente prova antes/depois.
+
+## Auto-send e bloqueios
+
+O campo correto é `auto_send=true` na mensagem aprovada. As flags globais
+continuam obrigatoriamente desligadas:
+
+```text
+CONFENGE_AUTO_SEND_ENABLED=false
+GREEN_AUTORUN=false
+CONFENGE_REQUIRE_HUMAN_APPROVAL=true
+```
+
+Ligar auto-send/autorun global derruba o boot e não é procedimento operacional.
+Não remova o kill switch durante deploy ou backfill. Não rode POST de smoke em
+produção além da reconciliação planejada.
+
+## Ordem de deploy
+
+1. **Warmbly primeiro.** Merge/deploy até
+   `000122_confenge_cohort_selection`, incluindo
+   `000121_confenge_human_gate_scheduling`, com backend e worker compatíveis. Prove
+   `/healthz`/`/ready`, flags globais falsas e kill switch intacto.
+2. **Governance depois.** O conector viaja na imagem de `context`; sempre build e
+   suba `context` junto com `web`:
+
+   ```bash
+   docker compose -p confenge-control-center \
+     -f docker-compose.production-edge.yml \
+     -f docker-compose.warmbly-human-gate.override.yml \
+     build context web
+   docker compose -p confenge-control-center \
+     -f docker-compose.production-edge.yml \
+     -f docker-compose.warmbly-human-gate.override.yml \
+     up -d context web
+   ```
+
+3. Prove `/healthz` duas vezes; `/ready` interno duas vezes em web/context/mcp
+   com `ready=true`; cockpit não autenticado 302 para Authelia; nginx em
+   `:80/:443`, Caddy somente loopback; zero erro novo nos logs.
+4. Só então execute e prove o backfill duas vezes.
+
+Rollback binário segue a ordem inversa: retire Governance antes de voltar o
+Warmbly. O down da migration 121 cancela trabalho `HUMAN_GATE_APPROVAL` não
+enviado para que o binário antigo não transporte autoridade que não compreende;
+o down da 122 também desfaz a seleção disjunta de cohorts. Use qualquer down
+somente com autorização explícita e prova preservada.
+
+## RBAC e teste
+
+`operators` deliberadamente podem fazer e-mail sair no futuro porque APPROVE
+agenda. `admins` reparam. A instalação atual mantém o fundador nos dois grupos;
+não há mudança de membership necessária. Teste ambas as identidades ForwardAuth:
+
+- `operators`: APPROVE permitido, reconciliação 403 antes do upstream;
+- `operators,admins`: APPROVE e reconciliação permitidos;
+- identidade sem `operators`: review recusado antes do upstream.
+
+Nunca envie `Remote-*` ou ator a partir do navegador. A borda injeta identidade
+e descarta query string de writes.
 
 ## Métricas e alertas
 
-Use os denominadores do próprio snapshot, nunca contagem de linhas da tela:
-`accounts_considered`, `accounts_eligible`, `accounts_excluded`,
-`recipients_final`, exclusões por reason, validations por estado, reviews
-efetivos/invalidados e agendamentos efetivos/invalidados. A trilha estruturada
-`warmbly.human_gate.before/after` mede tentativas, recusas, 401/403, 409,
-timeouts e latência por upstream status sem recipient, subject ou body.
+Observe validation por estado, reviews efetivos/invalidados, mappings de
+agendamento, touchpoints por estado, `due_at`, falhas de reconciliação, pausa,
+kill switch e envios por hora. GO/NO_GO pode aparecer somente como auditoria
+histórica, nunca como gate atual.
 
-Alertar e manter o disparo pausado quando: freshness STALE, validação UNKNOWN por timeout,
-qualquer late suppression/opt-out, conflito repetido, 5xx, divergência de
-denominadores, ou qualquer indício de auto-send/green autorun habilitado.
-
-## Smoke e rollback
-
-- Smoke de produção: somente GET de lista/detalhe com conta autorizada. POST é
-  reservado à operação comercial explicitamente autorizada neste runbook.
-- Escritas: sandbox/fixtures, mailbox `.invalid`/Mailpit e kill switch ativo.
-- Nunca use reconciliação ou APPROVE para validar uma entrega e nunca envie mail
-  como parte de um smoke: são decisões comerciais, não passos de verificação.
-- Rollback app: reverta primeiro Governance, depois Warmbly; versões persistidas
-  continuam inertes e legíveis.
-- Rollback schema: somente após rollback dos dois apps, execute a migration
-  `000116...down.sql`. Ela remove apenas dados do gate novo; não toca grants,
-  touchpoints, suppression ou outcome existentes. Exporte receipts antes se a
-  trilha precisar ser retida.
-
-## Ordem de PR/deploy
-
-1. Warmbly `feat/confenge-human-gate-api`: migration 000116, contrato e APIs.
-   É aditivo e compatível com clientes/CLI existentes; deploya sem exposição no
-   Control Center.
-2. Governance `feat/cc-warmbly-human-gate`: proxy autenticado, RBAC, rotas e UI.
-   Depende do contrato Warmbly já implantado; até lá o canal falha fechado.
-   Preserve o hash existente e acrescente `admins` ao operador autorizado em
-   `users.yml`, com backup e validação; jamais rode `generate-local.sh` para isso.
-   `operators` continua podendo revisar; a reconciliação em lote exige `admins`.
-3. Crie pelo endpoint auditado `/v1/api-keys` uma credencial separada com máscara
-   decimal exata `196` (`read_contacts|write_contacts|write_campaigns`), prazo de
-   rotação e sem `send_campaigns`. Instale-a atomicamente com
-   `install-warmbly-operator-token.sh SOURCE CC_SECRET_DIR 1000:1000`; o owner
-   numérico corresponde ao usuário `node` do Context e mantém o bind mount
-   legível com modo `0600`. Não altere a chave do collector.
-4. Aplique `docker-compose.warmbly-human-gate.override.yml` e faça apenas smoke
-   GET em produção.
-   Valide POST exclusivamente no sandbox. Auto-send e GREEN autorun permanecem
-   OFF durante e depois do rollout.
+Alerta imediato para: APPROVE efetivo sem scheduling, `effective` ausente
+tratado como aprovado, `auto_send` da mensagem diferente de true, drift depois
+do agendamento, write `UNKNOWN`, reconciliação com falha, flags globais ligadas,
+ou outbound mostrado como liberado sem leitura completa do servidor.

--- a/control-center/security/production/authelia/users.yml
+++ b/control-center/security/production/authelia/users.yml
@@ -9,5 +9,6 @@ users:
     email: "${CC_OPERATOR_EMAIL}"
     groups:
       - operators
-      # Bulk reconciliation is separated from routine review at the edge.
+      # Deliberate authority boundary: operators APPROVE and therefore queue;
+      # admins may run the explicit reconciliation repair.
       - admins

--- a/control-center/services/context/src/warmbly-operator/from-env.ts
+++ b/control-center/services/context/src/warmbly-operator/from-env.ts
@@ -184,7 +184,9 @@ export async function createWarmblyOperatorHandlerFromEnv(
       : {}),
   });
   return ((req) =>
-    (req.url ?? "").split("?")[0]?.startsWith("/v1/warmbly/operator/cohorts")
+    ["/v1/warmbly/operator/cohorts", "/v1/warmbly/operator/outbound-status"].some((prefix) =>
+      (req.url ?? "").split("?")[0]?.startsWith(prefix),
+    )
       ? humanGate(req as never)
       : operator(req as never)) as WarmblyOperatorHandler;
 }

--- a/control-center/services/context/test/warmbly-human-gate-adjust-mount.test.ts
+++ b/control-center/services/context/test/warmbly-human-gate-adjust-mount.test.ts
@@ -38,6 +38,7 @@ const AUTHELIA = {
   "Remote-Name": "Founder Confenge",
   "Remote-Email": "founder@confenge.invalid",
 };
+const AUTHELIA_ADMIN = { ...AUTHELIA, "Remote-Groups": "admins,operators" };
 
 function adjustBody(extra: Record<string, unknown> = {}): string {
   return JSON.stringify({
@@ -346,7 +347,7 @@ test("adjust accepts no client-settable actor and no identity from an untrusted 
   }
 });
 
-test("the current mount exposes no GO, cohort dispatch, send or queue route", async () => {
+test("the mount forbids cohort dispatch and exposes only admin reconciliation plus operator status", async () => {
   const upstream = await stubWarmbly();
   const { dir, path } = credentialFile();
   try {
@@ -361,8 +362,6 @@ test("the current mount exposes no GO, cohort dispatch, send or queue route", as
         const hostile = [
           `/v1/warmbly/operator/cohorts/${COHORT}/send`,
           `/v1/warmbly/operator/cohorts/${COHORT}/queue`,
-          `/v1/warmbly/operator/cohorts/${COHORT}/decision`,
-          `/v1/warmbly/operator/cohorts/${COHORT}/dispatch`,
           `/v1/warmbly/operator/cohorts/${COHORT}/candidates/${CANDIDATE}/send`,
           `/v1/warmbly/operator/cohorts/${COHORT}/candidates/${CANDIDATE}/dispatch`,
           `/v1/warmbly/operator/cohorts/${COHORT}/candidates/${CANDIDATE}/adjust/send`,
@@ -376,6 +375,52 @@ test("the current mount exposes no GO, cohort dispatch, send or queue route", as
           assert.ok(res.status === 404, `${route} answered ${res.status}`);
           await res.text();
         }
+
+        // The old cohort dispatch and GO routes are absent even for admins.
+        const asOperators = await fetch(`${base}/v1/warmbly/operator/cohorts/${COHORT}/dispatch`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...AUTHELIA },
+          body: adjustBody(),
+        });
+        assert.equal(asOperators.status, 404, "cohort dispatch is outside the human-gate allowlist");
+        await asOperators.text();
+        const oldGo = await fetch(`${base}/v1/warmbly/operator/cohorts/${COHORT}/decision`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...AUTHELIA_ADMIN },
+          body: JSON.stringify({ decision: "GO", reason: "fixture", idempotency_key: "idem-old-go" }),
+        });
+        assert.equal(oldGo.status, 404, "GO is no longer a live route");
+        await oldGo.text();
+
+        // Repair is the one admin-only global write. The role refusal happens
+        // at the edge, and the accepted call forwards an empty body and fixed path.
+        const reconcilePath = "/v1/warmbly/operator/cohorts/reconcile-approved";
+        const deniedRepair = await fetch(`${base}${reconcilePath}`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...AUTHELIA },
+          body: JSON.stringify({ idempotency_key: "idem-reconcile-denied" }),
+        });
+        assert.equal(deniedRepair.status, 403);
+        const deniedBody = (await deniedRepair.json()) as Record<string, unknown>;
+        assert.equal(deniedBody.code, "insufficient_human_gate_role");
+
+        const repaired = await fetch(`${base}${reconcilePath}?redirect=/v1/confenge/send`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...AUTHELIA_ADMIN },
+          body: JSON.stringify({ idempotency_key: "idem-reconcile-accepted", limit: 999 }),
+        });
+        assert.equal(repaired.status, 201);
+        await repaired.text();
+        const repairHit = upstream.hits.at(-1)!;
+        assert.equal(repairHit.url, "/v1/confenge/cohorts/reconcile-approved");
+        assert.equal(repairHit.body, "{}", "write query and caller payload are discarded");
+
+        const status = await fetch(`${base}/v1/warmbly/operator/outbound-status`, {
+          headers: AUTHELIA,
+        });
+        assert.equal(status.status, 201);
+        await status.text();
+        assert.equal(upstream.hits.at(-1)?.url, "/v1/confenge/status");
 
         // `fetch` collapses `..` before the request line is written, so a raw
         // socket is the only way to make the server itself see the traversal.
@@ -396,7 +441,11 @@ test("the current mount exposes no GO, cohort dispatch, send or queue route", as
         assert.doesNotMatch(raw, /adjust:r1/, "traversal must not reach the cohort surface");
       },
     );
-    assert.deepEqual(upstream.hits, [], "no hostile cohort route may reach Warmbly");
+    assert.deepEqual(
+      upstream.hits.map((hit) => hit.url),
+      ["/v1/confenge/cohorts/reconcile-approved", "/v1/confenge/status"],
+      "only the two fixed allowed calls may reach Warmbly",
+    );
   } finally {
     await upstream.close();
     rmSync(dir, { recursive: true, force: true });

--- a/control-center/tests/journey/fake-warmbly.mjs
+++ b/control-center/tests/journey/fake-warmbly.mjs
@@ -102,6 +102,18 @@ createServer((req, res) => {
     const body = raw ? JSON.parse(raw) : {};
     const list = [...versions.values()].sort((a, b) => b.version - a.version);
 
+    if (req.method === "GET" && p === "/v1/confenge/status") {
+      return send(res, 200, {
+        kill_switch: true,
+        sending_allowed: false,
+        sending_paused: false,
+        auto_send_enabled: false,
+        green_autorun_enabled: false,
+        commercial_window: { timezone: "America/Sao_Paulo", start: "09:00", end: "18:00" },
+        hourly_cap: 10,
+      });
+    }
+
     if (req.method === "GET" && p === "/v1/confenge/cohorts") return send(res, 200, { data: list });
 
     const one = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)$/);
@@ -146,63 +158,51 @@ createServer((req, res) => {
       if (body.decision === "APPROVE" && c.validation?.status !== "VALID") {
         return send(res, 422, { code: "validation_not_valid", message: "APPROVE requires a current VALID validation" });
       }
+      if (body.decision === "APPROVE" && body.acknowledged !== true) {
+        return send(res, 422, { code: "acknowledgement_required", message: "APPROVE requires acknowledged=true" });
+      }
       c.review = { id: randomUUID(), decision: body.decision, reason: body.reason ?? "", effective: body.decision === "APPROVE", invalidated_by: [], actor_id: "00000000-0000-4000-8000-00000000000a", created_at: new Date(0).toISOString(), correlation_id: "corr-review", receipt: `receipt-review-${body.decision}` };
-      return send(res, 200, { data: v, receipt: c.review.receipt, correlation_id: "corr-review" });
+      c.scheduling = body.decision === "APPROVE"
+        ? { state: "QUEUED", due_at: "2026-08-25T12:00:00Z", auto_send: true, sent_at: null }
+        : { state: "CANCELLED", due_at: null, auto_send: false, sent_at: null };
+      return send(res, 200, {
+        data: v,
+        scheduling: c.scheduling,
+        receipt: c.review.receipt,
+        correlation_id: "corr-review",
+      });
     }
 
-    // GO/NO-GO, so the journey can reach the state where a dispatch is offered.
-    const dec = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)\/decision$/);
-    if (req.method === "POST" && dec) {
-      const v = versions.get(dec[1]);
-      if (!v) return send(res, 404, { code: "not_found" });
-      if (body.confirmation !== `v${v.version}`) return send(res, 409, { code: "confirmation_mismatch", message: "confirmation must name the current version" });
-      // GO fails closed on anything still undecided, and on a cohort with
-      // nothing approved: an authority over zero sendable messages is not an
-      // authority. A candidate the founder held or rejected is decided.
-      const undecided = v.candidates.filter((c) => !c.review?.decision);
-      const approved = v.candidates.filter((c) => c.review?.decision === "APPROVE" && c.review?.effective === true);
-      if (body.decision === "GO" && undecided.length > 0) {
-        return send(res, 409, { code: "approval_missing_or_invalid", message: `${undecided.length} candidate(s) still undecided` });
-      }
-      if (body.decision === "GO" && approved.length === 0) {
-        return send(res, 409, { code: "approval_missing_or_invalid", message: "no effective APPROVE in this version" });
-      }
-      v.decision = { decision: body.decision, reason: body.reason ?? "", actor_id: "00000000-0000-4000-8000-00000000000a", receipt: `receipt-decision-${body.decision}` };
-      return send(res, 200, { data: v, receipt: v.decision.receipt, correlation_id: "corr-decision" });
-    }
-
-    // Bounded dispatch: hands the GO'd cohort to the queue. It never sends —
-    // exactly like the real one, which enqueues and lets the worker deliver.
-    const dis = p.match(/^\/v1\/confenge\/cohorts\/([0-9a-f-]+)\/dispatch$/);
-    if (req.method === "POST" && dis) {
-      const v = versions.get(dis[1]);
-      if (!v) return send(res, 404, { code: "not_found" });
-      if (v.decision?.decision !== "GO") return send(res, 409, { code: "cohort_grant_missing", message: "no bounded authority for this version" });
-      const eligible = v.candidates.filter((c) => c.review?.decision === "APPROVE" && c.review?.effective === true);
-      let attempted = 0;
-      let skipped = 0;
-      for (const c of eligible) {
-        if (c.queued_at) { skipped += 1; continue; }
-        c.queued_at = "2026-08-23T18:30:00Z";
-        attempted += 1;
+    // Admin repair: same scheduling projection as APPROVE, global and safe to
+    // run repeatedly. Candidate ids repeat across immutable versions, so the
+    // report distinguishes bindings from unique messages just like production.
+    if (req.method === "POST" && p === "/v1/confenge/cohorts/reconcile-approved") {
+      const approved = list.flatMap((v) => v.candidates
+        .filter((c) => c.review?.decision === "APPROVE" && c.review?.effective === true)
+        .map((c) => ({ version: v, candidate: c })));
+      let scheduled = 0;
+      let already = 0;
+      for (const { candidate: c } of approved) {
+        if (c.scheduling?.auto_send === true && ["QUEUED", "SENT"].includes(c.scheduling.state) && c.scheduling.due_at) {
+          already += 1;
+          continue;
+        }
+        c.scheduling = { state: "QUEUED", due_at: "2026-08-25T12:00:00Z", auto_send: true, sent_at: null };
+        scheduled += 1;
       }
       return send(res, 200, {
+        outcome: "APPLIED",
         data: {
-          authorization_id: "00000000-0000-4000-8000-0000000000a1",
-          cohort_id: v.cohort_id,
-          attempted,
-          provider_accepted: attempted,
+          approval_records: approved.length,
+          latest_approved_bindings: approved.length,
+          unique_approved_candidates: new Set(approved.map(({ candidate: c }) => c.candidate_id)).size,
+          scheduled,
+          already_scheduled: already,
           failed: 0,
-          skipped_duplicate: skipped,
-          blocked: 0,
-          real_email_sent: false,
-          auto_send_enabled: false,
-          green_autorun_enabled: false,
-          kill_switch_available: true,
-          max_daily: 10,
+          failures: [],
         },
-        receipt: "receipt-dispatch-1",
-        correlation_id: "corr-dispatch",
+        receipt: "receipt-reconcile",
+        correlation_id: "corr-reconcile",
       });
     }
 
@@ -224,7 +224,12 @@ createServer((req, res) => {
       c.subject = body.subject;
       c.body_text = body.body_text;
       c.content_hash = `content-hash-v${next.version}`;
-      for (const x of next.candidates) { x.validation = null; x.review = null; x.blocked_by = ["validation_missing"]; }
+      for (const x of next.candidates) {
+        x.validation = null;
+        x.review = null;
+        x.scheduling = null;
+        x.blocked_by = ["validation_missing"];
+      }
       versions.set(next.id, next);
       return send(res, 201, {
         contract_version: "confenge.human-gate.v1",

--- a/control-center/tests/journey/journey.mjs
+++ b/control-center/tests/journey/journey.mjs
@@ -44,7 +44,8 @@ async function loadChromium() {
 const chromium = await loadChromium();
 
 const BASE = process.argv[2];
-// Same stack, forward-auth identity carrying `admins`. GO and dispatch live there.
+// Same stack, forward-auth identity carrying both groups. APPROVE remains with
+// operators; only idempotent approval repair is admins-only.
 const ADMIN_BASE = process.argv[3] ?? BASE;
 const exe = process.env.CC_CHROMIUM ?? (process.env.HOME + "/.cache/ms-playwright/chromium-1237/chrome-linux64/chrome");
 
@@ -87,6 +88,15 @@ if (await openReview.count() > 0) {
   await page.waitForTimeout(1200);
 }
 check("clicking through reaches a review with a resource", /#\/warmbly\/revisao/.test(page.url()) && /[0-9a-f-]{36}/.test(page.url()), page.url().split("#")[1] || "");
+
+// ---- 2b. Server-owned outbound block is visible before review work
+const outbound = page.locator("[data-outbound-status='blocked']").first();
+check("the server-owned outbound block is visible at the top", await outbound.count() === 1);
+const outboundText = await outbound.innerText().catch(() => "");
+check("the kill switch warning says APPROVE still queues but cannot leave",
+  /APPROVE enfileira/.test(outboundText) && /nenhuma mensagem sai/.test(outboundText)
+  && /Kill switch reportado\s+acionado/.test(outboundText.replace(/\n+/g, " ")),
+  outboundText.replace(/\s+/g, " ").slice(0, 120));
 
 // ---- 3. The message is readable by default
 // data-candidate sits on each per-candidate FORM (validate, approve, hold,
@@ -142,6 +152,8 @@ const cardBefore = await page.locator("[data-candidate-id]").count();
 check("the approve control carries no required motive and no acknowledgement checkbox",
   await page.locator("form.approve-form [name='ack']").count() === 0
   && await page.locator("form.approve-form [name='reason'][required]").count() === 0);
+check("the button says approval queues for sending",
+  /Aprovar e enfileirar para envio/.test(await firstApprove.innerText().catch(() => "")));
 await firstApprove.focus();
 const pendingBeforeShortcutGuards = await page.locator("[data-queue-progress-text]").first().innerText();
 await page.evaluate(() => {
@@ -216,7 +228,14 @@ check("HOLD/REJECT still demand a written motive",
 
 // ---- 10. RBAC is visible
 check("effective operator capability is shown", await page.locator("[data-can-review]").count() > 0);
-check("GO authority is stated explicitly", await page.locator("[data-go-authority], [data-can-decide]").count() > 0);
+check("operators can approve and the screen states that it enqueues",
+  await page.locator("[data-can-review='true']").count() > 0
+  && /APPROVE enfileira/.test(await page.locator("[data-operator-identity]").first().innerText().catch(() => "")));
+check("operators cannot run the admin repair",
+  await page.locator("[data-can-reconcile='false']").count() > 0
+  && await page.locator("[data-reconcile-submit][disabled]").count() === 1);
+check("GO and cohort dispatch controls are absent",
+  await page.locator("form[data-human-gate='decide'], form[data-human-gate='dispatch']").count() === 0);
 
 // ---- 11. Adjust: two-step, diff before write, then vN+1
 const adjustEditor = page.locator("[data-adjust-editor]").first();
@@ -277,32 +296,63 @@ await page.reload({ waitUntil: "networkidle" });
 await page.waitForTimeout(1000);
 check("a reload keeps the same resource", page.url() === before, page.url().split("#")[1] || "");
 
-// ---- 11b. On the new version: decide everything, GO, then hand it to the queue
+// ---- 11b. On the new version: APPROVE itself schedules; admin repair is exceptional
 //
-// This is where the founder actually ends. v2 was frozen with every validation
-// reset, so approving here also exercises the auto-verification path, and the
-// one recipient that never verifies has to be held by hand before GO is
-// possible at all. GO and dispatch are admins-only, so this runs against the
-// forward-auth identity that carries that group — and the operators-only page
-// is checked first, to prove the refusal is real and not merely cosmetic.
+// v2 was frozen with every validation reset. The two forward-auth identities
+// prove the deliberate RBAC split: operators approve-and-queue, while admins
+// may only replay the same path for already-recorded approvals.
 if (adjusted) {
   const v2 = (page.url().split("resource=")[1] || "").slice(0, 36);
 
-  // The operators-only identity must not be able to decide or dispatch.
-  check("an operators-only session cannot register GO", 
-    await page.locator("form[data-human-gate='decide'] button[disabled]").count() > 0);
-  check("and is told which group it is missing",
-    await page.locator("[data-go-authority='absent']").count() > 0);
+  check("the operators-only identity has enabled approve-and-queue controls",
+    await page.locator("[data-approve-submit]:not([disabled])").count() > 0);
+  check("the operators-only identity cannot run reconciliation",
+    await page.locator("[data-reconcile-submit][disabled]").count() === 1);
+  const deniedRepairResponse = await fetch(`${BASE}/v1/warmbly/operator/cohorts/reconcile-approved`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ idempotency_key: "journey-operator-repair-denied" }),
+  });
+  const deniedRepair = deniedRepairResponse.status;
+  await deniedRepairResponse.text();
+  check("operators are refused at the edge before admin repair reaches Warmbly", deniedRepair === 403,
+    `HTTP ${deniedRepair}`);
 
   const admin = await newPage();
   await admin.goto(`${ADMIN_BASE}/#/warmbly/revisao?resource=${v2}&estado=todas`, { waitUntil: "networkidle" });
   await admin.waitForTimeout(1400);
   const title = await admin.locator("#review-title").innerText().catch(() => "");
-  check("the admins session opens the same version", /v2/i.test(title), title);
+  check("the admins+operators session opens the same version", /v2/i.test(title), title);
+  check("that identity can run the explicit repair",
+    await admin.locator("[data-reconcile-submit]:not([disabled])").count() === 1);
 
-  // Approve everything except the mailbox the stand-in refuses to verify.
-  // Always taking `.first()` would spend every round re-clicking that one: its
-  // approval correctly stops before APPROVE, so it never leaves the queue.
+  // Two tabs approve the same candidate from the same initial server state.
+  // Warmbly projects one scheduling record on the candidate, so neither a
+  // double write nor two browser views can create a second queued message.
+  const racingTab = await newPage();
+  await racingTab.goto(`${ADMIN_BASE}/#/warmbly/revisao?resource=${v2}&estado=todas`, { waitUntil: "networkidle" });
+  await racingTab.waitForTimeout(1200);
+  const raceCard = admin
+    .locator("[data-candidate-id]")
+    .filter({ hasNotText: "empresa-quatro" })
+    .locator("[data-approve-submit]:not([disabled])")
+    .first();
+  const raceId = await raceCard.evaluate((button) =>
+    button.closest("[data-candidate-id]")?.getAttribute("data-candidate-id") || "",
+  ).catch(() => "");
+  const otherRace = racingTab
+    .locator(`[data-candidate-id="${raceId}"] [data-approve-submit]:not([disabled])`)
+    .first();
+  if (raceId && await otherRace.count() > 0) {
+    await Promise.all([raceCard.click(), otherRace.click()]);
+    await Promise.all([admin.waitForTimeout(2200), racingTab.waitForTimeout(2200)]);
+  }
+  check("two tabs approving the same candidate leave one queued scheduling record",
+    raceId !== ""
+    && await admin.locator(`[data-candidate-id="${raceId}"][data-queue-state='aprovado'] [data-scheduling-confirmed='true']`).count() === 1);
+  await racingTab.close();
+
+  // Approve everything else except the mailbox the stand-in refuses to verify.
   for (let round = 0; round < 6; round += 1) {
     const btn = admin
       .locator("[data-candidate-id]")
@@ -314,13 +364,9 @@ if (adjusted) {
     await admin.waitForTimeout(2200);
   }
   const stillPending = await admin.locator("[data-queue-pending]").first().getAttribute("data-queue-pending");
-  check("approving drains v2 down to the recipient that cannot be verified", stillPending === "1",
+  check("approve-and-queue drains v2 down to the recipient that cannot verify", stillPending === "1",
     `${stillPending} pending`);
 
-  // The stubborn one is held by hand, with a written motive.
-  // Scoped to the card that is actually stuck. `.first()` on the whole page
-  // would land on an already-approved candidate and flip it out of Aprovadas —
-  // which is exactly what it did the first time this journey ran.
   const hold = admin
     .locator("[data-candidate-id]")
     .filter({ hasText: "empresa-quatro" })
@@ -334,50 +380,34 @@ if (adjusted) {
   const progress2 = await admin.locator("[data-queue-progress-text]").first().innerText().catch(() => "");
   check("nothing is left pending on v2", /0 pendente/.test(progress2), progress2.replace(/\s+/g, " "));
 
-  // Dispatch must not be on the page before GO.
-  check("no dispatch control exists before GO", await admin.locator("form[data-human-gate='dispatch']").count() === 0);
-  check("and the page says why", await admin.locator("[data-dispatch-gate='no-go']").count() > 0);
+  const scheduledCards = admin.locator("[data-queue-state='aprovado'] [data-scheduling-confirmed='true']");
+  check("all four approvals are QUEUED with due_at and auto_send=true, without GO",
+    await scheduledCards.count() === 4
+    && await admin.locator("[data-scheduling-state='QUEUED']").count() === 4
+    && await admin.locator("[data-scheduling-confirmed='true']").filter({ hasText: "auto_send da mensagem" }).count() === 4,
+    `${await scheduledCards.count()} scheduled cards`);
+  check("kill switch remains visible after approval and says queued mail cannot leave",
+    await admin.locator("[data-outbound-status='blocked']").count() === 1
+    && /nenhuma mensagem sai/.test(await admin.locator("[data-outbound-status='blocked']").innerText().catch(() => "")));
+  check("there is still no GO or cohort dispatch after every decision",
+    await admin.locator("form[data-human-gate='decide'], form[data-human-gate='dispatch']").count() === 0);
 
-  // GO.
-  const go = admin.locator("form[data-human-gate='decide']").first();
-  await go.locator("select[name='decision']").selectOption("GO");
-  await go.locator("[name='reason']").first().fill("cohort revisada e aprovada pelo fundador");
-  await go.locator("[name='confirmation']").first().fill("v2");
-  await go.locator("button[type=submit]").first().click();
-  await admin.waitForTimeout(2200);
-  const goOutcome = await admin.locator("[data-write-result]").first().innerText().catch(() => "");
-  check("GO is registered on the version", /EXECUTADA/.test(goOutcome), goOutcome.replace(/\s+/g, " ").slice(0, 70));
-
-  // Only now does the dispatch control exist.
-  const dispatchForm = admin.locator("form[data-human-gate='dispatch']");
-  const hasDispatch = await dispatchForm.count() === 1;
-  check("the dispatch control appears only after GO", hasDispatch);
-  if (!hasDispatch) { await admin.close(); throw new Error("dispatch control absent after GO"); }
-  check("it states that it queues and does not send",
-    (await admin.locator("[data-dispatch-meaning]").first().innerText().catch(() => "")).includes("não envia e-mail"));
-  check("it names the gates Warmbly still enforces",
-    (await admin.locator("[data-dispatch-gates]").first().innerText().catch(() => "")).includes("kill switch"));
-
-  // The cohort reaches the queue only with the typed version.
-  await dispatchForm.locator("[name='confirmation']").first().fill("v2");
-  await dispatchForm.locator("button[type=submit]").first().click();
-  await admin.waitForTimeout(2600);
-  const counts = await admin.locator("[data-dispatch-counts]").first().innerText().catch(() => "");
-  check("the cohort reached the queue and the numbers come from the server",
-    /Tentados/.test(counts) && /Aceitos pelo provedor/.test(counts), counts.replace(/\s+/g, " ").slice(0, 90));
-  check("the outcome says queued, not delivered",
-    (await admin.locator("[data-dispatch-not-sent]").first().innerText().catch(() => "")).includes("não de entrega"));
-  check("the dispatch carried a receipt",
-    /receipt|recibo/i.test(await admin.locator("[data-write-evidence]").first().innerText().catch(() => "")));
-
-  // Repeating is safe, and the server is what says so.
-  await admin.locator("form[data-human-gate='dispatch'] [name='confirmation']").first().fill("v2");
-  await admin.locator("form[data-human-gate='dispatch'] button[type=submit]").first().click();
-  await admin.waitForTimeout(2600);
-  const again = await admin.locator("[data-dispatch-counts]").first().innerText().catch(() => "");
-  const dup = (again.match(/Pulados por duplicidade\s*(\d+)/) || [])[1];
-  check("a repeated dispatch queues nothing new and counts the duplicates", dup !== undefined && Number(dup) > 0,
-    again.replace(/\s+/g, " ").slice(0, 90));
+  // Admin repair runs twice. The first and second calls both find the same
+  // already-scheduled bindings; the second cannot duplicate anything.
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await admin.locator("[data-reconcile-submit]:not([disabled])").click();
+    await admin.waitForTimeout(2200);
+  }
+  const reconciliation = await admin.locator("[data-reconcile-counts]").first().innerText().catch(() => "");
+  check("reconciliation reports server counts after a second execution",
+    /Registros APPROVE no histórico/.test(reconciliation)
+    && /Candidatos únicos aprovados/.test(reconciliation)
+    && /Agendados agora\s*0/.test(reconciliation)
+    && /Já agendados\s*[1-9]/.test(reconciliation),
+    reconciliation.replace(/\s+/g, " ").slice(0, 160));
+  check("the second repair is confirmed by server reread and carries a receipt",
+    await admin.locator("[data-readback='confirmed']").count() > 0
+    && /receipt|recibo/i.test(await admin.locator("[data-write-evidence]").first().innerText().catch(() => "")));
   await admin.close();
 }
 
@@ -402,6 +432,8 @@ const approvedCards = await reviewed.locator("[data-queue-state='aprovado']").co
 check("the approved recorte holds exactly the two decided messages, with no second APPROVE offered",
   approvedCards === 2 && await reviewed.locator("[data-gate-key$=':APPROVE']").count() === 0,
   `${approvedCards} approved cards`);
+check("both pre-adjustment approvals were scheduled by the same APPROVE call",
+  await reviewed.locator("[data-scheduling-confirmed='true'][data-scheduling-state='QUEUED']").count() === 2);
 
 // ---- 12c. The queue works on a phone
 await reviewed.setViewportSize({ width: 390, height: 844 });

--- a/control-center/tests/journey/run.sh
+++ b/control-center/tests/journey/run.sh
@@ -14,10 +14,9 @@ APP="$CC/apps/web-shell"
 WORK="$(mktemp -d)"
 
 WPORT=${WPORT:-8099}; CPORT=${CPORT:-8098}; SPORT=${SPORT:-8097}; EPORT=${EPORT:-8096}
-# A second edge+shell pair whose forward-auth identity carries `admins`.
-# GO and cohort dispatch are admins-only, so proving both the refusal (on the
-# operators-only pair) and the happy path needs two identities, and the fake
-# edge fixes its groups at startup.
+# A second edge+shell pair whose forward-auth identity carries both groups.
+# APPROVE stays with operators; only idempotent approval reconciliation is
+# admins-only. The two fixed identities prove both sides of that boundary.
 EPORT2=${EPORT2:-8095}; SPORT2=${SPORT2:-8094}
 TOKEN=stub-operator-token
 TOKFILE="$WORK/token"; printf %s "$TOKEN" > "$TOKFILE"


### PR DESCRIPTION
## Resultado

- APPROVE na Revisão passa a confirmar agendamento `QUEUED` com `due_at`, sem GO e sem entrega extra.
- GO/NO-GO fica somente no histórico de auditoria; HOLD/REJECT continuam cancelando pendências no Warmbly.
- o antigo controle de entrega vira reparo idempotente de aprovações anteriores, restrito a `admins`.
- a Revisão mostra o kill switch e demais bloqueios de outbound antes da fila.
- `operators` continuam autorizados a aprovar, agora com texto explícito de que APPROVE enfileira.
- o conector continua com allowlist fixa e descarta query string em escritas.

## Dependência já implantada

Warmbly PRs #160 e #163; produção em `67bc89890fcf7731647ff96feaab50cb3a4d0222`. Global auto-send e Green autorun permanecem desligados; cada mensagem aprovada é gravada com `auto_send=true`.

## Verificação local

- `bash control-center/tests/journey/run.sh`: 67/67 em Chromium real, duas identidades ForwardAuth
- `cd control-center && npm test`: 23 workspaces verdes
- `npx tsx --test tests/convergence/*.test.ts`: 66/66
- `npm run typecheck`: verde
- web-shell final: 418/418
- connector: 170 pass; context: 109/109; cohort/review: 120/120
- segunda passada adversarial concluída; teste de RBAC endurecido para provar bloqueio na borda antes do upstream

## Produção

Depois dos checks e merge: rebuild de `context` e `web`, porque o conector viaja na imagem de context; então reparo idempotente duas vezes e prova SQL antes/depois. O kill switch não será removido.