### PR TITLE
fix(control-center): preservar verdade da paginação de revisão

### DIFF
--- a/control-center/apps/web-shell/README.md
+++ b/control-center/apps/web-shell/README.md
@@ -129,9 +129,14 @@ que abrem modos explícitos do mesmo inspector; não existe dropdown genérico
 próxima mensagem e o foco acompanha o inspector. No mobile o inspector vem antes
 da lista completa, e no desktop os dois formam colunas sem um segundo scroll.
 
-Este recorte não afirma total do servidor: mostra somente quantas mensagens estão
-carregadas. Total/cursor, carregamento incremental, filtros e batch pertencem aos
-incrementos seguintes da fila escalável.
+O hash também preserva `offset`. A resposta versionada
+`control-center.review-draft-page.v1` mantém a página e a cobertura separadas dos
+itens: quando o Warmbly prova `pagination.total`, a tela diz **N carregados de M
+no servidor**, mostra o restante e habilita Anterior/Próxima conforme a prova.
+Sem total, ela diz literalmente que o total não foi informado; `has_more` válido
+pode provar apenas a continuidade, nunca o denominador. Metadado contraditório
+falha fechado como `UNPROVEN`. Filtros, batch e um cursor opaco novo continuam
+fora deste recorte.
 
 ## Cards de alerta
 

--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -160,7 +160,19 @@ await page.route(/\/v1\/commercial\/review-drafts(?:\?|$)/, async (route) => {
   await route.fulfill({
     status: 200,
     contentType: "application/json",
-    body: JSON.stringify({ data: reviewRows }),
+    body: JSON.stringify({
+      schema_version: "control-center.review-draft-page.v1",
+      data: reviewRows,
+      page: {
+        limit: 100,
+        offset: 0,
+        loaded_count: 55,
+        coverage_status: "TOTAL_KNOWN",
+        total_count: 55,
+        remaining_count: 0,
+        has_more: false,
+      },
+    }),
   });
 });
 
@@ -445,6 +457,13 @@ try {
     throw new Error(
       `review workbench multiplied controls: rows=${reviewListCount} inspectors=${reviewInspectorCount} forms=${reviewFormCount}`,
     );
+  }
+  const reviewCoverage = await page.locator('[data-review-coverage="TOTAL_KNOWN"]').innerText();
+  if (!reviewCoverage.includes("55 carregados de 55 no servidor") || !reviewCoverage.includes("0 restantes")) {
+    throw new Error(`review coverage lost authoritative pagination: ${reviewCoverage}`);
+  }
+  if (await page.locator('[data-review-page="next"]').count() !== 0) {
+    throw new Error("review workbench invented a next page after an authoritative end");
   }
   const approveLabel = await page.locator("[data-approve-submit]").innerText();
   if (!approveLabel.includes("Aprovar e agendar para contato-0@empresa-exemplo.test")) {

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -77,6 +77,76 @@ function stringValue(record: Record<string, unknown>, key: string): string | und
   return typeof value === "string" && value.trim() !== "" ? value : undefined;
 }
 
+const REVIEW_PAGE_LIMIT = 100;
+
+function reviewOffsetOf(location: string | undefined): number {
+  const raw = queryParamsOf(location ?? "").offset;
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) return 0;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed <= 100_000 ? parsed : 0;
+}
+
+function reviewPageFrom(
+  payload: Record<string, unknown> | null | undefined,
+  loadedCount: number,
+  requestedOffset: number,
+): Record<string, unknown> {
+  const fallback = {
+    limit: REVIEW_PAGE_LIMIT,
+    offset: requestedOffset,
+    loaded_count: loadedCount,
+    coverage_status: "UNPROVEN",
+  };
+  if (payload?.schema_version !== "control-center.review-draft-page.v1") return fallback;
+  const page = asRecord(payload.page);
+  if (
+    !page ||
+    page.limit !== REVIEW_PAGE_LIMIT ||
+    page.offset !== requestedOffset ||
+    page.loaded_count !== loadedCount
+  ) return fallback;
+
+  if (page.coverage_status === "TOTAL_KNOWN") {
+    const total = page.total_count;
+    const remaining = page.remaining_count;
+    const hasMore = page.has_more;
+    const pageEnd = requestedOffset + loadedCount;
+    if (
+      typeof total !== "number" || !Number.isSafeInteger(total) || total < pageEnd ||
+      typeof remaining !== "number" || remaining !== total - pageEnd ||
+      typeof hasMore !== "boolean" || hasMore !== (pageEnd < total) ||
+      (hasMore && loadedCount !== REVIEW_PAGE_LIMIT) ||
+      (hasMore && page.next_offset !== pageEnd) ||
+      (!hasMore && page.next_offset !== undefined)
+    ) return fallback;
+    return {
+      ...fallback,
+      coverage_status: "TOTAL_KNOWN",
+      total_count: total,
+      remaining_count: remaining,
+      has_more: hasMore,
+      ...(hasMore ? { next_offset: pageEnd } : {}),
+    };
+  }
+
+  if (page.coverage_status === "PAGE_ONLY") {
+    const hasMore = page.has_more;
+    const pageEnd = requestedOffset + loadedCount;
+    if (
+      typeof hasMore !== "boolean" ||
+      (hasMore && (loadedCount !== REVIEW_PAGE_LIMIT || page.next_offset !== pageEnd)) ||
+      (!hasMore && page.next_offset !== undefined)
+    ) return fallback;
+    return {
+      ...fallback,
+      coverage_status: "PAGE_ONLY",
+      has_more: hasMore,
+      ...(hasMore ? { next_offset: pageEnd } : {}),
+    };
+  }
+  return fallback;
+}
+
 function validReceiptInstant(value: string, now = Date.now()): boolean {
   if (!isUtcDateTime(value)) return false;
   const parsed = Date.parse(value);
@@ -1121,11 +1191,15 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
         // During a rolling deployment the read model may precede the review
         // proxy. A 404 means the optional surface is not available yet; it
         // must not blank the rest of the commercial cockpit.
-        const reviewPayload = asRecord(await this.readReviewJson("/v1/commercial/review-drafts?limit=100&offset=0"));
+        const reviewOffset = reviewOffsetOf(location);
+        const reviewPayload = asRecord(await this.readReviewJson(
+          `/v1/commercial/review-drafts?limit=${REVIEW_PAGE_LIMIT}&offset=${reviewOffset}`,
+        ));
         const reviewRows = itemsOf(reviewPayload?.data ?? reviewPayload);
         page.commercial.operations = {
           ...(page.commercial.operations ?? {}),
           review_drafts: reviewRows,
+          review_draft_page: reviewPageFrom(reviewPayload, reviewRows.length, reviewOffset),
         };
       }
     }

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -8,7 +8,7 @@ import type {
 } from "./adapters/contract";
 import { APPROVAL_DEFAULT_REASON, isWarmblyGateAction } from "./adapters/contract";
 import { WARMBLY_DISPATCH_PATHS, type WriteShortcutKind } from "./adapters/paths";
