### PR TITLE
[P0] Validar prova sanitizada de lotes síncronos de agentes

### DIFF
--- a/.github/workflows/commercial-authority.yml
+++ b/.github/workflows/commercial-authority.yml
@@ -23,5 +23,7 @@ jobs:
         run: python scripts/validate_legal_founder_approved.py
       - name: Validate partner program
         run: python scripts/validate_partner_program.py
+      - name: Validate sanitized synchronous agent batch proof
+        run: python scripts/validate_agent_outreach_batch.py
       - name: Adversarial tests
-        run: python -m pytest tests/test_commercial_authority.py tests/test_offer_convergence.py tests/test_commercial_mainline.py tests/test_legal_provisional.py tests/test_legal_founder_approved.py tests/test_partner_program.py tests/test_delivery_contracts.py tests/test_delivery_readiness.py tests/test_delivery_capacity.py tests/test_delivery_canary_gate.py -q
+        run: python -m pytest tests/test_commercial_authority.py tests/test_offer_convergence.py tests/test_commercial_mainline.py tests/test_legal_provisional.py tests/test_legal_founder_approved.py tests/test_partner_program.py tests/test_delivery_contracts.py tests/test_delivery_readiness.py tests/test_delivery_capacity.py tests/test_delivery_canary_gate.py tests/test_agent_outreach_batch.py -q

--- a/commercial/fixtures/agent-outreach-batch-proof.example.v1.json
+++ b/commercial/fixtures/agent-outreach-batch-proof.example.v1.json
@@ -3,6 +3,8 @@
   "agent_batch_id": "agent-batch-fixture-001",
   "source_run_id": "supplier-run-2026-08-25",
   "source_run_hash": "sha256:b7b4d8c60defdd4c0183bc8e94c4fd0701d5f4eebcd8037600a2731278cbb7ac",
+  "lead_ref_scheme": "HMAC_SHA256_V1",
+  "lead_ref_key_version": "outreach-lead-ref.v1",
   "executor_ref": "agent-fixture-01",
   "started_at": "2026-08-25T10:00:00Z",
   "completed_at": "2026-08-25T10:15:00Z",
@@ -13,6 +15,7 @@
   "universe": {
     "target_confirmed_total": 8245,
     "batch_reserved": 2,
+    "unique_processed_total_before_batch": 0,
     "unique_processed_total_after_batch": 2,
     "remaining_after_batch": 8243
   },
