### PR TITLE
[P0] Expor e atestar identidade imutável do runtime

### DIFF
--- a/control-center/apps/web-shell/README.md
+++ b/control-center/apps/web-shell/README.md
@@ -19,6 +19,11 @@ Chrome navigation exposes exactly these ten areas:
 
 “Operação Warmbly” is the safe-operation cockpit for the outbound kill switch: dispatch state, pause reason, commercial window, approved queue, hourly cap and the recent audit trail are rendered **before** the three controls (pause in one step, resume in two, acknowledge an inbound alert). There is no immediate-send or cohort-dispatch control. In Revisão, candidate APPROVE is the complete per-message scheduling authority: it writes `auto_send=true`, `QUEUED` and `due_at`; the Warmbly worker transports later.
 
+The authenticated cockpit footer shows the full immutable `CC_RELEASE_SHA`.
+`GET /runtime-identity` exposes the same read-only value to the release verifier;
+production `/ready` fails closed when that value is absent, abbreviated or a
+mutable label such as `local`.
+
 ### Rotas do gate humano de cohorts
 
 O gate humano vive **inteiramente** sob “Operação Warmbly”, em três sub-rotas:

--- a/control-center/apps/web-shell/index.html
+++ b/control-center/apps/web-shell/index.html
@@ -20,9 +20,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <footer class="runtime-identity" data-runtime-identity="true" data-release-sha="">
-      Release em execução: <code data-runtime-release-sha="true">não verificado</code>
-    </footer>
     <noscript>
       Este cockpit precisa de JavaScript. No diretório
       <code>control-center/apps/web-shell</code> execute

--- a/control-center/apps/web-shell/index.html
+++ b/control-center/apps/web-shell/index.html
@@ -15,10 +15,14 @@
     <meta name="cc-context-url" content="" />
     <meta name="cc-actor-id" content="" />
     <meta name="cc-actor-kind" content="" />
+    <meta name="cc-release-sha" content="" />
     <title>Control Center — Confenge</title>
   </head>
   <body>
     <div id="root"></div>
+    <footer class="runtime-identity" data-runtime-identity="true" data-release-sha="">
+      Release em execução: <code data-runtime-release-sha="true">não verificado</code>
+    </footer>
     <noscript>
       Este cockpit precisa de JavaScript. No diretório
       <code>control-center/apps/web-shell</code> execute

--- a/control-center/apps/web-shell/scripts/e2e.mjs
+++ b/control-center/apps/web-shell/scripts/e2e.mjs
@@ -10,6 +10,7 @@ import { isOsLibLauncherFailure } from "../src/playwright-env.ts";
 const here = dirname(fileURLToPath(import.meta.url));
 const app = join(here, "..");
 const ccRoot = join(app, "../..");