-import { parseHash } from "./destinations";
+import { parseHash, withQueryParams } from "./destinations";
 import { LIST_FORM_FIELDS, defaultParamValues, listHref, listSpecById } from "./filter";
 import {
   beginGateFlight,
@@ -490,9 +490,11 @@ export function bindReviewActions(
             adapter.lastOperatorResult = result;
             if (result.ok) {
               const destinationId = action === "SAVE_ADJUSTMENT" ? id : nextReviewId;
-              completionHash = destinationId
-                ? `#/comercial/rascunhos?resource=${encodeURIComponent(destinationId)}&${REVIEW_FOCUS_PARAM}=${REVIEW_FOCUS_VALUE}`
-                : `#/comercial/rascunhos?${REVIEW_FOCUS_PARAM}=${REVIEW_FOCUS_VALUE}`;
+              completionHash = withQueryParams(currentHash ?? "#/comercial/rascunhos", {
+                resource: destinationId || null,
+                mode: null,
+                [REVIEW_FOCUS_PARAM]: REVIEW_FOCUS_VALUE,
+              });
             }
           }
         })

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -1,5 +1,6 @@
 import { escapeHtml } from "../escape";
 import { formatLocal, isUtcDateTime } from "../datetime";
+import { withQueryParams } from "../destinations";
 import { ACTIVITY_LIST, EXCEPTION_LIST } from "../filter";
 import { formatMoney } from "../money";
 import { ownMapValue } from "../own-map";