@@ -30,6 +33,7 @@
   "summary": {
     "reserved_count": 2,
     "completed_count": 2,
+    "newly_processed": 2,
     "datalake_attempted": 2,
     "web_attempted": 2,
     "reconciled_count": 2,
@@ -42,7 +46,8 @@
   },
   "members": [
     {
-      "lead_ref": "sha256:1d3f39947f5df5ccd0ada5099320ead76c296d7ae6b89025275bad9e6772f545",
+      "lead_ref": "hmac-sha256:1d3f39947f5df5ccd0ada5099320ead76c296d7ae6b89025275bad9e6772f545",
+      "denominator_effect": "NEWLY_PROCESSED",
       "lanes": {
         "datalake": {
           "status": "OBSERVED",
@@ -60,7 +65,7 @@
       "reconciliation_status": "DATALAKE_WEB_CORROBORATED",
       "critical_conflict": false,
       "outcome": "IMPORTED_NEEDS_REVIEW",
-      "idempotency_key": "sha256:b87cea1bf936bdf3a5e933e7f0d2f40a3e888f87447d581d92a239c3817ca4fd",
+      "idempotency_key": "sha256:2740d18be49e2c2a32749fd57bf7b558d66cdba6fe81ff844fbc281489dd13f1",
       "draft": {
         "state": "NEEDS_REVIEW",
         "recipient_class": "GENERIC_COMPANY",
@@ -70,7 +75,8 @@
       }
     },
     {
-      "lead_ref": "sha256:1dd80a9160c04c4e00a18414c7b1bb69bd1adb4f2f80907eeb3566e5184944f3",
+      "lead_ref": "hmac-sha256:1dd80a9160c04c4e00a18414c7b1bb69bd1adb4f2f80907eeb3566e5184944f3",
+      "denominator_effect": "NEWLY_PROCESSED",
       "lanes": {
         "datalake": {
           "status": "OBSERVED",
@@ -88,7 +94,7 @@
       "reconciliation_status": "DATALAKE_ONLY",
       "critical_conflict": false,
       "outcome": "BLOCKED",
-      "idempotency_key": "sha256:a52b7e1ebb470d85850f1573b93c90c07ff28f1715a3b14b3aa6c8541a78d15f",
+      "idempotency_key": "sha256:6336b2161eb0bc6994bedc34bf4b51731971bc72c69ba9ddc4ace5acfa3591ee",
       "blocker": {
         "code": "NO_PUBLIC_EMAIL_FOUND",
         "next_action_code": "RESEARCH_ALTERNATE_PUBLIC_SOURCE",

--- a/commercial/fixtures/agent-outreach-batch-proof.example.v1.json
+++ b/commercial/fixtures/agent-outreach-batch-proof.example.v1.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": "confenge.agent-outreach-batch-proof.v1",
+  "agent_batch_id": "agent-batch-fixture-001",
+  "source_run_id": "supplier-run-2026-08-25",
+  "source_run_hash": "sha256:b7b4d8c60defdd4c0183bc8e94c4fd0701d5f4eebcd8037600a2731278cbb7ac",
+  "executor_ref": "agent-fixture-01",
+  "started_at": "2026-08-25T10:00:00Z",
+  "completed_at": "2026-08-25T10:15:00Z",
+  "reservation_expires_at": "2026-08-25T11:00:00Z",
+  "policy_version": "outreach-agent-policy.v1",
+  "template_version": "first-touch-forwarding.v1",
+  "evidence_version": "web-datalake-bundle.v1",
+  "universe": {
+    "target_confirmed_total": 8245,
+    "batch_reserved": 2,
+    "unique_processed_total_after_batch": 2,
+    "remaining_after_batch": 8243
+  },
+  "safety": {
+    "llm_api_calls": 0,
+    "runtime_generation": false,
+    "provider_mutations": 0,
+    "approvals": 0,
+    "scheduled": 0,
+    "sent": 0,
+    "auto_send_changed": false,
+    "kill_switch_changed": false,
+    "operational_data_included": false
+  },
+  "summary": {
+    "reserved_count": 2,
+    "completed_count": 2,
+    "datalake_attempted": 2,
+    "web_attempted": 2,
+    "reconciled_count": 2,
+    "draft_generated": 1,
+    "imported_needs_review": 1,
+    "blocked": 1,
+    "duplicate": 0,
+    "invalid": 0,
+    "retry_required": 0
+  },
+  "members": [
+    {
+      "lead_ref": "sha256:1d3f39947f5df5ccd0ada5099320ead76c296d7ae6b89025275bad9e6772f545",
+      "lanes": {
+        "datalake": {
+          "status": "OBSERVED",
+          "observed_at": "2026-08-25T10:03:00Z",
+          "attempt_hash": "sha256:4306ee076f605585ade6f2841576014b32ab24f92d830e23ed861b224cffb57b",
+          "evidence_count": 2
+        },
+        "web": {
+          "status": "OBSERVED",
+          "observed_at": "2026-08-25T10:07:00Z",
+          "attempt_hash": "sha256:140cd99c677d58c6e645ba05cce235eb6213c630f621b59014651f93d92418b8",
+          "evidence_count": 1
+        }
+      },
+      "reconciliation_status": "DATALAKE_WEB_CORROBORATED",
+      "critical_conflict": false,
+      "outcome": "IMPORTED_NEEDS_REVIEW",
+      "idempotency_key": "sha256:b87cea1bf936bdf3a5e933e7f0d2f40a3e888f87447d581d92a239c3817ca4fd",
+      "draft": {
+        "state": "NEEDS_REVIEW",
+        "recipient_class": "GENERIC_COMPANY",
+        "content_hash": "sha256:6629370797aaf37357bf51c8670771076b446c0d5ffa410e00a111e1051be197",
+        "evidence_bundle_hash": "sha256:7fe7429b2dd71050c680db6ee387ead79c03ee3ae85db3d6331c58f0e5cd946f",
+        "import_receipt_hash": "sha256:2b98f68963e3fcaec73f70ee5c7489c55748025f2b8299e2c25951299a57e549"
+      }
+    },
+    {
+      "lead_ref": "sha256:1dd80a9160c04c4e00a18414c7b1bb69bd1adb4f2f80907eeb3566e5184944f3",
+      "lanes": {
+        "datalake": {
+          "status": "OBSERVED",
+          "observed_at": "2026-08-25T10:09:00Z",
+          "attempt_hash": "sha256:0ff11302f0240308e2b2ed0298555d46b7d1355475f408c93100b8b9b9e35a2f",
+          "evidence_count": 1
+        },
+        "web": {
+          "status": "NO_MATCH",
+          "observed_at": "2026-08-25T10:13:00Z",
+          "attempt_hash": "sha256:5e59f93a0699749d0912ed6efe09efa0af5a3abaf818402824092f87400ca271",
+          "evidence_count": 0
+        }
+      },
+      "reconciliation_status": "DATALAKE_ONLY",
+      "critical_conflict": false,
+      "outcome": "BLOCKED",
+      "idempotency_key": "sha256:a52b7e1ebb470d85850f1573b93c90c07ff28f1715a3b14b3aa6c8541a78d15f",
+      "blocker": {
+        "code": "NO_PUBLIC_EMAIL_FOUND",
+        "next_action_code": "RESEARCH_ALTERNATE_PUBLIC_SOURCE",
+        "evidence_hash": "sha256:e9c89d6007811d439ca40afd57ada641ac79e9287d83a3324bccd206855a1d99"
+      }
+    }
+  ]
+}

--- a/docs/ops/AGENT-OUTREACH-BATCH-PROOF.md
+++ b/docs/ops/AGENT-OUTREACH-BATCH-PROOF.md
@@ -42,23 +42,27 @@ contrato.
    prova sanitizada. Só então encerre a reserva.
 
 O endereço, texto, fontes e CNPJ não são substituídos por valores fictícios no
-manifesto: eles simplesmente não são exportados. `lead_ref` é a referência
-salted e estável do CNPJ produzida pela autoridade operacional.
+manifesto: eles simplesmente não são exportados. `lead_ref` é uma referência
+estável produzida com HMAC-SHA256 e chave privada versionada pela autoridade
+operacional. Um SHA simples do CNPJ é recusado porque permitiria enumeração a
+partir de listas públicas.
 
 ## Idempotência
 
 O gate recalcula a chave pública segura sobre:
 
 ```text
-source_run_id + lead_ref + evidence_version + template_version
+source_run_id + source_run_hash + lead_ref + lead_ref_key_version + evidence_version + template_version + policy_version
 ```
 
-Como `lead_ref` representa de forma estável o CNPJ privado, reexecutar o mesmo
-tuple produz a mesma chave. Alterar fato/evidência ou template produz nova
-versão. Ao validar mais de um manifesto, o gate também rejeita:
+Como `lead_ref` representa de forma estável e não enumerável o CNPJ privado,
+reexecutar o mesmo tuple produz a mesma chave. Alterar source run, fato/evidência,
+template ou policy produz nova versão. Ao validar mais de um manifesto, o gate
+também rejeita:
 
-- janelas sobrepostas para o mesmo `source_run_id + lead_ref`;
+- janelas de reserva sobrepostas para o mesmo `lead_ref`, inclusive entre source runs;
 - dois imports `NEEDS_REVIEW` com a mesma chave idempotente;
+- dois membros que reivindicam o mesmo recibo individual de importação;
 - dois membros iguais dentro do mesmo lote.
 
 ## Exportação sanitizada
@@ -67,7 +71,8 @@ Parta do exemplo
 `commercial/fixtures/agent-outreach-batch-proof.example.v1.json` e substitua
 somente por valores sanitizados derivados do lote privado. O manifesto exige:
 
-- denominador, processados únicos e restante reconciliados;
+- denominador, processados únicos antes/depois e restante reconciliados pelo
+  efeito explícito de cada membro;
 - ambas as lanes por membro, mesmo quando o resultado é `NO_MATCH` ou `ERROR`;
 - outcome terminal para todos os reservados;
 - hashes de tentativa/evidência/conteúdo/recibo em vez dos dados;

--- a/docs/ops/AGENT-OUTREACH-BATCH-PROOF.md
+++ b/docs/ops/AGENT-OUTREACH-BATCH-PROOF.md
@@ -1,0 +1,108 @@
+# Prova sanitizada de lotes síncronos de agentes
+
+Este contrato permite que Governance coordene e audite os lotes da issue #129
+sem virar uma base paralela de leads. Pesquisa, evidência original, CNPJ,
+contatos, assunto e corpo permanecem nas autoridades privadas existentes do
+extra-cli/Warmbly. O repositório público recebe somente referências opacas,
+hashes, estados e contagens reconciliáveis.
+
+O pacote não executa pesquisa, não acessa o datalake, não gera mensagem, não
+importa draft e não chama provider. Ele valida uma prova produzida **depois**
+que um agente conclui seu lote privado.
+
+## Autoridades e fronteiras
+
+- O universo e o `source_run_id` vêm do workflow canônico do extra-cli.
+- A lane datalake usa `LOCAL_DATALAKE_DSN` e as consultas canônicas por CNPJ.
+- A lane web é executada pelo agente, abrindo a fonte original; snippet, MX ou
+  sintaxe de e-mail isolados não contam como atribuição.
+- O draft é importado pelo contrato já existente e precisa ser relido como
+  `NEEDS_REVIEW`.
+- Governance guarda apenas
+  `confenge.agent-outreach-batch-proof.v1`; nunca o feed privado.
+
+Nenhum worker, cron, API de LLM, composer, lake, CRM ou fila é criado por este
+contrato.
+
+## Sequência obrigatória do agente
+
+1. Reserve IDs/CNPJs disjuntos na autoridade privada e obtenha um
+   `agent_batch_id`, início e expiração. Não trabalhe um membro já reservado por
+   outro agente.
+2. Para cada membro, execute datalake e web. Registre privadamente consultas,
+   URLs originais, timestamps, contatos, conflitos e confidence.
+3. Reconcilie a empresa/CNPJ. `CONFLICT`, `UNKNOWN` ou erro de qualquer lane
+   bloqueia importação.
+4. Quando houver e-mail atribuível, escreva o primeiro toque durante a sessão
+   do agente e importe exatamente uma versão para `NEEDS_REVIEW`. Caixa
+   genérica/freemail usa CTA de encaminhamento; endereço inferido é proibido.
+5. Para cada membro sem draft, registre blocker e próxima ação na autoridade
+   privada. Falha individual não remove o lead do denominador.
+6. Releia o estado importado, calcule hashes dos bundles/recibos e exporte a
+   prova sanitizada. Só então encerre a reserva.
+
+O endereço, texto, fontes e CNPJ não são substituídos por valores fictícios no
+manifesto: eles simplesmente não são exportados. `lead_ref` é a referência
+salted e estável do CNPJ produzida pela autoridade operacional.
+
+## Idempotência
+
+O gate recalcula a chave pública segura sobre:
+
+```text
+source_run_id + lead_ref + evidence_version + template_version
+```
+
+Como `lead_ref` representa de forma estável o CNPJ privado, reexecutar o mesmo
+tuple produz a mesma chave. Alterar fato/evidência ou template produz nova
+versão. Ao validar mais de um manifesto, o gate também rejeita:
+
+- janelas sobrepostas para o mesmo `source_run_id + lead_ref`;
+- dois imports `NEEDS_REVIEW` com a mesma chave idempotente;
+- dois membros iguais dentro do mesmo lote.
+
+## Exportação sanitizada
+
+Parta do exemplo
+`commercial/fixtures/agent-outreach-batch-proof.example.v1.json` e substitua
+somente por valores sanitizados derivados do lote privado. O manifesto exige:
+
+- denominador, processados únicos e restante reconciliados;
+- ambas as lanes por membro, mesmo quando o resultado é `NO_MATCH` ou `ERROR`;
+- outcome terminal para todos os reservados;
+- hashes de tentativa/evidência/conteúdo/recibo em vez dos dados;
+- resumo exatamente derivado dos membros;
+- zero LLM API, provider mutation, aprovação, scheduling e envio;
+- `auto_send` e kill switch inalterados;
+- `operational_data_included=false`.
+
+O validador recusa campos ou valores contendo e-mail, CNPJ, URL, empresa,
+contato, assunto ou corpo. Valide um lote:
+
+```bash
+python3 scripts/validate_agent_outreach_batch.py /caminho/seguro/batch-proof.json
+```
+
+Valide vários manifestos juntos para provar disjunção e idempotência:
+
+```bash
+python3 scripts/validate_agent_outreach_batch.py \
+  /caminho/seguro/batch-001-proof.json \
+  /caminho/seguro/batch-002-proof.json
+```
+
+Saída `ok=true` inclui o hash canônico de cada manifesto. Esse hash pode ser
+referenciado na issue sem publicar o lote privado.
+
+## O que este pacote prova — e o que não prova
+
+Uma validação verde prova consistência estrutural, ausência de dados
+operacionais no manifesto, execução declarada das duas lanes, outcome por
+membro, disjunção entre os manifestos fornecidos e ausência declarada dos
+efeitos proibidos. Ela não prova sozinha que o datalake, a página web ou o
+recibo privado são verdadeiros; essa evidência permanece operacional e deve
+ser revisável por quem possui acesso autorizado.
+
+O fixture versionado é apenas exemplo sanitizado. Ele não declara que um lote
+real, as 110 contas iniciais, as 25 `READY_TO_GENERATE`, o buffer de 500 ou o
+universo de 8.245 já foram processados.

--- a/schemas/agent-outreach-batch-proof.v1.schema.json
+++ b/schemas/agent-outreach-batch-proof.v1.schema.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confenge.com.br/schemas/agent-outreach-batch-proof.v1.schema.json",
+  "title": "Sanitized proof of a synchronous outreach agent batch",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "agent_batch_id",
+    "source_run_id",
+    "source_run_hash",
+    "executor_ref",
+    "started_at",
+    "completed_at",
+    "reservation_expires_at",
+    "policy_version",
+    "template_version",
+    "evidence_version",
+    "universe",
+    "safety",
+    "summary",
+    "members"
+  ],
+  "properties": {
+    "schema_version": { "const": "confenge.agent-outreach-batch-proof.v1" },
+    "agent_batch_id": { "$ref": "#/$defs/token" },
+    "source_run_id": { "$ref": "#/$defs/token" },
+    "source_run_hash": { "$ref": "#/$defs/hash" },
+    "executor_ref": { "$ref": "#/$defs/token" },
+    "started_at": { "$ref": "#/$defs/timestamp" },
+    "completed_at": { "$ref": "#/$defs/timestamp" },
+    "reservation_expires_at": { "$ref": "#/$defs/timestamp" },
+    "policy_version": { "$ref": "#/$defs/token" },
+    "template_version": { "$ref": "#/$defs/token" },
+    "evidence_version": { "$ref": "#/$defs/token" },
+    "universe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target_confirmed_total", "batch_reserved", "unique_processed_total_after_batch", "remaining_after_batch"],
+      "properties": {
+        "target_confirmed_total": { "$ref": "#/$defs/count" },
+        "batch_reserved": { "$ref": "#/$defs/count" },
+        "unique_processed_total_after_batch": { "$ref": "#/$defs/count" },
+        "remaining_after_batch": { "$ref": "#/$defs/count" }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "llm_api_calls",
+        "runtime_generation",
+        "provider_mutations",
+        "approvals",
+        "scheduled",
+        "sent",
+        "auto_send_changed",
+        "kill_switch_changed",
+        "operational_data_included"
+      ],
+      "properties": {
+        "llm_api_calls": { "const": 0 },
+        "runtime_generation": { "const": false },
+        "provider_mutations": { "const": 0 },
+        "approvals": { "const": 0 },
+        "scheduled": { "const": 0 },
+        "sent": { "const": 0 },
+        "auto_send_changed": { "const": false },
+        "kill_switch_changed": { "const": false },
+        "operational_data_included": { "const": false }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reserved_count",
+        "completed_count",
+        "datalake_attempted",
+        "web_attempted",
+        "reconciled_count",
+        "draft_generated",
+        "imported_needs_review",
+        "blocked",
+        "duplicate",
+        "invalid",
+        "retry_required"
+      ],
+      "properties": {
+        "reserved_count": { "$ref": "#/$defs/count" },
+        "completed_count": { "$ref": "#/$defs/count" },
+        "datalake_attempted": { "$ref": "#/$defs/count" },
+        "web_attempted": { "$ref": "#/$defs/count" },
+        "reconciled_count": { "$ref": "#/$defs/count" },
+        "draft_generated": { "$ref": "#/$defs/count" },
+        "imported_needs_review": { "$ref": "#/$defs/count" },
+        "blocked": { "$ref": "#/$defs/count" },
+        "duplicate": { "$ref": "#/$defs/count" },
+        "invalid": { "$ref": "#/$defs/count" },
+        "retry_required": { "$ref": "#/$defs/count" }
+      }
+    },
+    "members": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 500,
+      "items": { "$ref": "#/$defs/member" }
+    }
+  },
+  "$defs": {
+    "token": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "lane": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "observed_at", "attempt_hash", "evidence_count"],
+      "properties": {
+        "status": { "enum": ["OBSERVED", "NO_MATCH", "ERROR"] },
+        "observed_at": { "$ref": "#/$defs/timestamp" },
+        "attempt_hash": { "$ref": "#/$defs/hash" },
+        "evidence_count": { "$ref": "#/$defs/count" }
+      }
+    },
+    "draft": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "recipient_class", "content_hash", "evidence_bundle_hash", "import_receipt_hash"],
+      "properties": {
+        "state": { "const": "NEEDS_REVIEW" },
+        "recipient_class": {
+          "enum": ["DIRECT_PERSON", "ROLE_OR_DEPARTMENT", "GENERIC_COMPANY", "PUBLIC_COMPANY_FREEMAIL"]
+        },
+        "content_hash": { "$ref": "#/$defs/hash" },
+        "evidence_bundle_hash": { "$ref": "#/$defs/hash" },
+        "import_receipt_hash": { "$ref": "#/$defs/hash" }
+      }
+    },
+    "blocker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "next_action_code", "evidence_hash"],
+      "properties": {
+        "code": { "$ref": "#/$defs/token" },
+        "next_action_code": { "$ref": "#/$defs/token" },
+        "evidence_hash": { "$ref": "#/$defs/hash" }
+      }
+    },
+    "member": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lead_ref",
+        "lanes",
+        "reconciliation_status",
+        "critical_conflict",
+        "outcome",
+        "idempotency_key"
+      ],
+      "properties": {
+        "lead_ref": { "$ref": "#/$defs/hash" },
+        "lanes": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["datalake", "web"],
+          "properties": {
+            "datalake": { "$ref": "#/$defs/lane" },
+            "web": { "$ref": "#/$defs/lane" }
+          }
+        },
+        "reconciliation_status": {
+          "enum": ["DATALAKE_WEB_CORROBORATED", "DATALAKE_ONLY", "WEB_ONLY", "CONFLICT", "UNKNOWN"]
+        },
+        "critical_conflict": { "type": "boolean" },
+        "outcome": { "enum": ["IMPORTED_NEEDS_REVIEW", "BLOCKED", "DUPLICATE", "INVALID", "RETRY_REQUIRED"] },
+        "idempotency_key": { "$ref": "#/$defs/hash" },
+        "draft": { "$ref": "#/$defs/draft" },
+        "blocker": { "$ref": "#/$defs/blocker" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "outcome": { "const": "IMPORTED_NEEDS_REVIEW" } }, "required": ["outcome"] },
+          "then": { "required": ["draft"], "not": { "required": ["blocker"] } },
+          "else": { "required": ["blocker"], "not": { "required": ["draft"] } }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/agent-outreach-batch-proof.v1.schema.json
+++ b/schemas/agent-outreach-batch-proof.v1.schema.json
@@ -9,6 +9,8 @@
     "agent_batch_id",
     "source_run_id",
     "source_run_hash",