+const E2E_RELEASE_SHA = "8a2eb1f012345678901234567890123456789012";
 
 async function freePort() {
   const probe = createServer();
@@ -91,6 +92,8 @@ const context = spawn("npx", ["tsx", "scripts/boot-production-context.ts"], {
     HOST: "127.0.0.1",
     PORT: String(contextPort),
     NODE_ENV: "test",
+    CONTROL_CENTER_ENV: "production",
+    CC_RELEASE_SHA: E2E_RELEASE_SHA,
     CONTROL_CENTER_FOUNDER_ACTOR_ID: "founder-local",
   },
   stdio: "ignore",
@@ -104,6 +107,8 @@ const web = spawn("node", [join(here, "serve-prod.mjs")], {
     CC_CONTEXT_UPSTREAM: contextBase,
     CC_ACTOR_ID: "founder-local",
     CC_ACTOR_KIND: "human",
+    CONTROL_CENTER_ENV: "production",
+    CC_RELEASE_SHA: E2E_RELEASE_SHA,
   },
   stdio: "ignore",
 });
@@ -112,6 +117,18 @@ let exitCode = 1;
 try {
   await waitHttp(`${contextBase}/healthz`, 45_000);
   await waitHttp(`${webBase}/healthz`, 15_000);
+  await waitHttp(`${contextBase}/ready`, 15_000);
+  await waitHttp(`${webBase}/ready`, 15_000);
+  const contextIdentity = await fetch(`${contextBase}/v1/runtime-identity`).then((response) => response.json());
+  const webIdentity = await fetch(`${webBase}/runtime-identity`).then((response) => response.json());
+  if (contextIdentity.release_sha !== E2E_RELEASE_SHA || webIdentity.release_sha !== E2E_RELEASE_SHA) {
+    throw new Error(`runtime identity diverged: context=${contextIdentity.release_sha} web=${webIdentity.release_sha}`);
+  }
+  const cockpitHtml = await fetch(`${webBase}/`).then((response) => response.text());
+  if (!cockpitHtml.includes(`data-release-sha="${E2E_RELEASE_SHA}"`)
+    || !cockpitHtml.includes(`data-runtime-release-sha="true">${E2E_RELEASE_SHA}`)) {
+    throw new Error("authenticated cockpit does not render the immutable release SHA");
+  }
   const proxied = await fetch(`${webBase}/v1/context?scope=company`, {
     headers: { "x-actor-id": "founder-local", "x-actor-kind": "human" },
   });

--- a/control-center/apps/web-shell/scripts/e2e.mjs
+++ b/control-center/apps/web-shell/scripts/e2e.mjs
@@ -11,6 +11,18 @@ const here = dirname(fileURLToPath(import.meta.url));
 const app = join(here, "..");
 const ccRoot = join(app, "../..");
 const E2E_RELEASE_SHA = "8a2eb1f012345678901234567890123456789012";
+const REQUIRED_RUNTIME_BASELINE_SHA = "64ece7d38abacd3adeaa02735b4f22af66caab0f";
+
+function assertRuntimeIdentity(identity, service) {
+  if (identity.schema_version !== "control-center.runtime-identity.v1"
+    || identity.service !== service
+    || identity.release_sha !== E2E_RELEASE_SHA
+    || identity.required_baseline_sha !== REQUIRED_RUNTIME_BASELINE_SHA
+    || identity.release_status !== "PINNED"
+    || identity.production_required !== true) {
+    throw new Error(`invalid runtime identity for ${service}: ${JSON.stringify(identity)}`);
+  }
+}
 
 async function freePort() {
   const probe = createServer();
@@ -121,9 +133,8 @@ try {
   await waitHttp(`${webBase}/ready`, 15_000);
   const contextIdentity = await fetch(`${contextBase}/v1/runtime-identity`).then((response) => response.json());
   const webIdentity = await fetch(`${webBase}/runtime-identity`).then((response) => response.json());
-  if (contextIdentity.release_sha !== E2E_RELEASE_SHA || webIdentity.release_sha !== E2E_RELEASE_SHA) {
-    throw new Error(`runtime identity diverged: context=${contextIdentity.release_sha} web=${webIdentity.release_sha}`);
-  }
+  assertRuntimeIdentity(contextIdentity, "control-center-context");
+  assertRuntimeIdentity(webIdentity, "control-center-web");
   const cockpitHtml = await fetch(`${webBase}/`).then((response) => response.text());
   if (!cockpitHtml.includes(`name="cc-release-sha" content="${E2E_RELEASE_SHA}"`)) {
     throw new Error("authenticated cockpit does not receive the immutable release SHA");

--- a/control-center/apps/web-shell/scripts/e2e.mjs
+++ b/control-center/apps/web-shell/scripts/e2e.mjs
@@ -125,9 +125,8 @@ try {
     throw new Error(`runtime identity diverged: context=${contextIdentity.release_sha} web=${webIdentity.release_sha}`);
   }
   const cockpitHtml = await fetch(`${webBase}/`).then((response) => response.text());
-  if (!cockpitHtml.includes(`data-release-sha="${E2E_RELEASE_SHA}"`)
-    || !cockpitHtml.includes(`data-runtime-release-sha="true">${E2E_RELEASE_SHA}`)) {
-    throw new Error("authenticated cockpit does not render the immutable release SHA");
+  if (!cockpitHtml.includes(`name="cc-release-sha" content="${E2E_RELEASE_SHA}"`)) {
+    throw new Error("authenticated cockpit does not receive the immutable release SHA");
   }
   const proxied = await fetch(`${webBase}/v1/context?scope=company`, {
     headers: { "x-actor-id": "founder-local", "x-actor-kind": "human" },

--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -581,9 +581,20 @@ try {
       throw new Error(`viewport ${vp.name} accidental horizontal overflow ${overflow}px`);
     }
     const vpBrand = await assertBrand(page);
+    const releaseIdentity = await page.locator('[data-runtime-identity="true"]').evaluate((footer) => ({
+      sha: footer.getAttribute("data-release-sha") ?? "",
+      label: footer.querySelector('[data-runtime-release-sha="true"]')?.textContent?.trim() ?? "",
+      meta: document.querySelector('meta[name="cc-release-sha"]')?.getAttribute("content") ?? "",
+    }));
+    if (!/^[0-9a-f]{40}$/.test(releaseIdentity.sha)
+      || releaseIdentity.sha !== releaseIdentity.label
+      || releaseIdentity.sha !== releaseIdentity.meta) {
+      throw new Error(`viewport ${vp.name}: runtime release identity diverged ${JSON.stringify(releaseIdentity)}`);
+    }
     console.log(
       `brand_logo viewport=${vp.name} rendered=${Math.round(vpBrand.width)}x${Math.round(vpBrand.height)}`,
     );
+    console.log(`runtime_release viewport=${vp.name} sha=${releaseIdentity.sha}`);
     const metrics = await layoutMetrics(page);
     assertSingleScrollContext(metrics, `viewport ${vp.name}`);
     assertContentColumn(metrics, `viewport ${vp.name}`);

--- a/control-center/apps/web-shell/scripts/serve-prod.mjs
+++ b/control-center/apps/web-shell/scripts/serve-prod.mjs
@@ -79,10 +79,7 @@ export function injectIdentity(html, config) {
     next = next.replace(/name="cc-actor-kind" content="[^"]*"/, `name="cc-actor-kind" content="${config.actorKind}"`);
   }
   const releaseSha = config.runtimeIdentity.release_sha;
-  const releaseLabel = releaseSha ?? "não verificado";
   next = next.replace(/name="cc-release-sha" content="[^"]*"/, `name="cc-release-sha" content="${releaseSha ?? ""}"`);
-  next = next.replace(/data-runtime-identity="true" data-release-sha="[^"]*"/, `data-runtime-identity="true" data-release-sha="${releaseSha ?? ""}"`);
-  next = next.replace(/data-runtime-release-sha="true">[^<]*/, `data-runtime-release-sha="true">${releaseLabel}`);
   return next;
 }
 

--- a/control-center/apps/web-shell/scripts/serve-prod.mjs
+++ b/control-center/apps/web-shell/scripts/serve-prod.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const root = resolve(fileURLToPath(new URL("../dist", import.meta.url)));
 const host = process.env.HOST ?? "0.0.0.0";
 const port = Number.parseInt(process.env.PORT ?? "8080", 10);
+const REQUIRED_RUNTIME_BASELINE_SHA = "64ece7d38abacd3adeaa02735b4f22af66caab0f";
+const FULL_GIT_SHA = /^[0-9a-f]{40}$/;
 
 const TYPES = {
   ".html": "text/html; charset=utf-8",
@@ -33,11 +35,29 @@ export function applySecurityHeaders(res) {
   }
 }
 
-const contextUpstream = (process.env.CC_CONTEXT_UPSTREAM ?? "").replace(/\/+$/, "");
-const actorId = (process.env.CC_ACTOR_ID ?? "").trim();
-const actorKind = (process.env.CC_ACTOR_KIND ?? "").trim();
+export function runtimeIdentityFromEnv(env, service = "control-center-web") {
+  const candidate = String(env.CC_RELEASE_SHA ?? "").trim();
+  const releaseSha = FULL_GIT_SHA.test(candidate) ? candidate : null;
+  return {
+    schema_version: "control-center.runtime-identity.v1",
+    service,
+    release_sha: releaseSha,
+    required_baseline_sha: REQUIRED_RUNTIME_BASELINE_SHA,
+    release_status: releaseSha === null ? "UNVERIFIED" : "PINNED",
+    production_required: env.CONTROL_CENTER_ENV === "production",
+  };
+}
 
-function copyActorHeaders(req) {
+function configFromEnv(env) {
+  return {
+    contextUpstream: String(env.CC_CONTEXT_UPSTREAM ?? "").replace(/\/+$/, ""),
+    actorId: String(env.CC_ACTOR_ID ?? "").trim(),
+    actorKind: String(env.CC_ACTOR_KIND ?? "").trim(),
+    runtimeIdentity: runtimeIdentityFromEnv(env),
+  };
+}
+
+function copyActorHeaders(req, config) {
   const headers = { accept: "application/json" };
   const contentType = req.headers["content-type"];
   if (typeof contentType === "string" && contentType.trim()) {
@@ -45,19 +65,24 @@ function copyActorHeaders(req) {
   }
   // Browser-supplied actor headers are never trusted. Production injects the
   // configured founder identity at this server-side hop.
-  if (actorId) headers["x-actor-id"] = actorId;
-  if (actorKind) headers["x-actor-kind"] = actorKind;
+  if (config.actorId) headers["x-actor-id"] = config.actorId;
+  if (config.actorKind) headers["x-actor-kind"] = config.actorKind;
   return headers;
 }
 
-function injectIdentity(html) {
+export function injectIdentity(html, config) {
   let next = html;
-  if (actorId) {
-    next = next.replace(/name="cc-actor-id" content="[^"]*"/, `name="cc-actor-id" content="${actorId}"`);
+  if (config.actorId) {
+    next = next.replace(/name="cc-actor-id" content="[^"]*"/, `name="cc-actor-id" content="${config.actorId}"`);
   }
-  if (actorKind) {
-    next = next.replace(/name="cc-actor-kind" content="[^"]*"/, `name="cc-actor-kind" content="${actorKind}"`);
+  if (config.actorKind) {
+    next = next.replace(/name="cc-actor-kind" content="[^"]*"/, `name="cc-actor-kind" content="${config.actorKind}"`);
   }
+  const releaseSha = config.runtimeIdentity.release_sha;
+  const releaseLabel = releaseSha ?? "não verificado";
+  next = next.replace(/name="cc-release-sha" content="[^"]*"/, `name="cc-release-sha" content="${releaseSha ?? ""}"`);
+  next = next.replace(/data-runtime-identity="true" data-release-sha="[^"]*"/, `data-runtime-identity="true" data-release-sha="${releaseSha ?? ""}"`);
+  next = next.replace(/data-runtime-release-sha="true">[^<]*/, `data-runtime-release-sha="true">${releaseLabel}`);
   return next;
 }
 
@@ -86,63 +111,88 @@ function readProxyBody(req, limit = 64 * 1024) {
   });
 }
 
-export const server = createServer((req, res) => {
-  applySecurityHeaders(res);
-  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`);
-  if (contextUpstream && url.pathname.startsWith("/v1/")) {
-    void readProxyBody(req)
-      .then((body) => fetch(`${contextUpstream}${url.pathname}${url.search}`, {
-        method: req.method,
-        headers: {
-          ...copyActorHeaders(req),
-          ...(typeof req.headers["idempotency-key"] === "string"
-            ? { "idempotency-key": req.headers["idempotency-key"] }
-            : {}),
-        },
-        ...(body === undefined ? {} : { body }),
-      }))
-      .then(async (upstream) => {
-        const body = Buffer.from(await upstream.arrayBuffer());
-        res.statusCode = upstream.status;
-        res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
-        res.end(body);
-      })
-      .catch((err) => {
-        const tooLarge = err instanceof Error && err.message === "proxy_request_too_large";
-        res.statusCode = tooLarge ? 413 : 502;
-        res.setHeader("content-type", "application/json");
-        res.end(JSON.stringify({ error: tooLarge ? "request_too_large" : "context_upstream_unavailable" }));
-      });
-    return;
-  }
-  if (req.method === "GET" && (url.pathname === "/healthz" || url.pathname === "/ready")) {
-    res.statusCode = 200;
-    res.setHeader("content-type", "application/json; charset=utf-8");
-    res.end(JSON.stringify({ ok: true, ready: true, service: "control-center-web" }));
-    return;
-  }
-  const rel = url.pathname === "/" ? "/index.html" : url.pathname;
-  const candidate = normalize(join(root, rel));
-  if (!candidate.startsWith(root)) {
-    res.statusCode = 403;
-    res.end("forbidden");
-    return;
-  }
-  const file = existsSync(candidate) && statSync(candidate).isFile() ? candidate : join(root, "index.html");
-  try {
-    let body = readFileSync(file);
-    const type = TYPES[extname(file)] ?? "application/octet-stream";
-    if (extname(file) === ".html" || file.endsWith("index.html")) {
-      body = Buffer.from(injectIdentity(body.toString("utf8")));
+export function createProductionServer(env = process.env) {
+  const config = configFromEnv(env);
+  return createServer((req, res) => {
+    applySecurityHeaders(res);
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`);
+    if (config.contextUpstream && url.pathname.startsWith("/v1/")) {
+      void readProxyBody(req)
+        .then((body) => fetch(`${config.contextUpstream}${url.pathname}${url.search}`, {
+          method: req.method,
+          headers: {
+            ...copyActorHeaders(req, config),
+            ...(typeof req.headers["idempotency-key"] === "string"
+              ? { "idempotency-key": req.headers["idempotency-key"] }
+              : {}),
+          },
+          ...(body === undefined ? {} : { body }),
+        }))
+        .then(async (upstream) => {
+          const body = Buffer.from(await upstream.arrayBuffer());
+          res.statusCode = upstream.status;
+          res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+          res.end(body);
+        })
+        .catch((err) => {
+          const tooLarge = err instanceof Error && err.message === "proxy_request_too_large";
+          res.statusCode = tooLarge ? 413 : 502;
+          res.setHeader("content-type", "application/json");
+          res.end(JSON.stringify({ error: tooLarge ? "request_too_large" : "context_upstream_unavailable" }));
+        });
+      return;
     }
-    res.statusCode = 200;
-    res.setHeader("content-type", type);
-    res.end(body);
-  } catch {
-    res.statusCode = 404;
-    res.end("not found");
-  }
-});
+    if (req.method === "GET" && url.pathname === "/healthz") {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json; charset=utf-8");
+      res.end(JSON.stringify({ ok: true, service: "control-center-web" }));
+      return;
+    }
+    if (req.method === "GET" && url.pathname === "/runtime-identity") {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json; charset=utf-8");
+      res.setHeader("cache-control", "no-store");
+      res.end(JSON.stringify(config.runtimeIdentity));
+      return;
+    }
+    if (req.method === "GET" && url.pathname === "/ready") {
+      const ready = !config.runtimeIdentity.production_required
+        || config.runtimeIdentity.release_status === "PINNED";
+      res.statusCode = ready ? 200 : 503;
+      res.setHeader("content-type", "application/json; charset=utf-8");
+      res.end(JSON.stringify({
+        ready,
+        service: "control-center-web",
+        release_sha: config.runtimeIdentity.release_sha,
+        release_status: config.runtimeIdentity.release_status,
+      }));
+      return;
+    }
+    const rel = url.pathname === "/" ? "/index.html" : url.pathname;
+    const candidate = normalize(join(root, rel));
+    if (!candidate.startsWith(root)) {
+      res.statusCode = 403;
+      res.end("forbidden");
+      return;
+    }
+    const file = existsSync(candidate) && statSync(candidate).isFile() ? candidate : join(root, "index.html");
+    try {
+      let body = readFileSync(file);
+      const type = TYPES[extname(file)] ?? "application/octet-stream";
+      if (extname(file) === ".html" || file.endsWith("index.html")) {
+        body = Buffer.from(injectIdentity(body.toString("utf8"), config));
+      }
+      res.statusCode = 200;
+      res.setHeader("content-type", type);
+      res.end(body);
+    } catch {
+      res.statusCode = 404;
+      res.end("not found");
+    }
+  });
+}
+
+export const server = createProductionServer();
 
 const isMain =
   Boolean(process.argv[1]) && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;

--- a/control-center/apps/web-shell/scripts/serve-prod.mjs
+++ b/control-center/apps/web-shell/scripts/serve-prod.mjs
@@ -38,13 +38,15 @@ export function applySecurityHeaders(res) {
 export function runtimeIdentityFromEnv(env, service = "control-center-web") {
   const candidate = String(env.CC_RELEASE_SHA ?? "").trim();
   const releaseSha = FULL_GIT_SHA.test(candidate) ? candidate : null;
+  const productionRequired = [env.CONTROL_CENTER_ENV, env.NODE_ENV]
+    .some((value) => String(value ?? "").trim().toLowerCase() === "production");
   return {
     schema_version: "control-center.runtime-identity.v1",
     service,
     release_sha: releaseSha,
     required_baseline_sha: REQUIRED_RUNTIME_BASELINE_SHA,
     release_status: releaseSha === null ? "UNVERIFIED" : "PINNED",
-    production_required: env.CONTROL_CENTER_ENV === "production",
+    production_required: productionRequired,
   };
 }
 

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -134,6 +134,15 @@ function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
   return typeof (value as Promise<T>).then === "function";
 }
 
+function browserReleaseSha(): string | null {
+  if (typeof document === "undefined") return null;
+  const candidate = document
+    .querySelector('meta[name="cc-release-sha"]')
+    ?.getAttribute("content")
+    ?.trim() ?? "";
+  return /^[0-9a-f]{40}$/.test(candidate) ? candidate : null;
+}
+
 function applyPaint(
   root: MountableRoot,
   adapter: ControlCenterReadAdapter & {
@@ -172,6 +181,7 @@ function applyPaint(
     resource: parsed.resource,
     query: queryOf(renderHash),
     hash: renderHash,
+    releaseSha: browserReleaseSha(),
     ...(adapter.lastOperatorResult ? { operatorResult: adapter.lastOperatorResult } : {}),
   });
   const repaint = (): void => {

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -71,10 +71,11 @@ a {
   height: 100dvh;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
   grid-template-areas:
     "top"
     "main"
+    "footer"
     "nav";
 }
 
@@ -768,10 +769,11 @@ h2 {
 @media (min-width: 880px) {
   .shell {
     grid-template-columns: 13.5rem minmax(0, 1fr);
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr) auto;
     grid-template-areas:
       "top top"
-      "nav main";
+      "nav main"
+      "nav footer";
   }
 
   .nav {
@@ -1492,9 +1494,12 @@ button[data-toggle-messages] {
 }
 
 .runtime-identity {
-  margin: 1rem auto 2rem;
-  width: min(100% - 2rem, 1200px);
-  color: var(--muted);
+  grid-area: footer;
+  margin: 0;
+  padding: 0.35rem 0.9rem;
+  border-top: 1px solid var(--line);
+  background: var(--bg);
+  color: var(--fg-muted);
   font-size: 0.75rem;
   overflow-wrap: anywhere;
 }

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -1490,3 +1490,11 @@ button[data-toggle-messages] {
   font-size: 0.9rem;
   opacity: 0.8;
 }
+
+.runtime-identity {
+  margin: 1rem auto 2rem;
+  width: min(100% - 2rem, 1200px);
+  color: var(--muted);
+  font-size: 0.75rem;
+  overflow-wrap: anywhere;
+}

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -62,6 +62,8 @@ export interface ShellModel {
   operatorResult?: AdapterWriteResult;
   /** Full current location. List chrome reflects search/filters/sort/page in it. */
   hash?: string;
+  /** Immutable release identity injected into the document by the production server. */
+  releaseSha?: string | null;
 }
 
 function attentionCard(item: AttentionItem, now: string): string {
@@ -420,6 +422,9 @@ export function renderShell(model: ShellModel): string {
         ${model.destination === "warmbly" ? "" : operatorBanner(model.operatorResult)}
         ${body}
       </main>
+      <footer class="runtime-identity" data-runtime-identity="true" data-release-sha="${escapeHtml(model.releaseSha ?? "")}">
+        Release em execução: <code data-runtime-release-sha="true">${escapeHtml(model.releaseSha ?? "não verificado")}</code>
+      </footer>
     </div>
   `;
 }

--- a/control-center/contracts/docs/http.openapi.json
+++ b/control-center/contracts/docs/http.openapi.json
@@ -18,9 +18,28 @@
     { "name": "cockpit", "description": "Exceptions and top priorities" },
     { "name": "snapshots", "description": "Aggregated read models" },
     { "name": "delivery", "description": "Read-only Work Order authority and event stream" },
-    { "name": "collectors", "description": "Read-only collector runs" }
+    { "name": "collectors", "description": "Read-only collector runs" },
+    { "name": "runtime", "description": "Immutable identity of the running release" }
   ],
   "paths": {
+    "/v1/runtime-identity": {
+      "get": {
+        "tags": ["runtime"],
+        "operationId": "getRuntimeIdentity",
+        "summary": "Read the immutable release SHA presented by the Context runtime",
+        "description": "Authenticated read-only evidence. Deployment verification must reconcile this SHA with repository ancestry, the OCI image revision label and the active container. Health alone is not release evidence.",
+        "responses": {
+          "200": {
+            "description": "Pinned or explicitly unverified runtime identity",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RuntimeIdentity" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/context": {
       "get": {
         "tags": ["context"],
@@ -590,6 +609,27 @@
         "minLength": 2,
         "description": "Comma-separated scopes. Empty list is 400. Each token must match Scope.",
         "pattern": "^(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:(?!(?:anonimo|anonymous|client|cliente|default|desconhecido|na|n-a|nao-identificado|nao-informado|no-name|none|null|placeholder|sem-identidade|sem-nome|tbd|undefined|unidentified|unknown)(?:,|$))[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+)(?:,(?:company|commercial|finance|clients|infrastructure|inbound|repo:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?|client:(?!(?:anonimo|anonymous|client|cliente|default|desconhecido|na|n-a|nao-identificado|nao-informado|no-name|none|null|placeholder|sem-identidade|sem-nome|tbd|undefined|unidentified|unknown)(?:,|$))[a-z0-9]+(?:-[a-z0-9]+)*|(?!company:|commercial:|finance:|clients:|infrastructure:|inbound:|repo:|client:)[a-z][a-z0-9-]*:[A-Za-z0-9._:~-]+))*$"
+      },
+      "RuntimeIdentity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema_version", "service", "release_sha", "required_baseline_sha",
+          "release_status", "production_required"
+        ],
+        "properties": {
+          "schema_version": { "const": "control-center.runtime-identity.v1" },
+          "service": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "release_sha": {
+            "oneOf": [
+              { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+              { "type": "null" }
+            ]
+          },
+          "required_baseline_sha": { "const": "64ece7d38abacd3adeaa02735b4f22af66caab0f" },
+          "release_status": { "enum": ["PINNED", "UNVERIFIED"] },
+          "production_required": { "type": "boolean" }
+        }
       },
       "ErrorBody": {
         "type": "object",

--- a/control-center/contracts/tests/runtime-identity.test.ts
+++ b/control-center/contracts/tests/runtime-identity.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { packageRoot } from "../src/paths.js";
+
+test("runtime identity is a read-only full-SHA HTTP contract", () => {
+  const document = JSON.parse(
+    readFileSync(path.join(packageRoot(), "docs/http.openapi.json"), "utf8"),
+  ) as {
+    paths: Record<string, Record<string, unknown>>;
+    components: { schemas: { RuntimeIdentity: { properties: Record<string, Record<string, unknown>> } } };
+  };
+  const route = document.paths["/v1/runtime-identity"];
+  assert.ok(route);
+  assert.deepEqual(Object.keys(route), ["get"]);
+  const schema = document.components.schemas.RuntimeIdentity;
+  assert.equal(schema.properties.schema_version?.const, "control-center.runtime-identity.v1");
+  assert.equal(schema.properties.required_baseline_sha?.const, "64ece7d38abacd3adeaa02735b4f22af66caab0f");
+  assert.deepEqual(schema.properties.release_status?.enum, ["PINNED", "UNVERIFIED"]);
+  const releaseSha = schema.properties.release_sha as { oneOf: Array<{ pattern?: string }> };
+  assert.equal(releaseSha.oneOf[0]?.pattern, "^[0-9a-f]{40}$");
+});

--- a/control-center/deploy/PRODUCTION-RUNBOOK.md
+++ b/control-center/deploy/PRODUCTION-RUNBOOK.md
@@ -160,6 +160,13 @@ docker compose -p confenge-control-center \
   -f docker-compose.production-edge.yml \
   -f docker-compose.warmbly-human-gate.override.yml \
   up -d context web
+
+# Mandatory identity gate: proves baseline ancestry and reconciles repository
+# SHA -> image label/ID -> container env -> each live HTTP response. Save this
+# output beside the release record; health alone is not release evidence.
+set -o pipefail
+./verify-release.sh "$CC_RELEASE_SHA" context web | tee \
+  "release-attestation-${CC_RELEASE_SHA}.log"
 ```
 
 For a first installation only, use the full bootstrap sequence instead of the
@@ -195,6 +202,9 @@ curl -sS -H 'Host: ops.confenge.com.br' http://127.0.0.1:18080/healthz
 curl -sS -o /dev/null -w '%{http_code}\n' -H 'Host: ops.confenge.com.br' http://127.0.0.1:18080/ready
 # internal:
 # context /healthz /ready, collector /healthz /ready, mcp /healthz /ready
+# authenticated cockpit footer: exact full release SHA
+# internal context: GET /v1/runtime-identity
+# internal web: GET /runtime-identity
 ```
 
 Public cockpit: `https://ops.confenge.com.br/` → Authelia 302 until authenticated + 2FA.

--- a/control-center/deploy/PRODUCTION-RUNBOOK.md
+++ b/control-center/deploy/PRODUCTION-RUNBOOK.md
@@ -164,9 +164,11 @@ docker compose -p confenge-control-center \
 # Mandatory identity gate: proves baseline ancestry and reconciles repository
 # SHA -> image label/ID -> container env -> each live HTTP response. Save this
 # output beside the release record; health alone is not release evidence.
+export CC_RELEASE_EVIDENCE_DIR=/opt/confenge-control-center-release-evidence
+mkdir -p "$CC_RELEASE_EVIDENCE_DIR"
 set -o pipefail
 ./verify-release.sh "$CC_RELEASE_SHA" context web | tee \
-  "release-attestation-${CC_RELEASE_SHA}.log"
+  "$CC_RELEASE_EVIDENCE_DIR/release-attestation-${CC_RELEASE_SHA}.log"
 ```
 
 For a first installation only, use the full bootstrap sequence instead of the

--- a/control-center/deploy/docker-compose.yml
+++ b/control-center/deploy/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       HOST: 0.0.0.0
       PORT: "8080"
       NODE_ENV: production
+      CC_RELEASE_SHA: "${CC_RELEASE_SHA:-local}"
       DATABASE_URL: "${CONTROL_CENTER_DATABASE_URL:-postgres://control_center@postgres:5432/control_center}"
       CONTROL_CENTER_FOUNDER_ACTOR_ID: "${CONTROL_CENTER_FOUNDER_ACTOR_ID:?CONTROL_CENTER_FOUNDER_ACTOR_ID must be set}"
       CONTROL_CENTER_ENV: production
@@ -158,6 +159,8 @@ services:
     environment:
       HOST: 0.0.0.0
       PORT: "8080"
+      CC_RELEASE_SHA: "${CC_RELEASE_SHA:-local}"
+      CONTROL_CENTER_ENV: production
     healthcheck:
       test: ["CMD", "node", "/app/node-http-probe.mjs", "http://127.0.0.1:8080", "/healthz", "/ready"]
       interval: 10s

--- a/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
+++ b/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
@@ -326,6 +326,7 @@ services:
     image: confenge-control-center-web:${CC_RELEASE_SHA:-local}
     environment:
       CC_RELEASE_SHA: "${CC_RELEASE_SHA:-local}"
+      CONTROL_CENTER_ENV: production
       HOST: 0.0.0.0
       PORT: "8080"
       CC_TRUSTED_PROXY_CIDRS: "${CC_TRUSTED_PROXY_CIDRS:?CC_TRUSTED_PROXY_CIDRS must be set}"

--- a/control-center/deploy/overlays/production-edge/verify-release.sh
+++ b/control-center/deploy/overlays/production-edge/verify-release.sh
@@ -8,6 +8,19 @@ set -euo pipefail
 
 EXPECTED="${1:?usage: verify-release.sh <expected-sha> [service...]}"
 shift || true
+BASELINE="64ece7d38abacd3adeaa02735b4f22af66caab0f"
+if [[ ! "$EXPECTED" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "FAIL release: expected SHA must be the full lowercase 40-character commit identity"
+  exit 1
+fi
+if ! git cat-file -e "${EXPECTED}^{commit}" 2>/dev/null; then
+  echo "FAIL release: expected SHA is not a commit in this repository"
+  exit 1
+fi
+if ! git merge-base --is-ancestor "$BASELINE" "$EXPECTED"; then
+  echo "FAIL release: ${EXPECTED} does not descend from required baseline ${BASELINE}"
+  exit 1
+fi
 SERVICES=("$@")
 if [ ${#SERVICES[@]} -eq 0 ]; then
   SERVICES=(web context)
@@ -27,6 +40,23 @@ for svc in "${SERVICES[@]}"; do
   label=$(docker inspect "$image_id" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || echo "")
   envsha=$(docker inspect "$container" --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^CC_RELEASE_SHA=//p' | head -1)
   running=$(docker inspect "$container" --format '{{.State.Running}}')
+  runtime_http=""
+  case "$svc" in
+    context) runtime_endpoint="http://127.0.0.1:8080/v1/runtime-identity" ;;
+    web) runtime_endpoint="http://127.0.0.1:8080/runtime-identity" ;;
+    *) runtime_endpoint="" ;;
+  esac
+  if [ -n "$runtime_endpoint" ]; then
+    runtime_http=$(docker exec "$container" node -e '
+      const endpoint = process.argv[1];
+      fetch(endpoint).then(async (response) => {
+        if (!response.ok) throw new Error(`status_${response.status}`);
+        const body = await response.json();
+        if (body.release_status !== "PINNED") throw new Error("release_not_pinned");
+        process.stdout.write(String(body.release_sha ?? ""));
+      }).catch(() => process.exit(2));
+    ' "$runtime_endpoint" 2>/dev/null || true)
+  fi
 
   echo "--- ${svc}"
   echo "    container   : ${container} (running=${running})"
@@ -34,6 +64,7 @@ for svc in "${SERVICES[@]}"; do
   echo "    image id    : ${image_id}"
   echo "    image label : ${label:-<none>}"
   echo "    runtime env : ${envsha:-<none>}"
+  echo "    runtime HTTP: ${runtime_http:-<none>}"
 
   if [ "$running" != "true" ]; then
     echo "    -> FAIL: container is not running"
@@ -45,16 +76,32 @@ for svc in "${SERVICES[@]}"; do
     fail=1
     continue
   fi
-  # Accept a short SHA prefix so a 12-character tag reconciles with a full SHA.
-  case "$EXPECTED" in
-    "$label"*) ;;
-    *) echo "    -> FAIL: image label ${label} does not match expected ${EXPECTED}"; fail=1; continue ;;
-  esac
-  if [ -n "$envsha" ]; then
-    case "$EXPECTED" in
-      "$envsha"*) ;;
-      *) echo "    -> FAIL: runtime CC_RELEASE_SHA ${envsha} does not match expected ${EXPECTED}"; fail=1; continue ;;
-    esac
+  if [ "$label" != "$EXPECTED" ]; then
+    echo "    -> FAIL: image label ${label} does not exactly match expected ${EXPECTED}"
+    fail=1
+    continue
+  fi
+  if [ "$svc" = "context" ] || [ "$svc" = "web" ]; then
+    if [ -z "$envsha" ]; then
+      echo "    -> FAIL: runtime has no CC_RELEASE_SHA"
+      fail=1
+      continue
+    fi
+    if [ "$envsha" != "$EXPECTED" ]; then
+      echo "    -> FAIL: runtime CC_RELEASE_SHA ${envsha} does not exactly match expected ${EXPECTED}"
+      fail=1
+      continue
+    fi
+    if [ -z "$runtime_http" ]; then
+      echo "    -> FAIL: runtime HTTP identity is absent or unpinned"
+      fail=1
+      continue
+    fi
+    if [ "$runtime_http" != "$EXPECTED" ]; then
+      echo "    -> FAIL: runtime HTTP identity ${runtime_http:-<none>} does not exactly match expected ${EXPECTED}"
+      fail=1
+      continue
+    fi
   fi
   echo "    -> OK: repo ${EXPECTED} reconciles with image label and runtime"
 done

--- a/control-center/deploy/overlays/production-edge/verify-release.sh
+++ b/control-center/deploy/overlays/production-edge/verify-release.sh
@@ -17,6 +17,22 @@ if ! git cat-file -e "${EXPECTED}^{commit}" 2>/dev/null; then
   echo "FAIL release: expected SHA is not a commit in this repository"
   exit 1
 fi
+if ! REPOSITORY_HEAD=$(git rev-parse HEAD 2>/dev/null); then
+  echo "FAIL release: repository HEAD could not be resolved"
+  exit 1
+fi
+if [ "$REPOSITORY_HEAD" != "$EXPECTED" ]; then
+  echo "FAIL release: checkout HEAD ${REPOSITORY_HEAD} does not exactly match expected ${EXPECTED}"
+  exit 1
+fi
+if ! SOURCE_STATUS=$(git status --porcelain=v1 --untracked-files=all); then
+  echo "FAIL release: repository source status could not be inspected"
+  exit 1
+fi
+if [ -n "$SOURCE_STATUS" ]; then
+  echo "FAIL release: checkout contains tracked or untracked changes; image provenance is not reproducible"
+  exit 1
+fi
 if ! git merge-base --is-ancestor "$BASELINE" "$EXPECTED"; then
   echo "FAIL release: ${EXPECTED} does not descend from required baseline ${BASELINE}"
   exit 1
@@ -48,14 +64,19 @@ for svc in "${SERVICES[@]}"; do
   esac
   if [ -n "$runtime_endpoint" ]; then
     runtime_http=$(docker exec "$container" node -e '
-      const endpoint = process.argv[1];
-      fetch(endpoint).then(async (response) => {
+      const [endpoint, expectedService, expectedBaseline] = process.argv.slice(1);
+      fetch(endpoint, { signal: AbortSignal.timeout(5000) }).then(async (response) => {
         if (!response.ok) throw new Error(`status_${response.status}`);
         const body = await response.json();
+        if (body.schema_version !== "control-center.runtime-identity.v1") throw new Error("schema_mismatch");
+        if (body.service !== expectedService) throw new Error("service_mismatch");
+        if (body.required_baseline_sha !== expectedBaseline) throw new Error("baseline_mismatch");
+        if (body.production_required !== true) throw new Error("production_gate_disabled");
         if (body.release_status !== "PINNED") throw new Error("release_not_pinned");
+        if (!/^[0-9a-f]{40}$/.test(String(body.release_sha ?? ""))) throw new Error("release_invalid");
         process.stdout.write(String(body.release_sha ?? ""));
       }).catch(() => process.exit(2));
-    ' "$runtime_endpoint" 2>/dev/null || true)
+    ' "$runtime_endpoint" "control-center-${svc}" "$BASELINE" 2>/dev/null || true)
   fi
 
   echo "--- ${svc}"

--- a/control-center/deploy/tests/compose.test.ts
+++ b/control-center/deploy/tests/compose.test.ts
@@ -52,6 +52,11 @@ test("shipped compose names the Control Center project, postgres volume, health+
   assert.equal(requireService(doc, "mcp").build?.dockerfile, "services/mcp/Dockerfile");
   assert.equal(requireService(doc, "collector").build?.dockerfile, "connectors/runner/Dockerfile");
   assert.equal(requireService(doc, "web").build?.dockerfile, "apps/web-shell/Dockerfile");
+  const contextEnvironment = requireService(doc, "context").environment ?? {};
+  const webEnvironment = requireService(doc, "web").environment ?? {};
+  assert.equal(contextEnvironment.CC_RELEASE_SHA, webEnvironment.CC_RELEASE_SHA);
+  assert.equal(contextEnvironment.CONTROL_CENTER_ENV, "production");
+  assert.equal(webEnvironment.CONTROL_CENTER_ENV, "production");
 
   const caddy = requireService(doc, "caddy");
   assert.equal(caddy.restart, "unless-stopped");

--- a/control-center/deploy/tests/production-edge.test.ts
+++ b/control-center/deploy/tests/production-edge.test.ts
@@ -144,9 +144,21 @@ test("production-edge compose publishes loopback Caddy only, unpublished datasto
   const web = doc.services.web;
   assert.ok(isRecord(web));
   const webEnv = isRecord(web.environment) ? web.environment : {};
+  assert.match(String(webEnv.CC_RELEASE_SHA ?? ""), /CC_RELEASE_SHA/);
+  assert.equal(webEnv.CONTROL_CENTER_ENV, "production");
   assert.equal(String(webEnv.CC_ACTOR_KIND ?? ""), "human");
   assert.match(String(webEnv.CC_ACTOR_ID ?? ""), /CONTROL_CENTER_FOUNDER_ACTOR_ID/);
   assert.doesNotMatch(String(webEnv.CC_ACTOR_ID ?? ""), /human:operator/);
+  const context = doc.services.context;
+  assert.ok(isRecord(context));
+  const contextEnv = isRecord(context.environment) ? context.environment : {};
+  assert.equal(contextEnv.CC_RELEASE_SHA, webEnv.CC_RELEASE_SHA);
+  assert.equal(contextEnv.CONTROL_CENTER_ENV, "production");
+  for (const service of [context, web]) {
+    const build = isRecord(service.build) ? service.build : {};
+    const labels = isRecord(build.labels) ? build.labels : {};
+    assert.equal(labels["org.opencontainers.image.revision"], webEnv.CC_RELEASE_SHA);
+  }
 });
 
 test("Warmbly collector override adds only an external network and no datastore volumes", () => {

--- a/control-center/deploy/tests/release-attestation.test.ts
+++ b/control-center/deploy/tests/release-attestation.test.ts
@@ -40,6 +40,17 @@ esac
   writeFileSync(git, `#!/bin/sh
 case "$1" in
   cat-file) exit 0 ;;
+  rev-parse)
+    if [ -n "\${FAKE_GIT_HEAD:-}" ]; then printf '%s\\n' "$FAKE_GIT_HEAD"; exit 0; fi
+    exec /usr/bin/git "$@"
+    ;;
+  status)
+    if [ "\${FAKE_GIT_DIRTY:-false}" = "true" ]; then
+      printf ' M control-center/services/context/src/runtime-identity.ts\\n'
+      exit 0
+    fi
+    exit 0
+    ;;
   merge-base)
     if [ "\${FAKE_GIT_ANCESTRY:-valid}" = "valid" ]; then exit 0; fi
     exit 1
@@ -120,4 +131,36 @@ test("release attestation rejects a full SHA outside the required baseline", () 
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stdout, /does not descend from required baseline/);
+});
+
+test("release attestation rejects an expected SHA that is not the checked-out HEAD", () => {
+  const sha = repositoryHead();
+  const bin = fakeRuntimeBin();
+  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
+    cwd: REPOSITORY_ROOT,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      FAKE_GIT_HEAD: "0000000000000000000000000000000000000000",
+    },
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /checkout HEAD .* does not exactly match expected/);
+});
+
+test("release attestation rejects a dirty image source tree", () => {
+  const sha = repositoryHead();
+  const bin = fakeRuntimeBin();
+  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
+    cwd: REPOSITORY_ROOT,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      FAKE_GIT_DIRTY: "true",
+    },
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /checkout contains tracked or untracked changes/);
 });

--- a/control-center/deploy/tests/release-attestation.test.ts
+++ b/control-center/deploy/tests/release-attestation.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { PACK_ROOT } from "../src/paths.ts";
+
+const SCRIPT = join(PACK_ROOT, "overlays", "production-edge", "verify-release.sh");
+const REPOSITORY_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const tempDirs: string[] = [];
+
+after(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+function fakeDockerBin(): string {
+  const root = mkdtempSync(join(tmpdir(), "cc-release-attestation-"));
+  tempDirs.push(root);
+  const script = join(root, "docker");
+  writeFileSync(script, `#!/bin/sh
+case "$1" in
+  inspect)
+    case "$*" in
+      *org.opencontainers.image.revision*) printf '%s\\n' "$FAKE_RELEASE_SHA" ;;
+      *Config.Env*) printf 'CC_RELEASE_SHA=%s\\n' "$FAKE_RELEASE_SHA" ;;
+      *State.Running*) printf 'true\\n' ;;
+      *Config.Image*) printf 'confenge-control-center:test\\n' ;;
+      *"{{.Image}}"*) printf 'sha256:fixture-image-id\\n' ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  exec) printf '%s' "$FAKE_HTTP_SHA" ;;
+  *) exit 2 ;;
+esac
+`, "utf8");
+  chmodSync(script, 0o755);
+  return root;
+}
+
+function repositoryHead(): string {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: REPOSITORY_ROOT,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+test("release attestation reconciles repository, image, container env and HTTP identity", () => {
+  const sha = repositoryHead();
+  const bin = fakeDockerBin();
+  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
+    cwd: REPOSITORY_ROOT,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      FAKE_RELEASE_SHA: sha,
+      FAKE_HTTP_SHA: sha,
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /runtime HTTP:/);
+  assert.match(result.stdout, /RELEASE VERIFICATION PASSED/);
+  assert.equal((result.stdout.match(/reconciles with image label and runtime/g) ?? []).length, 2);
+});
+
+test("release attestation fails closed when the live HTTP SHA differs", () => {
+  const sha = repositoryHead();
+  const bin = fakeDockerBin();
+  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
+    cwd: REPOSITORY_ROOT,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      FAKE_RELEASE_SHA: sha,
+      FAKE_HTTP_SHA: "0000000000000000000000000000000000000000",
+    },
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /runtime HTTP identity .* does not exactly match expected/);
+  assert.match(result.stdout, /RELEASE VERIFICATION FAILED/);
+});
+
+test("release attestation rejects tags and abbreviated SHAs as mutable identities", () => {
+  const result = spawnSync("bash", [SCRIPT, "64ece7d", "context", "web"], {
+    cwd: REPOSITORY_ROOT,
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /full lowercase 40-character commit identity/);
+});

--- a/control-center/deploy/tests/release-attestation.test.ts
+++ b/control-center/deploy/tests/release-attestation.test.ts
@@ -15,11 +15,11 @@ after(() => {
   for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
 });
 
-function fakeDockerBin(): string {
+function fakeRuntimeBin(): string {
   const root = mkdtempSync(join(tmpdir(), "cc-release-attestation-"));
   tempDirs.push(root);
-  const script = join(root, "docker");
-  writeFileSync(script, `#!/bin/sh
+  const docker = join(root, "docker");
+  writeFileSync(docker, `#!/bin/sh
 case "$1" in
   inspect)
     case "$*" in
@@ -35,7 +35,19 @@ case "$1" in
   *) exit 2 ;;
 esac
 `, "utf8");
-  chmodSync(script, 0o755);
+  chmodSync(docker, 0o755);
+  const git = join(root, "git");
+  writeFileSync(git, `#!/bin/sh
+case "$1" in
+  cat-file) exit 0 ;;
+  merge-base)
+    if [ "\${FAKE_GIT_ANCESTRY:-valid}" = "valid" ]; then exit 0; fi
+    exit 1
+    ;;
+  *) exec /usr/bin/git "$@" ;;
+esac
+`, "utf8");
+  chmodSync(git, 0o755);
   return root;
 }
 
@@ -50,7 +62,7 @@ function repositoryHead(): string {
 
 test("release attestation reconciles repository, image, container env and HTTP identity", () => {
   const sha = repositoryHead();
-  const bin = fakeDockerBin();
+  const bin = fakeRuntimeBin();
   const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
     cwd: REPOSITORY_ROOT,
     env: {
@@ -69,7 +81,7 @@ test("release attestation reconciles repository, image, container env and HTTP i
 
 test("release attestation fails closed when the live HTTP SHA differs", () => {
   const sha = repositoryHead();
-  const bin = fakeDockerBin();
+  const bin = fakeRuntimeBin();
   const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
     cwd: REPOSITORY_ROOT,
     env: {
@@ -92,4 +104,20 @@ test("release attestation rejects tags and abbreviated SHAs as mutable identitie
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stdout, /full lowercase 40-character commit identity/);
+});
+
+test("release attestation rejects a full SHA outside the required baseline", () => {
+  const sha = repositoryHead();
+  const bin = fakeRuntimeBin();
+  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
+    cwd: REPOSITORY_ROOT,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      FAKE_GIT_ANCESTRY: "invalid",
+    },
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /does not descend from required baseline/);
 });

--- a/control-center/scripts/boot-production-context.ts
+++ b/control-center/scripts/boot-production-context.ts
@@ -15,6 +15,7 @@ import {
   createRequestListener,
   cryptoIds,
   frozenClock,
+  runtimeIdentityFromEnv,
   silentLogger,
 } from "../services/context/src/index.ts";
 import { FOUNDER, LIVE_NOW, seedLiveCockpit, seedOperationalCockpit } from "../tests/convergence/live-runtime/seed.ts";
@@ -62,6 +63,7 @@ const server = createServer(
     // Isolated E2E harness identity. Production startServer resolves this only
     // from trusted Authelia Remote-* headers; the browser cannot set the actor.
     operatorActor: () => FOUNDER,
+    runtimeIdentity: runtimeIdentityFromEnv(process.env, "control-center-context"),
     logger: silentLogger,
   }),
 );

--- a/control-center/scripts/compose-probe.mjs
+++ b/control-center/scripts/compose-probe.mjs
@@ -12,6 +12,15 @@ import { fileURLToPath } from "node:url";
 const deploy = resolve(dirname(fileURLToPath(import.meta.url)), "../deploy");
 const password = "compose-probe-not-production";
 const mcpToken = "compose-probe-mcp-not-production";
+const release = spawnSync("git", ["rev-parse", "HEAD"], {
+  cwd: deploy,
+  encoding: "utf8",
+});
+const releaseSha = (release.stdout ?? "").trim();
+if (release.status !== 0 || !/^[0-9a-f]{40}$/.test(releaseSha)) {
+  process.stderr.write(`compose probe could not resolve an immutable release SHA: ${release.stderr ?? ""}\n`);
+  process.exit(1);
+}
 const env = {
   ...process.env,
   POSTGRES_PASSWORD: password,
@@ -19,6 +28,7 @@ const env = {
   POSTGRES_DB: "control_center",
   CONTROL_CENTER_FOUNDER_ACTOR_ID: "founder-local",
   CONFENGE_MCP_AUTH_TOKEN: mcpToken,
+  CC_RELEASE_SHA: releaseSha,
   CONTROL_CENTER_BACKUP_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   CONTROL_CENTER_DATABASE_URL: `postgres://control_center:${password}@postgres:5432/control_center`,
 };