@@ -1071,6 +1072,17 @@ function reviewRows(text: string, min: number, max: number): number {
 
 type ReviewInspectorMode = "inspect" | "edit" | "reject";
 
+interface ReviewPageView {
+  limit: number;
+  offset: number;
+  loadedCount: number;
+  coverageStatus: "TOTAL_KNOWN" | "PAGE_ONLY" | "UNPROVEN";
+  totalCount?: number;
+  remainingCount?: number;
+  hasMore?: boolean;
+  nextOffset?: number;
+}
+
 function reviewInspectorMode(query: string | null): ReviewInspectorMode {
   const mode = new URLSearchParams(query ?? "").get("mode");
   return mode === "edit" || mode === "reject" ? mode : "inspect";
@@ -1089,10 +1101,103 @@ function reviewDraftActionable(item: unknown): boolean {
   return readEditorialState({ ...row, actionable: row.editorial_actionable }).actionable;
 }
 
-function reviewDraftHref(id: string, mode: ReviewInspectorMode = "inspect"): string {
-  const params = new URLSearchParams({ resource: id });
-  if (mode !== "inspect") params.set("mode", mode);
-  return `#/comercial/rascunhos?${params.toString()}`;
+function reviewRouteHash(hash: string): string {
+  const query = hash.split("?")[1];
+  return query ? `#/comercial/rascunhos?${query}` : "#/comercial/rascunhos";
+}
+
+function reviewDraftHref(
+  id: string,
+  mode: ReviewInspectorMode = "inspect",
+  hash = "#/comercial/rascunhos",
+): string {
+  return withQueryParams(reviewRouteHash(hash), {
+    resource: id,
+    mode: mode === "inspect" ? null : mode,
+    focus: null,
+  });
+}
+
+function reviewPageView(value: unknown, loadedCount: number): ReviewPageView {
+  const row = reviewDraftRow(value);
+  const limit = typeof row.limit === "number" && Number.isSafeInteger(row.limit) && row.limit > 0 && row.limit <= 200
+    ? row.limit
+    : 100;
+  const offset = typeof row.offset === "number" && Number.isSafeInteger(row.offset) && row.offset >= 0
+    ? row.offset
+    : 0;
+  const fallback: ReviewPageView = { limit, offset, loadedCount, coverageStatus: "UNPROVEN" };
+  if (row.loaded_count !== loadedCount) return fallback;
+  const pageEnd = offset + loadedCount;
+  if (
+    row.coverage_status === "TOTAL_KNOWN" &&
+    typeof row.total_count === "number" && Number.isSafeInteger(row.total_count) && row.total_count >= pageEnd &&
+    typeof row.remaining_count === "number" && row.remaining_count === row.total_count - pageEnd &&
+    typeof row.has_more === "boolean" && row.has_more === (pageEnd < row.total_count) &&
+    (!row.has_more || (loadedCount === limit && row.next_offset === pageEnd)) &&
+    (row.has_more || row.next_offset === undefined)
+  ) {
+    return {
+      ...fallback,
+      coverageStatus: "TOTAL_KNOWN",
+      totalCount: row.total_count,
+      remainingCount: row.remaining_count,
+      hasMore: row.has_more,
+      ...(row.has_more ? { nextOffset: pageEnd } : {}),
+    };
+  }
+  if (
+    row.coverage_status === "PAGE_ONLY" &&
+    typeof row.has_more === "boolean" &&
+    (!row.has_more || (loadedCount === limit && row.next_offset === pageEnd)) &&
+    (row.has_more || row.next_offset === undefined)
+  ) {
+    return {
+      ...fallback,
+      coverageStatus: "PAGE_ONLY",
+      hasMore: row.has_more,
+      ...(row.has_more ? { nextOffset: pageEnd } : {}),
+    };
+  }
+  return fallback;
+}
+
+function reviewCoverage(page: ReviewPageView): string {
+  if (page.coverageStatus === "TOTAL_KNOWN") {
+    return `<p data-review-coverage="TOTAL_KNOWN"><strong>${page.loadedCount}</strong> carregados de <strong>${page.totalCount}</strong> no servidor; <strong>${page.remainingCount}</strong> restantes após este recorte.</p>`;
+  }
+  if (page.coverageStatus === "PAGE_ONLY") {
+    const continuation = page.hasMore
+      ? "O servidor confirmou outra página, mas não informou o total."
+      : "O servidor confirmou o fim da lista, mas não informou o total.";
+    return `<p data-review-coverage="PAGE_ONLY"><strong>${page.loadedCount}</strong> carregados neste recorte. ${continuation}</p>`;
+  }
+  return `<p data-review-coverage="UNPROVEN"><strong>${page.loadedCount}</strong> carregados neste recorte; total do servidor não informado.</p>`;
+}
+
+function reviewPagination(page: ReviewPageView, hash: string): string {
+  const previousOffset = page.offset > 0 ? Math.max(0, page.offset - page.limit) : null;
+  const previous = previousOffset === null
+    ? `<span class="page-step" aria-disabled="true">Página anterior</span>`
+    : `<a class="page-step" data-review-page="previous" href="${escapeHtml(withQueryParams(reviewRouteHash(hash), {
+        offset: previousOffset === 0 ? null : String(previousOffset),
+        resource: null,
+        mode: null,
+        focus: null,
+      }))}">Página anterior</a>`;
+  const next = page.hasMore === true && page.nextOffset !== undefined
+    ? `<a class="page-step" data-review-page="next" href="${escapeHtml(withQueryParams(reviewRouteHash(hash), {
+        offset: String(page.nextOffset),
+        resource: null,
+        mode: null,
+        focus: null,
+      }))}">Próxima página</a>`
+    : `<span class="page-step" aria-disabled="true">Próxima página não provada</span>`;
+  const first = page.loadedCount === 0 ? 0 : page.offset + 1;
+  const last = page.offset + page.loadedCount;
+  return `<nav class="pagination review-pagination" aria-label="Paginação da fila de revisão" data-review-pagination="${escapeHtml(page.coverageStatus)}">
+      ${previous}<span class="page-position">Itens ${first}–${last}</span>${next}
+    </nav>`;
 }
 
 function selectedReviewIndex(items: readonly unknown[], resource: string | null): number {
@@ -1110,7 +1215,7 @@ function nextActionableReviewId(items: readonly unknown[], selected: number): st
   return null;
 }
 
-function reviewDraftListItem(item: unknown, selected: boolean): string {
+function reviewDraftListItem(item: unknown, selected: boolean, hash: string): string {
   const row = reviewDraftRow(item);
   const account = reviewDraftRow(row.account);
   const id = reviewDraftId(item);
@@ -1121,7 +1226,7 @@ function reviewDraftListItem(item: unknown, selected: boolean): string {
   const recipient = String(row.recipient ?? "destinatário ausente");
   const route = reviewRouteClass(routeClass) ?? REVIEW_UNREPORTED;
   return `<li class="review-queue-item" data-review-list-item="${escapeHtml(id)}" data-editorial-actionable="${editorial.actionable ? "true" : "false"}">
-            <a data-review-row="${escapeHtml(id)}" href="${escapeHtml(reviewDraftHref(id))}" aria-current="${selected ? "page" : "false"}">
+            <a data-review-row="${escapeHtml(id)}" href="${escapeHtml(reviewDraftHref(id, "inspect", hash))}" aria-current="${selected ? "page" : "false"}">
               <strong>${escapeHtml(company)}</strong>
               <span>${escapeHtml(recipient)}</span>
               <span>${escapeHtml(route)}</span>
@@ -1135,6 +1240,7 @@ function reviewDraftInspector(
   item: unknown,
   nextReviewId: string | null,
   mode: ReviewInspectorMode,
+  hash: string,
 ): string {
   const row = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
   const account = row.account && typeof row.account === "object" ? (row.account as Record<string, unknown>) : {};
@@ -1219,7 +1325,7 @@ function reviewDraftInspector(
                 <label>Corpo <textarea name="body_text" rows="${bodyRows}">${escapeHtml(bodyText)}</textarea></label>
                 <div class="review-actions">
                   <button type="submit" data-review-save="true">Salvar ajuste</button>
-                  <a class="button" href="${escapeHtml(reviewDraftHref(id))}">Cancelar edição</a>
+                  <a class="button" href="${escapeHtml(reviewDraftHref(id, "inspect", hash))}">Cancelar edição</a>
                 </div>
               </form>`
       : mode === "reject"
@@ -1231,7 +1337,7 @@ function reviewDraftInspector(
                 <label>Motivo para reescrita <textarea name="reason" rows="4" required></textarea></label>
                 <div class="review-actions">
                   <button type="submit" data-review-reject="true">Rejeitar e solicitar reescrita</button>
-                  <a class="button" href="${escapeHtml(reviewDraftHref(id))}">Cancelar rejeição</a>
+                  <a class="button" href="${escapeHtml(reviewDraftHref(id, "inspect", hash))}">Cancelar rejeição</a>
                 </div>
               </form>`
         : `${readOnlyMessage}<form data-review-form="${escapeHtml(id)}" data-review-mode="approve" class="operator-form review-decision-form approve-form">
@@ -1241,8 +1347,8 @@ function reviewDraftInspector(
                 <textarea name="body_text" hidden>${escapeHtml(bodyText)}</textarea>
                 <div class="review-actions">
                   <button type="submit" data-approve-submit="true">Aprovar e agendar para ${escapeHtml(String(row.recipient ?? "destinatário ausente"))}</button>
-                  <a class="button" data-review-edit="true" href="${escapeHtml(reviewDraftHref(id, "edit"))}">Editar</a>
-                  <a class="button" data-review-reject="true" href="${escapeHtml(reviewDraftHref(id, "reject"))}">Rejeitar/segurar</a>
+                  <a class="button" data-review-edit="true" href="${escapeHtml(reviewDraftHref(id, "edit", hash))}">Editar</a>
+                  <a class="button" data-review-reject="true" href="${escapeHtml(reviewDraftHref(id, "reject", hash))}">Rejeitar/segurar</a>
                 </div>
               </form>`;
   return `<article class="card review-draft review-inspector" tabindex="-1" data-review-inspector="${escapeHtml(id)}" data-draft-id="${escapeHtml(id)}" data-state="${escapeHtml(String(row.state ?? ""))}" data-editorial-state="${escapeHtml(editorial.state)}" data-editorial-actionable="${actionable ? "true" : "false"}" data-composer-version="${escapeHtml(composerVersion ?? "")}">
@@ -1279,6 +1385,7 @@ function commercialOps(
   const pipeline = Array.isArray(ops.pipeline) ? ops.pipeline : [];
   const exceptions = Array.isArray(ops.exceptions) ? ops.exceptions : [];
   const reviewDrafts = Array.isArray(ops.review_drafts) ? ops.review_drafts : [];
+  const reviewPage = reviewPageView(ops.review_draft_page, reviewDrafts.length);
   const availability = snapshot.availability ?? "UNKNOWN";
   let body = "";
   if (current === "rascunhos") {
@@ -1290,16 +1397,17 @@ function commercialOps(
     const mode = reviewInspectorMode(query);
     body = `<section aria-labelledby="rascunhos-title" data-review-workbench-count="${reviewDrafts.length}"><h2 id="rascunhos-title">Revisão editorial</h2>
       <p class="constraint">Aprovar vincula o hash exato e agenda a próxima janela útil. Nenhum botão envia imediatamente.</p>
-      <p><strong>${reviewDrafts.length}</strong> mensagem(ns) carregada(s) neste recorte. A lista não afirma o total do servidor.</p>
+      ${reviewCoverage(reviewPage)}
       ${selectionFellBack ? `<p class="banner stale" role="status" data-review-selection-fallback="true">A mensagem solicitada não está neste recorte; mostrando a próxima mensagem disponível.</p>` : ""}
       ${reviewDrafts.length === 0
         ? `<p class="banner empty">Nenhum rascunho aguardando revisão.</p>`
         : `<div class="review-workbench">
             <nav class="review-queue-panel" aria-label="Mensagens aguardando revisão">
-              <ol class="review-queue">${reviewDrafts.map((item, index) => reviewDraftListItem(item, index === selectedIndex)).join("")}</ol>
+              <ol class="review-queue">${reviewDrafts.map((item, index) => reviewDraftListItem(item, index === selectedIndex, hash)).join("")}</ol>
             </nav>
-            ${selectedDraft === undefined ? "" : reviewDraftInspector(selectedDraft, nextReviewId, mode)}
+            ${selectedDraft === undefined ? "" : reviewDraftInspector(selectedDraft, nextReviewId, mode, hash)}
           </div>`}
+      ${reviewPagination(reviewPage, hash)}
     </section>`;
   } else if (current === "cohorts") {
     const acquisition = Array.isArray(cohorts.acquisition) ? cohorts.acquisition : [];

--- a/control-center/apps/web-shell/tests/review-drafts.test.ts
+++ b/control-center/apps/web-shell/tests/review-drafts.test.ts
@@ -266,10 +266,11 @@ test("a confirmed decision navigates to the next actionable draft", async () => 
     adapter as never,
     () => { painted += 1; },
     (hash) => { destination = hash; },
+    `#/comercial/rascunhos?offset=100&resource=${DRAFT_ID}`,
   );
   listener?.({ preventDefault(): void {} } as unknown as Event);
   await new Promise((resolve) => setTimeout(resolve, 0));
-  assert.equal(destination, `#/comercial/rascunhos?resource=${nextId}&focus=review`);
+  assert.equal(destination, `#/comercial/rascunhos?offset=100&resource=${nextId}&focus=review`);
   assert.equal(submitted?.generic_recipient_acknowledged, true);
   assert.equal(painted, 0);
 });
@@ -336,20 +337,6 @@ test("unsaved edits must be persisted and reread before APPROVE", () => {
 
 const LEGACY_ID = "99999999-8888-4777-8666-555555555555";
 
-function reviewSurface(rows: unknown[], resource: string | null = null, query: string | null = null): Promise<string> {
-  const router = operationalRouter();
-  const { fetchImpl } = recordingFetch((path) => {
-    if (path.startsWith("/v1/commercial/review-drafts")) return { data: rows };
-    return router(path);
-  });
-  const adapter = createHttpAdapter("http://context.test", fetchImpl, { kind: "human", id: "founder-local" });
-  return adapter.readDestination("comercial").then((result) => {
-    assert.equal(result.ok, true);
-    if (!result.ok || result.loading) throw new Error("comercial não carregou");
-    return commercialBlock(result.page.commercial!, "rascunhos", resource, query);
-  });
-}
-
 const RICH_DRAFT = {
   id: DRAFT_ID,
   account_id: "account-1",
@@ -373,6 +360,100 @@ const RICH_DRAFT = {
   editorial_reason_codes: ["FACT_FRESH", "ROUTE_OK"],
   target_fit: { state: "FIT", reason: "porte e setor compatíveis", fresh: true, as_of: "2026-08-20T12:00:00Z" },
 };
+
+function reviewSurface(rows: unknown[], resource: string | null = null, query: string | null = null): Promise<string> {
+  const router = operationalRouter();
+  const { fetchImpl } = recordingFetch((path) => {
+    if (path.startsWith("/v1/commercial/review-drafts")) return { data: rows };
+    return router(path);
+  });
+  const adapter = createHttpAdapter("http://context.test", fetchImpl, { kind: "human", id: "founder-local" });
+  return adapter.readDestination("comercial").then((result) => {
+    assert.equal(result.ok, true);
+    if (!result.ok || result.loading) throw new Error("comercial não carregou");
+    return commercialBlock(result.page.commercial!, "rascunhos", resource, query);
+  });
+}
+
+test("review adapter preserves an authoritative server total and offset navigation", async () => {
+  const rows = Array.from({ length: 100 }, (_, index) => ({
+    ...RICH_DRAFT,
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+  }));
+  const router = operationalRouter();
+  const { fetchImpl, calls } = recordingFetch((path) => {
+    if (path.startsWith("/v1/commercial/review-drafts")) {
+      return {
+        schema_version: "control-center.review-draft-page.v1",
+        data: rows,
+        page: {
+          limit: 100,
+          offset: 100,
+          loaded_count: 100,
+          coverage_status: "TOTAL_KNOWN",
+          total_count: 250,
+          remaining_count: 50,
+          has_more: true,
+          next_offset: 200,
+        },
+      };
+    }
+    return router(path);
+  });
+  const hash = "#/comercial/rascunhos?offset=100";
+  const adapter = createHttpAdapter("http://context.test", fetchImpl, { kind: "human", id: "founder-local" });
+  const result = await adapter.readDestination("comercial", hash);
+  assert.equal(result.ok, true);
+  if (!result.ok || result.loading) return;
+  assert.ok(calls.some((call) => call.endsWith("/v1/commercial/review-drafts?limit=100&offset=100")));
+  assert.deepEqual(result.page.commercial?.operations?.review_draft_page, {
+    limit: 100,
+    offset: 100,
+    loaded_count: 100,
+    coverage_status: "TOTAL_KNOWN",
+    total_count: 250,
+    remaining_count: 50,
+    has_more: true,
+    next_offset: 200,
+  });
+  const html = commercialBlock(result.page.commercial!, "rascunhos", null, "offset=100", hash);
+  assert.match(html, /data-review-coverage="TOTAL_KNOWN"><strong>100<\/strong> carregados de <strong>250<\/strong> no servidor; <strong>50<\/strong> restantes/);
+  assert.match(html, /data-review-page="previous" href="#\/comercial\/rascunhos"/);
+  assert.match(html, /data-review-page="next" href="#\/comercial\/rascunhos\?offset=200"/);
+  assert.match(html, /data-review-row="[^"]+" href="#\/comercial\/rascunhos\?offset=100&amp;resource=/);
+});
+
+test("missing or contradictory pagination stays unproven and cannot mint a next page", async () => {
+  const router = operationalRouter();
+  const { fetchImpl } = recordingFetch((path) => {
+    if (path.startsWith("/v1/commercial/review-drafts")) {
+      return {
+        schema_version: "control-center.review-draft-page.v1",
+        data: [RICH_DRAFT],
+        page: {
+          limit: 100,
+          offset: 0,
+          loaded_count: 1,
+          coverage_status: "TOTAL_KNOWN",
+          total_count: 0,
+          remaining_count: 0,
+          has_more: true,
+          next_offset: 1,
+        },
+      };
+    }
+    return router(path);
+  });
+  const adapter = createHttpAdapter("http://context.test", fetchImpl, { kind: "human", id: "founder-local" });
+  const result = await adapter.readDestination("comercial", "#/comercial/rascunhos");
+  assert.equal(result.ok, true);
+  if (!result.ok || result.loading) return;
+  const html = commercialBlock(result.page.commercial!, "rascunhos", null, null, "#/comercial/rascunhos");
+  assert.match(html, /data-review-coverage="UNPROVEN"/);
+  assert.match(html, /total do servidor não informado/);
+  assert.doesNotMatch(html, /data-review-page="next"/);
+  assert.match(html, /Próxima página não provada/);
+});
 
 test("review surface renders the judging context inline, with no details disclosure to open", async () => {
   const html = await reviewSurface([RICH_DRAFT]);

--- a/control-center/connectors/warmbly/README.md
+++ b/control-center/connectors/warmbly/README.md
@@ -76,6 +76,12 @@ The Control Center's `Comercial → Rascunhos` surface uses a dedicated, server-
 
 Every request requires the trusted founder identity. `APPROVE` carries `expected_content_hash` and only creates a durable queue entry for the next eligible business window. `REJECT` preserves the lead and routes the draft to AI-assisted editorial recovery. This bridge does not expose an immediate-send operation.
 
+The list boundary emits `control-center.review-draft-page.v1`. Requested
+`limit`/`offset` and the observed row count always describe the local page;
+server `total`, remaining rows and continuation are forwarded only when
+Warmbly's `pagination` object is type-safe and internally consistent. Missing or
+contradictory pagination becomes `UNPROVEN`, never a guessed total.
+
 An individual decision is not considered complete from HTTP status alone. The Context Service validates Warmbly's decision envelope, reads the exact touchpoint back, and emits a sanitized `control-center.review-decision-receipt.v1`. Empty/incompatible bodies, divergent hashes/states, missing `due_at` for `QUEUED`, and unavailable readback remain `not_confirmed`; clients must not issue a fresh intent while that outcome is ambiguous.
 
 ## Operator action channel (`src/operator/`)

--- a/control-center/connectors/warmbly/required_upstream_contract.json
+++ b/control-center/connectors/warmbly/required_upstream_contract.json
@@ -86,7 +86,7 @@
         "method": "GET",
         "path": "/v1/confenge/review/drafts",
         "permission": "PermViewContacts / APIPermReadContacts",
-        "notes": "bounded review list with exact content_hash, recipient risk and editorial state"
+        "notes": "bounded review list with exact content_hash, recipient risk and editorial state; pagination is forwarded only when total/has_more are present and consistent"
       },
       {
         "method": "GET",
@@ -131,6 +131,25 @@
     "Any POST outside operator_actions.mapped_writes and human_review_bridge.mapped_writes"
   ],
   "gaps": [
+    {
+      "id": "review draft list lacks authoritative pagination",
+      "method": "GET",
+      "path": "/v1/confenge/review/drafts",
+      "reason": "Warmbly currently returns only data for this offset-bounded list. Control Center therefore reports coverage_status=UNPROVEN and never promotes the loaded row count to the server total. Adding the standard pagination envelope unlocks truthful remaining/next navigation without a new authority.",
+      "min_request": {
+        "method": "GET",
+        "path": "/v1/confenge/review/drafts",
+        "query": { "limit": "100", "offset": "0" },
+        "headers": ["Authorization", "API-Version"]
+      },
+      "min_response": {
+        "status": 200,
+        "body": {
+          "data": [],
+          "pagination": { "total": 0, "has_more": false }
+        }
+      }
+    },
     {
       "id": "dispatch status lacks paused_by / paused_at",
       "method": "GET",

--- a/control-center/services/context/README.md
+++ b/control-center/services/context/README.md
@@ -60,6 +60,13 @@ POST /v1/commercial/review-batches
 
 As quatro rotas comerciais são uma ponte server-side protegida pela identidade operacional autenticada no edge para o human gate do Warmbly. `APPROVE` vincula `expected_content_hash` e agenda a próxima janela útil; não existe envio imediato nessa ponte.
 
+A listagem devolve `control-center.review-draft-page.v1`: `limit`, `offset` e
+`loaded_count` descrevem o recorte solicitado. `total_count`,
+`remaining_count`, `has_more` e `next_offset` só sobrevivem quando a paginação
+do Warmbly é válida e coerente. Ausência, tipo inválido, total menor que os itens
+observados ou continuidade contraditória resulta em `coverage_status=UNPROVEN`;
+o tamanho da página nunca é promovido a total do servidor.
+
 A resposta 2xx do write não é prova de efeito. Para uma decisão individual, a ponte parseia o envelope do Warmbly, executa `GET /v1/confenge/review/drafts/:id` e devolve `control-center.review-decision-receipt.v1`. `APPROVE` só sai como `confirmed` quando write e readback concordam em ID, hash/approved hash, operador, instante e `QUEUED|SENT`, com `due_at == scheduled_for` em `QUEUED`. Corpo vazio, divergência ou readback indisponível vira `not_confirmed` e orienta a não repetir antes de reler com a mesma `Idempotency-Key`.
 
 Headers obrigatórios em tudo exceto `/healthz`: `X-Actor-Id`, `X-Actor-Kind` (`human` | `agent` | `system`).

--- a/control-center/services/context/src/operational/warmbly-review.ts
+++ b/control-center/services/context/src/operational/warmbly-review.ts
@@ -116,11 +116,29 @@ export function reviewDraftPage(payload: unknown, limit: number, offset: number)
   if (!pagination || data.length > limit) return base;
 
   const total = nonNegativeInteger(pagination.total);
+  const declaredLimit = nonNegativeInteger(pagination.limit);
+  const declaredOffset = nonNegativeInteger(pagination.offset);
+  const declaredRemaining = nonNegativeInteger(pagination.remaining_count);
+  const declaredNextOffset = nonNegativeInteger(pagination.next_offset);
   const declaredHasMore = typeof pagination.has_more === "boolean"
     ? pagination.has_more
     : undefined;
   if (pagination.total !== undefined && pagination.total !== null && total === undefined) return base;
+  if (pagination.limit !== undefined && pagination.limit !== null && declaredLimit === undefined) return base;
+  if (pagination.offset !== undefined && pagination.offset !== null && declaredOffset === undefined) return base;
+  if (
+    pagination.remaining_count !== undefined &&
+    pagination.remaining_count !== null &&
+    declaredRemaining === undefined
+  ) return base;
+  if (
+    pagination.next_offset !== undefined &&
+    pagination.next_offset !== null &&
+    declaredNextOffset === undefined
+  ) return base;
   if (pagination.has_more !== undefined && declaredHasMore === undefined) return base;
+  if (declaredLimit !== undefined && declaredLimit !== limit) return base;
+  if (declaredOffset !== undefined && declaredOffset !== offset) return base;
   if (declaredHasMore === true && data.length === 0) return base;
 
   const pageEnd = offset + data.length;
@@ -128,6 +146,8 @@ export function reviewDraftPage(payload: unknown, limit: number, offset: number)
     if (total < pageEnd) return base;
     const hasMore = pageEnd < total;
     if (declaredHasMore !== undefined && declaredHasMore !== hasMore) return base;
+    if (declaredRemaining !== undefined && declaredRemaining !== total - pageEnd) return base;
+    if (declaredNextOffset !== undefined && (!hasMore || declaredNextOffset !== pageEnd)) return base;
     if (hasMore && data.length !== limit) return base;
     return {
       ...base,
@@ -143,6 +163,8 @@ export function reviewDraftPage(payload: unknown, limit: number, offset: number)
   }
 
   if (declaredHasMore !== undefined) {
+    if (declaredRemaining !== undefined) return base;
+    if (declaredNextOffset !== undefined && (!declaredHasMore || declaredNextOffset !== pageEnd)) return base;
     if (declaredHasMore && data.length !== limit) return base;
     return {
       ...base,

--- a/control-center/services/context/src/operational/warmbly-review.ts
+++ b/control-center/services/context/src/operational/warmbly-review.ts
@@ -43,6 +43,21 @@ export interface ReviewDecisionReceipt {
   approved_at?: string;
 }
 
+export interface ReviewDraftPage {
+  schema_version: "control-center.review-draft-page.v1";
+  data: unknown[];
+  page: {
+    limit: number;
+    offset: number;
+    loaded_count: number;
+    coverage_status: "TOTAL_KNOWN" | "PAGE_ONLY" | "UNPROVEN";
+    total_count?: number;
+    remaining_count?: number;
+    has_more?: boolean;
+    next_offset?: number;
+  };
+}
+
 export interface WarmblyReviewPort {
   list(actor: ActorRef, query: URLSearchParams): Promise<unknown>;
   get(actor: ActorRef, id: string): Promise<unknown>;
@@ -64,6 +79,82 @@ function record(value: unknown): Record<string, unknown> | undefined {
 
 function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+/**
+ * Warmbly owns the review backlog. This boundary publishes only pagination it
+ * can prove from Warmbly's response; the page length is never promoted to a
+ * server total. Invalid or contradictory metadata is discarded as UNPROVEN.
+ */
+export function reviewDraftPage(payload: unknown, limit: number, offset: number): ReviewDraftPage {
+  const root = record(payload);
+  if (!root || !Array.isArray(root.data)) {
+    throw new ServiceError(
+      "warmbly_review_failed",
+      "Warmbly review list did not contain a data array",
+      502,
+    );
+  }
+  const data = root.data;
+  const base: ReviewDraftPage = {
+    schema_version: "control-center.review-draft-page.v1",
+    data,
+    page: {
+      limit,
+      offset,
+      loaded_count: data.length,
+      coverage_status: "UNPROVEN",
+    },
+  };
+  const pagination = record(root.pagination);
+  if (!pagination || data.length > limit) return base;
+
+  const total = nonNegativeInteger(pagination.total);
+  const declaredHasMore = typeof pagination.has_more === "boolean"
+    ? pagination.has_more
+    : undefined;
+  if (pagination.total !== undefined && pagination.total !== null && total === undefined) return base;
+  if (pagination.has_more !== undefined && declaredHasMore === undefined) return base;
+  if (declaredHasMore === true && data.length === 0) return base;
+
+  const pageEnd = offset + data.length;
+  if (total !== undefined) {
+    if (total < pageEnd) return base;
+    const hasMore = pageEnd < total;
+    if (declaredHasMore !== undefined && declaredHasMore !== hasMore) return base;
+    if (hasMore && data.length !== limit) return base;
+    return {
+      ...base,
+      page: {
+        ...base.page,
+        coverage_status: "TOTAL_KNOWN",
+        total_count: total,
+        remaining_count: total - pageEnd,
+        has_more: hasMore,
+        ...(hasMore ? { next_offset: pageEnd } : {}),
+      },
+    };
+  }
+
+  if (declaredHasMore !== undefined) {
+    if (declaredHasMore && data.length !== limit) return base;
+    return {
+      ...base,
+      page: {
+        ...base.page,
+        coverage_status: "PAGE_ONLY",
+        has_more: declaredHasMore,
+        ...(declaredHasMore ? { next_offset: pageEnd } : {}),
+      },
+    };
+  }
+  return base;
 }
 
 function instant(value: unknown): string | undefined {
@@ -302,7 +393,8 @@ export function createWarmblyReviewPortFromEnv(
     async list(_actor, query) {
       const limit = boundedInt(query.get("limit"), 100, 200);
       const offset = boundedInt(query.get("offset"), 0, 100_000);
-      return request(`/v1/confenge/review/drafts?limit=${limit}&offset=${offset}`);
+      const payload = await request(`/v1/confenge/review/drafts?limit=${limit}&offset=${offset}`);
+      return reviewDraftPage(payload, limit, offset);
     },
     async get(_actor, id) {
       assertId(id);

--- a/control-center/services/context/test/warmbly-review.test.ts
+++ b/control-center/services/context/test/warmbly-review.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { bootFromEnv } from "../src/boot.ts";
 import { createRequestListener } from "../src/http.ts";
 import { silentLogger } from "../src/log.ts";
-import { createWarmblyReviewPortFromEnv } from "../src/operational/warmbly-review.ts";
+import { createWarmblyReviewPortFromEnv, reviewDraftPage } from "../src/operational/warmbly-review.ts";
 import type { WarmblyReviewPort } from "../src/operational/warmbly-review.ts";
 
 const FOUNDER = { kind: "human" as const, id: "founder-local" };
@@ -33,6 +33,58 @@ function decisionBody(touchpoint = queuedTouchpoint(), scheduledFor: unknown = D
   return { data: { touchpoint, scheduled_for: scheduledFor } };
 }
 
+test("review list publishes only authoritative and internally consistent pagination", () => {
+  const rows = Array.from({ length: 55 }, (_, index) => ({ id: `draft-${index}` }));
+  const fullPage = Array.from({ length: 100 }, (_, index) => ({ id: `draft-${index}` }));
+  assert.deepEqual(reviewDraftPage({ data: fullPage, pagination: { total: 250, has_more: true } }, 100, 100).page, {
+    limit: 100,
+    offset: 100,
+    loaded_count: 100,
+    coverage_status: "TOTAL_KNOWN",
+    total_count: 250,
+    remaining_count: 50,
+    has_more: true,
+    next_offset: 200,
+  });
+  assert.deepEqual(reviewDraftPage({ data: fullPage, pagination: { has_more: true } }, 100, 100).page, {
+    limit: 100,
+    offset: 100,
+    loaded_count: 100,
+    coverage_status: "PAGE_ONLY",
+    has_more: true,
+    next_offset: 200,
+  });
+  assert.deepEqual(reviewDraftPage({ data: rows, pagination: { total: 155, has_more: false } }, 100, 100).page, {
+    limit: 100,
+    offset: 100,
+    loaded_count: 55,
+    coverage_status: "TOTAL_KNOWN",
+    total_count: 155,
+    remaining_count: 0,
+    has_more: false,
+  });
+  assert.equal(reviewDraftPage({ data: rows }, 100, 0).page.coverage_status, "UNPROVEN");
+
+  const contradictions = [
+    { total: 54, has_more: false },
+    { total: 250, has_more: false },
+    { total: -1, has_more: true },
+    { total: "250", has_more: true },
+    { has_more: "true" },
+    { total: 250, has_more: true },
+  ];
+  for (const pagination of contradictions) {
+    const page = reviewDraftPage({ data: rows, pagination }, 100, 0).page;
+    assert.equal(page.coverage_status, "UNPROVEN");
+    assert.equal(Object.hasOwn(page, "total_count"), false);
+    assert.equal(Object.hasOwn(page, "has_more"), false);
+  }
+  assert.throws(
+    () => reviewDraftPage({ data: { id: "not-a-list" } }, 100, 0),
+    /did not contain a data array/,
+  );
+});
+
 test("Warmbly review proxy preserves exact-hash decision metadata", async () => {
   const calls: Array<{ url: string; init: RequestInit }> = [];
   const fetchImpl = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
@@ -54,7 +106,17 @@ test("Warmbly review proxy preserves exact-hash decision metadata", async () => 
   }, fetchImpl);
   assert.ok(port);
 
-  await port.list(FOUNDER, new URLSearchParams({ limit: "999", offset: "12" }));
+  const listed = await port.list(FOUNDER, new URLSearchParams({ limit: "999", offset: "12" }));
+  assert.deepEqual(listed, {
+    schema_version: "control-center.review-draft-page.v1",
+    data: [],
+    page: {
+      limit: 200,
+      offset: 12,
+      loaded_count: 0,
+      coverage_status: "UNPROVEN",
+    },
+  });
   const result = await port.decide(FOUNDER, DRAFT_ID, {
     action: "APPROVE",
     expected_content_hash: HASH,

--- a/control-center/services/context/test/warmbly-review.test.ts
+++ b/control-center/services/context/test/warmbly-review.test.ts
@@ -36,7 +36,17 @@ function decisionBody(touchpoint = queuedTouchpoint(), scheduledFor: unknown = D
 test("review list publishes only authoritative and internally consistent pagination", () => {
   const rows = Array.from({ length: 55 }, (_, index) => ({ id: `draft-${index}` }));
   const fullPage = Array.from({ length: 100 }, (_, index) => ({ id: `draft-${index}` }));
-  assert.deepEqual(reviewDraftPage({ data: fullPage, pagination: { total: 250, has_more: true } }, 100, 100).page, {
+  assert.deepEqual(reviewDraftPage({
+    data: fullPage,
+    pagination: {
+      limit: 100,
+      offset: 100,
+      total: 250,
+      remaining_count: 50,
+      has_more: true,
+      next_offset: 200,
+    },
+  }, 100, 100).page, {
     limit: 100,
     offset: 100,
     loaded_count: 100,
@@ -78,6 +88,18 @@ test("review list publishes only authoritative and internally consistent paginat
     assert.equal(page.coverage_status, "UNPROVEN");
     assert.equal(Object.hasOwn(page, "total_count"), false);
     assert.equal(Object.hasOwn(page, "has_more"), false);
+  }
+  const cursorContradictions = [
+    { total: 250, has_more: true, next_offset: 999 },
+    { total: 250, has_more: true, remaining_count: 1 },
+    { total: 250, has_more: true, limit: 50 },
+    { total: 250, has_more: true, offset: 0 },
+    { has_more: true, next_offset: "200" },
+  ];
+  for (const pagination of cursorContradictions) {
+    const page = reviewDraftPage({ data: fullPage, pagination }, 100, 100).page;
+    assert.equal(page.coverage_status, "UNPROVEN");
+    assert.equal(Object.hasOwn(page, "next_offset"), false);
   }
   assert.throws(
     () => reviewDraftPage({ data: { id: "not-a-list" } }, 100, 0),


### PR DESCRIPTION
## Contexto

Corte atômico do P0 #128, decomposto em #134. Este PR é empilhado sobre #133 porque pagina a lista/inspector introduzida naquele PR.

## Mudanças

- publica `control-center.review-draft-page.v1` no Context Service
- preserva `limit`, `offset` e `loaded_count` sem promover o tamanho da página a total
- aceita `total_count`, `remaining_count`, `has_more` e `next_offset` somente quando a paginação do Warmbly é válida e coerente
- falha fechado como `UNPROVEN` para ausência, tipos inválidos, total contraditório ou página curta que alega continuidade
- carrega `offset` a partir do hash e mantém o recorte ao selecionar, editar ou decidir um draft
- mostra N carregados de M no servidor quando M é provado e oferece Anterior/Próxima somente com evidência
- registra no contrato upstream que o Warmbly atual ainda não publica paginação autoritativa

## Validação

- typecheck de todos os workspaces
- `npm test` completo dos workspaces, repetição limpa
- Context Service: 123 testes
- web shell: 436 testes
- `npm run test:integration`
- build de produção
- Playwright real completo: 55/55, restante 0, uma ação, overflow horizontal 0 em 390x844 e nenhuma próxima página inventada
- `npm audit --omit=dev --audit-level=critical`: 0 vulnerabilidades

## Risco e rollback

O endpoint Warmbly atual não traz `pagination`; portanto, após este PR a UI continuará mostrando `UNPROVEN` até o produtor publicar `total`/`has_more`. Esse é o comportamento seguro e explícito. Rollback: reverter o commit d27fc94.

Closes #134
Parent: #128
Depends on #133