### PR TITLE
fix(control-center): falhar fechado no readback de decisões

### DIFF
--- a/control-center/apps/web-shell/src/adapters/contract.ts
+++ b/control-center/apps/web-shell/src/adapters/contract.ts
@@ -103,6 +103,27 @@ export interface GateReconcileCounts {
   failures?: readonly { cohortId?: string; candidateId?: string; reason: string }[];
 }
 
+/**
+ * Server-observed result of one commercial draft decision.
+ *
+ * This is deliberately distinct from an optimistic UI state. The Context
+ * Service emits it only after comparing Warmbly's write response with a
+ * canonical GET of the same touchpoint.
+ */
+export interface ReviewDecisionEvidence {
+  action: "SAVE_ADJUSTMENT" | "APPROVE" | "REJECT";
+  touchpointId: string;
+  expectedContentHash: string;
+  contentHash?: string;
+  approvedContentHash?: string;
+  state?: string;
+  dueAt?: string;
+  scheduledFor?: string;
+  approvedBy?: string;
+  approvedAt?: string;
+  observedAt: string;
+}
+
 export interface AdapterWriteResult {
   ok: boolean;
   path: string;
@@ -169,6 +190,8 @@ export interface AdapterWriteResult {
   reconcile?: GateReconcileCounts;
   /** Result of the GET readback performed after a definitive response. */
   readback?: GateReadback;
+  /** Canonical receipt/readback for a Comercial → Rascunhos decision. */
+  reviewDecision?: ReviewDecisionEvidence;
 }
 
 /**

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -86,6 +86,159 @@ function validReceiptInstant(value: string, now = Date.now()): boolean {
   return inputSecond === parsedSecond;
 }
 
+type ReviewDraftAction = "SAVE_ADJUSTMENT" | "APPROVE" | "REJECT";
+
+function reviewDecisionFailure(
+  path: string,
+  message: string,
+  status?: number,
+  code = "review_result_not_confirmed",
+): AdapterWriteResult {
+  return {
+    ok: false,
+    path,
+    kind: "nota",
+    message,
+    outcome: "unknown",
+    code,
+    ...(status === undefined ? {} : { status }),
+    readback: { status: "not_confirmed", detail: message },
+  };
+}
+
+function reviewDecisionResult(
+  input: { id: string; action: ReviewDraftAction; expected_content_hash: string },
+  path: string,
+  idempotency: string,
+  status: number,
+  payload: unknown,
+): AdapterWriteResult {
+  const body = asRecord(payload);
+  const readback = asRecord(body?.readback);
+  const outcome = stringValue(body ?? {}, "outcome");
+  const action = stringValue(body ?? {}, "action");
+  const touchpointId = stringValue(body ?? {}, "touchpoint_id");
+  const expectedContentHash = stringValue(body ?? {}, "expected_content_hash");
+  const correlationId = stringValue(body ?? {}, "correlation_id");
+  const observedAt = stringValue(body ?? {}, "observed_at");
+  const message = stringValue(body ?? {}, "message");
+  const readbackStatus = stringValue(readback ?? {}, "status");
+  const readbackDetail = stringValue(readback ?? {}, "detail");
+  const envelopeValid =
+    body?.schema_version === "control-center.review-decision-receipt.v1" &&
+    (outcome === "confirmed" || outcome === "not_confirmed") &&
+    action === input.action &&
+    touchpointId === input.id &&
+    expectedContentHash === input.expected_content_hash &&
+    correlationId === idempotency &&
+    observedAt !== undefined &&
+    validReceiptInstant(observedAt) &&
+    message !== undefined &&
+    (readbackStatus === "confirmed" || readbackStatus === "not_confirmed" || readbackStatus === "unavailable") &&
+    readbackDetail !== undefined;
+  if (!envelopeValid) {
+    return reviewDecisionFailure(
+      path,
+      "Resultado não confirmado. Não repita ainda: o servidor retornou um recibo incompatível.",
+      status,
+      "review_receipt_invalid",
+    );
+  }
+
+  const evidence = {
+    action: action as ReviewDraftAction,
+    touchpointId: touchpointId!,
+    expectedContentHash: expectedContentHash!,
+    ...(stringValue(body, "content_hash") ? { contentHash: stringValue(body, "content_hash")! } : {}),
+    ...(stringValue(body, "approved_content_hash")
+      ? { approvedContentHash: stringValue(body, "approved_content_hash")! }
+      : {}),
+    ...(stringValue(body, "state") ? { state: stringValue(body, "state")! } : {}),
+    ...(stringValue(body, "due_at") ? { dueAt: stringValue(body, "due_at")! } : {}),
+    ...(stringValue(body, "scheduled_for") ? { scheduledFor: stringValue(body, "scheduled_for")! } : {}),
+    ...(stringValue(body, "approved_by") ? { approvedBy: stringValue(body, "approved_by")! } : {}),
+    ...(stringValue(body, "approved_at") ? { approvedAt: stringValue(body, "approved_at")! } : {}),
+    observedAt: observedAt!,
+  };
+  const adapterReadback = {
+    status: readbackStatus === "confirmed"
+      ? "confirmed" as const
+      : readbackStatus === "unavailable"
+        ? "unavailable" as const
+        : "not_confirmed" as const,
+    detail: readbackDetail!,
+  };
+  if (outcome !== "confirmed") {
+    return {
+      ...reviewDecisionFailure(path, message!, status),
+      readback: adapterReadback,
+      reviewDecision: evidence,
+    };
+  }
+
+  const receiptId = stringValue(body, "receipt_id");
+  const contentHash = stringValue(body, "content_hash");
+  const state = stringValue(body, "state");
+  let confirmationFailure: string | undefined;
+  if (!receiptId || !contentHash || !state || readbackStatus !== "confirmed") {
+    confirmationFailure = "receipt, hash, estado ou readback confirmado ausente";
+  } else if (input.action === "APPROVE") {
+    const approvedHash = stringValue(body, "approved_content_hash");
+    const approvedBy = stringValue(body, "approved_by");
+    const approvedAt = stringValue(body, "approved_at");
+    const dueAt = stringValue(body, "due_at");
+    const scheduledFor = stringValue(body, "scheduled_for");
+    if (contentHash !== input.expected_content_hash || approvedHash !== input.expected_content_hash) {
+      confirmationFailure = "o servidor não confirmou o hash exato aprovado";
+    } else if (state !== "QUEUED" && state !== "SENT") {
+      confirmationFailure = "APPROVE não foi observado em QUEUED ou SENT";
+    } else if (!approvedBy || !approvedAt || !isUtcDateTime(approvedAt)) {
+      confirmationFailure = "ator ou instante de aprovação ausente";
+    } else if (
+      state === "QUEUED" &&
+      (!dueAt || !scheduledFor || !isUtcDateTime(dueAt) || dueAt !== scheduledFor)
+    ) {
+      confirmationFailure = "QUEUED não possui due_at/scheduled_for confirmado";
+    }
+  } else if (input.action === "REJECT") {
+    if (contentHash !== input.expected_content_hash || state !== "REJECTED_REWRITE_PENDING") {
+      confirmationFailure = "REJECT não foi confirmado sobre o hash e estado esperados";
+    }
+  } else if (state !== "NEEDS_REVIEW" && state !== "DRAFTED") {
+    confirmationFailure = "SAVE_ADJUSTMENT não permaneceu em revisão";
+  }
+  if (confirmationFailure) {
+    return {
+      ...reviewDecisionFailure(
+        path,
+        `Resultado não confirmado. Não repita ainda: ${confirmationFailure}.`,
+        status,
+        "review_confirmation_invalid",
+      ),
+      reviewDecision: evidence,
+    };
+  }
+
+  return {
+    ok: true,
+    path,
+    kind: "nota",
+    message: message!,
+    outcome: "executed",
+    status,
+    receipt: {
+      id: receiptId!,
+      correlation_id: correlationId!,
+      occurred_at: observedAt!,
+      outcome: "accepted",
+      target: touchpointId!,
+      writes_to: "warmbly",
+    },
+    readback: adapterReadback,
+    reviewDecision: evidence,
+  };
+}
+
 /* ------------------------------------------------------------------ *
  * Human-gate response reading.
  *
@@ -744,22 +897,30 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
         } catch {
           // The status remains the safe diagnostic.
         }
-        const failed: AdapterWriteResult = { ok: false, path, kind: "nota", message };
+        const failed: AdapterWriteResult = {
+          ...reviewDecisionFailure(path, message, response.status, "review_write_refused"),
+          outcome: response.status >= 500 ? "unknown" : "refused",
+        };
         this.lastOperatorResult = failed;
         return failed;
       }
-      const message = input.action === "APPROVE"
-        ? "mensagem aprovada e agendada para a próxima janela útil"
-        : input.action === "REJECT"
-          ? "rascunho rejeitado e devolvido para reescrita"
-          : "ajuste salvo; aprovação ainda pendente";
-      const accepted: AdapterWriteResult = { ok: true, path, kind: "nota", message };
-      this.lastOperatorResult = accepted;
-      return accepted;
+      let payload: unknown;
+      try {
+        payload = raw.trim() === "" ? undefined : JSON.parse(raw) as unknown;
+      } catch {
+        payload = undefined;
+      }
+      const result = reviewDecisionResult(input, path, idempotency, response.status, payload);
+      this.lastOperatorResult = result;
+      return result;
     } catch (err) {
       const failed: AdapterWriteResult = {
-        ok: false, path, kind: "nota",
-        message: err instanceof Error ? err.message : "Warmbly indisponível",
+        ...reviewDecisionFailure(
+          path,
+          `Resultado não confirmado. Não repita ainda: ${err instanceof Error ? err.message : "Warmbly indisponível"}.`,
+          undefined,
+          "browser_transport",
+        ),
       };
       this.lastOperatorResult = failed;
       return failed;

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -111,8 +111,19 @@ export interface MountableRoot {
   querySelectorAll?(selector: string): ArrayLike<{
     addEventListener(type: string, listener: (event: Event) => void): void;
     getAttribute(name: string): string | null;
-    querySelector(selector: string): { value: string; checked?: boolean } | null;
-    querySelectorAll?(selector: string): ArrayLike<{ value: string; checked?: boolean }>;
+    setAttribute?(name: string, value: string): void;
+    querySelector(selector: string): {
+      value: string;
+      checked?: boolean;
+      disabled?: boolean;
+      textContent?: string | null;
+    } | null;
+    querySelectorAll?(selector: string): ArrayLike<{
+      value: string;
+      checked?: boolean;
+      disabled?: boolean;
+      textContent?: string | null;
+    }>;
     focus?(options?: { preventScroll?: boolean }): void;
     scrollIntoView?(options?: { block?: "center"; inline?: "nearest" }): void;
   }>;
@@ -385,7 +396,7 @@ function restoreListFocus(painted: boolean): void {
   if (element instanceof HTMLSelectElement) element.focus();
 }
 
-function bindReviewActions(
+export function bindReviewActions(
   root: MountableRoot,
   adapter: ControlCenterReadAdapter,
   onDone: () => void,
@@ -395,24 +406,62 @@ function bindReviewActions(
   for (let i = 0; i < forms.length; i += 1) {
     const form = forms[i];
     if (!form) continue;
+    let inFlight = false;
     form.addEventListener("submit", (event) => {
       event.preventDefault();
+      if (inFlight) return;
       const id = form.getAttribute("data-review-form") ?? "";
       const action = form.querySelector('[name="action"]')?.value as "SAVE_ADJUSTMENT" | "APPROVE" | "REJECT" | undefined;
       const expected = form.querySelector('[name="expected_content_hash"]')?.value ?? "";
       if (!id || !action || !expected) return;
-      void Promise.resolve(adapter.reviewDraftAction?.({
+      const subject = form.querySelector('[name="subject"]')?.value ?? "";
+      const bodyText = form.querySelector('[name="body_text"]')?.value ?? "";
+      const originalSubject = form.querySelector('[name="original_subject"]')?.value ?? subject;
+      const originalBodyText = form.querySelector('[name="original_body_text"]')?.value ?? bodyText;
+      if (action !== "SAVE_ADJUSTMENT" && (subject !== originalSubject || bodyText !== originalBodyText)) {
+        adapter.lastOperatorResult = {
+          ok: false,
+          path: `/v1/commercial/review-drafts/${encodeURIComponent(id)}`,
+          kind: "nota",
+          message: "Há ajustes ainda não salvos. Salve o ajuste e releia o novo hash antes de aprovar ou rejeitar.",
+          outcome: "refused",
+          code: "review_adjustment_not_saved",
+        };
+        onDone();
+        return;
+      }
+      inFlight = true;
+      form.setAttribute?.("aria-busy", "true");
+      const controls = form.querySelectorAll?.("button,input,select,textarea") ?? [];
+      for (let controlIndex = 0; controlIndex < controls.length; controlIndex += 1) {
+        const control = controls[controlIndex];
+        if (control) control.disabled = true;
+      }
+      const submit = form.querySelector('button[type="submit"]');
+      if (submit) submit.textContent = "Confirmando no servidor…";
+      const request = {
         id,
         action,
         expected_content_hash: expected,
-        subject: form.querySelector('[name="subject"]')?.value ?? "",
-        body_text: form.querySelector('[name="body_text"]')?.value ?? "",
+        ...(action === "SAVE_ADJUSTMENT" ? { subject, body_text: bodyText } : {}),
         reason: form.querySelector('[name="reason"]')?.value ?? "",
         generic_recipient_acknowledged: form.querySelector('[name="generic_ack"]')?.value === "true",
-      })).then((result) => {
-        if (result) adapter.lastOperatorResult = result;
-        onDone();
-      });
+      };
+      void Promise.resolve(adapter.reviewDraftAction?.(request))
+        .then((result) => {
+          if (result) adapter.lastOperatorResult = result;
+        })
+        .catch((err: unknown) => {
+          adapter.lastOperatorResult = {
+            ok: false,
+            path: `/v1/commercial/review-drafts/${encodeURIComponent(id)}`,
+            kind: "nota",
+            message: `Resultado não confirmado. Não repita ainda: ${err instanceof Error ? err.message : "falha inesperada"}.`,
+            outcome: "unknown",
+            code: "browser_transport",
+          };
+        })
+        .finally(onDone);
     });
   }
 }

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -1138,6 +1138,8 @@ function reviewDraftCard(item: unknown): string {
   const decision = actionable
     ? `<form data-review-form="${escapeHtml(id)}" class="operator-form">
                 <input type="hidden" name="expected_content_hash" value="${escapeHtml(contentHash)}" />
+                <textarea name="original_subject" hidden>${escapeHtml(subject)}</textarea>
+                <textarea name="original_body_text" hidden>${escapeHtml(bodyText)}</textarea>
                 <label>Assunto <textarea name="subject" rows="${subjectRows}">${escapeHtml(subject)}</textarea></label>
                 <label>Corpo <textarea name="body_text" rows="${bodyRows}">${escapeHtml(bodyText)}</textarea></label>
                 <label>Decisão <select name="action">

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -151,11 +151,12 @@ function viewBanner(view: ViewState<DestinationPage>): string {
   return "";
 }
 
-function operatorBanner(result: AdapterWriteResult | undefined): string {
+export function operatorBanner(result: AdapterWriteResult | undefined): string {
   if (!result) return "";
   const cls = result.ok ? "ok" : "error";
   const role = result.ok ? "status" : "alert";
   const receipt = result.receipt;
+  const review = result.reviewDecision;
   const outcomeLabels: Record<string, string> = {
     accepted: "aceito",
     duplicate: "duplicado; receipt original preservado",
@@ -164,14 +165,26 @@ function operatorBanner(result: AdapterWriteResult | undefined): string {
     refused: "recusado",
     unknown: "indeterminado",
   };
-  const recovery = result.outcome === "unknown"
+  const recovery = review && !result.ok
+    ? "Não repita agora: releia este rascunho e use a mesma correlação somente depois de confirmar o estado no servidor."
+    : review?.action === "APPROVE" && result.ok
+      ? "O agendamento foi confirmado; verifique pausa/kill switch antes de interpretar quando a mensagem poderá sair."
+      : result.outcome === "unknown"
     ? "Não repita agora: releia a origem e a auditoria para saber se a escrita ocorreu."
     : !result.ok
       ? "Revise sua sessão/permissão e tente novamente somente depois de confirmar que nada foi aplicado."
       : receipt?.writes_to === "warmbly"
         ? "Releia o estado do Warmbly para confirmar o efeito observado."
         : "A mudança ficou apenas na auditoria local; execute a correção indicada na origem quando aplicável.";
-  const message = !result.ok
+  const message = review && !result.ok
+    ? "Resultado não confirmado. A mensagem continua em Ação necessária até novo readback."
+    : review?.action === "APPROVE"
+      ? "Aprovação e agendamento confirmados pelo servidor."
+      : review?.action === "REJECT"
+        ? "Rejeição e encaminhamento para reescrita confirmados pelo servidor."
+        : review?.action === "SAVE_ADJUSTMENT"
+          ? "Ajuste confirmado; a aprovação continua pendente."
+          : !result.ok
     ? "A ação não foi concluída. Consulte o detalhe técnico antes de tentar novamente."
     : result.path === WARMBLY_DISPATCH_PATHS.pause
       ? "Disparos pausados."
@@ -188,11 +201,19 @@ function operatorBanner(result: AdapterWriteResult | undefined): string {
     <p>${escapeHtml(message)}</p>
     <p><strong>Próxima ação:</strong> ${escapeHtml(recovery)}</p>
     ${receipt ? `<dl class="facts" data-action-receipt="true">
-      <div data-receipt-id="${escapeHtml(receipt.id)}"><dt>Receipt</dt><dd>registro append-only confirmado</dd></div>
-      <div><dt>Ator</dt><dd>${escapeHtml(receipt.actor_id ?? (receipt.writes_to === "warmbly" ? "sessão autenticada na borda" : "não retornado"))}</dd></div>
+      <div data-receipt-id="${escapeHtml(receipt.id)}"><dt>Receipt</dt><dd>${review ? "write + readback canônico confirmados" : "registro append-only confirmado"}</dd></div>
+      <div><dt>Ator</dt><dd>${escapeHtml(review?.approvedBy ?? receipt.actor_id ?? (receipt.writes_to === "warmbly" ? "sessão autenticada na borda" : "não retornado"))}</dd></div>
       <div data-correlation-id="${escapeHtml(receipt.correlation_id)}"><dt>Sessão/correlação</dt><dd>registrada para esta ação</dd></div>
       <div><dt>Desfecho</dt><dd>${escapeHtml(ownMapValue(outcomeLabels, receipt.outcome) ?? "desfecho não catalogado")}</dd></div>
       <div><dt>Fronteira de escrita</dt><dd>${receipt.writes_to === "warmbly" ? "Warmbly" : "somente Control Center"}</dd></div>
+    </dl>` : ""}
+    ${review ? `<dl class="facts" data-review-decision-receipt="true">
+      <div data-review-touchpoint="${escapeHtml(review.touchpointId)}"><dt>Mensagem</dt><dd>${escapeHtml(review.touchpointId)}</dd></div>
+      <div><dt>Decisão</dt><dd>${escapeHtml(review.action)}</dd></div>
+      <div data-review-state="${escapeHtml(review.state ?? "não confirmado")}"><dt>Estado observado</dt><dd>${escapeHtml(review.state ?? "não confirmado")}</dd></div>
+      <div><dt>Pode sair?</dt><dd>${review.state === "QUEUED" || review.state === "SENT" ? "agendada pelo Warmbly; pausa e kill switch ainda governam a saída" : "não confirmado"}</dd></div>
+      <div data-review-due-at="${escapeHtml(review.dueAt ?? "")}"><dt>Primeiro horário observado</dt><dd>${escapeHtml(review.dueAt ?? "não confirmado")}</dd></div>
+      <div><dt>Última observação</dt><dd>${escapeHtml(review.observedAt)}</dd></div>
     </dl>` : ""}
     ${technicalDetails([
       { term: "path", value: result.path },
@@ -203,6 +224,11 @@ function operatorBanner(result: AdapterWriteResult | undefined): string {
       { term: "correlation_id", value: receipt?.correlation_id ?? "" },
       { term: "occurred_at", value: receipt?.occurred_at ?? "" },
       { term: "target", value: receipt?.target ?? "" },
+      { term: "expected_content_hash", value: review?.expectedContentHash ?? "" },
+      { term: "content_hash", value: review?.contentHash ?? "" },
+      { term: "approved_content_hash", value: review?.approvedContentHash ?? "" },
+      { term: "scheduled_for", value: review?.scheduledFor ?? "" },
+      { term: "approved_at", value: review?.approvedAt ?? "" },
     ], "operator-write-result")}
   </div>`;
 }

--- a/control-center/apps/web-shell/tests/review-drafts.test.ts
+++ b/control-center/apps/web-shell/tests/review-drafts.test.ts
@@ -1,10 +1,39 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { bindReviewActions } from "../src/app";
 import { createHttpAdapter } from "../src/adapters";
 import { commercialBlock } from "../src/ui/domains";
+import { operatorBanner } from "../src/ui/render";
 import { recordingFetch, operationalRouter } from "./helpers";
 
 const DRAFT_ID = "11111111-2222-4333-8444-555555555555";
+const HASH = "sha256:exact";
+
+function confirmedDecision(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const observedAt = new Date(Date.now() - 1_000).toISOString();
+  const approvedAt = new Date(Date.now() - 2_000).toISOString();
+  const dueAt = new Date(Date.now() + 86_400_000).toISOString();
+  return {
+    schema_version: "control-center.review-decision-receipt.v1",
+    outcome: "confirmed",
+    action: "APPROVE",
+    touchpoint_id: DRAFT_ID,
+    expected_content_hash: HASH,
+    correlation_id: `review:APPROVE:${DRAFT_ID}:${HASH}`,
+    observed_at: observedAt,
+    message: `Aprovação confirmada no servidor em QUEUED para ${dueAt}.`,
+    readback: { status: "confirmed", detail: "write e readback confirmam a mesma versão persistida" },
+    receipt_id: `review:${DRAFT_ID}:2026-08-25T04:00:01Z`,
+    content_hash: HASH,
+    approved_content_hash: HASH,
+    state: "QUEUED",
+    due_at: dueAt,
+    scheduled_for: dueAt,
+    approved_by: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    approved_at: approvedAt,
+    ...overrides,
+  };
+}
 
 test("commercial review surface renders editable exact-hash decisions without an immediate-send control", async () => {
   const router = operationalRouter();
@@ -38,23 +67,192 @@ test("commercial review surface renders editable exact-hash decisions without an
   assert.doesNotMatch(html, /enviar agora|dispatch-now/i);
 });
 
-test("review decision posts the expected hash and reports next-window scheduling", async () => {
-  let request: RequestInit | undefined;
+test("review decision posts the expected hash and only confirms a canonical receipt", async () => {
+  const requests: RequestInit[] = [];
   const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit) => {
-    request = init;
-    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    requests.push(init ?? {});
+    return new Response(JSON.stringify(confirmedDecision()), { status: 200 });
   }) as typeof fetch;
   const adapter = createHttpAdapter("http://context.test", fetchImpl, { kind: "human", id: "founder-local" });
   const result = await adapter.reviewDraftAction({
     id: DRAFT_ID,
     action: "APPROVE",
-    expected_content_hash: "sha256:exact",
+    expected_content_hash: HASH,
   });
   assert.equal(result.ok, true);
-  assert.match(result.message, /próxima janela útil/);
-  assert.match(String(request?.body), /sha256:exact/);
-  const headers = request?.headers as Record<string, string>;
-  assert.match(String(headers["idempotency-key"]), /sha256:exact/);
+  assert.match(result.message, /confirmada no servidor/);
+  assert.equal(result.outcome, "executed");
+  assert.equal(result.readback?.status, "confirmed");
+  assert.equal(result.reviewDecision?.state, "QUEUED");
+  assert.equal(result.reviewDecision?.approvedContentHash, HASH);
+  assert.equal(result.receipt?.writes_to, "warmbly");
+  assert.match(String(requests[0]?.body), /sha256:exact/);
+  const headers = requests[0]?.headers as Record<string, string>;
+  assert.equal(headers["idempotency-key"], `review:APPROVE:${DRAFT_ID}:${HASH}`);
+
+  const replay = await adapter.reviewDraftAction({ id: DRAFT_ID, action: "APPROVE", expected_content_hash: HASH });
+  assert.equal(replay.ok, true);
+  const replayHeaders = requests[1]?.headers as Record<string, string>;
+  assert.equal(replayHeaders["idempotency-key"], headers["idempotency-key"]);
+  assert.equal(replay.receipt?.id, result.receipt?.id);
+
+  const html = operatorBanner(result);
+  assert.match(html, /Aprovação e agendamento confirmados pelo servidor/);
+  assert.match(html, /data-review-decision-receipt="true"/);
+  assert.match(html, /data-review-state="QUEUED"/);
+  assert.match(html, /data-review-due-at=/);
+  assert.match(html, /agendada pelo Warmbly; pausa e kill switch ainda governam a saída/);
+  assert.match(html, /write \+ readback canônico confirmados/);
+});
+
+test("browser never turns malformed or incomplete 2xx review bodies into success", async (t) => {
+  const cases: Array<{ name: string; body?: unknown }> = [
+    { name: "empty body", body: undefined },
+    { name: "legacy ok boolean", body: { ok: true } },
+    { name: "wrong id", body: confirmedDecision({ touchpoint_id: "99999999-8888-4777-8666-555555555555" }) },
+    { name: "wrong hash", body: confirmedDecision({ content_hash: "sha256:other" }) },
+    { name: "APPROVE not effective", body: confirmedDecision({ state: "NEEDS_REVIEW" }) },
+    { name: "QUEUED without due_at", body: confirmedDecision({ due_at: "", scheduled_for: "" }) },
+    { name: "readback stale", body: confirmedDecision({ readback: { status: "not_confirmed", detail: "stale" } }) },
+  ];
+  for (const scenario of cases) {
+    await t.test(scenario.name, async () => {
+      const fetchImpl = (async () => scenario.body === undefined
+        ? new Response(null, { status: 204 })
+        : new Response(JSON.stringify(scenario.body), { status: 200 })) as typeof fetch;
+      const adapter = createHttpAdapter("http://context.test", fetchImpl, { kind: "human", id: "founder-local" });
+      const result = await adapter.reviewDraftAction({
+        id: DRAFT_ID,
+        action: "APPROVE",
+        expected_content_hash: HASH,
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.outcome, "unknown");
+      assert.match(result.message, /não confirmado|recibo incompatível/i);
+      assert.doesNotMatch(result.message, /aprovada e agendada para a próxima janela útil/i);
+    });
+  }
+});
+
+test("server not_confirmed and browser transport failure both say not to repeat", async () => {
+  const notConfirmed = confirmedDecision({
+    outcome: "not_confirmed",
+    message: "Resultado não confirmado. Não repita ainda: readback indisponível.",
+    readback: { status: "unavailable", detail: "readback indisponível" },
+    receipt_id: undefined,
+    state: undefined,
+    due_at: undefined,
+    scheduled_for: undefined,
+  });
+  const serverAdapter = createHttpAdapter(
+    "http://context.test",
+    (async () => new Response(JSON.stringify(notConfirmed), { status: 200 })) as typeof fetch,
+    { kind: "human", id: "founder-local" },
+  );
+  const serverResult = await serverAdapter.reviewDraftAction({
+    id: DRAFT_ID,
+    action: "APPROVE",
+    expected_content_hash: HASH,
+  });
+  assert.equal(serverResult.ok, false);
+  assert.equal(serverResult.readback?.status, "unavailable");
+  assert.match(serverResult.message, /não repita ainda/i);
+  const unconfirmedHtml = operatorBanner(serverResult);
+  assert.match(unconfirmedHtml, /Resultado não confirmado/);
+  assert.match(unconfirmedHtml, /continua em Ação necessária/);
+  assert.match(unconfirmedHtml, /Não repita agora/);
+
+  const transportAdapter = createHttpAdapter(
+    "http://context.test",
+    (async () => { throw new Error("timeout pós-write"); }) as typeof fetch,
+    { kind: "human", id: "founder-local" },
+  );
+  const transportResult = await transportAdapter.reviewDraftAction({
+    id: DRAFT_ID,
+    action: "APPROVE",
+    expected_content_hash: HASH,
+  });
+  assert.equal(transportResult.ok, false);
+  assert.equal(transportResult.code, "browser_transport");
+  assert.match(transportResult.message, /não repita ainda/i);
+});
+
+test("review submit disables every control immediately and ignores a second click", async () => {
+  let release: (() => void) | undefined;
+  const held = new Promise<void>((resolve) => { release = resolve; });
+  let calls = 0;
+  let painted = 0;
+  const controls = Array.from({ length: 6 }, () => ({ value: "", disabled: false, textContent: "" }));
+  const fields: Record<string, { value: string; disabled?: boolean; textContent?: string }> = {
+    action: { value: "APPROVE" },
+    expected_content_hash: { value: HASH },
+    subject: { value: "Assunto" },
+    body_text: { value: "Corpo" },
+    original_subject: { value: "Assunto" },
+    original_body_text: { value: "Corpo" },
+    reason: { value: "" },
+    generic_ack: { value: "true" },
+    submit: controls[0]!,
+  };
+  let listener: ((event: Event) => void) | undefined;
+  const form = {
+    addEventListener(_type: string, next: (event: Event) => void): void { listener = next; },
+    getAttribute(name: string): string | null { return name === "data-review-form" ? DRAFT_ID : null; },
+    setAttribute(): void {},
+    querySelector(selector: string) {
+      if (selector === 'button[type="submit"]') return fields.submit!;
+      const name = selector.match(/name="([^"]+)"/)?.[1] ?? "";
+      return fields[name] ?? null;
+    },
+    querySelectorAll(): typeof controls { return controls; },
+  };
+  const adapter = {
+    reviewDraftAction: async () => {
+      calls += 1;
+      await held;
+      return { ok: true, path: "/review", kind: "nota" as const, message: "confirmado" };
+    },
+  };
+  bindReviewActions({ innerHTML: "", querySelectorAll: () => [form] } as never, adapter as never, () => { painted += 1; });
+  const event = { preventDefault(): void {} } as unknown as Event;
+  listener?.(event);
+  listener?.(event);
+  assert.equal(calls, 1);
+  assert.equal(controls.every((control) => control.disabled), true);
+  assert.equal(fields.submit?.textContent, "Confirmando no servidor…");
+  release?.();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(painted, 1);
+});
+
+test("unsaved edits must be persisted and reread before APPROVE", () => {
+  let called = false;
+  let painted = 0;
+  const fields: Record<string, { value: string }> = {
+    action: { value: "APPROVE" },
+    expected_content_hash: { value: HASH },
+    subject: { value: "Assunto alterado" },
+    body_text: { value: "Corpo" },
+    original_subject: { value: "Assunto original" },
+    original_body_text: { value: "Corpo" },
+    reason: { value: "" },
+    generic_ack: { value: "false" },
+  };
+  let listener: ((event: Event) => void) | undefined;
+  const form = {
+    addEventListener(_type: string, next: (event: Event) => void): void { listener = next; },
+    getAttribute(): string { return DRAFT_ID; },
+    querySelector(selector: string) {
+      const name = selector.match(/name="([^"]+)"/)?.[1] ?? "";
+      return fields[name] ?? null;
+    },
+  };
+  const adapter = { reviewDraftAction: async () => { called = true; throw new Error("must not run"); } };
+  bindReviewActions({ innerHTML: "", querySelectorAll: () => [form] } as never, adapter as never, () => { painted += 1; });
+  listener?.({ preventDefault(): void {} } as unknown as Event);
+  assert.equal(called, false);
+  assert.equal(painted, 1);
+  assert.equal((adapter as { lastOperatorResult?: { code?: string } }).lastOperatorResult?.code, "review_adjustment_not_saved");
 });
 
 const LEGACY_ID = "99999999-8888-4777-8666-555555555555";

--- a/control-center/connectors/warmbly/README.md
+++ b/control-center/connectors/warmbly/README.md
@@ -76,6 +76,8 @@ The Control Center's `Comercial → Rascunhos` surface uses a dedicated, server-
 
 Every request requires the trusted founder identity. `APPROVE` carries `expected_content_hash` and only creates a durable queue entry for the next eligible business window. `REJECT` preserves the lead and routes the draft to AI-assisted editorial recovery. This bridge does not expose an immediate-send operation.
 
+An individual decision is not considered complete from HTTP status alone. The Context Service validates Warmbly's decision envelope, reads the exact touchpoint back, and emits a sanitized `control-center.review-decision-receipt.v1`. Empty/incompatible bodies, divergent hashes/states, missing `due_at` for `QUEUED`, and unavailable readback remain `not_confirmed`; clients must not issue a fresh intent while that outcome is ambiguous.
+
 ## Operator action channel (`src/operator/`)
 
 The only write surface in this connector. Read `required_upstream_contract.json → operator_actions` for the upstream table.

--- a/control-center/connectors/warmbly/required_upstream_contract.json
+++ b/control-center/connectors/warmbly/required_upstream_contract.json
@@ -101,7 +101,7 @@
         "path": "/v1/confenge/review/drafts/{draft_id}/decision",
         "permission": "PermManageContacts / APIPermWriteContacts",
         "actions": ["SAVE_ADJUSTMENT", "APPROVE", "REJECT"],
-        "notes": "APPROVE binds expected_content_hash and schedules the exact copy for the next eligible business window; it never sends immediately"
+        "notes": "APPROVE binds expected_content_hash and schedules the exact copy for the next eligible business window; it never sends immediately; Control Center requires the decision response plus canonical GET readback before confirming the effect"
       },
       {
         "method": "POST",

--- a/control-center/services/context/README.md
+++ b/control-center/services/context/README.md
@@ -60,6 +60,8 @@ POST /v1/commercial/review-batches
 
 As quatro rotas comerciais são uma ponte server-side protegida pela identidade operacional autenticada no edge para o human gate do Warmbly. `APPROVE` vincula `expected_content_hash` e agenda a próxima janela útil; não existe envio imediato nessa ponte.
 
+A resposta 2xx do write não é prova de efeito. Para uma decisão individual, a ponte parseia o envelope do Warmbly, executa `GET /v1/confenge/review/drafts/:id` e devolve `control-center.review-decision-receipt.v1`. `APPROVE` só sai como `confirmed` quando write e readback concordam em ID, hash/approved hash, operador, instante e `QUEUED|SENT`, com `due_at == scheduled_for` em `QUEUED`. Corpo vazio, divergência ou readback indisponível vira `not_confirmed` e orienta a não repetir antes de reler com a mesma `Idempotency-Key`.
+
 Headers obrigatórios em tudo exceto `/healthz`: `X-Actor-Id`, `X-Actor-Kind` (`human` | `agent` | `system`).
 
 ## Como rodar

--- a/control-center/services/context/src/operational/warmbly-review.ts
+++ b/control-center/services/context/src/operational/warmbly-review.ts
@@ -4,6 +4,44 @@ import { invalid, ServiceError } from "../errors.ts";
 import type { ActorRef } from "../types.ts";
 
 const ID = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+const REVIEW_DECISIONS = ["SAVE_ADJUSTMENT", "APPROVE", "REJECT"] as const;
+type ReviewDecision = (typeof REVIEW_DECISIONS)[number];
+
+interface ReviewDecisionInput {
+  action: ReviewDecision;
+  expectedContentHash: string;
+}
+
+interface ObservedTouchpoint {
+  id: string;
+  contentHash: string;
+  approvedContentHash?: string;
+  state: string;
+  dueAt?: string;
+  approvedBy?: string;
+  approvedAt?: string;
+  updatedAt?: string;
+}
+
+export interface ReviewDecisionReceipt {
+  schema_version: "control-center.review-decision-receipt.v1";
+  outcome: "confirmed" | "not_confirmed";
+  action: ReviewDecision;
+  touchpoint_id: string;
+  expected_content_hash: string;
+  correlation_id: string;
+  observed_at: string;
+  message: string;
+  readback: { status: "confirmed" | "not_confirmed" | "unavailable"; detail: string };
+  receipt_id?: string;
+  content_hash?: string;
+  approved_content_hash?: string;
+  state?: string;
+  due_at?: string;
+  scheduled_for?: string;
+  approved_by?: string;
+  approved_at?: string;
+}
 
 export interface WarmblyReviewPort {
   list(actor: ActorRef, query: URLSearchParams): Promise<unknown>;
@@ -16,6 +54,172 @@ function boundedInt(value: string | null, fallback: number, max: number): number
   const parsed = Number.parseInt(value ?? "", 10);
   if (!Number.isInteger(parsed) || parsed < 0) return fallback;
   return Math.min(parsed, max);
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function instant(value: unknown): string | undefined {
+  const text = nonEmptyString(value);
+  return text !== undefined && !Number.isNaN(Date.parse(text)) ? text : undefined;
+}
+
+function decisionInput(body: unknown): ReviewDecisionInput {
+  const input = record(body);
+  const action = nonEmptyString(input?.action);
+  const expectedContentHash = nonEmptyString(input?.expected_content_hash);
+  if (!(REVIEW_DECISIONS as readonly string[]).includes(action ?? "")) {
+    throw invalid("action must be SAVE_ADJUSTMENT, APPROVE or REJECT");
+  }
+  if (!expectedContentHash) throw invalid("expected_content_hash is required");
+  if (action !== "SAVE_ADJUSTMENT" && (input?.subject !== undefined || input?.body_text !== undefined)) {
+    throw invalid("save the adjustment before APPROVE or REJECT");
+  }
+  return { action: action as ReviewDecision, expectedContentHash };
+}
+
+function touchpointFrom(payload: unknown, decisionResponse: boolean): ObservedTouchpoint | undefined {
+  const root = record(payload);
+  const data = record(root?.data) ?? root;
+  const row = decisionResponse ? record(data?.touchpoint) : (record(data?.touchpoint) ?? data);
+  const id = nonEmptyString(row?.id);
+  const contentHash = nonEmptyString(row?.content_hash);
+  const state = nonEmptyString(row?.state);
+  if (!id || !contentHash || !state) return undefined;
+  return {
+    id,
+    contentHash,
+    state,
+    ...(nonEmptyString(row?.approved_content_hash) !== undefined
+      ? { approvedContentHash: nonEmptyString(row?.approved_content_hash)! }
+      : {}),
+    ...(instant(row?.due_at) !== undefined ? { dueAt: instant(row?.due_at)! } : {}),
+    ...(nonEmptyString(row?.approved_by) !== undefined ? { approvedBy: nonEmptyString(row?.approved_by)! } : {}),
+    ...(instant(row?.approved_at) !== undefined ? { approvedAt: instant(row?.approved_at)! } : {}),
+    ...(instant(row?.updated_at) !== undefined ? { updatedAt: instant(row?.updated_at)! } : {}),
+  };
+}
+
+function scheduledForFrom(payload: unknown): string | undefined {
+  const root = record(payload);
+  const data = record(root?.data) ?? root;
+  return instant(data?.scheduled_for);
+}
+
+function consistencyFailure(
+  input: ReviewDecisionInput,
+  id: string,
+  write: ObservedTouchpoint | undefined,
+  readback: ObservedTouchpoint | undefined,
+  scheduledFor: string | undefined,
+): string | undefined {
+  if (!write) return "a resposta da escrita não contém um touchpoint válido";
+  if (!readback) return "o readback não contém um touchpoint válido";
+  if (write.id !== id || readback.id !== id) return "o ID observado diverge do rascunho decidido";
+  if (write.id !== readback.id) return "write e readback apontam para touchpoints diferentes";
+  if (write.contentHash !== readback.contentHash) return "o content_hash mudou entre write e readback";
+  if (write.state !== readback.state) return "o estado mudou entre write e readback";
+  if (!write.updatedAt || !readback.updatedAt || write.updatedAt !== readback.updatedAt) {
+    return "write e readback não provam a mesma versão atualizada";
+  }
+
+  if (input.action === "APPROVE") {
+    if (write.contentHash !== input.expectedContentHash || readback.contentHash !== input.expectedContentHash) {
+      return "o content_hash aprovado diverge do hash exato revisado";
+    }
+    if (
+      write.approvedContentHash !== input.expectedContentHash ||
+      readback.approvedContentHash !== input.expectedContentHash
+    ) {
+      return "approved_content_hash não confirma o hash exato revisado";
+    }
+    if (readback.state !== "QUEUED" && readback.state !== "SENT") {
+      return "APPROVE não foi observado em QUEUED ou SENT";
+    }
+    if (!write.approvedBy || !readback.approvedBy || write.approvedBy !== readback.approvedBy) {
+      return "o operador que aprovou não foi confirmado";
+    }
+    if (!write.approvedAt || !readback.approvedAt || write.approvedAt !== readback.approvedAt) {
+      return "o instante da aprovação não foi confirmado";
+    }
+    if (readback.state === "QUEUED") {
+      if (!write.dueAt || !readback.dueAt || write.dueAt !== readback.dueAt) {
+        return "QUEUED sem due_at estável entre write e readback";
+      }
+      if (!scheduledFor || scheduledFor !== readback.dueAt) {
+        return "scheduled_for não confirma o due_at observado";
+      }
+    }
+    return undefined;
+  }
+
+  if (input.action === "REJECT") {
+    if (write.contentHash !== input.expectedContentHash) return "REJECT não preservou o hash revisado";
+    if (readback.state !== "REJECTED_REWRITE_PENDING") {
+      return "REJECT não foi observado em REJECTED_REWRITE_PENDING";
+    }
+    if (write.approvedContentHash || readback.approvedContentHash) {
+      return "REJECT manteve um approved_content_hash inesperado";
+    }
+    return undefined;
+  }
+
+  if (readback.state !== "NEEDS_REVIEW" && readback.state !== "DRAFTED") {
+    return "SAVE_ADJUSTMENT não permaneceu em revisão";
+  }
+  if (write.approvedContentHash || readback.approvedContentHash) {
+    return "SAVE_ADJUSTMENT manteve um approved_content_hash inesperado";
+  }
+  return undefined;
+}
+
+function receipt(
+  input: ReviewDecisionInput,
+  id: string,
+  idempotencyKey: string,
+  outcome: ReviewDecisionReceipt["outcome"],
+  readbackStatus: ReviewDecisionReceipt["readback"]["status"],
+  detail: string,
+  observed: ObservedTouchpoint | undefined,
+  scheduledFor: string | undefined,
+): ReviewDecisionReceipt {
+  const observedAt = new Date().toISOString();
+  const confirmed = outcome === "confirmed";
+  const message = confirmed
+    ? input.action === "APPROVE"
+      ? `Aprovação confirmada no servidor em ${observed?.state}${observed?.dueAt ? ` para ${observed.dueAt}` : ""}.`
+      : input.action === "REJECT"
+        ? "Rejeição confirmada no servidor e encaminhada para reescrita."
+        : "Ajuste confirmado no servidor; a aprovação continua pendente."
+    : `Resultado não confirmado. Não repita ainda: ${detail}.`;
+  return {
+    schema_version: "control-center.review-decision-receipt.v1",
+    outcome,
+    action: input.action,
+    touchpoint_id: id,
+    expected_content_hash: input.expectedContentHash,
+    correlation_id: idempotencyKey,
+    observed_at: observedAt,
+    message,
+    readback: { status: readbackStatus, detail },
+    ...(confirmed && observed?.updatedAt
+      ? { receipt_id: `review:${observed.id}:${observed.updatedAt}` }
+      : {}),
+    ...(observed?.contentHash ? { content_hash: observed.contentHash } : {}),
+    ...(observed?.approvedContentHash ? { approved_content_hash: observed.approvedContentHash } : {}),
+    ...(observed?.state ? { state: observed.state } : {}),
+    ...(observed?.dueAt ? { due_at: observed.dueAt } : {}),
+    ...(scheduledFor ? { scheduled_for: scheduledFor } : {}),
+    ...(observed?.approvedBy ? { approved_by: observed.approvedBy } : {}),
+    ...(observed?.approvedAt ? { approved_at: observed.approvedAt } : {}),
+  };
 }
 
 export function createWarmblyReviewPortFromEnv(
@@ -36,7 +240,10 @@ export function createWarmblyReviewPortFromEnv(
   }
   if (!baseUrl || !token) return undefined;
 
-  async function request(path: string, init: RequestInit = {}): Promise<unknown> {
+  async function requestResult(
+    path: string,
+    init: RequestInit = {},
+  ): Promise<{ body: unknown; validJson: boolean; status: number }> {
     let response: Response;
     try {
       response = await fetchImpl(`${baseUrl}${path}`, {
@@ -54,11 +261,17 @@ export function createWarmblyReviewPortFromEnv(
       throw new ServiceError("warmbly_review_failed", "Warmbly review is unavailable", 502);
     }
     const text = await response.text();
-    let body: unknown = {};
+    let body: unknown;
+    let validJson = false;
     try {
-      body = text ? (JSON.parse(text) as unknown) : {};
+      if (text.trim() !== "") {
+        body = JSON.parse(text) as unknown;
+        validJson = true;
+      }
     } catch {
-      throw invalid(`Warmbly returned invalid JSON (${response.status})`);
+      // A successful write with a broken body is still ambiguous. The decision
+      // path performs readback and returns not_confirmed instead of pretending
+      // the write did not happen.
     }
     if (!response.ok) {
       const rec = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
@@ -66,7 +279,19 @@ export function createWarmblyReviewPortFromEnv(
       const code = status === 409 ? "conflict" : "warmbly_review_failed";
       throw new ServiceError(code, String(rec.message ?? rec.error ?? `Warmbly review failed (${status})`), status);
     }
-    return body;
+    return { body, validJson, status: response.status };
+  }
+
+  async function request(path: string, init: RequestInit = {}): Promise<unknown> {
+    const response = await requestResult(path, init);
+    if (!response.validJson) {
+      throw new ServiceError(
+        "warmbly_review_failed",
+        `Warmbly returned an empty or invalid JSON body (${response.status})`,
+        502,
+      );
+    }
+    return response.body;
   }
 
   function assertId(id: string): void {
@@ -86,11 +311,68 @@ export function createWarmblyReviewPortFromEnv(
     async decide(_actor, id, body, idempotencyKey) {
       assertId(id);
       if (!idempotencyKey) throw invalid("Idempotency-Key is required");
-      return request(`/v1/confenge/review/drafts/${id}/decision`, {
-        method: "POST",
-        headers: { "idempotency-key": idempotencyKey },
-        body: JSON.stringify(body),
-      });
+      const input = decisionInput(body);
+      let writeResponse: { body: unknown; validJson: boolean; status: number };
+      try {
+        writeResponse = await requestResult(`/v1/confenge/review/drafts/${id}/decision`, {
+          method: "POST",
+          headers: { "idempotency-key": idempotencyKey },
+          body: JSON.stringify(body),
+        });
+      } catch (err) {
+        if (err instanceof ServiceError && err.code === "warmbly_review_failed" && err.httpStatus >= 500) {
+          throw new ServiceError(
+            "warmbly_review_failed",
+            "Resultado não confirmado. Não repita ainda: o transporte falhou durante a escrita; releia com a mesma Idempotency-Key",
+            502,
+          );
+        }
+        throw err;
+      }
+
+      const write = writeResponse.validJson ? touchpointFrom(writeResponse.body, true) : undefined;
+      const scheduledFor = writeResponse.validJson ? scheduledForFrom(writeResponse.body) : undefined;
+      let readbackPayload: unknown;
+      try {
+        readbackPayload = await request(`/v1/confenge/review/drafts/${id}`);
+      } catch {
+        return receipt(
+          input,
+          id,
+          idempotencyKey,
+          "not_confirmed",
+          "unavailable",
+          "o readback canônico ficou indisponível depois da escrita",
+          write,
+          scheduledFor,
+        );
+      }
+      const readback = touchpointFrom(readbackPayload, false);
+      const failure = writeResponse.validJson
+        ? consistencyFailure(input, id, write, readback, scheduledFor)
+        : `a escrita respondeu HTTP ${writeResponse.status} sem JSON utilizável`;
+      if (failure) {
+        return receipt(
+          input,
+          id,
+          idempotencyKey,
+          "not_confirmed",
+          "not_confirmed",
+          failure,
+          readback ?? write,
+          scheduledFor,
+        );
+      }
+      return receipt(
+        input,
+        id,
+        idempotencyKey,
+        "confirmed",
+        "confirmed",
+        "write e readback confirmam a mesma versão persistida",
+        readback,
+        scheduledFor,
+      );
     },
     async approveBatch(_actor, body, idempotencyKey) {
       if (!idempotencyKey) throw invalid("Idempotency-Key is required");

--- a/control-center/services/context/test/warmbly-review.test.ts
+++ b/control-center/services/context/test/warmbly-review.test.ts
@@ -10,12 +10,40 @@ import type { WarmblyReviewPort } from "../src/operational/warmbly-review.ts";
 const FOUNDER = { kind: "human" as const, id: "founder-local" };
 const AUTHENTICATED_OPERATOR = { kind: "human" as const, id: "operator" };
 const DRAFT_ID = "11111111-2222-4333-8444-555555555555";
+const HASH = "sha256:exact";
+const DUE_AT = "2026-08-26T12:00:00Z";
+const APPROVED_AT = "2026-08-25T04:00:00Z";
+const UPDATED_AT = "2026-08-25T04:00:01Z";
+
+function queuedTouchpoint(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: DRAFT_ID,
+    content_hash: HASH,
+    approved_content_hash: HASH,
+    state: "QUEUED",
+    due_at: DUE_AT,
+    approved_by: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    approved_at: APPROVED_AT,
+    updated_at: UPDATED_AT,
+    ...overrides,
+  };
+}
+
+function decisionBody(touchpoint = queuedTouchpoint(), scheduledFor: unknown = DUE_AT): unknown {
+  return { data: { touchpoint, scheduled_for: scheduledFor } };
+}
 
 test("Warmbly review proxy preserves exact-hash decision metadata", async () => {
   const calls: Array<{ url: string; init: RequestInit }> = [];
   const fetchImpl = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
-    calls.push({ url: String(input), init });
-    return new Response(JSON.stringify({ ok: true, items: [] }), {
+    const url = String(input);
+    calls.push({ url, init });
+    const body = init.method === "POST"
+      ? decisionBody()
+      : url.endsWith(`/v1/confenge/review/drafts/${DRAFT_ID}`)
+        ? { data: queuedTouchpoint() }
+        : { data: [] };
+    return new Response(JSON.stringify(body), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
@@ -27,17 +55,239 @@ test("Warmbly review proxy preserves exact-hash decision metadata", async () => 
   assert.ok(port);
 
   await port.list(FOUNDER, new URLSearchParams({ limit: "999", offset: "12" }));
-  await port.decide(FOUNDER, DRAFT_ID, {
+  const result = await port.decide(FOUNDER, DRAFT_ID, {
     action: "APPROVE",
-    expected_content_hash: "sha256:exact",
+    expected_content_hash: HASH,
   }, "review-key");
 
   assert.equal(calls[0]?.url, "https://warmbly.example.test/v1/confenge/review/drafts?limit=200&offset=12");
   assert.equal(calls[1]?.url, `https://warmbly.example.test/v1/confenge/review/drafts/${DRAFT_ID}/decision`);
+  assert.equal(calls[2]?.url, `https://warmbly.example.test/v1/confenge/review/drafts/${DRAFT_ID}`);
   const headers = calls[1]?.init.headers as Record<string, string>;
   assert.equal(headers.authorization, "Bearer test-token");
   assert.equal(headers["idempotency-key"], "review-key");
   assert.match(String(calls[1]?.init.body), /expected_content_hash/);
+  assert.deepEqual(result, {
+    schema_version: "control-center.review-decision-receipt.v1",
+    outcome: "confirmed",
+    action: "APPROVE",
+    touchpoint_id: DRAFT_ID,
+    expected_content_hash: HASH,
+    correlation_id: "review-key",
+    observed_at: (result as { observed_at: string }).observed_at,
+    message: `Aprovação confirmada no servidor em QUEUED para ${DUE_AT}.`,
+    readback: {
+      status: "confirmed",
+      detail: "write e readback confirmam a mesma versão persistida",
+    },
+    receipt_id: `review:${DRAFT_ID}:${UPDATED_AT}`,
+    content_hash: HASH,
+    approved_content_hash: HASH,
+    state: "QUEUED",
+    due_at: DUE_AT,
+    scheduled_for: DUE_AT,
+    approved_by: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    approved_at: APPROVED_AT,
+  });
+});
+
+test("2xx vazio continua não confirmado mesmo quando o GET posterior parece agendado", async () => {
+  const fetchImpl = (async (_input: RequestInfo | URL, init: RequestInit = {}) => {
+    if (init.method === "POST") return new Response(null, { status: 204 });
+    return new Response(JSON.stringify({ data: queuedTouchpoint() }), { status: 200 });
+  }) as typeof fetch;
+  const port = createWarmblyReviewPortFromEnv({
+    WARMBLY_BASE_URL: "https://warmbly.example.test",
+    WARMBLY_API_TOKEN: "test-token",
+  }, fetchImpl);
+  assert.ok(port);
+  const result = await port.decide(FOUNDER, DRAFT_ID, {
+    action: "APPROVE",
+    expected_content_hash: HASH,
+  }, "review-key") as Record<string, unknown>;
+  assert.equal(result.outcome, "not_confirmed");
+  assert.match(String(result.message), /não repita ainda/i);
+  assert.match(String((result.readback as Record<string, unknown>).detail), /sem JSON utilizável/);
+  assert.equal(Object.hasOwn(result, "receipt_id"), false);
+});
+
+test("APPROVE falha fechado para resposta incompatível, hash divergente, scheduling ausente e readback stale", async (t) => {
+  const cases: Array<{
+    name: string;
+    write: unknown;
+    readback: unknown;
+    failure: RegExp;
+  }> = [
+    {
+      name: "body incompatível",
+      write: { data: { ok: true } },
+      readback: { data: queuedTouchpoint() },
+      failure: /não contém um touchpoint válido/,
+    },
+    {
+      name: "hash divergente",
+      write: decisionBody(queuedTouchpoint({ content_hash: "sha256:other", approved_content_hash: "sha256:other" })),
+      readback: { data: queuedTouchpoint({ content_hash: "sha256:other", approved_content_hash: "sha256:other" }) },
+      failure: /diverge do hash exato/,
+    },
+    {
+      name: "sem due_at",
+      write: decisionBody(queuedTouchpoint({ due_at: "" }), undefined),
+      readback: { data: queuedTouchpoint({ due_at: "" }) },
+      failure: /sem due_at estável/,
+    },
+    {
+      name: "readback stale",
+      write: decisionBody(),
+      readback: { data: queuedTouchpoint({ state: "NEEDS_REVIEW", approved_content_hash: "", due_at: "" }) },
+      failure: /estado mudou/,
+    },
+  ];
+  for (const scenario of cases) {
+    await t.test(scenario.name, async () => {
+      const fetchImpl = (async (_input: RequestInfo | URL, init: RequestInit = {}) => new Response(
+        JSON.stringify(init.method === "POST" ? scenario.write : scenario.readback),
+        { status: 200 },
+      )) as typeof fetch;
+      const port = createWarmblyReviewPortFromEnv({
+        WARMBLY_BASE_URL: "https://warmbly.example.test",
+        WARMBLY_API_TOKEN: "test-token",
+      }, fetchImpl);
+      assert.ok(port);
+      const result = await port.decide(FOUNDER, DRAFT_ID, {
+        action: "APPROVE",
+        expected_content_hash: HASH,
+      }, "review-key") as Record<string, unknown>;
+      assert.equal(result.outcome, "not_confirmed");
+      assert.match(String((result.readback as Record<string, unknown>).detail), scenario.failure);
+    });
+  }
+});
+
+test("readback indisponível após write retorna receipt ambíguo sem convidar replay", async () => {
+  const fetchImpl = (async (_input: RequestInfo | URL, init: RequestInit = {}) => {
+    if (init.method === "POST") return new Response(JSON.stringify(decisionBody()), { status: 200 });
+    throw new Error("timeout");
+  }) as typeof fetch;
+  const port = createWarmblyReviewPortFromEnv({
+    WARMBLY_BASE_URL: "https://warmbly.example.test",
+    WARMBLY_API_TOKEN: "test-token",
+  }, fetchImpl);
+  assert.ok(port);
+  const result = await port.decide(FOUNDER, DRAFT_ID, {
+    action: "APPROVE",
+    expected_content_hash: HASH,
+  }, "review-key") as Record<string, unknown>;
+  assert.equal(result.outcome, "not_confirmed");
+  assert.deepEqual(result.readback, {
+    status: "unavailable",
+    detail: "o readback canônico ficou indisponível depois da escrita",
+  });
+  assert.match(String(result.message), /não repita ainda/i);
+});
+
+test("replay confirmado preserva correlation e receipt sem segunda semântica", async () => {
+  const keys: string[] = [];
+  const fetchImpl = (async (_input: RequestInfo | URL, init: RequestInit = {}) => {
+    if (init.method === "POST") {
+      keys.push(String((init.headers as Record<string, string>)["idempotency-key"]));
+      return new Response(JSON.stringify(decisionBody()), { status: 200 });
+    }
+    return new Response(JSON.stringify({ data: queuedTouchpoint() }), { status: 200 });
+  }) as typeof fetch;
+  const port = createWarmblyReviewPortFromEnv({
+    WARMBLY_BASE_URL: "https://warmbly.example.test",
+    WARMBLY_API_TOKEN: "test-token",
+  }, fetchImpl);
+  assert.ok(port);
+  const input = { action: "APPROVE", expected_content_hash: HASH };
+  const first = await port.decide(FOUNDER, DRAFT_ID, input, "review-key") as Record<string, unknown>;
+  const replay = await port.decide(FOUNDER, DRAFT_ID, input, "review-key") as Record<string, unknown>;
+  assert.deepEqual(keys, ["review-key", "review-key"]);
+  assert.equal(first.receipt_id, replay.receipt_id);
+  assert.equal(first.outcome, "confirmed");
+  assert.equal(replay.outcome, "confirmed");
+});
+
+test("APPROVE não aceita edição implícita no mesmo write", async () => {
+  let called = false;
+  const fetchImpl = (async () => {
+    called = true;
+    return new Response(JSON.stringify(decisionBody()), { status: 200 });
+  }) as typeof fetch;
+  const port = createWarmblyReviewPortFromEnv({
+    WARMBLY_BASE_URL: "https://warmbly.example.test",
+    WARMBLY_API_TOKEN: "test-token",
+  }, fetchImpl);
+  assert.ok(port);
+  await assert.rejects(
+    port.decide(FOUNDER, DRAFT_ID, {
+      action: "APPROVE",
+      expected_content_hash: HASH,
+      subject: "mudou",
+    }, "review-key"),
+    /save the adjustment before APPROVE/,
+  );
+  assert.equal(called, false);
+});
+
+test("SAVE_ADJUSTMENT e REJECT também exigem write/readback da mesma versão", async (t) => {
+  const cases = [
+    {
+      action: "SAVE_ADJUSTMENT",
+      body: { action: "SAVE_ADJUSTMENT", expected_content_hash: HASH, subject: "novo assunto" },
+      touchpoint: queuedTouchpoint({
+        content_hash: "sha256:adjusted",
+        approved_content_hash: "",
+        state: "NEEDS_REVIEW",
+        due_at: "",
+        approved_by: "",
+        approved_at: "",
+      }),
+    },
+    {
+      action: "REJECT",
+      body: { action: "REJECT", expected_content_hash: HASH, reason: "tom inadequado" },
+      touchpoint: queuedTouchpoint({
+        approved_content_hash: "",
+        state: "REJECTED_REWRITE_PENDING",
+        due_at: "",
+        approved_by: "",
+        approved_at: "",
+      }),
+    },
+  ] as const;
+  for (const scenario of cases) {
+    await t.test(scenario.action, async () => {
+      const fetchImpl = (async (_input: RequestInfo | URL, init: RequestInit = {}) => new Response(
+        JSON.stringify(init.method === "POST"
+          ? { data: { touchpoint: scenario.touchpoint } }
+          : { data: scenario.touchpoint }),
+        { status: 200 },
+      )) as typeof fetch;
+      const port = createWarmblyReviewPortFromEnv({
+        WARMBLY_BASE_URL: "https://warmbly.example.test",
+        WARMBLY_API_TOKEN: "test-token",
+      }, fetchImpl);
+      assert.ok(port);
+      const result = await port.decide(FOUNDER, DRAFT_ID, scenario.body, "review-key") as Record<string, unknown>;
+      assert.equal(result.outcome, "confirmed");
+      assert.equal(result.action, scenario.action);
+      assert.equal((result.readback as Record<string, unknown>).status, "confirmed");
+    });
+  }
+});
+
+test("falha de transporte durante o POST preserva ambiguidade e a mesma chave de recuperação", async () => {
+  const port = createWarmblyReviewPortFromEnv({
+    WARMBLY_BASE_URL: "https://warmbly.example.test",
+    WARMBLY_API_TOKEN: "test-token",
+  }, (async () => { throw new Error("timeout"); }) as typeof fetch);
+  assert.ok(port);
+  await assert.rejects(
+    port.decide(FOUNDER, DRAFT_ID, { action: "APPROVE", expected_content_hash: HASH }, "review-key"),
+    /não repita ainda.*mesma Idempotency-Key/i,
+  );
 });
 
 test("Warmbly review proxy stays absent when its credential is not configured", () => {


### PR DESCRIPTION
## Context

A P0 #127 permitia que uma resposta 2xx vazia, inválida ou divergente fosse apresentada ao operador como aprovação/agendamento confirmado. Esta PR entrega o recorte atômico #130 e mantém a issue pai aberta para os demais incrementos.

## Changes

- exige recibo normalizado e readback canônico da mesma versão persistida;
- valida ID, hash, estado, ator, horário de aprovação e agendamento antes de confirmar APPROVE;
- falha fechado em resposta vazia/inválida, divergência, timeout e readback indisponível;
- preserva a mesma chave de idempotência por ação, rascunho e hash;
- bloqueia duplo clique e aprovação/rejeição com ajuste ainda não salvo;
- mostra ao operador touchpoint, estado observado, due_at, hashes e ressalva de pausa/kill switch;
- adiciona testes adversariais no Context e no web-shell.

## Testing Plan

- [x] npm run typecheck && npm test
- [x] npm run build --workspaces --if-present
- [x] npm run test:integration (67 testes)
- [x] python3 -m pytest (120 testes)
- [x] validadores Python do repositório
- [x] npm audit --omit=dev --audit-level=critical (0 vulnerabilidades)
- [x] Playwright no navegador (CI)

## Risks & Rollback

O contrato mais estrito passa a classificar respostas legadas ou incompletas como não confirmadas. Esse comportamento é deliberadamente fail-closed. Rollback: reverter o commit c4ce970 e restaurar Context/web-shell em conjunto.

Closes #130
Parent: #127