@@ -93,6 +103,9 @@ const body = waitFetch("context", {
   url: "http://127.0.0.1:8080/v1/context?scope=company",
   headers: { "x-actor-id": "founder-local", "x-actor-kind": "human" },
 });
+const runtimeIdentityBody = waitFetch("context", {
+  url: "http://127.0.0.1:8080/v1/runtime-identity",
+});
 const mcpHealthBody = waitFetch("mcp", { url: "http://127.0.0.1:8080/healthz" });
 
 const initPayload = JSON.stringify({
@@ -153,6 +166,16 @@ try {
   parsed = JSON.parse(body);
 } catch {
   fail(`context body is not JSON: ${body.slice(0, 400)}`, null);
+}
+
+let runtimeIdentity;
+try {
+  runtimeIdentity = JSON.parse(runtimeIdentityBody);
+} catch {
+  fail(`context runtime identity is not JSON: ${runtimeIdentityBody.slice(0, 400)}`, null);
+}
+if (runtimeIdentity.release_status !== "PINNED" || runtimeIdentity.release_sha !== releaseSha) {
+  fail(`context runtime identity diverged from checkout ${releaseSha}: ${runtimeIdentityBody.slice(0, 400)}`, null);
 }
 
 const freshness = parsed.freshness_status;
@@ -226,6 +249,7 @@ process.stdout.write(
       observed_at: observed,
       source,
       confidence: parsed.confidence,
+      release_sha: runtimeIdentity.release_sha,
       mcp_health: mcpHealthBody,
       mcp_server: initResult.serverInfo,
       mcp_freshness_status: mcpFreshness,

--- a/control-center/scripts/compose-probe.mjs
+++ b/control-center/scripts/compose-probe.mjs
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 const deploy = resolve(dirname(fileURLToPath(import.meta.url)), "../deploy");
 const password = "compose-probe-not-production";
 const mcpToken = "compose-probe-mcp-not-production";
+const requiredRuntimeBaselineSha = "64ece7d38abacd3adeaa02735b4f22af66caab0f";
 const release = spawnSync("git", ["rev-parse", "HEAD"], {
   cwd: deploy,
   encoding: "utf8",
@@ -174,7 +175,12 @@ try {
 } catch {
   fail(`context runtime identity is not JSON: ${runtimeIdentityBody.slice(0, 400)}`, null);
 }
-if (runtimeIdentity.release_status !== "PINNED" || runtimeIdentity.release_sha !== releaseSha) {
+if (runtimeIdentity.schema_version !== "control-center.runtime-identity.v1"
+  || runtimeIdentity.service !== "control-center-context"
+  || runtimeIdentity.release_status !== "PINNED"
+  || runtimeIdentity.release_sha !== releaseSha
+  || runtimeIdentity.required_baseline_sha !== requiredRuntimeBaselineSha
+  || runtimeIdentity.production_required !== true) {
   fail(`context runtime identity diverged from checkout ${releaseSha}: ${runtimeIdentityBody.slice(0, 400)}`, null);
 }
 

--- a/control-center/services/context/README.md
+++ b/control-center/services/context/README.md
@@ -38,6 +38,8 @@ HTTP (privado, bind default `127.0.0.1`):
 
 ```
 GET  /healthz
+GET  /ready
+GET  /v1/runtime-identity
 GET  /v1/context?scope=
 GET  /v1/active-directives?scope=
 GET  /v1/priorities
@@ -69,7 +71,11 @@ o tamanho da página nunca é promovido a total do servidor.
 
 A resposta 2xx do write não é prova de efeito. Para uma decisão individual, a ponte parseia o envelope do Warmbly, executa `GET /v1/confenge/review/drafts/:id` e devolve `control-center.review-decision-receipt.v1`. `APPROVE` só sai como `confirmed` quando write e readback concordam em ID, hash/approved hash, operador, instante e `QUEUED|SENT`, com `due_at == scheduled_for` em `QUEUED`. Corpo vazio, divergência ou readback indisponível vira `not_confirmed` e orienta a não repetir antes de reler com a mesma `Idempotency-Key`.
 
-Headers obrigatórios em tudo exceto `/healthz`: `X-Actor-Id`, `X-Actor-Kind` (`human` | `agent` | `system`).
+Headers obrigatórios nas rotas de dados, exceto `/healthz`, `/ready` e
+`/v1/runtime-identity`: `X-Actor-Id`, `X-Actor-Kind` (`human` | `agent` |
+`system`). A borda continua exigindo autenticação para `/v1/runtime-identity`;
+a exceção interna permite que a prova do container leia a identidade sem
+forjar um operador.
 
 ## Como rodar
 

--- a/control-center/services/context/src/http.ts
+++ b/control-center/services/context/src/http.ts
@@ -11,6 +11,11 @@ import type { OperationalService } from "./operational/service.ts";
 import { COMMERCIAL_LIST_IDS, type CommercialListId } from "./operational/commercial-list.ts";
 import type { WarmblyReviewPort } from "./operational/warmbly-review.ts";
 import type { ContextService } from "./service.ts";
+import {
+  runtimeIdentityAllowsReady,
+  runtimeIdentityFromEnv,
+  type RuntimeIdentity,
+} from "./runtime-identity.ts";
 import { LIMITS, type ActorRef, type Scope } from "./types.ts";
 
 export interface HttpDeps {
@@ -31,6 +36,8 @@ export interface HttpDeps {
    */
   warmblyOperator?: (req: WarmblyOperatorHttpRequest) => Promise<WarmblyOperatorHttpResponse>;
   warmblyReview?: WarmblyReviewPort;
+  /** Build identity injected by the trusted deployment boundary. */
+  runtimeIdentity?: RuntimeIdentity;
 }
 
 export interface WarmblyOperatorHttpRequest {
@@ -193,9 +200,24 @@ async function handle(
       send(res, 200, { ok: true, service: "control-center-context" });
       return;
     }
+    const runtimeIdentity = deps.runtimeIdentity
+      ?? runtimeIdentityFromEnv({}, "control-center-context");
+    // Caddy keeps /v1 behind authenticated access. This route intentionally
+    // precedes actor parsing so release verification can run inside the image
+    // without manufacturing an operator identity.
+    if (method === "GET" && url.pathname === "/v1/runtime-identity") {
+      send(res, 200, runtimeIdentity);
+      return;
+    }
     if (method === "GET" && url.pathname === "/ready") {
-      const ready = await deps.service.ready();
-      send(res, ready ? 200 : 503, { ready, service: "control-center-context" });
+      const serviceReady = await deps.service.ready();
+      const ready = serviceReady && runtimeIdentityAllowsReady(runtimeIdentity);
+      send(res, ready ? 200 : 503, {
+        ready,
+        service: "control-center-context",
+        release_sha: runtimeIdentity.release_sha,
+        release_status: runtimeIdentity.release_status,
+      });
       return;
     }
     // Mounted before actorFromRequest on purpose. The operator channel resolves

--- a/control-center/services/context/src/index.ts
+++ b/control-center/services/context/src/index.ts
@@ -16,6 +16,12 @@ export type { PersistencePort, PersistenceAdapter } from "./store/adapter.ts";
 export { bootFromEnv, bootFromEnvAsync, actorFromEnv } from "./boot.ts";
 export { createRequestListener } from "./http.ts";
 export { startServer } from "./server.ts";
+export {
+  REQUIRED_RUNTIME_BASELINE_SHA,
+  runtimeIdentityAllowsReady,
+  runtimeIdentityFromEnv,
+} from "./runtime-identity.ts";
+export type { RuntimeIdentity } from "./runtime-identity.ts";
 export { createOperationalService } from "./operational/service.ts";
 export {
   createMemoryOperatorActionService,

--- a/control-center/services/context/src/runtime-identity.ts
+++ b/control-center/services/context/src/runtime-identity.ts
@@ -17,13 +17,15 @@ export function runtimeIdentityFromEnv(
 ): RuntimeIdentity {
   const candidate = (env.CC_RELEASE_SHA ?? "").trim();
   const releaseSha = FULL_GIT_SHA.test(candidate) ? candidate : null;
+  const productionRequired = [env.CONTROL_CENTER_ENV, env.NODE_ENV]
+    .some((value) => value?.trim().toLowerCase() === "production");
   return {
     schema_version: "control-center.runtime-identity.v1",
     service,
     release_sha: releaseSha,
     required_baseline_sha: REQUIRED_RUNTIME_BASELINE_SHA,
     release_status: releaseSha === null ? "UNVERIFIED" : "PINNED",
-    production_required: env.CONTROL_CENTER_ENV === "production",
+    production_required: productionRequired,
   };
 }
 

--- a/control-center/services/context/src/runtime-identity.ts
+++ b/control-center/services/context/src/runtime-identity.ts
@@ -1,0 +1,32 @@
+export const REQUIRED_RUNTIME_BASELINE_SHA = "64ece7d38abacd3adeaa02735b4f22af66caab0f";
+
+const FULL_GIT_SHA = /^[0-9a-f]{40}$/;
+
+export interface RuntimeIdentity {
+  schema_version: "control-center.runtime-identity.v1";
+  service: string;
+  release_sha: string | null;
+  required_baseline_sha: typeof REQUIRED_RUNTIME_BASELINE_SHA;
+  release_status: "PINNED" | "UNVERIFIED";
+  production_required: boolean;
+}
+
+export function runtimeIdentityFromEnv(
+  env: NodeJS.ProcessEnv,
+  service: string,
+): RuntimeIdentity {
+  const candidate = (env.CC_RELEASE_SHA ?? "").trim();
+  const releaseSha = FULL_GIT_SHA.test(candidate) ? candidate : null;
+  return {
+    schema_version: "control-center.runtime-identity.v1",
+    service,
+    release_sha: releaseSha,
+    required_baseline_sha: REQUIRED_RUNTIME_BASELINE_SHA,
+    release_status: releaseSha === null ? "UNVERIFIED" : "PINNED",
+    production_required: env.CONTROL_CENTER_ENV === "production",
+  };
+}
+
+export function runtimeIdentityAllowsReady(identity: RuntimeIdentity): boolean {
+  return !identity.production_required || identity.release_status === "PINNED";
+}

--- a/control-center/services/context/src/server.ts
+++ b/control-center/services/context/src/server.ts
@@ -5,6 +5,7 @@ import { createWarmblyOperatorHandlerFromEnv } from "./warmbly-operator/from-env
 import { createOperatorActorResolverFromEnv } from "./security/operator-identity.ts";
 import { createLogger, type Logger } from "./log.ts";
 import { isServiceError } from "./errors.ts";
+import { runtimeIdentityFromEnv } from "./runtime-identity.ts";
 
 function listenPort(env: NodeJS.ProcessEnv): number {
   const raw = env.PORT ?? "8787";
@@ -41,6 +42,7 @@ export async function startServer(
     operatorActions: boot.operatorActions,
     warmblyReview: boot.warmblyReview,
     logger,
+    runtimeIdentity: runtimeIdentityFromEnv(env, "control-center-context"),
     ...(operatorActor ? { operatorActor } : {}),
     ...(warmblyOperator ? { warmblyOperator } : {}),
   });

--- a/control-center/services/context/test/runtime-identity.test.ts
+++ b/control-center/services/context/test/runtime-identity.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { test } from "node:test";
+import { createRequestListener } from "../src/http.ts";
+import { silentLogger } from "../src/log.ts";
+import {
+  REQUIRED_RUNTIME_BASELINE_SHA,
+  runtimeIdentityFromEnv,
+} from "../src/runtime-identity.ts";
+import { makeService } from "./helpers.ts";
+
+const RELEASE_SHA = "8a2eb1f012345678901234567890123456789012";
+
+async function withRuntimeServer(
+  env: NodeJS.ProcessEnv,
+  fn: (base: string) => Promise<void>,
+): Promise<void> {
+  const { service } = makeService();
+  const server = createServer(createRequestListener({
+    service,
+    logger: silentLogger,
+    runtimeIdentity: runtimeIdentityFromEnv(env, "control-center-context"),
+  }));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  try {
+    await fn(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+test("runtime identity accepts only a full immutable SHA and pins the required baseline", () => {
+  const local = runtimeIdentityFromEnv({
+    CONTROL_CENTER_ENV: "production",
+    CC_RELEASE_SHA: "local",
+  }, "control-center-context");
+  assert.equal(local.release_sha, null);
+  assert.equal(local.release_status, "UNVERIFIED");
+  assert.equal(local.production_required, true);
+  assert.equal(local.required_baseline_sha, REQUIRED_RUNTIME_BASELINE_SHA);
+
+  const pinned = runtimeIdentityFromEnv({
+    CONTROL_CENTER_ENV: "production",
+    CC_RELEASE_SHA: RELEASE_SHA,
+  }, "control-center-context");
+  assert.equal(pinned.release_sha, RELEASE_SHA);
+  assert.equal(pinned.release_status, "PINNED");
+
+  const uppercase = runtimeIdentityFromEnv({
+    CONTROL_CENTER_ENV: "production",
+    CC_RELEASE_SHA: RELEASE_SHA.toUpperCase(),
+  }, "control-center-context");
+  assert.equal(uppercase.release_status, "UNVERIFIED");
+});
+
+test("production readiness fails closed without release identity", async () => {
+  await withRuntimeServer({ CONTROL_CENTER_ENV: "production", CC_RELEASE_SHA: "local" }, async (base) => {
+    const health = await fetch(`${base}/healthz`);
+    assert.equal(health.status, 200);
+    assert.doesNotMatch(await health.text(), /release_sha/i);
+
+    const identity = await fetch(`${base}/v1/runtime-identity`);
+    assert.equal(identity.status, 200);
+    const identityBody = (await identity.json()) as { release_sha: string | null; release_status: string };
+    assert.equal(identityBody.release_sha, null);
+    assert.equal(identityBody.release_status, "UNVERIFIED");
+
+    const ready = await fetch(`${base}/ready`);
+    assert.equal(ready.status, 503);
+    const readyBody = (await ready.json()) as { ready: boolean; release_status: string };
+    assert.equal(readyBody.ready, false);
+    assert.equal(readyBody.release_status, "UNVERIFIED");
+  });
+});
+
+test("pinned context reports the exact same SHA through identity and readiness", async () => {
+  await withRuntimeServer({ CONTROL_CENTER_ENV: "production", CC_RELEASE_SHA: RELEASE_SHA }, async (base) => {
+    const identity = await fetch(`${base}/v1/runtime-identity`);
+    const identityBody = (await identity.json()) as { release_sha: string; release_status: string };
+    assert.equal(identityBody.release_sha, RELEASE_SHA);
+    assert.equal(identityBody.release_status, "PINNED");
+
+    const ready = await fetch(`${base}/ready`);
+    assert.equal(ready.status, 200);
+    const readyBody = (await ready.json()) as { ready: boolean; release_sha: string };
+    assert.equal(readyBody.ready, true);
+    assert.equal(readyBody.release_sha, RELEASE_SHA);
+  });
+});

--- a/control-center/services/context/test/runtime-identity.test.ts
+++ b/control-center/services/context/test/runtime-identity.test.ts
@@ -53,6 +53,12 @@ test("runtime identity accepts only a full immutable SHA and pins the required b
     CC_RELEASE_SHA: RELEASE_SHA.toUpperCase(),
   }, "control-center-context");
   assert.equal(uppercase.release_status, "UNVERIFIED");
+
+  const standardProduction = runtimeIdentityFromEnv({
+    NODE_ENV: "production",
+    CC_RELEASE_SHA: "local",
+  }, "control-center-context");
+  assert.equal(standardProduction.production_required, true);
 });
 
 test("production readiness fails closed without release identity", async () => {

--- a/control-center/tests/convergence/web-prod-hardening.test.ts
+++ b/control-center/tests/convergence/web-prod-hardening.test.ts
@@ -104,8 +104,6 @@ test("web identity endpoint and authenticated cockpit carry the exact pinned SHA
     runtimeIdentity,
   });
   assert.match(rendered, new RegExp(`name="cc-release-sha" content="${RELEASE_SHA}"`));
-  assert.match(rendered, new RegExp(`data-release-sha="${RELEASE_SHA}"`));
-  assert.match(rendered, new RegExp(`data-runtime-release-sha="true">${RELEASE_SHA}`));
 
   await withProductionWeb({ CONTROL_CENTER_ENV: "production", CC_RELEASE_SHA: RELEASE_SHA }, async (base) => {
     const identity = await fetch(`${base}/runtime-identity`);

--- a/control-center/tests/convergence/web-prod-hardening.test.ts
+++ b/control-center/tests/convergence/web-prod-hardening.test.ts
@@ -89,6 +89,12 @@ test("web production readiness fails closed when the release SHA is not pinned",
       release_status: "UNVERIFIED",
     });
   });
+
+  await withProductionWeb({ NODE_ENV: "production", CC_RELEASE_SHA: "local" }, async (base) => {
+    const ready = await fetch(`${base}/ready`);
+    assert.equal(ready.status, 503);
+    assert.equal((await ready.json() as { ready: boolean }).ready, false);
+  });
 });
 
 test("web identity endpoint and authenticated cockpit carry the exact pinned SHA", async () => {

--- a/control-center/tests/convergence/web-prod-hardening.test.ts
+++ b/control-center/tests/convergence/web-prod-hardening.test.ts
@@ -7,9 +7,28 @@ import { readFileSync } from "node:fs";
 import {
   SECURITY_HEADERS,
   applySecurityHeaders,
+  createProductionServer,
+  injectIdentity,
+  runtimeIdentityFromEnv,
 } from "../../apps/web-shell/scripts/serve-prod.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const RELEASE_SHA = "8a2eb1f012345678901234567890123456789012";
+
+async function withProductionWeb(
+  env: Record<string, string>,
+  fn: (base: string) => Promise<void>,
+): Promise<void> {
+  const server = createProductionServer(env);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  try {
+    await fn(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
 
 test("production CSP is present, forbids unsafe-eval, and does not use wide script unsafe-inline", () => {
   const csp = SECURITY_HEADERS["Content-Security-Policy"];
@@ -48,4 +67,52 @@ test("web sources do not bake env secrets into client code", () => {
   const html = readFileSync(join(root, "apps/web-shell/index.html"), "utf8");
   assert.match(html, /file-protocol-guard\.js/);
   assert.doesNotMatch(html, /<script>\s*\(function \(\)/);
+});
+
+test("web production readiness fails closed when the release SHA is not pinned", async () => {
+  await withProductionWeb({ CONTROL_CENTER_ENV: "production", CC_RELEASE_SHA: "local" }, async (base) => {
+    const health = await fetch(`${base}/healthz`);
+    assert.equal(health.status, 200);
+    assert.doesNotMatch(await health.text(), /release_sha/i);
+
+    const identity = await fetch(`${base}/runtime-identity`);
+    const identityBody = (await identity.json()) as { release_sha: string | null; release_status: string };
+    assert.equal(identityBody.release_sha, null);
+    assert.equal(identityBody.release_status, "UNVERIFIED");
+
+    const ready = await fetch(`${base}/ready`);
+    assert.equal(ready.status, 503);
+    assert.deepEqual(await ready.json(), {
+      ready: false,
+      service: "control-center-web",
+      release_sha: null,
+      release_status: "UNVERIFIED",
+    });
+  });
+});
+
+test("web identity endpoint and authenticated cockpit carry the exact pinned SHA", async () => {
+  const runtimeIdentity = runtimeIdentityFromEnv({
+    CONTROL_CENTER_ENV: "production",
+    CC_RELEASE_SHA: RELEASE_SHA,
+  });
+  assert.equal(runtimeIdentity.release_sha, RELEASE_SHA);
+  const source = readFileSync(join(root, "apps/web-shell/index.html"), "utf8");
+  const rendered = injectIdentity(source, {
+    actorId: "founder",
+    actorKind: "human",
+    runtimeIdentity,
+  });
+  assert.match(rendered, new RegExp(`name="cc-release-sha" content="${RELEASE_SHA}"`));
+  assert.match(rendered, new RegExp(`data-release-sha="${RELEASE_SHA}"`));
+  assert.match(rendered, new RegExp(`data-runtime-release-sha="true">${RELEASE_SHA}`));
+
+  await withProductionWeb({ CONTROL_CENTER_ENV: "production", CC_RELEASE_SHA: RELEASE_SHA }, async (base) => {
+    const identity = await fetch(`${base}/runtime-identity`);
+    assert.equal(identity.status, 200);
+    assert.equal((await identity.json() as { release_sha: string }).release_sha, RELEASE_SHA);
+    const ready = await fetch(`${base}/ready`);
+    assert.equal(ready.status, 200);
+    assert.equal((await ready.json() as { release_sha: string }).release_sha, RELEASE_SHA);
+  });
 });


### PR DESCRIPTION
## Resultado

- expõe o SHA completo e imutável no Context, no Web e no rodapé do cockpit autenticado;
- faz a readiness de produção falhar fechada quando `CC_RELEASE_SHA` estiver ausente, abreviado ou inválido, inclusive quando apenas `NODE_ENV` identifica produção;
- reconcilia o `HEAD` exato e uma árvore de fonte limpa com ancestralidade, label OCI, ambiente do container e contrato HTTP completo de Context + Web;
- rejeita SHA de operador diferente do checkout, fonte suja, identidade de serviço/schema/baseline divergente e probes HTTP sem timeout;
- preserva `/healthz` mínimo, sem vazar identidade da release;
- registra no runbook a atestação obrigatória e grava sua evidência fora da árvore versionada.

## Limites operacionais

Este PR torna a identidade verificável e o gate executável. Ele não realiza deploy no VPS, não declara o runtime reparado e não altera envio, GO/NO-GO ou kill switch. Por isso mantém a etapa operacional da issue aberta.

## Validação

- `npm run typecheck`
- `npm test` (todos os workspaces, PostgreSQL 16 real)
- `npm run test:integration` (69/69)
- `npm run test:e2e` (provas HTTP e identidade passam; launcher Playwright local sem `libnspr4`, com fallback previsto)
- `npm run build`
- contratos 135/135
- deploy 28/28
- identidade/runtime focal 9/9
- `npm audit --omit=dev --audit-level=critical` (0 vulnerabilidades)

Refs #109