### PR TITLE
fix(web-shell): trocar formulários por inspector único

### DIFF
--- a/control-center/apps/web-shell/README.md
+++ b/control-center/apps/web-shell/README.md
@@ -114,6 +114,25 @@ diz isso e desabilita o editor em vez de oferecer um controle que não escreve.
 
 Hoje is an attention cockpit: open exceptions plus **at most three** current priorities. There is no chat composer. `Comercial → Rascunhos` is the founder's exact-copy review surface: adjust, approve for the next eligible business window, or reject back into editorial recovery. Financial mutations and immediate commercial send are not offered.
 
+### Comercial → Rascunhos: lista + inspector
+
+`#/comercial/rascunhos?resource=<draft-id>` mantém o backlog como linhas compactas
+e renderiza assunto, corpo, contexto e controles somente no inspector selecionado.
+Mesmo com 500 linhas existe no máximo um `data-review-form` no DOM. Sem
+`resource`, a primeira mensagem acionável é selecionada; um deep link ausente
+falha para a próxima disponível com aviso explícito.
+
+No caminho feliz há um único CTA: **Aprovar e agendar para <e-mail>**. A classe de
+rota não abre checkbox ou modal. Editar e Rejeitar/segurar são links secundários
+que abrem modos explícitos do mesmo inspector; não existe dropdown genérico
+“Registrar decisão”. Depois de receipt/readback confirmado, a URL seleciona a
+próxima mensagem e o foco acompanha o inspector. No mobile o inspector vem antes
+da lista completa, e no desktop os dois formam colunas sem um segundo scroll.
+
+Este recorte não afirma total do servidor: mostra somente quantas mensagens estão
+carregadas. Total/cursor, carregamento incremental, filtros e batch pertencem aos
+incrementos seguintes da fila escalável.
+
 ## Cards de alerta
 
 Alertas (top 3 e incidentes) usam um card com duas metades, montado em