+    "lead_ref_scheme",
+    "lead_ref_key_version",
     "executor_ref",
     "started_at",
     "completed_at",
@@ -26,6 +28,8 @@
     "agent_batch_id": { "$ref": "#/$defs/token" },
     "source_run_id": { "$ref": "#/$defs/token" },
     "source_run_hash": { "$ref": "#/$defs/hash" },
+    "lead_ref_scheme": { "const": "HMAC_SHA256_V1" },
+    "lead_ref_key_version": { "$ref": "#/$defs/token" },
     "executor_ref": { "$ref": "#/$defs/token" },
     "started_at": { "$ref": "#/$defs/timestamp" },
     "completed_at": { "$ref": "#/$defs/timestamp" },
@@ -36,10 +40,17 @@
     "universe": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["target_confirmed_total", "batch_reserved", "unique_processed_total_after_batch", "remaining_after_batch"],
+      "required": [
+        "target_confirmed_total",
+        "batch_reserved",
+        "unique_processed_total_before_batch",
+        "unique_processed_total_after_batch",
+        "remaining_after_batch"
+      ],
       "properties": {
         "target_confirmed_total": { "$ref": "#/$defs/count" },
         "batch_reserved": { "$ref": "#/$defs/count" },
+        "unique_processed_total_before_batch": { "$ref": "#/$defs/count" },
         "unique_processed_total_after_batch": { "$ref": "#/$defs/count" },
         "remaining_after_batch": { "$ref": "#/$defs/count" }
       }