--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -70,6 +70,7 @@ const destinations = [
 ];
 
 const extraHashes = [
+  "comercial/rascunhos",
   "comercial/cohorts",
   "comercial/atividade",
   "comercial/pipeline",
@@ -132,6 +133,36 @@ const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
 const errors = [];
 page.on("pageerror", (err) => errors.push(String(err)));
 page.on("crash", () => errors.push("page crashed"));
+
+// The isolated Context harness has no Warmbly token, so its review proxy is
+// deliberately unavailable. Intercept only the read endpoint with a realistic
+// backlog to exercise the production-built list + inspector at volume without
+// enabling any write or outbound side effect.
+const reviewRows = Array.from({ length: 55 }, (_, index) => ({
+  id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+  account_id: `account-e2e-${index}`,
+  recipient: `contato-${index}@empresa-exemplo.test`,
+  subject: `Revisão do primeiro toque ${index}`,
+  body_text: `Olá,\n\nObservamos o edital público ${index} e gostaríamos de conversar com a pessoa responsável.\n\nPode nos encaminhar?`,
+  state: "NEEDS_REVIEW",
+  purpose: "INITIAL",
+  ordinal: 1,
+  content_hash: `sha256:e2e-${index}`,
+  account: { nome_fantasia: `Empresa de infraestrutura ${index}` },
+  fact_used: `Edital público ${index} observado no recorte atual`,
+  evidence_ids: [`evidence-e2e-${index}`],
+  fact_source: "e2e_fixture",
+  route_class: "GENERIC_COMPANY",
+  editorial_state: "CURRENT",
+  editorial_actionable: true,
+}));
+await page.route(/\/v1\/commercial\/review-drafts(?:\?|$)/, async (route) => {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ data: reviewRows }),
+  });
+});
 
 /**
  * Geometry of the content column plus every element that currently owns a
@@ -258,6 +289,15 @@ async function assertBrand(page) {
   if (!(await logo.isVisible())) {
     throw new Error("CONFENGE mark is not visible in the topbar");
   }
+  // Hash and viewport matrix navigation repaint the shell asynchronously. Wait
+  // for the same image to be decoded and laid out, rather than sampling the
+  // brief 0px box between the old and new paint. A genuinely missing/collapsed
+  // mark still times out and fails this gate.
+  await page.waitForFunction(() => {
+    const image = document.querySelector("header.topbar img.brand-logo");
+    if (!(image instanceof HTMLImageElement)) return false;
+    return image.complete && image.naturalWidth > 0 && image.getBoundingClientRect().height >= 14;
+  }, undefined, { timeout: 5_000 });
   const alt = await logo.getAttribute("alt");
   if (alt !== "CONFENGE") {
     throw new Error(`brand logo alt is ${JSON.stringify(alt)}, expected "CONFENGE"`);
@@ -395,6 +435,40 @@ try {
     console.log(`hash=${hash} filled_chars=${destFilled.filled}`);
   }
 
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(`${baseUrl}#/comercial/rascunhos`, { waitUntil: "networkidle" });
+  await page.waitForSelector('[data-review-workbench-count="55"]');
+  const reviewListCount = await page.locator("[data-review-list-item]").count();
+  const reviewInspectorCount = await page.locator("[data-review-inspector]").count();
+  const reviewFormCount = await page.locator("[data-review-form]").count();
+  if (reviewListCount !== 55 || reviewInspectorCount !== 1 || reviewFormCount !== 1) {
+    throw new Error(
+      `review workbench multiplied controls: rows=${reviewListCount} inspectors=${reviewInspectorCount} forms=${reviewFormCount}`,
+    );
+  }
+  const approveLabel = await page.locator("[data-approve-submit]").innerText();
+  if (!approveLabel.includes("Aprovar e agendar para contato-0@empresa-exemplo.test")) {
+    throw new Error(`review primary action is not explicit: ${approveLabel}`);
+  }
+  const reviewOverflow = await page.evaluate(
+    () => Math.max(0, document.documentElement.scrollWidth - document.documentElement.clientWidth),
+  );
+  if (reviewOverflow > 1) {
+    throw new Error(`review workbench overflows 390px viewport by ${reviewOverflow}px`);
+  }
+  const reviewTitleBox = await page.locator("#rascunhos-title").boundingBox();
+  const approveBox = await page.locator("[data-approve-submit]").boundingBox();
+  if (!reviewTitleBox || !approveBox || approveBox.y - reviewTitleBox.y > 844) {
+    throw new Error(
+      `review primary action is more than one 390x844 viewport from the task heading: title=${JSON.stringify(reviewTitleBox)} approve=${JSON.stringify(approveBox)}`,
+    );
+  }
+  const reviewShot = screenshotPath.replace(/(\.[a-z]+)$/i, "-review-workbench$1");
+  await page.screenshot({ path: reviewShot, fullPage: true });
+  console.log(
+    `critical_path=review_list_to_inspector rows=${reviewListCount} forms=${reviewFormCount} viewport=390 overflow=${reviewOverflow} action_distance=${Math.round(approveBox.y - reviewTitleBox.y)} screenshot=${reviewShot}`,
+  );
+
   // Critical operator journey (#65/#67): daily triage → detail → exception →
   // authorized sandbox action → receipt. Navigation into the detail is done
   // with Enter so a mouse-only implementation cannot satisfy this proof.
@@ -478,7 +552,7 @@ try {
   for (const vp of viewports) {
     await page.setViewportSize({ width: vp.width, height: vp.height });
     await page.goto(`${baseUrl}#/hoje`, { waitUntil: "networkidle" });
-    await page.waitForSelector('[data-destination="hoje"]');
+    await page.waitForSelector('[data-destination="hoje"][data-view-state="ready"]');
     const vpFilled = await assertFilled(page, 40);
     if (vpFilled.box.width < Math.min(300, vp.width - 24)) {
       throw new Error(`viewport ${vp.name} width ${vpFilled.box.width} too small for ${vp.width}`);

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -123,6 +123,7 @@ export interface MountableRoot {
       checked?: boolean;
       disabled?: boolean;
       textContent?: string | null;
+      setAttribute?(name: string, value: string): void;
     }>;
     focus?(options?: { preventScroll?: boolean }): void;
     scrollIntoView?(options?: { block?: "center"; inline?: "nearest" }): void;
@@ -187,12 +188,13 @@ function applyPaint(
     ),
   );
   bindWarmblyHumanGate(root, adapter, repaint, navigate);
-  bindReviewActions(root, adapter, repaint);
+  bindReviewActions(root, adapter, repaint, navigate, renderHash);
   bindWarmblyGateFilters(root, renderHash, navigate);
   bindMessageToggle(root, renderHash, navigate);
   bindCopyControls(root);
   bindListFilters(root, renderHash, navigate);
   bindReviewQueueShortcut();
+  consumeReviewFocus(root, hash, replaceLocation);
   consumeQueueFocus(
     root,
     hash,
@@ -260,6 +262,26 @@ function bindCopyControls(root: MountableRoot): void {
 export type Navigate = (hash: string) => void;
 export type ReplaceLocation = (hash: string) => void;
 
+const REVIEW_FOCUS_PARAM = "focus";
+const REVIEW_FOCUS_VALUE = "review";
+
+export function consumeReviewFocus(
+  root: MountableRoot,
+  hash: string,
+  replaceLocation: ReplaceLocation,
+): void {
+  const stripped = hash.startsWith("#") ? hash.slice(1) : hash;
+  const [path = "/comercial/rascunhos", query = ""] = stripped.split("?");
+  const params = new URLSearchParams(query);
+  if (params.get(REVIEW_FOCUS_PARAM) !== REVIEW_FOCUS_VALUE) return;
+  params.delete(REVIEW_FOCUS_PARAM);
+  const nextQuery = params.toString();
+  replaceLocation(`#${path}${nextQuery ? `?${nextQuery}` : ""}`);
+  const inspector = root.querySelectorAll?.("[data-review-inspector]")[0];
+  inspector?.focus?.({ preventScroll: true });
+  inspector?.scrollIntoView?.({ block: "center", inline: "nearest" });
+}
+
 function defaultNavigate(hash: string): void {
   if (typeof window !== "undefined") {
     window.location.hash = hash;
@@ -288,6 +310,10 @@ export function consumeQueueFocus(
     consumedQueueFocus.delete(root);
     return false;
   }
+  // Comercial → Rascunhos shares the generic query-param name but owns this
+  // exact marker. Its inspector consumer already focused the next message; the
+  // list-row consumer must not steal that focus as an "invalid" activity token.
+  if (token === REVIEW_FOCUS_VALUE) return false;
   if (consumedQueueFocus.get(root) === hash) return false;
   consumedQueueFocus.set(root, hash);
   replaceLocation(stripQueueFocus(hash));
@@ -400,6 +426,8 @@ export function bindReviewActions(
   root: MountableRoot,
   adapter: ControlCenterReadAdapter,
   onDone: () => void,
+  navigate?: Navigate,
+  currentHash?: string,
 ): void {
   if (!adapter.reviewDraftAction || typeof root.querySelectorAll !== "function") return;
   const forms = root.querySelectorAll("[data-review-form]");
@@ -413,6 +441,7 @@ export function bindReviewActions(
       const id = form.getAttribute("data-review-form") ?? "";
       const action = form.querySelector('[name="action"]')?.value as "SAVE_ADJUSTMENT" | "APPROVE" | "REJECT" | undefined;
       const expected = form.querySelector('[name="expected_content_hash"]')?.value ?? "";
+      const nextReviewId = form.querySelector('[name="next_review_id"]')?.value ?? "";
       if (!id || !action || !expected) return;
       const subject = form.querySelector('[name="subject"]')?.value ?? "";
       const bodyText = form.querySelector('[name="body_text"]')?.value ?? "";
@@ -437,6 +466,10 @@ export function bindReviewActions(
         const control = controls[controlIndex];
         if (control) control.disabled = true;
       }
+      const actionLinks = form.querySelectorAll?.("a") ?? [];
+      for (let linkIndex = 0; linkIndex < actionLinks.length; linkIndex += 1) {
+        actionLinks[linkIndex]?.setAttribute?.("aria-disabled", "true");
+      }
       const submit = form.querySelector('button[type="submit"]');
       if (submit) submit.textContent = "Confirmando no servidor…";
       const request = {
@@ -447,9 +480,18 @@ export function bindReviewActions(
         reason: form.querySelector('[name="reason"]')?.value ?? "",
         generic_recipient_acknowledged: form.querySelector('[name="generic_ack"]')?.value === "true",
       };
+      let completionHash: string | null = null;
       void Promise.resolve(adapter.reviewDraftAction?.(request))
         .then((result) => {
-          if (result) adapter.lastOperatorResult = result;
+          if (result) {
+            adapter.lastOperatorResult = result;
+            if (result.ok) {
+              const destinationId = action === "SAVE_ADJUSTMENT" ? id : nextReviewId;
+              completionHash = destinationId
+                ? `#/comercial/rascunhos?resource=${encodeURIComponent(destinationId)}&${REVIEW_FOCUS_PARAM}=${REVIEW_FOCUS_VALUE}`
+                : `#/comercial/rascunhos?${REVIEW_FOCUS_PARAM}=${REVIEW_FOCUS_VALUE}`;
+            }
+          }
         })
         .catch((err: unknown) => {
           adapter.lastOperatorResult = {
@@ -461,7 +503,10 @@ export function bindReviewActions(
             code: "browser_transport",
           };
         })
-        .finally(onDone);
+        .finally(() => {
+          if (completionHash !== null && navigate && completionHash !== currentHash) navigate(completionHash);
+          else onDone();
+        });
     });
   }
 }

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -478,7 +478,10 @@ export function bindReviewActions(
         expected_content_hash: expected,
         ...(action === "SAVE_ADJUSTMENT" ? { subject, body_text: bodyText } : {}),
         reason: form.querySelector('[name="reason"]')?.value ?? "",
-        generic_recipient_acknowledged: form.querySelector('[name="generic_ack"]')?.value === "true",
+        // The primary CTA names the exact recipient. Per the review contract,
+        // clicking it is the acknowledgement; requiring another checkbox or
+        // select would reintroduce the friction this inspector removes.
+        ...(action === "APPROVE" ? { generic_recipient_acknowledged: true } : {}),
       };
       let completionHash: string | null = null;
       void Promise.resolve(adapter.reviewDraftAction?.(request))

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -238,6 +238,98 @@ a {
   border-radius: 0.4rem;
 }
 
+/* Comercial → Rascunhos keeps the backlog light: every row is a compact link,
+   while the exact message and the only decision form live in one inspector. */
+.review-workbench {
+  display: grid;
+  gap: 0.85rem;
+  min-width: 0;
+}
+
+.review-queue-panel,
+.review-inspector {
+  min-width: 0;
+}
+
+.review-queue {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.review-queue-item a {
+  display: grid;
+  gap: 0.15rem;
+  min-height: 44px;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 0.45rem;
+  color: var(--fg);
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.review-queue-item a span {
+  color: var(--fg-muted);
+  font-size: 0.88rem;
+}
+
+.review-queue-item a[aria-current="page"] {
+  border-color: var(--focus);
+  background: var(--bg-card);
+}
+
+.review-message {
+  min-width: 0;
+  padding: 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 0.45rem;
+  background: var(--bg-elev);
+}
+
+.review-message h4 {
+  margin-top: 0;
+}
+
+.review-message [data-exact-body] {
+  margin-bottom: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.review-actions > * {
+  min-height: 44px;
+}
+
+.review-decision-form[aria-busy="true"] .review-actions a[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+@media (max-width: 899px) {
+  /* On a phone the selected task comes first. The compact backlog follows it,
+     so 55 rows can never push the primary decision thousands of pixels away. */
+  .review-inspector {
+    order: -1;
+  }
+}
+
+@media (min-width: 900px) {
+  .review-workbench {
+    grid-template-columns: minmax(15rem, 0.7fr) minmax(0, 1.3fr);
+    align-items: start;
+  }
+}
+
 .cards {
   display: grid;
   gap: 0.75rem;

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -1069,7 +1069,73 @@ function reviewRows(text: string, min: number, max: number): number {
   return Math.min(max, Math.max(min, lines + 1));
 }
 
-function reviewDraftCard(item: unknown): string {
+type ReviewInspectorMode = "inspect" | "edit" | "reject";
+
+function reviewInspectorMode(query: string | null): ReviewInspectorMode {
+  const mode = new URLSearchParams(query ?? "").get("mode");
+  return mode === "edit" || mode === "reject" ? mode : "inspect";
+}
+
+function reviewDraftRow(item: unknown): Record<string, unknown> {
+  return item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+}
+
+function reviewDraftId(item: unknown): string {
+  return String(reviewDraftRow(item).id ?? "");
+}
+
+function reviewDraftActionable(item: unknown): boolean {
+  const row = reviewDraftRow(item);
+  return readEditorialState({ ...row, actionable: row.editorial_actionable }).actionable;
+}
+
+function reviewDraftHref(id: string, mode: ReviewInspectorMode = "inspect"): string {
+  const params = new URLSearchParams({ resource: id });
+  if (mode !== "inspect") params.set("mode", mode);
+  return `#/comercial/rascunhos?${params.toString()}`;
+}
+
+function selectedReviewIndex(items: readonly unknown[], resource: string | null): number {
+  const requested = resource === null ? -1 : items.findIndex((item) => reviewDraftId(item) === resource);
+  if (requested >= 0) return requested;
+  const actionable = items.findIndex((item) => reviewDraftActionable(item));
+  return actionable >= 0 ? actionable : 0;
+}
+
+function nextActionableReviewId(items: readonly unknown[], selected: number): string | null {
+  for (let offset = 1; offset < items.length; offset += 1) {
+    const item = items[(selected + offset) % items.length];
+    if (item !== undefined && reviewDraftActionable(item)) return reviewDraftId(item);
+  }
+  return null;
+}
+
+function reviewDraftListItem(item: unknown, selected: boolean): string {
+  const row = reviewDraftRow(item);
+  const account = reviewDraftRow(row.account);
+  const id = reviewDraftId(item);
+  const routeClass = reviewText(row.route_class);
+  const factUsed = reviewText(row.fact_used);
+  const editorial = readEditorialState({ ...row, actionable: row.editorial_actionable });
+  const company = String(account.nome_fantasia ?? account.razao_social ?? row.account_id ?? "Lead");
+  const recipient = String(row.recipient ?? "destinatário ausente");
+  const route = reviewRouteClass(routeClass) ?? REVIEW_UNREPORTED;
+  return `<li class="review-queue-item" data-review-list-item="${escapeHtml(id)}" data-editorial-actionable="${editorial.actionable ? "true" : "false"}">
+            <a data-review-row="${escapeHtml(id)}" href="${escapeHtml(reviewDraftHref(id))}" aria-current="${selected ? "page" : "false"}">
+              <strong>${escapeHtml(company)}</strong>
+              <span>${escapeHtml(recipient)}</span>
+              <span>${escapeHtml(route)}</span>
+              <span>${escapeHtml(factUsed ?? "fato observado ausente")}</span>
+              ${editorial.actionable ? "" : `<span>${escapeHtml(ownMapValue(EDITORIAL_STATE_LABELS, editorial.state) ?? editorial.state)}</span>`}
+            </a>
+          </li>`;
+}
+
+function reviewDraftInspector(
+  item: unknown,
+  nextReviewId: string | null,
+  mode: ReviewInspectorMode,
+): string {
   const row = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
   const account = row.account && typeof row.account === "object" ? (row.account as Record<string, unknown>) : {};
   const id = String(row.id ?? "");
@@ -1135,27 +1201,51 @@ function reviewDraftCard(item: unknown): string {
     ],
     "review-draft",
   );
-  const decision = actionable
-    ? `<form data-review-form="${escapeHtml(id)}" class="operator-form">
-                <input type="hidden" name="expected_content_hash" value="${escapeHtml(contentHash)}" />
+  const commonHidden = `<input type="hidden" name="expected_content_hash" value="${escapeHtml(contentHash)}" />
+                <input type="hidden" name="next_review_id" value="${escapeHtml(nextReviewId ?? "")}" />
                 <textarea name="original_subject" hidden>${escapeHtml(subject)}</textarea>
-                <textarea name="original_body_text" hidden>${escapeHtml(bodyText)}</textarea>
+                <textarea name="original_body_text" hidden>${escapeHtml(bodyText)}</textarea>`;
+  const readOnlyMessage = `<section class="review-message" aria-labelledby="review-subject-${escapeHtml(id)}">
+                <h4 id="review-subject-${escapeHtml(id)}">${escapeHtml(subject || "Assunto ausente")}</h4>
+                <p data-exact-body="true">${escapeHtml(bodyText || "Corpo ausente")}</p>
+              </section>`;
+  const decision = !actionable
+    ? `<div class="review-readonly" data-review-readonly="${escapeHtml(id)}">${readOnlyMessage}</div>`
+    : mode === "edit"
+      ? `<form data-review-form="${escapeHtml(id)}" data-review-mode="edit" class="operator-form review-decision-form">
+                ${commonHidden}
+                <input type="hidden" name="action" value="SAVE_ADJUSTMENT" />
                 <label>Assunto <textarea name="subject" rows="${subjectRows}">${escapeHtml(subject)}</textarea></label>
                 <label>Corpo <textarea name="body_text" rows="${bodyRows}">${escapeHtml(bodyText)}</textarea></label>
-                <label>Decisão <select name="action">
-                  <option value="SAVE_ADJUSTMENT">Salvar ajuste</option>
-                  <option value="APPROVE">Aprovar e agendar</option>
-                  <option value="REJECT">Rejeitar e reescrever</option>
-                </select></label>
-                <label>Motivo da rejeição <textarea name="reason"></textarea></label>
-                <label>Caixa genérica/departamental <select name="generic_ack"><option value="false">não confirmar</option><option value="true">confirmo conscientemente</option></select></label>
-                <button type="submit">Registrar decisão</button>
+                <div class="review-actions">
+                  <button type="submit" data-review-save="true">Salvar ajuste</button>
+                  <a class="button" href="${escapeHtml(reviewDraftHref(id))}">Cancelar edição</a>
+                </div>
               </form>`
-    : `<div class="operator-form review-readonly" data-review-readonly="${escapeHtml(id)}">
-                <label>Assunto <textarea name="subject" rows="${subjectRows}" readonly>${escapeHtml(subject)}</textarea></label>
-                <label>Corpo <textarea name="body_text" rows="${bodyRows}" readonly>${escapeHtml(bodyText)}</textarea></label>
-              </div>`;
-  return `<article class="card review-draft" data-draft-id="${escapeHtml(id)}" data-state="${escapeHtml(String(row.state ?? ""))}" data-editorial-state="${escapeHtml(editorial.state)}" data-editorial-actionable="${actionable ? "true" : "false"}" data-composer-version="${escapeHtml(composerVersion ?? "")}">
+      : mode === "reject"
+        ? `${readOnlyMessage}<form data-review-form="${escapeHtml(id)}" data-review-mode="reject" class="operator-form review-decision-form">
+                ${commonHidden}
+                <input type="hidden" name="action" value="REJECT" />
+                <textarea name="subject" hidden>${escapeHtml(subject)}</textarea>
+                <textarea name="body_text" hidden>${escapeHtml(bodyText)}</textarea>
+                <label>Motivo para reescrita <textarea name="reason" rows="4" required></textarea></label>
+                <div class="review-actions">
+                  <button type="submit" data-review-reject="true">Rejeitar e solicitar reescrita</button>
+                  <a class="button" href="${escapeHtml(reviewDraftHref(id))}">Cancelar rejeição</a>
+                </div>
+              </form>`
+        : `${readOnlyMessage}<form data-review-form="${escapeHtml(id)}" data-review-mode="approve" class="operator-form review-decision-form approve-form">
+                ${commonHidden}
+                <input type="hidden" name="action" value="APPROVE" />
+                <textarea name="subject" hidden>${escapeHtml(subject)}</textarea>
+                <textarea name="body_text" hidden>${escapeHtml(bodyText)}</textarea>
+                <div class="review-actions">
+                  <button type="submit" data-approve-submit="true">Aprovar e agendar para ${escapeHtml(String(row.recipient ?? "destinatário ausente"))}</button>
+                  <a class="button" data-review-edit="true" href="${escapeHtml(reviewDraftHref(id, "edit"))}">Editar</a>
+                  <a class="button" data-review-reject="true" href="${escapeHtml(reviewDraftHref(id, "reject"))}">Rejeitar/segurar</a>
+                </div>
+              </form>`;
+  return `<article class="card review-draft review-inspector" tabindex="-1" data-review-inspector="${escapeHtml(id)}" data-draft-id="${escapeHtml(id)}" data-state="${escapeHtml(String(row.state ?? ""))}" data-editorial-state="${escapeHtml(editorial.state)}" data-editorial-actionable="${actionable ? "true" : "false"}" data-composer-version="${escapeHtml(composerVersion ?? "")}">
               <p class="kicker">${escapeHtml(String(row.state ?? ""))} · ${escapeHtml(String(row.purpose ?? ""))} · toque ${escapeHtml(String(row.ordinal ?? ""))}</p>
               <h3>${escapeHtml(String(account.nome_fantasia ?? account.razao_social ?? row.account_id ?? "Lead"))}</h3>
               <p>Destinatário: ${escapeHtml(String(row.recipient ?? "ausente"))}</p>
@@ -1192,11 +1282,24 @@ function commercialOps(
   const availability = snapshot.availability ?? "UNKNOWN";
   let body = "";
   if (current === "rascunhos") {
-    body = `<section aria-labelledby="rascunhos-title"><h2 id="rascunhos-title">Revisão editorial</h2>
+    const selectedIndex = reviewDrafts.length === 0 ? -1 : selectedReviewIndex(reviewDrafts, resource);
+    const selectedDraft = selectedIndex >= 0 ? reviewDrafts[selectedIndex] : undefined;
+    const selectedId = selectedDraft === undefined ? null : reviewDraftId(selectedDraft);
+    const selectionFellBack = resource !== null && resource !== selectedId;
+    const nextReviewId = selectedIndex < 0 ? null : nextActionableReviewId(reviewDrafts, selectedIndex);
+    const mode = reviewInspectorMode(query);
+    body = `<section aria-labelledby="rascunhos-title" data-review-workbench-count="${reviewDrafts.length}"><h2 id="rascunhos-title">Revisão editorial</h2>
       <p class="constraint">Aprovar vincula o hash exato e agenda a próxima janela útil. Nenhum botão envia imediatamente.</p>
-      <div class="stack">${reviewDrafts.length === 0
+      <p><strong>${reviewDrafts.length}</strong> mensagem(ns) carregada(s) neste recorte. A lista não afirma o total do servidor.</p>
+      ${selectionFellBack ? `<p class="banner stale" role="status" data-review-selection-fallback="true">A mensagem solicitada não está neste recorte; mostrando a próxima mensagem disponível.</p>` : ""}
+      ${reviewDrafts.length === 0
         ? `<p class="banner empty">Nenhum rascunho aguardando revisão.</p>`
-        : reviewDrafts.map((item) => reviewDraftCard(item)).join("")}</div>
+        : `<div class="review-workbench">
+            <nav class="review-queue-panel" aria-label="Mensagens aguardando revisão">
+              <ol class="review-queue">${reviewDrafts.map((item, index) => reviewDraftListItem(item, index === selectedIndex)).join("")}</ol>
+            </nav>
+            ${selectedDraft === undefined ? "" : reviewDraftInspector(selectedDraft, nextReviewId, mode)}
+          </div>`}
     </section>`;
   } else if (current === "cohorts") {
     const acquisition = Array.isArray(cohorts.acquisition) ? cohorts.acquisition : [];

--- a/control-center/apps/web-shell/tests/review-drafts.test.ts
+++ b/control-center/apps/web-shell/tests/review-drafts.test.ts
@@ -254,8 +254,12 @@ test("a confirmed decision navigates to the next actionable draft", async () => 
   };
   let painted = 0;
   let destination = "";
+  let submitted: { generic_recipient_acknowledged?: boolean } | undefined;
   const adapter = {
-    reviewDraftAction: async () => ({ ok: true, path: "/review", kind: "nota" as const, message: "confirmado" }),
+    reviewDraftAction: async (input: { generic_recipient_acknowledged?: boolean }) => {
+      submitted = input;
+      return { ok: true, path: "/review", kind: "nota" as const, message: "confirmado" };
+    },
   };
   bindReviewActions(
     { innerHTML: "", querySelectorAll: () => [form] } as never,
@@ -266,6 +270,7 @@ test("a confirmed decision navigates to the next actionable draft", async () => 
   listener?.({ preventDefault(): void {} } as unknown as Event);
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(destination, `#/comercial/rascunhos?resource=${nextId}&focus=review`);
+  assert.equal(submitted?.generic_recipient_acknowledged, true);
   assert.equal(painted, 0);
 });
 

--- a/control-center/apps/web-shell/tests/review-drafts.test.ts
+++ b/control-center/apps/web-shell/tests/review-drafts.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { bindReviewActions } from "../src/app";
+import { bindReviewActions, consumeQueueFocus, consumeReviewFocus } from "../src/app";
 import { createHttpAdapter } from "../src/adapters";
 import { commercialBlock } from "../src/ui/domains";
 import { operatorBanner } from "../src/ui/render";
@@ -35,7 +35,7 @@ function confirmedDecision(overrides: Record<string, unknown> = {}): Record<stri
   };
 }
 
-test("commercial review surface renders editable exact-hash decisions without an immediate-send control", async () => {
+test("commercial review surface renders one exact-hash approval inspector without an immediate-send control", async () => {
   const router = operationalRouter();
   const { fetchImpl } = recordingFetch((path) => {
     if (path.startsWith("/v1/commercial/review-drafts")) {
@@ -60,9 +60,10 @@ test("commercial review surface renders editable exact-hash decisions without an
   if (!result.ok || result.loading) return;
   const html = commercialBlock(result.page.commercial!, "rascunhos");
   assert.match(html, new RegExp(`data-review-form="${DRAFT_ID}"`));
-  assert.match(html, /SAVE_ADJUSTMENT/);
-  assert.match(html, /APPROVE/);
-  assert.match(html, /REJECT/);
+  assert.match(html, /name="action" value="APPROVE"/);
+  assert.match(html, /Aprovar e agendar para contato@example\.test/);
+  assert.match(html, /data-review-edit="true"/);
+  assert.match(html, /data-review-reject="true"/);
   assert.match(html, /sha256:exact/);
   assert.doesNotMatch(html, /enviar agora|dispatch-now/i);
 });
@@ -225,6 +226,79 @@ test("review submit disables every control immediately and ignores a second clic
   assert.equal(painted, 1);
 });
 
+test("a confirmed decision navigates to the next actionable draft", async () => {
+  const nextId = "22222222-3333-4444-8555-666666666666";
+  const controls = Array.from({ length: 5 }, () => ({ value: "", disabled: false, textContent: "" }));
+  const fields: Record<string, { value: string; disabled?: boolean; textContent?: string }> = {
+    action: { value: "APPROVE" },
+    expected_content_hash: { value: HASH },
+    next_review_id: { value: nextId },
+    subject: { value: "Assunto" },
+    body_text: { value: "Corpo" },
+    original_subject: { value: "Assunto" },
+    original_body_text: { value: "Corpo" },
+    reason: { value: "" },
+    submit: controls[0]!,
+  };
+  let listener: ((event: Event) => void) | undefined;
+  const form = {
+    addEventListener(_type: string, next: (event: Event) => void): void { listener = next; },
+    getAttribute(name: string): string | null { return name === "data-review-form" ? DRAFT_ID : null; },
+    setAttribute(): void {},
+    querySelector(selector: string) {
+      if (selector === 'button[type="submit"]') return fields.submit!;
+      const name = selector.match(/name="([^"]+)"/)?.[1] ?? "";
+      return fields[name] ?? null;
+    },
+    querySelectorAll(): typeof controls { return controls; },
+  };
+  let painted = 0;
+  let destination = "";
+  const adapter = {
+    reviewDraftAction: async () => ({ ok: true, path: "/review", kind: "nota" as const, message: "confirmado" }),
+  };
+  bindReviewActions(
+    { innerHTML: "", querySelectorAll: () => [form] } as never,
+    adapter as never,
+    () => { painted += 1; },
+    (hash) => { destination = hash; },
+  );
+  listener?.({ preventDefault(): void {} } as unknown as Event);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(destination, `#/comercial/rascunhos?resource=${nextId}&focus=review`);
+  assert.equal(painted, 0);
+});
+
+test("the post-decision focus marker focuses the inspector once and is removed", () => {
+  let focused = 0;
+  let scrolled = 0;
+  let replaced = "";
+  const inspector = {
+    addEventListener(): void {},
+    getAttribute(): string | null { return null; },
+    focus(): void { focused += 1; },
+    scrollIntoView(): void { scrolled += 1; },
+  };
+  consumeReviewFocus(
+    { innerHTML: "", querySelectorAll: () => [inspector] } as never,
+    `#/comercial/rascunhos?resource=${DRAFT_ID}&focus=review`,
+    (hash) => { replaced = hash; },
+  );
+  assert.equal(focused, 1);
+  assert.equal(scrolled, 1);
+  assert.equal(replaced, `#/comercial/rascunhos?resource=${DRAFT_ID}`);
+  assert.equal(
+    consumeQueueFocus(
+      { innerHTML: "", querySelectorAll: () => [inspector] } as never,
+      `#/comercial/rascunhos?resource=${DRAFT_ID}&focus=review`,
+      true,
+      () => { throw new Error("activity focus must not consume review focus"); },
+    ),
+    false,
+  );
+  assert.equal(focused, 1);
+});
+
 test("unsaved edits must be persisted and reread before APPROVE", () => {
   let called = false;
   let painted = 0;
@@ -257,7 +331,7 @@ test("unsaved edits must be persisted and reread before APPROVE", () => {
 
 const LEGACY_ID = "99999999-8888-4777-8666-555555555555";
 
-function reviewSurface(rows: unknown[]): Promise<string> {
+function reviewSurface(rows: unknown[], resource: string | null = null, query: string | null = null): Promise<string> {
   const router = operationalRouter();
   const { fetchImpl } = recordingFetch((path) => {
     if (path.startsWith("/v1/commercial/review-drafts")) return { data: rows };
@@ -267,7 +341,7 @@ function reviewSurface(rows: unknown[]): Promise<string> {
   return adapter.readDestination("comercial").then((result) => {
     assert.equal(result.ok, true);
     if (!result.ok || result.loading) throw new Error("comercial não carregou");
-    return commercialBlock(result.page.commercial!, "rascunhos");
+    return commercialBlock(result.page.commercial!, "rascunhos", resource, query);
   });
 }
 
@@ -319,20 +393,39 @@ test("review surface renders the judging context inline, with no details disclos
   assert.doesNotMatch(html, /<details[^>]*>\s*<summary>Mensagem/);
 });
 
-test("a CURRENT row keeps the full editable decision form", async () => {
+test("a CURRENT row exposes approval as the primary action without a decision dropdown", async () => {
   const html = await reviewSurface([RICH_DRAFT]);
   assert.match(html, new RegExp(`data-review-form="${DRAFT_ID}"`));
   assert.match(html, /name="expected_content_hash" value="sha256:exact"/);
-  assert.match(html, /<option value="SAVE_ADJUSTMENT">/);
-  assert.match(html, /<option value="APPROVE">/);
-  assert.match(html, /<option value="REJECT">/);
-  assert.match(html, /name="reason"/);
-  assert.match(html, /name="generic_ack"/);
-  assert.match(html, /<button type="submit">Registrar decisão<\/button>/);
+  assert.match(html, /name="action" value="APPROVE"/);
+  assert.match(html, /data-approve-submit="true">Aprovar e agendar para obras@construtora\.test<\/button>/);
+  assert.match(html, /data-review-edit="true"/);
+  assert.match(html, /data-review-reject="true"/);
+  assert.doesNotMatch(html, /<select name="action">/);
+  assert.doesNotMatch(html, /name="reason"/);
+  assert.doesNotMatch(html, /name="generic_ack"/);
   assert.match(html, /data-editorial-actionable="true"/);
-  // Only subject and body are editable; the judging context is plain text.
-  assert.doesNotMatch(html, /<textarea name="subject"[^>]*readonly/);
+  assert.match(html, /data-review-mode="approve"/);
   assert.match(html, /Aprovar vincula o hash exato e agenda a próxima janela útil\./);
+});
+
+test("edit and reject modes keep one explicit exact-hash form", async () => {
+  const edit = await reviewSurface([RICH_DRAFT], DRAFT_ID, `resource=${DRAFT_ID}&mode=edit`);
+  assert.equal(edit.match(/data-review-form=/g)?.length, 1);
+  assert.match(edit, /data-review-mode="edit"/);
+  assert.match(edit, /name="action" value="SAVE_ADJUSTMENT"/);
+  assert.match(edit, /<textarea name="subject" rows="\d+">Laudo estrutural/);
+  assert.match(edit, /<textarea name="body_text" rows="\d+">Olá,/);
+  assert.match(edit, /Salvar ajuste/);
+  assert.doesNotMatch(edit, /name="generic_ack"/);
+
+  const reject = await reviewSurface([RICH_DRAFT], DRAFT_ID, `resource=${DRAFT_ID}&mode=reject`);
+  assert.equal(reject.match(/data-review-form=/g)?.length, 1);
+  assert.match(reject, /data-review-mode="reject"/);
+  assert.match(reject, /name="action" value="REJECT"/);
+  assert.match(reject, /Motivo para reescrita/);
+  assert.match(reject, /Rejeitar e solicitar reescrita/);
+  assert.doesNotMatch(reject, /<select name="action">/);
 });
 
 test("absent editorial fields render an explicit word instead of undefined", async () => {
@@ -400,8 +493,8 @@ test("a LEGACY_SUPERSEDED row is auditable but offers no decision control at all
   assert.match(html, /<dt>Reason codes<\/dt><dd>SUPERSEDED_BY_NEWER_DRAFT<\/dd>/);
   // History stays readable.
   assert.match(html, /Corpo histórico que segue auditável\./);
-  assert.match(html, /<textarea name="body_text" rows="\d+" readonly>/);
-  assert.match(html, /<textarea name="subject" rows="\d+" readonly>/);
+  assert.match(html, /data-review-readonly=/);
+  assert.match(html, /data-exact-body="true"/);
   // No decision surface is emitted, not even disabled.
   assert.doesNotMatch(html, new RegExp(`data-review-form="${LEGACY_ID}"`));
   assert.doesNotMatch(html, /SAVE_ADJUSTMENT/);
@@ -495,9 +588,41 @@ test("mixed rows keep decidable and historical drafts side by side", async () =>
     RICH_DRAFT,
     { ...RICH_DRAFT, id: LEGACY_ID, editorial_state: "LEGACY_SUPERSEDED", editorial_actionable: false },
   ]);
-  assert.equal(html.match(/class="card review-draft"/g)?.length, 2);
+  assert.equal(html.match(/data-review-list-item=/g)?.length, 2);
+  assert.equal(html.match(/data-review-inspector=/g)?.length, 1);
   assert.equal(html.match(/data-review-form=/g)?.length, 1);
-  assert.equal(html.match(/<button type="submit">/g)?.length, 1);
+  assert.equal(html.match(/<button type="submit"/g)?.length, 1);
+});
+
+test("a deep link selects one inspector and an absent resource falls back safely", async () => {
+  const secondId = "22222222-3333-4444-8555-666666666666";
+  const rows = [RICH_DRAFT, { ...RICH_DRAFT, id: secondId, recipient: "segunda@empresa.test" }];
+  const selected = await reviewSurface(rows, secondId, `resource=${secondId}`);
+  assert.match(selected, new RegExp(`data-review-row="${secondId}"[^>]+aria-current="page"`));
+  assert.match(selected, new RegExp(`data-review-inspector="${secondId}"`));
+  assert.doesNotMatch(selected, /data-review-selection-fallback/);
+
+  const missing = await reviewSurface(rows, "draft-inexistente", "resource=draft-inexistente");
+  assert.match(missing, /data-review-selection-fallback="true"/);
+  assert.match(missing, new RegExp(`data-review-inspector="${DRAFT_ID}"`));
+});
+
+test("0, 1, 55, 100 and 500 rows never create a form per backlog item", async () => {
+  for (const size of [0, 1, 55, 100, 500]) {
+    const rows = Array.from({ length: size }, (_, index) => ({
+      ...RICH_DRAFT,
+      id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+      account_id: `account-${index}`,
+      account: { nome_fantasia: `Empresa ${index}` },
+      recipient: `contato-${index}@example.test`,
+      content_hash: `sha256:${index}`,
+    }));
+    const html = await reviewSurface(rows);
+    assert.equal(html.match(/data-review-list-item=/g)?.length ?? 0, size, `${size} linhas`);
+    assert.equal(html.match(/data-review-inspector=/g)?.length ?? 0, size === 0 ? 0 : 1, `${size} inspectors`);
+    assert.equal(html.match(/data-review-form=/g)?.length ?? 0, size === 0 ? 0 : 1, `${size} forms`);
+    assert.ok((html.match(/<textarea/g)?.length ?? 0) <= 4, `${size} linhas não multiplicam textareas`);
+  }
 });
 
 test("um rascunho com fato e proveniência não ganha alerta de evidência inventado", async () => {


### PR DESCRIPTION
## Contexto

Entrega atômica do P0 #126, decomposta em #132. Este PR é empilhado sobre #131 porque a ação direta depende do recibo/readback estrito implementado em #130.

## Mudanças

- troca um formulário por card por uma lista compacta com um único inspector selecionado
- oferece CTAs explícitos para aprovar/agendar, editar e rejeitar/segurar
- mantém no máximo um formulário ativo e avança/foca a próxima tarefa após decisão confirmada
- adiciona deep link por resource e mode, com fallback seguro para recurso inválido
- adapta a ordem no mobile para mostrar a tarefa selecionada antes da lista longa
- documenta que a lista atual contém até 100 itens carregados, sem fingir total/cursor do servidor
- amplia os testes para 0, 1, 55, 100 e 500 itens e o probe real em viewport móvel

## Validação

- npm run typecheck
- npm test
- npm run test:integration
- npm run build
- npm run test:e2e (Playwright real, modo completo)
- probe: 55 linhas, 1 inspector, 1 formulário, overflow horizontal 0 px e CTA a 765 px do título em 390x844
- npm audit --omit=dev --audit-level=critical: 0 vulnerabilidades

## Risco e rollback

A lista continua limitada ao lote de até 100 retornado pelo contrato atual; paginação, cursor e total autoritativo permanecem fora deste corte e são sinalizados na UI. Rollback: reverter o commit 97a7c64.

Closes #132
Parent: #126
Depends on #131