@@ -76,6 +87,7 @@
       "required": [
         "reserved_count",
         "completed_count",
+        "newly_processed",
         "datalake_attempted",
         "web_attempted",
         "reconciled_count",
@@ -89,6 +101,7 @@
       "properties": {
         "reserved_count": { "$ref": "#/$defs/count" },
         "completed_count": { "$ref": "#/$defs/count" },
+        "newly_processed": { "$ref": "#/$defs/count" },
         "datalake_attempted": { "$ref": "#/$defs/count" },
         "web_attempted": { "$ref": "#/$defs/count" },
         "reconciled_count": { "$ref": "#/$defs/count" },
@@ -116,6 +129,10 @@
       "type": "string",
       "pattern": "^sha256:[0-9a-f]{64}$"
     },
+    "opaque_ref": {
+      "type": "string",
+      "pattern": "^hmac-sha256:[0-9a-f]{64}$"
+    },
     "timestamp": {
       "type": "string",
       "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
@@ -133,7 +150,13 @@
         "observed_at": { "$ref": "#/$defs/timestamp" },
         "attempt_hash": { "$ref": "#/$defs/hash" },
         "evidence_count": { "$ref": "#/$defs/count" }
-      }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "OBSERVED" } }, "required": ["status"] },
+          "then": { "properties": { "evidence_count": { "type": "integer", "minimum": 1 } } }
+        }
+      ]
     },
     "draft": {
       "type": "object",
@@ -164,6 +187,7 @@
       "additionalProperties": false,
       "required": [
         "lead_ref",
+        "denominator_effect",
         "lanes",
         "reconciliation_status",
         "critical_conflict",
@@ -171,7 +195,8 @@
         "idempotency_key"
       ],
       "properties": {
-        "lead_ref": { "$ref": "#/$defs/hash" },
+        "lead_ref": { "$ref": "#/$defs/opaque_ref" },
+        "denominator_effect": { "enum": ["NEWLY_PROCESSED", "ALREADY_PROCESSED"] },
         "lanes": {
           "type": "object",
           "additionalProperties": false,

--- a/scripts/validate_agent_outreach_batch.py
+++ b/scripts/validate_agent_outreach_batch.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Validate sanitized proof manifests for synchronous outreach agent batches.
+
+This validator coordinates evidence only. It does not read the datalake, search
+the web, generate copy, import drafts, approve, schedule, or send anything.
+Operational data remains in extra-cli/Warmbly; Governance receives opaque
+hashes and aggregate counts that can be reviewed without publishing contacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PROOF = ROOT / "commercial" / "fixtures" / "agent-outreach-batch-proof.example.v1.json"
+
+SCHEMA_VERSION = "confenge.agent-outreach-batch-proof.v1"
+HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+ISO_Z_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+EMAIL_RE = re.compile(r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![A-Za-z0-9.-])")
+URL_RE = re.compile(r"https?://", re.IGNORECASE)
+CNPJ_RE = re.compile(r"(?<!\d)(?:\d{2}[.\s-]?\d{3}[.\s-]?\d{3}[/\s-]?\d{4}[-\s]?\d{2}|\d{14})(?!\d)")
+
+LANE_STATUSES = frozenset({"OBSERVED", "NO_MATCH", "ERROR"})
+RECONCILIATION_STATUSES = frozenset(
+    {
+        "DATALAKE_WEB_CORROBORATED",
+        "DATALAKE_ONLY",
+        "WEB_ONLY",
+        "CONFLICT",
+        "UNKNOWN",
+    }
+)
+TERMINAL_OUTCOMES = frozenset(
+    {"IMPORTED_NEEDS_REVIEW", "BLOCKED", "DUPLICATE", "INVALID", "RETRY_REQUIRED"}
+)
+RECIPIENT_CLASSES = frozenset(
+    {"DIRECT_PERSON", "ROLE_OR_DEPARTMENT", "GENERIC_COMPANY", "PUBLIC_COMPANY_FREEMAIL"}
+)
+SUMMARY_KEYS = (
+    "reserved_count",
+    "completed_count",
+    "datalake_attempted",
+    "web_attempted",
+    "reconciled_count",
+    "draft_generated",
+    "imported_needs_review",
+    "blocked",
+    "duplicate",
+    "invalid",
+    "retry_required",
+)
+FORBIDDEN_DATA_KEYS = frozenset(
+    {
+        "cnpj",
+        "email",
+        "mailbox",
+        "recipient",
+        "recipient_address",
+        "company",
+        "company_name",
+        "contact_name",
+        "subject",
+        "body",
+        "body_text",
+        "url",
+        "source_url",
+    }
+)
+TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "agent_batch_id",
+        "source_run_id",
+        "source_run_hash",
+        "executor_ref",
+        "started_at",
+        "completed_at",
+        "reservation_expires_at",
+        "policy_version",
+        "template_version",
+        "evidence_version",
+        "universe",
+        "safety",
+        "summary",
+        "members",
+    }
+)
+
+
+class ValidationError(ValueError):
+    """The proof cannot support the claimed batch result."""
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_ref(value: Any) -> str:
+    return f"sha256:{hashlib.sha256(canonical_json(value)).hexdigest()}"
+
+
+def expected_idempotency_key(
+    source_run_id: str,
+    lead_ref: str,
+    evidence_version: str,
+    template_version: str,
+) -> str:
+    """Derive the public-safe equivalent of source-run+CNPJ+evidence+template.
+
+    ``lead_ref`` is the operational system's stable, salted CNPJ reference. The
+    raw CNPJ never enters the public proof, while rerunning the same tuple still
+    produces exactly the same key.
+    """
+
+    return sha256_ref(
+        {
+            "source_run_id": source_run_id,
+            "lead_ref": lead_ref,
+            "evidence_version": evidence_version,
+            "template_version": template_version,
+        }
+    )
+
+
+def _mapping(value: Any, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{path} must be an object")
+    return value
+
+
+def _exact_keys(value: Mapping[str, Any], expected: Iterable[str], path: str) -> None:
+    expected_set = frozenset(expected)
+    missing = sorted(expected_set - value.keys())
+    extra = sorted(value.keys() - expected_set)
+    if missing or extra:
+        raise ValidationError(f"{path} keys diverge: missing={missing} extra={extra}")
+
+
+def _token(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not TOKEN_RE.fullmatch(value):
+        raise ValidationError(f"{path} must be a bounded opaque token")
+    return value
+
+
+def _hash(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not HASH_RE.fullmatch(value):
+        raise ValidationError(f"{path} must be sha256:<64 lowercase hex>")
+    return value
+
+
+def _nonnegative_int(value: Any, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValidationError(f"{path} must be a non-negative integer")
+    return value
+
+
+def _timestamp(value: Any, path: str) -> datetime:
+    if not isinstance(value, str) or not ISO_Z_RE.fullmatch(value):
+        raise ValidationError(f"{path} must be UTC with whole seconds and Z")
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def assert_sanitized(value: Any, path: str = "$") -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            key_text = str(key)
+            if key_text.lower() in FORBIDDEN_DATA_KEYS:
+                raise ValidationError(f"{path}.{key_text} is operational/contact data and cannot be committed")
+            assert_sanitized(child, f"{path}.{key_text}")
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            assert_sanitized(child, f"{path}[{index}]")
+        return
+    if isinstance(value, str):
+        # Opaque SHA-256 references can contain long decimal runs by chance;
+        # they are already irreversible proof material, not raw CNPJ values.
+        if HASH_RE.fullmatch(value):
+            return
+        if EMAIL_RE.search(value):
+            raise ValidationError(f"{path} contains an email address")
+        if URL_RE.search(value):
+            raise ValidationError(f"{path} contains a source URL")
+        if CNPJ_RE.search(value):
+            raise ValidationError(f"{path} contains a CNPJ")
+
+
+def _validate_lane(value: Any, path: str, started: datetime, completed: datetime) -> Mapping[str, Any]:
+    lane = _mapping(value, path)
+    _exact_keys(lane, {"status", "observed_at", "attempt_hash", "evidence_count"}, path)
+    if lane["status"] not in LANE_STATUSES:
+        raise ValidationError(f"{path}.status is not an attempted lane result")
+    observed = _timestamp(lane["observed_at"], f"{path}.observed_at")
+    if observed < started or observed > completed:
+        raise ValidationError(f"{path}.observed_at falls outside the batch execution window")
+    _hash(lane["attempt_hash"], f"{path}.attempt_hash")
+    count = _nonnegative_int(lane["evidence_count"], f"{path}.evidence_count")
+    if lane["status"] == "OBSERVED" and count == 0:
+        raise ValidationError(f"{path} claims OBSERVED without evidence")
+    return lane
+
+
+def _validate_draft(value: Any, path: str) -> None:
+    draft = _mapping(value, path)
+    _exact_keys(
+        draft,
+        {"state", "recipient_class", "content_hash", "evidence_bundle_hash", "import_receipt_hash"},
+        path,
+    )
+    if draft["state"] != "NEEDS_REVIEW":
+        raise ValidationError(f"{path}.state must be NEEDS_REVIEW; approval/scheduling/send is forbidden")
+    if draft["recipient_class"] not in RECIPIENT_CLASSES:
+        raise ValidationError(f"{path}.recipient_class is not an attributable-company route")
+    for key in ("content_hash", "evidence_bundle_hash", "import_receipt_hash"):
+        _hash(draft[key], f"{path}.{key}")
+
+
+def validate_document(document: Any) -> dict[str, Any]:
+    assert_sanitized(document)
+    doc = _mapping(document, "$")
+    _exact_keys(doc, TOP_LEVEL_KEYS, "$")
+    if doc["schema_version"] != SCHEMA_VERSION:
+        raise ValidationError("$.schema_version is not the batch proof v1 contract")
+    for key in ("agent_batch_id", "source_run_id", "executor_ref", "policy_version", "template_version", "evidence_version"):
+        _token(doc[key], f"$.{key}")
+    _hash(doc["source_run_hash"], "$.source_run_hash")
+    started = _timestamp(doc["started_at"], "$.started_at")
+    completed = _timestamp(doc["completed_at"], "$.completed_at")
+    expires = _timestamp(doc["reservation_expires_at"], "$.reservation_expires_at")
+    if completed < started:
+        raise ValidationError("batch completed before it started")
+    if expires < completed:
+        raise ValidationError("batch completed after its reservation expired")
+
+    universe = _mapping(doc["universe"], "$.universe")
+    _exact_keys(
+        universe,
+        {"target_confirmed_total", "batch_reserved", "unique_processed_total_after_batch", "remaining_after_batch"},
+        "$.universe",
+    )
+    total = _nonnegative_int(universe["target_confirmed_total"], "$.universe.target_confirmed_total")
+    reserved = _nonnegative_int(universe["batch_reserved"], "$.universe.batch_reserved")
+    processed = _nonnegative_int(
+        universe["unique_processed_total_after_batch"], "$.universe.unique_processed_total_after_batch"
+    )
+    remaining = _nonnegative_int(universe["remaining_after_batch"], "$.universe.remaining_after_batch")
+    if reserved > total:
+        raise ValidationError("$.universe.batch_reserved exceeds the TARGET_CONFIRMED denominator")
+    if processed > total or remaining != total - processed:
+        raise ValidationError("$.universe does not reconcile processed and remaining against the denominator")
+
+    safety = _mapping(doc["safety"], "$.safety")
+    _exact_keys(
+        safety,
+        {
+            "llm_api_calls",
+            "runtime_generation",
+            "provider_mutations",
+            "approvals",
+            "scheduled",
+            "sent",
+            "auto_send_changed",
+            "kill_switch_changed",
+            "operational_data_included",
+        },
+        "$.safety",
+    )
+    for key in ("llm_api_calls", "provider_mutations", "approvals", "scheduled", "sent"):
+        if _nonnegative_int(safety[key], f"$.safety.{key}") != 0:
+            raise ValidationError(f"$.safety.{key} must be zero")
+    for key in ("runtime_generation", "auto_send_changed", "kill_switch_changed", "operational_data_included"):
+        if safety[key] is not False:
+            raise ValidationError(f"$.safety.{key} must be false")
+
+    members = doc["members"]
+    if not isinstance(members, list) or not members:
+        raise ValidationError("$.members must contain the entire reserved batch")
+    if len(members) > 500:
+        raise ValidationError("$.members may reserve at most 500 leads per synchronous agent batch")
+    if reserved != len(members):
+        raise ValidationError("$.universe.batch_reserved does not equal the member count")
+
+    lead_refs: set[str] = set()
+    idempotency_keys: set[str] = set()
+    outcome_counts = {outcome: 0 for outcome in TERMINAL_OUTCOMES}
+    reconciled_count = 0
+    generated_count = 0
+    for index, raw_member in enumerate(members):
+        path = f"$.members[{index}]"
+        member = _mapping(raw_member, path)
+        base_keys = {
+            "lead_ref",
+            "lanes",
+            "reconciliation_status",
+            "critical_conflict",
+            "outcome",
+            "idempotency_key",
+        }
+        outcome = member.get("outcome")
+        expected_keys = base_keys | ({"draft"} if outcome == "IMPORTED_NEEDS_REVIEW" else {"blocker"})
+        _exact_keys(member, expected_keys, path)
+        lead_ref = _hash(member["lead_ref"], f"{path}.lead_ref")
+        if lead_ref in lead_refs:
+            raise ValidationError(f"{path}.lead_ref is reserved twice in one batch")
+        lead_refs.add(lead_ref)
+
+        lanes = _mapping(member["lanes"], f"{path}.lanes")
+        _exact_keys(lanes, {"datalake", "web"}, f"{path}.lanes")
+        datalake = _validate_lane(lanes["datalake"], f"{path}.lanes.datalake", started, completed)
+        web = _validate_lane(lanes["web"], f"{path}.lanes.web", started, completed)
+
+        reconciliation = member["reconciliation_status"]
+        if reconciliation not in RECONCILIATION_STATUSES:
+            raise ValidationError(f"{path}.reconciliation_status is invalid")
+        if not isinstance(member["critical_conflict"], bool):
+            raise ValidationError(f"{path}.critical_conflict must be boolean")
+        if outcome not in TERMINAL_OUTCOMES:
+            raise ValidationError(f"{path}.outcome is not terminal")
+        outcome_counts[outcome] += 1
+        if reconciliation not in {"CONFLICT", "UNKNOWN"}:
+            reconciled_count += 1
+
+        expected_key = expected_idempotency_key(
+            doc["source_run_id"], lead_ref, doc["evidence_version"], doc["template_version"]
+        )
+        if member["idempotency_key"] != expected_key:
+            raise ValidationError(f"{path}.idempotency_key does not match source-run+lead+evidence+template")
+        if member["idempotency_key"] in idempotency_keys:
+            raise ValidationError(f"{path}.idempotency_key is duplicated")
+        idempotency_keys.add(member["idempotency_key"])
+
+        if outcome == "IMPORTED_NEEDS_REVIEW":
+            if datalake["status"] == "ERROR" or web["status"] == "ERROR":
+                raise ValidationError(f"{path} imported a draft while an evidence lane failed")
+            if reconciliation in {"CONFLICT", "UNKNOWN"} or member["critical_conflict"]:
+                raise ValidationError(f"{path} imported a draft without safe reconciliation")
+            _validate_draft(member["draft"], f"{path}.draft")
+            generated_count += 1
+        else:
+            blocker = _mapping(member["blocker"], f"{path}.blocker")
+            _exact_keys(blocker, {"code", "next_action_code", "evidence_hash"}, f"{path}.blocker")
+            _token(blocker["code"], f"{path}.blocker.code")
+            _token(blocker["next_action_code"], f"{path}.blocker.next_action_code")
+            _hash(blocker["evidence_hash"], f"{path}.blocker.evidence_hash")
+
+    summary = _mapping(doc["summary"], "$.summary")
+    _exact_keys(summary, SUMMARY_KEYS, "$.summary")
+    for key in SUMMARY_KEYS:
+        _nonnegative_int(summary[key], f"$.summary.{key}")
+    expected_summary = {
+        "reserved_count": len(members),
+        "completed_count": len(members),
+        "datalake_attempted": len(members),
+        "web_attempted": len(members),
+        "reconciled_count": reconciled_count,
+        "draft_generated": generated_count,
+        "imported_needs_review": outcome_counts["IMPORTED_NEEDS_REVIEW"],
+        "blocked": outcome_counts["BLOCKED"],
+        "duplicate": outcome_counts["DUPLICATE"],
+        "invalid": outcome_counts["INVALID"],
+        "retry_required": outcome_counts["RETRY_REQUIRED"],
+    }
+    if dict(summary) != expected_summary:
+        raise ValidationError(f"$.summary does not reconcile members: expected={expected_summary}")
+
+    return {
+        "agent_batch_id": doc["agent_batch_id"],
+        "source_run_id": doc["source_run_id"],
+        "started_at": started,
+        "completed_at": completed,
+        "member_outcomes": [(member["lead_ref"], member["idempotency_key"], member["outcome"]) for member in members],
+        "manifest_hash": sha256_ref(doc),
+    }
+
+
+def validate_documents(documents: Sequence[Any]) -> list[dict[str, Any]]:
+    results = [validate_document(document) for document in documents]
+    batch_ids: set[str] = set()
+    windows: dict[tuple[str, str], list[tuple[datetime, datetime, str]]] = {}
+    imported_by_key: dict[str, str] = {}
+    for result in results:
+        batch_id = result["agent_batch_id"]
+        if batch_id in batch_ids:
+            raise ValidationError(f"agent_batch_id {batch_id} is duplicated")
+        batch_ids.add(batch_id)
+        for lead_ref, key, outcome in result["member_outcomes"]:
+            lane_key = (result["source_run_id"], lead_ref)
+            for prior_start, prior_end, prior_batch in windows.get(lane_key, []):
+                if result["started_at"] < prior_end and prior_start < result["completed_at"]:
+                    raise ValidationError(
+                        f"lead {lead_ref} has overlapping reservations in {prior_batch} and {batch_id}"
+                    )
+            windows.setdefault(lane_key, []).append((result["started_at"], result["completed_at"], batch_id))
+            if outcome == "IMPORTED_NEEDS_REVIEW":
+                if key in imported_by_key:
+                    raise ValidationError(
+                        f"idempotency key was imported by both {imported_by_key[key]} and {batch_id}"
+                    )
+                imported_by_key[key] = batch_id
+    return results
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path, default=[DEFAULT_PROOF])
+    args = parser.parse_args(argv)
+    paths = args.paths or [DEFAULT_PROOF]
+    try:
+        documents = [load_json(path) for path in paths]
+        results = validate_documents(documents)
+    except (OSError, json.JSONDecodeError, ValidationError) as error:
+        print(json.dumps({"ok": False, "error": str(error)}, ensure_ascii=False), file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "schema_version": SCHEMA_VERSION,
+                "manifests": [
+                    {
+                        "path": str(path),
+                        "agent_batch_id": result["agent_batch_id"],
+                        "manifest_hash": result["manifest_hash"],
+                    }
+                    for path, result in zip(paths, results, strict=True)
+                ],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_agent_outreach_batch.py
+++ b/scripts/validate_agent_outreach_batch.py
@@ -23,6 +23,7 @@ DEFAULT_PROOF = ROOT / "commercial" / "fixtures" / "agent-outreach-batch-proof.e
 
 SCHEMA_VERSION = "confenge.agent-outreach-batch-proof.v1"
 HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+OPAQUE_REF_RE = re.compile(r"^hmac-sha256:[0-9a-f]{64}$")
 TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 ISO_Z_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
 EMAIL_RE = re.compile(r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![A-Za-z0-9.-])")
@@ -48,6 +49,7 @@ RECIPIENT_CLASSES = frozenset(
 SUMMARY_KEYS = (
     "reserved_count",
     "completed_count",
+    "newly_processed",
     "datalake_attempted",
     "web_attempted",
     "reconciled_count",
@@ -81,6 +83,8 @@ TOP_LEVEL_KEYS = frozenset(
         "agent_batch_id",
         "source_run_id",
         "source_run_hash",
+        "lead_ref_scheme",
+        "lead_ref_key_version",
         "executor_ref",
         "started_at",
         "completed_at",
@@ -110,23 +114,29 @@ def sha256_ref(value: Any) -> str:
 
 def expected_idempotency_key(
     source_run_id: str,
+    source_run_hash: str,
     lead_ref: str,
+    lead_ref_key_version: str,
     evidence_version: str,
     template_version: str,
+    policy_version: str,
 ) -> str:
-    """Derive the public-safe equivalent of source-run+CNPJ+evidence+template.
+    """Derive the public-safe source-run+lead+evidence+template+policy identity.
 
-    ``lead_ref`` is the operational system's stable, salted CNPJ reference. The
-    raw CNPJ never enters the public proof, while rerunning the same tuple still
-    produces exactly the same key.
+    ``lead_ref`` is the operational system's stable, secret-keyed CNPJ reference.
+    The raw CNPJ never enters the public proof, while rerunning the same tuple
+    still produces exactly the same key.
     """
 
     return sha256_ref(
         {
             "source_run_id": source_run_id,
+            "source_run_hash": source_run_hash,
             "lead_ref": lead_ref,
+            "lead_ref_key_version": lead_ref_key_version,
             "evidence_version": evidence_version,
             "template_version": template_version,
+            "policy_version": policy_version,
         }
     )
 
@@ -157,6 +167,12 @@ def _hash(value: Any, path: str) -> str:
     return value
 
 
+def _opaque_ref(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not OPAQUE_REF_RE.fullmatch(value):
+        raise ValidationError(f"{path} must be an HMAC-SHA256 opaque reference")
+    return value
+
+
 def _nonnegative_int(value: Any, path: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise ValidationError(f"{path} must be a non-negative integer")
@@ -166,7 +182,10 @@ def _nonnegative_int(value: Any, path: str) -> int:
 def _timestamp(value: Any, path: str) -> datetime:
     if not isinstance(value, str) or not ISO_Z_RE.fullmatch(value):
         raise ValidationError(f"{path} must be UTC with whole seconds and Z")
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValidationError(f"{path} is not a real UTC calendar instant") from error
 
 
 def assert_sanitized(value: Any, path: str = "$") -> None:
@@ -182,9 +201,9 @@ def assert_sanitized(value: Any, path: str = "$") -> None:
             assert_sanitized(child, f"{path}[{index}]")
         return
     if isinstance(value, str):
-        # Opaque SHA-256 references can contain long decimal runs by chance;
-        # they are already irreversible proof material, not raw CNPJ values.
-        if HASH_RE.fullmatch(value):
+        # Typed digest/HMAC references can contain long decimal runs by chance;
+        # they are proof material rather than raw CNPJ values.
+        if HASH_RE.fullmatch(value) or OPAQUE_REF_RE.fullmatch(value):
             return
         if EMAIL_RE.search(value):
             raise ValidationError(f"{path} contains an email address")
@@ -209,7 +228,7 @@ def _validate_lane(value: Any, path: str, started: datetime, completed: datetime
     return lane
 
 
-def _validate_draft(value: Any, path: str) -> None:
+def _validate_draft(value: Any, path: str) -> Mapping[str, Any]:
     draft = _mapping(value, path)
     _exact_keys(
         draft,
@@ -222,6 +241,9 @@ def _validate_draft(value: Any, path: str) -> None:
         raise ValidationError(f"{path}.recipient_class is not an attributable-company route")
     for key in ("content_hash", "evidence_bundle_hash", "import_receipt_hash"):
         _hash(draft[key], f"{path}.{key}")
+    if len({draft["content_hash"], draft["evidence_bundle_hash"], draft["import_receipt_hash"]}) != 3:
+        raise ValidationError(f"{path} reuses one hash for semantically distinct artifacts")
+    return draft
 
 
 def validate_document(document: Any) -> dict[str, Any]:
@@ -230,9 +252,19 @@ def validate_document(document: Any) -> dict[str, Any]:
     _exact_keys(doc, TOP_LEVEL_KEYS, "$")
     if doc["schema_version"] != SCHEMA_VERSION:
         raise ValidationError("$.schema_version is not the batch proof v1 contract")
-    for key in ("agent_batch_id", "source_run_id", "executor_ref", "policy_version", "template_version", "evidence_version"):
+    for key in (
+        "agent_batch_id",
+        "source_run_id",
+        "lead_ref_key_version",
+        "executor_ref",
+        "policy_version",
+        "template_version",
+        "evidence_version",
+    ):
         _token(doc[key], f"$.{key}")
     _hash(doc["source_run_hash"], "$.source_run_hash")
+    if doc["lead_ref_scheme"] != "HMAC_SHA256_V1":
+        raise ValidationError("$.lead_ref_scheme must be HMAC_SHA256_V1")
     started = _timestamp(doc["started_at"], "$.started_at")
     completed = _timestamp(doc["completed_at"], "$.completed_at")
     expires = _timestamp(doc["reservation_expires_at"], "$.reservation_expires_at")
@@ -244,18 +276,29 @@ def validate_document(document: Any) -> dict[str, Any]:
     universe = _mapping(doc["universe"], "$.universe")
     _exact_keys(
         universe,
-        {"target_confirmed_total", "batch_reserved", "unique_processed_total_after_batch", "remaining_after_batch"},
+        {
+            "target_confirmed_total",
+            "batch_reserved",
+            "unique_processed_total_before_batch",
+            "unique_processed_total_after_batch",
+            "remaining_after_batch",
+        },
         "$.universe",
     )
     total = _nonnegative_int(universe["target_confirmed_total"], "$.universe.target_confirmed_total")
     reserved = _nonnegative_int(universe["batch_reserved"], "$.universe.batch_reserved")
-    processed = _nonnegative_int(
+    processed_before = _nonnegative_int(
+        universe["unique_processed_total_before_batch"], "$.universe.unique_processed_total_before_batch"
+    )
+    processed_after = _nonnegative_int(
         universe["unique_processed_total_after_batch"], "$.universe.unique_processed_total_after_batch"
     )
     remaining = _nonnegative_int(universe["remaining_after_batch"], "$.universe.remaining_after_batch")
     if reserved > total:
         raise ValidationError("$.universe.batch_reserved exceeds the TARGET_CONFIRMED denominator")
-    if processed > total or remaining != total - processed:
+    if processed_before > total or processed_after > total or processed_after < processed_before:
+        raise ValidationError("$.universe processed totals are not monotonic within the denominator")
+    if remaining != total - processed_after:
         raise ValidationError("$.universe does not reconcile processed and remaining against the denominator")
 
     safety = _mapping(doc["safety"], "$.safety")
@@ -291,14 +334,17 @@ def validate_document(document: Any) -> dict[str, Any]:
 
     lead_refs: set[str] = set()
     idempotency_keys: set[str] = set()
+    import_receipt_hashes: set[str] = set()
     outcome_counts = {outcome: 0 for outcome in TERMINAL_OUTCOMES}
     reconciled_count = 0
     generated_count = 0
+    newly_processed = 0
     for index, raw_member in enumerate(members):
         path = f"$.members[{index}]"
         member = _mapping(raw_member, path)
         base_keys = {
             "lead_ref",
+            "denominator_effect",
             "lanes",
             "reconciliation_status",
             "critical_conflict",
@@ -308,10 +354,15 @@ def validate_document(document: Any) -> dict[str, Any]:
         outcome = member.get("outcome")
         expected_keys = base_keys | ({"draft"} if outcome == "IMPORTED_NEEDS_REVIEW" else {"blocker"})
         _exact_keys(member, expected_keys, path)
-        lead_ref = _hash(member["lead_ref"], f"{path}.lead_ref")
+        lead_ref = _opaque_ref(member["lead_ref"], f"{path}.lead_ref")
         if lead_ref in lead_refs:
             raise ValidationError(f"{path}.lead_ref is reserved twice in one batch")
         lead_refs.add(lead_ref)
+        denominator_effect = member["denominator_effect"]
+        if denominator_effect not in {"NEWLY_PROCESSED", "ALREADY_PROCESSED"}:
+            raise ValidationError(f"{path}.denominator_effect is invalid")
+        if denominator_effect == "NEWLY_PROCESSED":
+            newly_processed += 1
 
         lanes = _mapping(member["lanes"], f"{path}.lanes")
         _exact_keys(lanes, {"datalake", "web"}, f"{path}.lanes")
@@ -323,6 +374,19 @@ def validate_document(document: Any) -> dict[str, Any]:
             raise ValidationError(f"{path}.reconciliation_status is invalid")
         if not isinstance(member["critical_conflict"], bool):
             raise ValidationError(f"{path}.critical_conflict must be boolean")
+        lane_statuses = (datalake["status"], web["status"])
+        if "ERROR" in lane_statuses and reconciliation != "UNKNOWN":
+            raise ValidationError(f"{path}.reconciliation_status must be UNKNOWN after a lane error")
+        expected_lane_statuses = {
+            "DATALAKE_WEB_CORROBORATED": ("OBSERVED", "OBSERVED"),
+            "DATALAKE_ONLY": ("OBSERVED", "NO_MATCH"),
+            "WEB_ONLY": ("NO_MATCH", "OBSERVED"),
+            "CONFLICT": ("OBSERVED", "OBSERVED"),
+        }
+        if reconciliation in expected_lane_statuses and lane_statuses != expected_lane_statuses[reconciliation]:
+            raise ValidationError(f"{path}.reconciliation_status contradicts the two lane results")
+        if member["critical_conflict"] and reconciliation != "CONFLICT":
+            raise ValidationError(f"{path}.critical_conflict requires reconciliation_status CONFLICT")
         if outcome not in TERMINAL_OUTCOMES:
             raise ValidationError(f"{path}.outcome is not terminal")
         outcome_counts[outcome] += 1
@@ -330,10 +394,18 @@ def validate_document(document: Any) -> dict[str, Any]:
             reconciled_count += 1
 
         expected_key = expected_idempotency_key(
-            doc["source_run_id"], lead_ref, doc["evidence_version"], doc["template_version"]
+            doc["source_run_id"],
+            doc["source_run_hash"],
+            lead_ref,
+            doc["lead_ref_key_version"],
+            doc["evidence_version"],
+            doc["template_version"],
+            doc["policy_version"],
         )
         if member["idempotency_key"] != expected_key:
-            raise ValidationError(f"{path}.idempotency_key does not match source-run+lead+evidence+template")
+            raise ValidationError(
+                f"{path}.idempotency_key does not match source-run+lead-key+evidence+template+policy"
+            )
         if member["idempotency_key"] in idempotency_keys:
             raise ValidationError(f"{path}.idempotency_key is duplicated")
         idempotency_keys.add(member["idempotency_key"])
@@ -343,7 +415,11 @@ def validate_document(document: Any) -> dict[str, Any]:
                 raise ValidationError(f"{path} imported a draft while an evidence lane failed")
             if reconciliation in {"CONFLICT", "UNKNOWN"} or member["critical_conflict"]:
                 raise ValidationError(f"{path} imported a draft without safe reconciliation")
-            _validate_draft(member["draft"], f"{path}.draft")
+            draft = _validate_draft(member["draft"], f"{path}.draft")
+            receipt_hash = draft["import_receipt_hash"]
+            if receipt_hash in import_receipt_hashes:
+                raise ValidationError(f"{path}.draft.import_receipt_hash is reused by another member")
+            import_receipt_hashes.add(receipt_hash)
             generated_count += 1
         else:
             blocker = _mapping(member["blocker"], f"{path}.blocker")
@@ -359,6 +435,7 @@ def validate_document(document: Any) -> dict[str, Any]:
     expected_summary = {
         "reserved_count": len(members),
         "completed_count": len(members),
+        "newly_processed": newly_processed,
         "datalake_attempted": len(members),
         "web_attempted": len(members),
         "reconciled_count": reconciled_count,
@@ -371,13 +448,27 @@ def validate_document(document: Any) -> dict[str, Any]:
     }
     if dict(summary) != expected_summary:
         raise ValidationError(f"$.summary does not reconcile members: expected={expected_summary}")
+    if processed_after != processed_before + newly_processed:
+        raise ValidationError("$.universe processed delta does not equal members marked NEWLY_PROCESSED")
 
     return {
         "agent_batch_id": doc["agent_batch_id"],
         "source_run_id": doc["source_run_id"],
+        "source_run_hash": doc["source_run_hash"],
+        "lead_ref_key_version": doc["lead_ref_key_version"],
+        "target_confirmed_total": total,
         "started_at": started,
         "completed_at": completed,
-        "member_outcomes": [(member["lead_ref"], member["idempotency_key"], member["outcome"]) for member in members],
+        "reservation_expires_at": expires,
+        "member_outcomes": [
+            (
+                member["lead_ref"],
+                member["idempotency_key"],
+                member["outcome"],
+                member.get("draft", {}).get("import_receipt_hash"),
+            )
+            for member in members
+        ],
         "manifest_hash": sha256_ref(doc),
     }
 
@@ -385,27 +476,44 @@ def validate_document(document: Any) -> dict[str, Any]:
 def validate_documents(documents: Sequence[Any]) -> list[dict[str, Any]]:
     results = [validate_document(document) for document in documents]
     batch_ids: set[str] = set()
-    windows: dict[tuple[str, str], list[tuple[datetime, datetime, str]]] = {}
+    windows: dict[str, list[tuple[datetime, datetime, str]]] = {}
     imported_by_key: dict[str, str] = {}
+    imported_by_receipt: dict[str, str] = {}
+    source_runs: dict[str, tuple[str, int, str]] = {}
     for result in results:
         batch_id = result["agent_batch_id"]
         if batch_id in batch_ids:
             raise ValidationError(f"agent_batch_id {batch_id} is duplicated")
         batch_ids.add(batch_id)
-        for lead_ref, key, outcome in result["member_outcomes"]:
-            lane_key = (result["source_run_id"], lead_ref)
-            for prior_start, prior_end, prior_batch in windows.get(lane_key, []):
-                if result["started_at"] < prior_end and prior_start < result["completed_at"]:
+        source_run_id = result["source_run_id"]
+        source_identity = (
+            result["source_run_hash"],
+            result["target_confirmed_total"],
+            result["lead_ref_key_version"],
+        )
+        if source_run_id in source_runs and source_runs[source_run_id] != source_identity:
+            raise ValidationError(f"source_run_id {source_run_id} has divergent identity or denominator")
+        source_runs[source_run_id] = source_identity
+        for lead_ref, key, outcome, receipt_hash in result["member_outcomes"]:
+            for prior_start, prior_expiry, prior_batch in windows.get(lead_ref, []):
+                if result["started_at"] < prior_expiry and prior_start < result["reservation_expires_at"]:
                     raise ValidationError(
                         f"lead {lead_ref} has overlapping reservations in {prior_batch} and {batch_id}"
                     )
-            windows.setdefault(lane_key, []).append((result["started_at"], result["completed_at"], batch_id))
+            windows.setdefault(lead_ref, []).append(
+                (result["started_at"], result["reservation_expires_at"], batch_id)
+            )
             if outcome == "IMPORTED_NEEDS_REVIEW":
                 if key in imported_by_key:
                     raise ValidationError(
                         f"idempotency key was imported by both {imported_by_key[key]} and {batch_id}"
                     )
                 imported_by_key[key] = batch_id
+                if receipt_hash in imported_by_receipt:
+                    raise ValidationError(
+                        f"import receipt was claimed by both {imported_by_receipt[receipt_hash]} and {batch_id}"
+                    )
+                imported_by_receipt[receipt_hash] = batch_id
     return results
 
 

--- a/tests/test_agent_outreach_batch.py
+++ b/tests/test_agent_outreach_batch.py
@@ -34,6 +34,19 @@ def proof():
     return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
 
 
+def refresh_idempotency_keys(doc):
+    for member in doc["members"]:
+        member["idempotency_key"] = v.expected_idempotency_key(
+            doc["source_run_id"],
+            doc["source_run_hash"],
+            member["lead_ref"],
+            doc["lead_ref_key_version"],
+            doc["evidence_version"],
+            doc["template_version"],
+            doc["policy_version"],
+        )
+
+
 def test_sanitized_example_is_a_complete_reconciled_proof():
     result = v.validate_document(proof())
     assert result["agent_batch_id"] == "agent-batch-fixture-001"
@@ -46,6 +59,7 @@ def test_schema_fail_closes_and_only_allows_needs_review_drafts():
     assert schema["additionalProperties"] is False
     assert schema["$defs"]["member"]["additionalProperties"] is False
     assert schema["$defs"]["draft"]["properties"]["state"] == {"const": "NEEDS_REVIEW"}
+    assert schema["$defs"]["opaque_ref"]["pattern"].startswith("^hmac-sha256:")
     safety = schema["properties"]["safety"]["properties"]
     assert safety["llm_api_calls"] == {"const": 0}
     assert safety["approvals"] == {"const": 0}
@@ -57,14 +71,59 @@ def test_idempotency_is_stable_for_the_same_public_safe_tuple_and_changes_with_v
     doc = proof()
     member = doc["members"][0]
     expected = v.expected_idempotency_key(
-        doc["source_run_id"], member["lead_ref"], doc["evidence_version"], doc["template_version"]
+        doc["source_run_id"],
+        doc["source_run_hash"],
+        member["lead_ref"],
+        doc["lead_ref_key_version"],
+        doc["evidence_version"],
+        doc["template_version"],
+        doc["policy_version"],
     )
     assert expected == member["idempotency_key"]
     assert expected == v.expected_idempotency_key(
-        doc["source_run_id"], member["lead_ref"], doc["evidence_version"], doc["template_version"]
+        doc["source_run_id"],
+        doc["source_run_hash"],
+        member["lead_ref"],
+        doc["lead_ref_key_version"],
+        doc["evidence_version"],
+        doc["template_version"],
+        doc["policy_version"],
     )
     assert expected != v.expected_idempotency_key(
-        doc["source_run_id"], member["lead_ref"], "web-datalake-bundle.v2", doc["template_version"]
+        doc["source_run_id"],
+        doc["source_run_hash"],
+        member["lead_ref"],
+        doc["lead_ref_key_version"],
+        "web-datalake-bundle.v2",
+        doc["template_version"],
+        doc["policy_version"],
+    )
+    assert expected != v.expected_idempotency_key(
+        doc["source_run_id"],
+        "sha256:" + "0" * 64,
+        member["lead_ref"],
+        doc["lead_ref_key_version"],
+        doc["evidence_version"],
+        doc["template_version"],
+        doc["policy_version"],
+    )
+    assert expected != v.expected_idempotency_key(
+        doc["source_run_id"],
+        doc["source_run_hash"],
+        member["lead_ref"],
+        doc["lead_ref_key_version"],
+        doc["evidence_version"],
+        doc["template_version"],
+        "outreach-agent-policy.v2",
+    )
+    assert expected != v.expected_idempotency_key(
+        doc["source_run_id"],
+        doc["source_run_hash"],
+        member["lead_ref"],
+        "outreach-lead-ref.v2",
+        doc["evidence_version"],
+        doc["template_version"],
+        doc["policy_version"],
     )
 
 
@@ -79,11 +138,40 @@ def test_lane_failure_cannot_import_a_draft():
     doc = proof()
     doc["members"][0]["lanes"]["web"]["status"] = "ERROR"
     doc["members"][0]["lanes"]["web"]["evidence_count"] = 0
-    with pytest.raises(v.ValidationError, match="evidence lane failed"):
+    with pytest.raises(v.ValidationError, match="lane error|evidence lane failed"):
         v.validate_document(doc)
 
 
-@pytest.mark.parametrize("reconciliation,critical", [("CONFLICT", False), ("UNKNOWN", False), ("DATALAKE_ONLY", True)])
+@pytest.mark.parametrize(
+    "reconciliation,datalake,web",
+    [
+        ("DATALAKE_WEB_CORROBORATED", "OBSERVED", "NO_MATCH"),
+        ("DATALAKE_ONLY", "NO_MATCH", "OBSERVED"),
+        ("WEB_ONLY", "OBSERVED", "NO_MATCH"),
+        ("CONFLICT", "OBSERVED", "NO_MATCH"),
+        ("DATALAKE_ONLY", "OBSERVED", "ERROR"),
+    ],
+)
+def test_reconciliation_status_must_agree_with_both_lane_results(reconciliation, datalake, web):
+    doc = proof()
+    member = doc["members"][0]
+    member["reconciliation_status"] = reconciliation
+    member["lanes"]["datalake"]["status"] = datalake
+    member["lanes"]["web"]["status"] = web
+    for lane in member["lanes"].values():
+        lane["evidence_count"] = 1 if lane["status"] == "OBSERVED" else 0
+    with pytest.raises(v.ValidationError, match="reconciliation_status"):
+        v.validate_document(doc)
+
+
+def test_critical_conflict_cannot_hide_behind_a_non_conflict_status():
+    doc = proof()
+    doc["members"][1]["critical_conflict"] = True
+    with pytest.raises(v.ValidationError, match="critical_conflict requires"):
+        v.validate_document(doc)
+
+
+@pytest.mark.parametrize("reconciliation,critical", [("CONFLICT", False), ("UNKNOWN", False)])
 def test_conflict_unknown_or_critical_flag_cannot_import(reconciliation, critical):
     doc = proof()
     doc["members"][0]["reconciliation_status"] = reconciliation
@@ -117,6 +205,20 @@ def test_public_proof_rejects_contacts_identity_and_source_urls(key, value, matc
         v.validate_document(doc)
 
 
+def test_plain_sha256_cannot_masquerade_as_a_secret_keyed_lead_reference():
+    doc = proof()
+    doc["members"][0]["lead_ref"] = "sha256:" + "1" * 64
+    with pytest.raises(v.ValidationError, match="HMAC-SHA256 opaque reference"):
+        v.validate_document(doc)
+
+
+def test_invalid_calendar_timestamp_fails_as_a_validation_error_not_a_traceback():
+    doc = proof()
+    doc["completed_at"] = "2026-99-25T10:15:00Z"
+    with pytest.raises(v.ValidationError, match="real UTC calendar instant"):
+        v.validate_document(doc)
+
+
 def test_summary_and_denominator_cannot_drift_from_members():
     doc = proof()
     doc["summary"]["imported_needs_review"] = 2
@@ -131,6 +233,38 @@ def test_summary_and_denominator_cannot_drift_from_members():
     doc = proof()
     doc["universe"]["target_confirmed_total"] = 1
     with pytest.raises(v.ValidationError, match="exceeds the TARGET_CONFIRMED denominator"):
+        v.validate_document(doc)
+
+    doc = proof()
+    doc["universe"]["unique_processed_total_after_batch"] = 1
+    doc["universe"]["remaining_after_batch"] = 8244
+    with pytest.raises(v.ValidationError, match="processed delta"):
+        v.validate_document(doc)
+
+    doc = proof()
+    doc["members"][0]["denominator_effect"] = "ALREADY_PROCESSED"
+    with pytest.raises(v.ValidationError, match="summary does not reconcile"):
+        v.validate_document(doc)
+
+
+def test_distinct_proof_artifacts_cannot_reuse_one_hash():
+    doc = proof()
+    draft = doc["members"][0]["draft"]
+    draft["import_receipt_hash"] = draft["content_hash"]
+    with pytest.raises(v.ValidationError, match="semantically distinct artifacts"):
+        v.validate_document(doc)
+
+
+def test_one_import_receipt_cannot_be_claimed_by_two_members():
+    doc = proof()
+    second = doc["members"][1]
+    second["outcome"] = "IMPORTED_NEEDS_REVIEW"
+    second["draft"] = deepcopy(doc["members"][0]["draft"])
+    del second["blocker"]
+    doc["summary"]["draft_generated"] = 2
+    doc["summary"]["imported_needs_review"] = 2
+    doc["summary"]["blocked"] = 0
+    with pytest.raises(v.ValidationError, match="import_receipt_hash is reused"):
         v.validate_document(doc)
 
 
@@ -174,12 +308,18 @@ def test_two_agent_batches_cannot_overlap_on_the_same_lead():
     first = proof()
     second = deepcopy(first)
     second["agent_batch_id"] = "agent-batch-fixture-002"
-    second["started_at"] = "2026-08-25T10:10:00Z"
+    second["source_run_id"] = "supplier-run-2026-08-25-refresh"
+    second["source_run_hash"] = "sha256:" + "9" * 64
+    second["started_at"] = "2026-08-25T10:16:00Z"
     second["completed_at"] = "2026-08-25T10:25:00Z"
     second["reservation_expires_at"] = "2026-08-25T11:10:00Z"
     for member in second["members"]:
         for lane in member["lanes"].values():
             lane["observed_at"] = "2026-08-25T10:12:00Z"
+    for member in second["members"]:
+        for lane in member["lanes"].values():
+            lane["observed_at"] = "2026-08-25T10:20:00Z"
+    refresh_idempotency_keys(second)
     with pytest.raises(v.ValidationError, match="overlapping reservations"):
         v.validate_documents([first, second])
 
@@ -188,13 +328,41 @@ def test_two_batches_cannot_claim_the_same_import_receipt_tuple_twice():
     first = proof()
     second = deepcopy(first)
     second["agent_batch_id"] = "agent-batch-fixture-003"
-    second["started_at"] = "2026-08-25T10:16:00Z"
-    second["completed_at"] = "2026-08-25T10:31:00Z"
-    second["reservation_expires_at"] = "2026-08-25T11:16:00Z"
+    second["started_at"] = "2026-08-25T11:00:00Z"
+    second["completed_at"] = "2026-08-25T11:15:00Z"
+    second["reservation_expires_at"] = "2026-08-25T12:00:00Z"
     for member in second["members"]:
         for lane in member["lanes"].values():
-            lane["observed_at"] = "2026-08-25T10:20:00Z"
+            lane["observed_at"] = "2026-08-25T11:05:00Z"
     with pytest.raises(v.ValidationError, match="idempotency key was imported"):
+        v.validate_documents([first, second])
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("source_run_hash", "sha256:" + "8" * 64),
+        ("lead_ref_key_version", "outreach-lead-ref.v2"),
+        ("target_confirmed_total", 9000),
+    ],
+)
+def test_same_source_run_id_cannot_change_identity_or_denominator(field, value):
+    first = proof()
+    second = deepcopy(first)
+    second["agent_batch_id"] = "agent-batch-fixture-source-drift"
+    second["started_at"] = "2026-08-25T11:00:00Z"
+    second["completed_at"] = "2026-08-25T11:15:00Z"
+    second["reservation_expires_at"] = "2026-08-25T12:00:00Z"
+    for member in second["members"]:
+        for lane in member["lanes"].values():
+            lane["observed_at"] = "2026-08-25T11:05:00Z"
+    if field in {"source_run_hash", "lead_ref_key_version"}:
+        second[field] = value
+        refresh_idempotency_keys(second)
+    else:
+        second["universe"][field] = value
+        second["universe"]["remaining_after_batch"] = value - 2
+    with pytest.raises(v.ValidationError, match="divergent identity or denominator"):
         v.validate_documents([first, second])
 
 

--- a/tests/test_agent_outreach_batch.py
+++ b/tests/test_agent_outreach_batch.py
@@ -1,0 +1,242 @@
+"""Adversarial tests for synchronous agent-batch proof manifests."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT / "scripts" / "validate_agent_outreach_batch.py"
+FIXTURE_PATH = ROOT / "commercial" / "fixtures" / "agent-outreach-batch-proof.example.v1.json"
+SCHEMA_PATH = ROOT / "schemas" / "agent-outreach-batch-proof.v1.schema.json"
+CNPJ_FIXTURE = ".".join(("12", "345", "678")) + "/" + "0001" + "-" + "90"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_agent_outreach_batch", VALIDATOR_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+v = load_validator()
+
+
+def proof():
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_sanitized_example_is_a_complete_reconciled_proof():
+    result = v.validate_document(proof())
+    assert result["agent_batch_id"] == "agent-batch-fixture-001"
+    assert result["manifest_hash"].startswith("sha256:")
+    assert len(result["member_outcomes"]) == 2
+
+
+def test_schema_fail_closes_and_only_allows_needs_review_drafts():
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert schema["additionalProperties"] is False
+    assert schema["$defs"]["member"]["additionalProperties"] is False
+    assert schema["$defs"]["draft"]["properties"]["state"] == {"const": "NEEDS_REVIEW"}
+    safety = schema["properties"]["safety"]["properties"]
+    assert safety["llm_api_calls"] == {"const": 0}
+    assert safety["approvals"] == {"const": 0}
+    assert safety["scheduled"] == {"const": 0}
+    assert safety["sent"] == {"const": 0}
+
+
+def test_idempotency_is_stable_for_the_same_public_safe_tuple_and_changes_with_versions():
+    doc = proof()
+    member = doc["members"][0]
+    expected = v.expected_idempotency_key(
+        doc["source_run_id"], member["lead_ref"], doc["evidence_version"], doc["template_version"]
+    )
+    assert expected == member["idempotency_key"]
+    assert expected == v.expected_idempotency_key(
+        doc["source_run_id"], member["lead_ref"], doc["evidence_version"], doc["template_version"]
+    )
+    assert expected != v.expected_idempotency_key(
+        doc["source_run_id"], member["lead_ref"], "web-datalake-bundle.v2", doc["template_version"]
+    )
+
+
+def test_omitting_either_required_lane_fails_closed():
+    doc = proof()
+    del doc["members"][0]["lanes"]["web"]
+    with pytest.raises(v.ValidationError, match="lanes.*keys diverge"):
+        v.validate_document(doc)
+
+
+def test_lane_failure_cannot_import_a_draft():
+    doc = proof()
+    doc["members"][0]["lanes"]["web"]["status"] = "ERROR"
+    doc["members"][0]["lanes"]["web"]["evidence_count"] = 0
+    with pytest.raises(v.ValidationError, match="evidence lane failed"):
+        v.validate_document(doc)
+
+
+@pytest.mark.parametrize("reconciliation,critical", [("CONFLICT", False), ("UNKNOWN", False), ("DATALAKE_ONLY", True)])
+def test_conflict_unknown_or_critical_flag_cannot_import(reconciliation, critical):
+    doc = proof()
+    doc["members"][0]["reconciliation_status"] = reconciliation
+    doc["members"][0]["critical_conflict"] = critical
+    with pytest.raises(v.ValidationError, match="without safe reconciliation"):
+        v.validate_document(doc)
+
+
+@pytest.mark.parametrize("state", ["APPROVED", "QUEUED", "SENT", "DRAFTED"])
+def test_generation_proof_can_only_end_in_needs_review(state):
+    doc = proof()
+    doc["members"][0]["draft"]["state"] = state
+    with pytest.raises(v.ValidationError, match="must be NEEDS_REVIEW"):
+        v.validate_document(doc)
+
+
+@pytest.mark.parametrize(
+    "key,value,match",
+    [
+        ("email", "fixture@example.invalid", "operational/contact data"),
+        ("company_name", "Empresa Fixture", "operational/contact data"),
+        ("note", "fixture@example.invalid", "email address"),
+        ("note", "https://example.invalid/contact", "source URL"),
+        ("note", CNPJ_FIXTURE, "CNPJ"),
+    ],
+)
+def test_public_proof_rejects_contacts_identity_and_source_urls(key, value, match):
+    doc = proof()
+    doc["members"][0][key] = value
+    with pytest.raises(v.ValidationError, match=match):
+        v.validate_document(doc)
+
+
+def test_summary_and_denominator_cannot_drift_from_members():
+    doc = proof()
+    doc["summary"]["imported_needs_review"] = 2
+    with pytest.raises(v.ValidationError, match="summary does not reconcile"):
+        v.validate_document(doc)
+
+    doc = proof()
+    doc["universe"]["remaining_after_batch"] = 0
+    with pytest.raises(v.ValidationError, match="does not reconcile processed and remaining"):
+        v.validate_document(doc)
+
+    doc = proof()
+    doc["universe"]["target_confirmed_total"] = 1
+    with pytest.raises(v.ValidationError, match="exceeds the TARGET_CONFIRMED denominator"):
+        v.validate_document(doc)
+
+
+def test_one_synchronous_batch_is_bounded_to_500_members():
+    doc = proof()
+    doc["members"] = doc["members"] * 251
+    doc["universe"]["batch_reserved"] = len(doc["members"])
+    with pytest.raises(v.ValidationError, match="at most 500"):
+        v.validate_document(doc)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("llm_api_calls", 1),
+        ("provider_mutations", 1),
+        ("approvals", 1),
+        ("scheduled", 1),
+        ("sent", 1),
+        ("runtime_generation", True),
+        ("auto_send_changed", True),
+        ("kill_switch_changed", True),
+        ("operational_data_included", True),
+    ],
+)
+def test_every_forbidden_side_effect_is_fail_closed(field, value):
+    doc = proof()
+    doc["safety"][field] = value
+    with pytest.raises(v.ValidationError, match=field):
+        v.validate_document(doc)
+
+
+def test_same_lead_cannot_be_reserved_twice_in_one_batch():
+    doc = proof()
+    doc["members"][1]["lead_ref"] = doc["members"][0]["lead_ref"]
+    with pytest.raises(v.ValidationError, match="reserved twice"):
+        v.validate_document(doc)
+
+
+def test_two_agent_batches_cannot_overlap_on_the_same_lead():
+    first = proof()
+    second = deepcopy(first)
+    second["agent_batch_id"] = "agent-batch-fixture-002"
+    second["started_at"] = "2026-08-25T10:10:00Z"
+    second["completed_at"] = "2026-08-25T10:25:00Z"
+    second["reservation_expires_at"] = "2026-08-25T11:10:00Z"
+    for member in second["members"]:
+        for lane in member["lanes"].values():
+            lane["observed_at"] = "2026-08-25T10:12:00Z"
+    with pytest.raises(v.ValidationError, match="overlapping reservations"):
+        v.validate_documents([first, second])
+
+
+def test_two_batches_cannot_claim_the_same_import_receipt_tuple_twice():
+    first = proof()
+    second = deepcopy(first)
+    second["agent_batch_id"] = "agent-batch-fixture-003"
+    second["started_at"] = "2026-08-25T10:16:00Z"
+    second["completed_at"] = "2026-08-25T10:31:00Z"
+    second["reservation_expires_at"] = "2026-08-25T11:16:00Z"
+    for member in second["members"]:
+        for lane in member["lanes"].values():
+            lane["observed_at"] = "2026-08-25T10:20:00Z"
+    with pytest.raises(v.ValidationError, match="idempotency key was imported"):
+        v.validate_documents([first, second])
+
+
+def test_cli_validates_the_shipped_fixture_and_fails_on_a_leak(tmp_path):
+    valid = subprocess.run(
+        [sys.executable, str(VALIDATOR_PATH), str(FIXTURE_PATH)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert valid.returncode == 0, valid.stderr
+    assert json.loads(valid.stdout)["ok"] is True
+
+    leaked = proof()
+    leaked["members"][0]["note"] = "fixture@example.invalid"
+    leaked_path = tmp_path / "leaked.json"
+    leaked_path.write_text(json.dumps(leaked), encoding="utf-8")
+    invalid = subprocess.run(
+        [sys.executable, str(VALIDATOR_PATH), str(leaked_path)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert invalid.returncode == 1
+    assert json.loads(invalid.stderr)["ok"] is False
+
+
+def test_validator_has_no_network_database_or_model_client_imports():
+    source = VALIDATOR_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported.update(
+        node.module.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    )
+    assert imported.isdisjoint({"requests", "httpx", "urllib", "socket", "psycopg", "openai", "anthropic"})
+    assert "subprocess" not in imported


### PR DESCRIPTION
## Resultado

- cria o contrato `confenge.agent-outreach-batch-proof.v1` para coordenar lotes de até 500 sem criar lake, CRM, worker, composer ou fila paralelos;
- exige prova consistente das lanes datalake e web por membro e bloqueia erro, conflito ou reconciliação `UNKNOWN`;
- usa referência `lead_ref` HMAC-SHA256 com chave privada versionada, recusando SHA simples enumerável de CNPJ;
- deriva idempotência por source run id+hash, referência opaca/key version e versões de evidência/template/policy;
- rejeita reservas sobrepostas até a expiração real, inclusive entre source runs, além de chave ou recibo individual reutilizados;
- vincula denominador antes/depois ao efeito `NEWLY_PROCESSED|ALREADY_PROCESSED` de cada membro e deriva todo o resumo;
- falha fechado para timestamps inválidos, reconciliações incompatíveis com as lanes e hashes reutilizados entre artefatos distintos;
- falha fechado para APPROVED/QUEUED/SENT, LLM API, mutação de provider, scheduling, envio, auto-send ou kill switch alterado;
- impede que e-mail, CNPJ, URL, empresa, contato, assunto ou corpo entrem no manifesto público.

## Fronteira operacional

O PR entrega coordenação e prova sanitizada em Governance. Ele não acessa o datalake, não faz web search, não gera/importa mensagens reais e não declara processadas as 110 contas, as 25 READY_TO_GENERATE, o buffer de 500 ou o universo de 8.245. Evidência e dados originais permanecem nas autoridades privadas do extra-cli/Warmbly.

## Validação

- validadores comerciais, legais e de parceiros: pass
- `python3 scripts/validate_agent_outreach_batch.py`: pass
- `python3 -m pytest tests -q`: 191 passed
- 45 testes adversariais específicos do contrato
- `npm audit --omit=dev --audit-level=critical`: 0 vulnerabilidades

Refs #129