### PR TITLE
[P0] Tornar auditáveis as jornadas autenticadas

### DIFF
--- a/control-center/apps/web-shell/package.json
+++ b/control-center/apps/web-shell/package.json
@@ -11,6 +11,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview --host 127.0.0.1 --port 4173",
+    "audit:ux": "tsx scripts/live-ux-audit.ts",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test tests/*.test.ts",
     "test:e2e": "tsx scripts/e2e.mjs"

--- a/control-center/apps/web-shell/scripts/live-ux-audit.ts
+++ b/control-center/apps/web-shell/scripts/live-ux-audit.ts
@@ -1,0 +1,54 @@
+import { readFile } from "node:fs/promises";
+import {
+  buildLiveUxAuditPlan,
+  validateLiveUxAudit,
+} from "../src/live-ux-audit.ts";
+
+function usage(): never {
+  process.stderr.write(
+    [
+      "Usage:",
+      "  npm run audit:ux --workspace=@confenge/control-center-web-shell -- plan",
+      "  npm run audit:ux --workspace=@confenge/control-center-web-shell -- validate <evidence.json>",
+      "  npm run audit:ux --workspace=@confenge/control-center-web-shell -- gate <evidence.json>",
+      "",
+      "validate checks provenance and evidence completeness.",
+      "gate additionally requires every live human observation to pass.",
+    ].join("\n"),
+  );
+  process.exit(64);
+}
+
+async function readEvidence(path: string): Promise<unknown> {
+  const serialized = await readFile(path, "utf8");
+  return JSON.parse(serialized) as unknown;
+}
+
+async function main(): Promise<void> {
+  const [command, path, ...extra] = process.argv.slice(2);
+  if (extra.length > 0) usage();
+
+  if (command === "plan" && path === undefined) {
+    const plan = buildLiveUxAuditPlan();
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    if (plan.consistencyErrors.length > 0) process.exitCode = 1;
+    return;
+  }
+
+  if ((command === "validate" || command === "gate") && path !== undefined) {
+    const result = validateLiveUxAudit(await readEvidence(path));
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.valid || (command === "gate" && !result.auditPassed)) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  usage();
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`live UX audit failed: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/control-center/apps/web-shell/scripts/live-ux-audit.ts
+++ b/control-center/apps/web-shell/scripts/live-ux-audit.ts
@@ -1,6 +1,11 @@
-import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
 import {
   buildLiveUxAuditPlan,
+  liveUxAuditIssueNumbers,
+  liveUxAuditMediaDigests,
   validateLiveUxAudit,
 } from "../src/live-ux-audit.ts";
 
@@ -10,10 +15,10 @@ function usage(): never {
       "Usage:",
       "  npm run audit:ux --workspace=@confenge/control-center-web-shell -- plan",
       "  npm run audit:ux --workspace=@confenge/control-center-web-shell -- validate <evidence.json>",
-      "  npm run audit:ux --workspace=@confenge/control-center-web-shell -- gate <evidence.json>",
+      "  npm run audit:ux --workspace=@confenge/control-center-web-shell -- gate <evidence.json> <media-directory>",
       "",
-      "validate checks provenance and evidence completeness.",
-      "gate additionally requires every live human observation to pass.",
+      "validate checks provenance, completeness, and that friction issues exist.",
+      "gate additionally requires every observation to pass and every media digest to resolve to a real file.",
     ].join("\n"),
   );
   process.exit(64);
@@ -24,21 +29,92 @@ async function readEvidence(path: string): Promise<unknown> {
   return JSON.parse(serialized) as unknown;
 }
 
+async function sha256File(path: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function filesBelow(directory: string): Promise<readonly string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await filesBelow(path));
+    if (entry.isFile()) files.push(path);
+  }
+  return files;
+}
+
+async function verifyMedia(value: unknown, directory: string): Promise<readonly string[]> {
+  const expected = new Set(liveUxAuditMediaDigests(value));
+  const observed = new Set<string>();
+  for (const path of await filesBelow(directory)) observed.add(await sha256File(path));
+  return [...expected]
+    .filter((digest) => !observed.has(digest))
+    .map((digest) => `Media artifact ${digest} is absent from the authorized media directory.`);
+}
+
+async function verifyIssues(value: unknown): Promise<readonly string[]> {
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "confenge-live-ux-audit",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  return (await Promise.all(liveUxAuditIssueNumbers(value).map(async (issueNumber) => {
+    try {
+      const response = await fetch(
+        `https://api.github.com/repos/tjsasakifln/Governance/issues/${issueNumber}`,
+        { headers, signal: AbortSignal.timeout(5_000) },
+      );
+      if (!response.ok) return `Governance issue #${issueNumber} could not be verified (HTTP ${response.status}).`;
+      const issue = await response.json() as Record<string, unknown>;
+      if ("pull_request" in issue) return `Governance reference #${issueNumber} is a pull request, not a finding issue.`;
+      if (issue.number !== issueNumber) return `Governance issue #${issueNumber} returned a divergent identity.`;
+      return null;
+    } catch {
+      return `Governance issue #${issueNumber} could not be verified.`;
+    }
+  }))).filter((error): error is string => error !== null);
+}
+
 async function main(): Promise<void> {
-  const [command, path, ...extra] = process.argv.slice(2);
+  const [command, path, mediaDirectory, ...extra] = process.argv.slice(2);
   if (extra.length > 0) usage();
 
-  if (command === "plan" && path === undefined) {
+  if (command === "plan" && path === undefined && mediaDirectory === undefined) {
     const plan = buildLiveUxAuditPlan();
     process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
     if (plan.consistencyErrors.length > 0) process.exitCode = 1;
     return;
   }
 
-  if ((command === "validate" || command === "gate") && path !== undefined) {
-    const result = validateLiveUxAudit(await readEvidence(path));
-    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-    if (!result.valid || (command === "gate" && !result.auditPassed)) {
+  if (
+    path !== undefined &&
+    ((command === "validate" && mediaDirectory === undefined) ||
+      (command === "gate" && mediaDirectory !== undefined))
+  ) {
+    const evidence = await readEvidence(path);
+    const result = validateLiveUxAudit(evidence);
+    const issueErrors = result.valid ? await verifyIssues(evidence) : [];
+    const mediaErrors = command === "gate" && result.valid
+      ? await verifyMedia(evidence, mediaDirectory)
+      : [];
+    const errors = [...result.errors, ...issueErrors, ...mediaErrors];
+    const completed = {
+      ...result,
+      valid: result.valid && issueErrors.length === 0,
+      auditPassed:
+        command === "gate" &&
+        result.uxCriteriaPassed &&
+        issueErrors.length === 0 &&
+        mediaErrors.length === 0,
+      errors,
+    };
+    process.stdout.write(`${JSON.stringify(completed, null, 2)}\n`);
+    if (!completed.valid || (command === "gate" && !completed.auditPassed)) {
       process.exitCode = 1;
     }
     return;

--- a/control-center/apps/web-shell/src/live-ux-audit.ts
+++ b/control-center/apps/web-shell/src/live-ux-audit.ts
@@ -1,0 +1,560 @@
+import {
+  COMMERCIAL_SURFACES,
+  DESTINATIONS,
+  WARMBLY_SURFACES,
+  getDestination,
+} from "./destinations";
+
+export const LIVE_UX_AUDIT_SCHEMA = "confenge.live-ux-audit.v1" as const;
+export const LIVE_UX_AUDIT_ORIGIN = "https://ops.confenge.com.br" as const;
+
+export const VIEWPORTS = [
+  {
+    id: "primary-mobile",
+    label: "Mobile principal (uso com uma mão)",
+    width: 390,
+    height: 844,
+  },
+  {
+    id: "secondary-desktop",
+    label: "Desktop complementar",
+    minWidth: 1280,
+    minHeight: 720,
+  },
+] as const;
+
+export type ViewportId = (typeof VIEWPORTS)[number]["id"];
+
+export interface AuditRoute {
+  readonly key: string;
+  readonly path: string;
+  readonly label: string;
+}
+
+const destinationRoutes: readonly AuditRoute[] = DESTINATIONS.map((destination) => ({
+  key: `destination:${destination.id}`,
+  path: destination.path,
+  label: destination.label,
+}));
+
+const commercialRoot = getDestination("comercial").path;
+const commercialRoutes: readonly AuditRoute[] = COMMERCIAL_SURFACES.map((surface) => ({
+  key: `commercial:${surface}`,
+  path: `${commercialRoot}/${surface}`,
+  label: `Comercial / ${surface}`,
+}));
+
+const warmblyRoot = getDestination("warmbly").path;
+const warmblyRoutes: readonly AuditRoute[] = WARMBLY_SURFACES.map((surface) => ({
+  key: `warmbly:${surface}`,
+  path: `${warmblyRoot}/${surface}`,
+  label: `Operação Warmbly / ${surface}`,
+}));
+
+/**
+ * This inventory is intentionally derived from the navigation registries.
+ * Adding a destination or registered sub-surface makes the audit consistency
+ * test fail until a journey owns the new route.
+ */
+export const LIVE_AUDIT_ROUTES: readonly AuditRoute[] = [
+  ...destinationRoutes,
+  ...commercialRoutes,
+  ...warmblyRoutes,
+];
+
+export const JOURNEY_IDS = [
+  "attention-today",
+  "review-approve-next",
+  "adjust-hold-reject",
+  "inbound-triage",
+  "exception-resolution",
+  "client-lead-history-return",
+  "transversal-without-internal-ids",
+  "outbound-state-pause",
+  "resume-after-return-reload-reauth",
+  "recover-stale-error-permission-unknown",
+] as const;
+
+export type JourneyId = (typeof JOURNEY_IDS)[number];
+
+export interface JourneyDefinition {
+  readonly id: JourneyId;
+  readonly label: string;
+  readonly operatorGoal: string;
+  readonly requiredRouteKeys: readonly string[];
+  readonly relatedIssues: readonly number[];
+}
+
+/**
+ * The ten minimum journeys from Governance #111. Route ownership is explicit
+ * so that the registry-derived coverage check cannot silently ignore a page.
+ */
+export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
+  {
+    id: "attention-today",
+    label: "Entender o que exige atenção hoje",
+    operatorGoal: "Orientar-se em até três segundos e escolher a primeira ação segura.",
+    requiredRouteKeys: ["destination:hoje"],
+    relatedIssues: [106, 107, 110, 112, 113, 115, 116],
+  },
+  {
+    id: "review-approve-next",
+    label: "Revisar a fila, aprovar e seguir para o próximo item",
+    operatorGoal: "Concluir a revisão humana sem perder contexto entre itens.",
+    requiredRouteKeys: ["warmbly:revisao"],
+    relatedIssues: [110, 112, 113, 115],
+  },
+  {
+    id: "adjust-hold-reject",
+    label: "Ajustar, colocar em HOLD ou rejeitar",
+    operatorGoal: "Distinguir as três decisões e confirmar seu efeito antes da mutação.",
+    requiredRouteKeys: ["warmbly:revisao", "warmbly:operacao"],
+    relatedIssues: [110, 112, 113, 115],
+  },
+  {
+    id: "inbound-triage",
+    label: "Triar o inbound sem inventar atribuição",
+    operatorGoal: "Localizar sinal, proveniência e próxima ação do inbound.",
+    requiredRouteKeys: ["destination:crescimento", "commercial:cohorts"],
+    relatedIssues: [106, 107, 110, 116],
+  },
+  {
+    id: "exception-resolution",
+    label: "Resolver uma exceção operacional",
+    operatorGoal: "Compreender causa, autoridade e ação de recuperação segura.",
+    requiredRouteKeys: ["commercial:excecoes"],
+    relatedIssues: [107, 110, 112, 113, 114, 115],
+  },
+  {
+    id: "client-lead-history-return",
+    label: "Localizar cliente ou lead, consultar histórico e voltar",
+    operatorGoal: "Navegar ida e volta preservando o recorte e a posição de trabalho.",
+    requiredRouteKeys: [
+      "destination:clientes",
+      "commercial:atividade",
+      "commercial:pipeline",
+    ],
+    relatedIssues: [106, 107, 110, 116],
+  },
+  {
+    id: "transversal-without-internal-ids",
+    label: "Consultar domínios transversais sem conhecer IDs internos",
+    operatorGoal: "Encontrar informação por linguagem operacional e proveniência visível.",
+    requiredRouteKeys: [
+      "destination:financeiro",
+      "destination:engenharia",
+      "destination:infra",
+      "destination:agentes",
+    ],
+    relatedIssues: [106, 107, 110, 116],
+  },
+  {
+    id: "outbound-state-pause",
+    label: "Entender o estado do outbound e pausá-lo com segurança",
+    operatorGoal: "Ver estado, janela e limites antes de uma pausa reversível.",
+    requiredRouteKeys: [
+      "destination:warmbly",
+      "warmbly:operacao",
+      "warmbly:cohorts",
+    ],
+    relatedIssues: [107, 110, 112, 113, 115],
+  },
+  {
+    id: "resume-after-return-reload-reauth",
+    label: "Retomar a tarefa após voltar, recarregar ou reautenticar",
+    operatorGoal: "Recuperar contexto e decisão sem depender de memória da arquitetura.",
+    requiredRouteKeys: ["destination:memoria"],
+    relatedIssues: [106, 107, 110, 116],
+  },
+  {
+    id: "recover-stale-error-permission-unknown",
+    label: "Recuperar-se de stale, erro, permissão ou estado desconhecido",
+    operatorGoal: "Distinguir o estado e encontrar uma recuperação acionável e segura.",
+    requiredRouteKeys: [
+      "destination:comercial",
+      "commercial:visao",
+      "commercial:rascunhos",
+    ],
+    relatedIssues: [106, 107, 110, 112, 113, 114, 115, 116],
+  },
+] as const;
+
+export interface AuditPlan {
+  readonly schemaVersion: typeof LIVE_UX_AUDIT_SCHEMA;
+  readonly status: "NOT_EXECUTED";
+  readonly warning: string;
+  readonly origin: typeof LIVE_UX_AUDIT_ORIGIN;
+  readonly routes: readonly AuditRoute[];
+  readonly journeys: readonly JourneyDefinition[];
+  readonly viewports: typeof VIEWPORTS;
+  readonly consistencyErrors: readonly string[];
+  readonly protocol: readonly string[];
+}
+
+export function auditPlanConsistencyErrors(): readonly string[] {
+  const errors: string[] = [];
+  const routeKeys = new Set(LIVE_AUDIT_ROUTES.map((route) => route.key));
+  const assigned = new Set<string>();
+
+  for (const journey of LIVE_AUDIT_JOURNEYS) {
+    for (const routeKey of journey.requiredRouteKeys) {
+      if (!routeKeys.has(routeKey)) {
+        errors.push(`Journey ${journey.id} references unknown route ${routeKey}.`);
+      }
+      assigned.add(routeKey);
+    }
+  }
+
+  for (const route of LIVE_AUDIT_ROUTES) {
+    if (!assigned.has(route.key)) {
+      errors.push(`Route ${route.key} (${route.path}) has no live audit journey.`);
+    }
+  }
+
+  if (new Set(LIVE_AUDIT_ROUTES.map((route) => route.path)).size !== LIVE_AUDIT_ROUTES.length) {
+    errors.push("The live audit route inventory contains duplicate paths.");
+  }
+  if (new Set(LIVE_AUDIT_JOURNEYS.map((journey) => journey.id)).size !== JOURNEY_IDS.length) {
+    errors.push("The live audit journey inventory contains duplicate or missing IDs.");
+  }
+
+  return errors;
+}
+
+export function buildLiveUxAuditPlan(): AuditPlan {
+  return {
+    schemaVersion: LIVE_UX_AUDIT_SCHEMA,
+    status: "NOT_EXECUTED",
+    warning:
+      "This plan is not evidence and does not approve UX. A human external operator must execute it against the authenticated live origin.",
+    origin: LIVE_UX_AUDIT_ORIGIN,
+    routes: LIVE_AUDIT_ROUTES,
+    journeys: LIVE_AUDIT_JOURNEYS,
+    viewports: VIEWPORTS,
+    consistencyErrors: auditPlanConsistencyErrors(),
+    protocol: [
+      "Use a skeptical external human operator with no architecture memory.",
+      "Execute every journey at 390x844 and repeat it on a complementary desktop viewport.",
+      "Allow exactly three seconds for initial orientation.",
+      "Use sanitized data; never send real email, issue GO, resume outbound, or perform an irreversible action.",
+      "Record video and screenshots plus orientation time, first-action time, steps, outcome, and immutable runtime SHA.",
+      "Open or complement an issue for every friction; a P0/P1 finding may not remain only in media, comments, or documents.",
+    ],
+  };
+}
+
+export type AuditOutcome = "PASS" | "FRICTION" | "BLOCKED";
+export type FrictionSeverity = "P0" | "P1" | "P2" | "P3";
+
+export interface AuditValidationResult {
+  readonly valid: boolean;
+  readonly auditPassed: boolean;
+  readonly errors: readonly string[];
+  readonly gateFailures: readonly string[];
+}
+
+type JsonObject = Record<string, unknown>;
+
+const fullShaPattern = /^[0-9a-f]{40}$/;
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const governanceIssuePattern = /^https:\/\/github\.com\/tjsasakifln\/Governance\/issues\/[1-9][0-9]*$/;
+const rfc3339Pattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function stringArray(value: unknown): readonly string[] | null {
+  if (!Array.isArray(value) || !value.every(isNonEmptyString)) return null;
+  return value;
+}
+
+function exactMembers(actual: readonly string[], expected: readonly string[]): boolean {
+  return actual.length === expected.length &&
+    new Set(actual).size === actual.length &&
+    expected.every((item) => actual.includes(item));
+}
+
+function validateViewport(
+  value: unknown,
+  expectedId: ViewportId,
+  path: string,
+  errors: string[],
+): void {
+  if (!isObject(value)) {
+    errors.push(`${path} must be an object.`);
+    return;
+  }
+  if (value.id !== expectedId) {
+    errors.push(`${path}.id must be ${expectedId}.`);
+  }
+  if (expectedId === "primary-mobile") {
+    if (value.width !== 390 || value.height !== 844) {
+      errors.push(`${path} must record the exact 390x844 primary viewport.`);
+    }
+    return;
+  }
+  if (!isNonNegativeInteger(value.width) || value.width < 1280) {
+    errors.push(`${path}.width must be at least 1280 for the complementary desktop run.`);
+  }
+  if (!isNonNegativeInteger(value.height) || value.height < 720) {
+    errors.push(`${path}.height must be at least 720 for the complementary desktop run.`);
+  }
+}
+
+function validateFriction(
+  value: unknown,
+  path: string,
+  errors: string[],
+): void {
+  if (!isObject(value)) {
+    errors.push(`${path} must be an object.`);
+    return;
+  }
+  if (!["P0", "P1", "P2", "P3"].includes(String(value.severity))) {
+    errors.push(`${path}.severity must be P0, P1, P2, or P3.`);
+  }
+  if (!isNonEmptyString(value.summary)) {
+    errors.push(`${path}.summary is required.`);
+  }
+  if (!isNonEmptyString(value.issueUrl) || !governanceIssuePattern.test(value.issueUrl)) {
+    errors.push(`${path}.issueUrl must point to a numbered Governance issue.`);
+  }
+  const acceptanceCriteria = stringArray(value.acceptanceCriteria);
+  if (!acceptanceCriteria || acceptanceCriteria.length === 0) {
+    errors.push(`${path}.acceptanceCriteria must contain at least one verifiable criterion.`);
+  }
+}
+
+function validateObservation(
+  value: unknown,
+  journey: JourneyDefinition,
+  viewportId: ViewportId,
+  runtimeSha: string,
+  path: string,
+  errors: string[],
+  gateFailures: string[],
+): void {
+  if (!isObject(value)) {
+    errors.push(`${path} must be an object.`);
+    return;
+  }
+
+  if (value.journeyId !== journey.id) {
+    errors.push(`${path}.journeyId must be ${journey.id}.`);
+  }
+  validateViewport(value.viewport, viewportId, `${path}.viewport`, errors);
+
+  const routeKeys = stringArray(value.routeKeys);
+  if (!routeKeys || !exactMembers(routeKeys, journey.requiredRouteKeys)) {
+    errors.push(`${path}.routeKeys must contain every route assigned to ${journey.id}, exactly once.`);
+  }
+  if (value.runtimeSha !== runtimeSha) {
+    errors.push(`${path}.runtimeSha must match environment.runtimeSha.`);
+  }
+  if (value.sanitizedData !== true) {
+    errors.push(`${path}.sanitizedData must be true.`);
+  }
+
+  const steps = stringArray(value.steps);
+  if (!steps || steps.length === 0) {
+    errors.push(`${path}.steps must record at least one sanitized operator step.`);
+  }
+  if (!isNonNegativeInteger(value.orientationMs)) {
+    errors.push(`${path}.orientationMs must be a non-negative integer.`);
+  } else if (value.orientationMs > 3_000) {
+    gateFailures.push(`${journey.id}/${viewportId} exceeded the 3000ms orientation budget.`);
+  }
+
+  const outcome = value.outcome;
+  if (!["PASS", "FRICTION", "BLOCKED"].includes(String(outcome))) {
+    errors.push(`${path}.outcome must be PASS, FRICTION, or BLOCKED.`);
+  } else if (outcome !== "PASS") {
+    gateFailures.push(`${journey.id}/${viewportId} ended as ${String(outcome)}.`);
+  }
+
+  if (outcome === "BLOCKED") {
+    if (value.firstActionMs !== null && !isNonNegativeInteger(value.firstActionMs)) {
+      errors.push(`${path}.firstActionMs must be null or a non-negative integer when blocked.`);
+    }
+  } else if (!isNonNegativeInteger(value.firstActionMs)) {
+    errors.push(`${path}.firstActionMs must be a non-negative integer.`);
+  }
+  if (
+    isNonNegativeInteger(value.firstActionMs) &&
+    isNonNegativeInteger(value.orientationMs) &&
+    value.firstActionMs < value.orientationMs
+  ) {
+    errors.push(`${path}.firstActionMs may not be earlier than orientationMs.`);
+  }
+
+  if (!isNonEmptyString(value.videoSha256) || !sha256Pattern.test(value.videoSha256)) {
+    errors.push(`${path}.videoSha256 must be a lowercase SHA-256 digest.`);
+  }
+  const screenshotSha256s = stringArray(value.screenshotSha256s);
+  if (
+    !screenshotSha256s ||
+    screenshotSha256s.length === 0 ||
+    screenshotSha256s.some((digest) => !sha256Pattern.test(digest))
+  ) {
+    errors.push(`${path}.screenshotSha256s must contain lowercase SHA-256 digests.`);
+  }
+
+  if (!Array.isArray(value.frictions)) {
+    errors.push(`${path}.frictions must be an array.`);
+  } else {
+    value.frictions.forEach((friction, index) => {
+      validateFriction(friction, `${path}.frictions[${index}]`, errors);
+    });
+    if (outcome === "PASS" && value.frictions.length > 0) {
+      errors.push(`${path} cannot be PASS while recording frictions.`);
+    }
+    if ((outcome === "FRICTION" || outcome === "BLOCKED") && value.frictions.length === 0) {
+      errors.push(`${path} must link at least one friction issue when it is not PASS.`);
+    }
+  }
+}
+
+/**
+ * Validates provenance/completeness separately from the actual UX pass gate.
+ * A truthful FRICTION/BLOCKED manifest can be structurally valid, but it can
+ * never make `auditPassed` true or close the live audit.
+ */
+export function validateLiveUxAudit(value: unknown): AuditValidationResult {
+  const errors = [...auditPlanConsistencyErrors()];
+  const gateFailures: string[] = [];
+
+  if (!isObject(value)) {
+    return {
+      valid: false,
+      auditPassed: false,
+      errors: [...errors, "Audit evidence must be a JSON object."],
+      gateFailures,
+    };
+  }
+
+  if (value.schemaVersion !== LIVE_UX_AUDIT_SCHEMA) {
+    errors.push(`schemaVersion must be ${LIVE_UX_AUDIT_SCHEMA}.`);
+  }
+  if (value.executionMode !== "HUMAN_AUTHENTICATED_LIVE") {
+    errors.push("executionMode must be HUMAN_AUTHENTICATED_LIVE; automation is not a substitute.");
+  }
+
+  let runtimeSha = "";
+  if (!isObject(value.environment)) {
+    errors.push("environment must be an object.");
+  } else {
+    if (value.environment.origin !== LIVE_UX_AUDIT_ORIGIN) {
+      errors.push(`environment.origin must be ${LIVE_UX_AUDIT_ORIGIN}.`);
+    }
+    if (!isNonEmptyString(value.environment.runtimeSha) || !fullShaPattern.test(value.environment.runtimeSha)) {
+      errors.push("environment.runtimeSha must be a full lowercase 40-character Git SHA.");
+    } else {
+      runtimeSha = value.environment.runtimeSha;
+    }
+    if (!isNonEmptyString(value.environment.capturedAt) || !rfc3339Pattern.test(value.environment.capturedAt)) {
+      errors.push("environment.capturedAt must be an RFC 3339 timestamp with timezone.");
+    }
+  }
+
+  if (!isObject(value.operator)) {
+    errors.push("operator must be an object.");
+  } else {
+    if (
+      !isNonEmptyString(value.operator.pseudonym) ||
+      value.operator.pseudonym.includes("@") ||
+      value.operator.pseudonym.length > 80
+    ) {
+      errors.push("operator.pseudonym must be a non-email pseudonym of at most 80 characters.");
+    }
+    if (!isNonEmptyString(value.operator.role)) {
+      errors.push("operator.role is required.");
+    }
+    if (value.operator.human !== true || value.operator.independent !== true) {
+      errors.push("operator must attest human=true and independent=true.");
+    }
+  }
+
+  if (!isObject(value.safety)) {
+    errors.push("safety must be an object.");
+  } else {
+    if (value.safety.syntheticDataOnly !== true) {
+      errors.push("safety.syntheticDataOnly must be true.");
+    }
+    for (const forbidden of [
+      "realEmailSent",
+      "goIssued",
+      "outboundResumed",
+      "irreversibleAction",
+    ] as const) {
+      if (value.safety[forbidden] !== false) {
+        errors.push(`safety.${forbidden} must be false.`);
+      }
+    }
+  }
+
+  const observations = Array.isArray(value.observations) ? value.observations : [];
+  if (!Array.isArray(value.observations)) {
+    errors.push("observations must be an array.");
+  }
+
+  const expectedPairs = new Map<string, { journey: JourneyDefinition; viewportId: ViewportId }>();
+  for (const journey of LIVE_AUDIT_JOURNEYS) {
+    for (const viewport of VIEWPORTS) {
+      expectedPairs.set(`${journey.id}/${viewport.id}`, { journey, viewportId: viewport.id });
+    }
+  }
+
+  const seenPairs = new Set<string>();
+  observations.forEach((observation, index) => {
+    const path = `observations[${index}]`;
+    if (!isObject(observation)) {
+      errors.push(`${path} must be an object.`);
+      return;
+    }
+    const pairKey = `${String(observation.journeyId)}/${
+      isObject(observation.viewport) ? String(observation.viewport.id) : "undefined"
+    }`;
+    const expected = expectedPairs.get(pairKey);
+    if (!expected) {
+      errors.push(`${path} identifies an unknown journey/viewport pair (${pairKey}).`);
+      return;
+    }
+    if (seenPairs.has(pairKey)) {
+      errors.push(`${path} duplicates journey/viewport pair ${pairKey}.`);
+      return;
+    }
+    seenPairs.add(pairKey);
+    validateObservation(
+      observation,
+      expected.journey,
+      expected.viewportId,
+      runtimeSha,
+      path,
+      errors,
+      gateFailures,
+    );
+  });
+
+  for (const pairKey of expectedPairs.keys()) {
+    if (!seenPairs.has(pairKey)) {
+      errors.push(`Missing required observation ${pairKey}.`);
+    }
+  }
+
+  const valid = errors.length === 0;
+  return {
+    valid,
+    auditPassed: valid && gateFailures.length === 0,
+    errors,
+    gateFailures,
+  };
+}

--- a/control-center/apps/web-shell/src/live-ux-audit.ts
+++ b/control-center/apps/web-shell/src/live-ux-audit.ts
@@ -7,6 +7,8 @@ import {
 
 export const LIVE_UX_AUDIT_SCHEMA = "confenge.live-ux-audit.v1" as const;
 export const LIVE_UX_AUDIT_ORIGIN = "https://ops.confenge.com.br" as const;
+export const RUNTIME_IDENTITY_SCHEMA = "control-center.runtime-identity.v1" as const;
+export const LIVE_UX_REQUIRED_RUNTIME_BASELINE_SHA = "64ece7d38abacd3adeaa02735b4f22af66caab0f" as const;
 
 export const VIEWPORTS = [
   {
@@ -14,12 +16,14 @@ export const VIEWPORTS = [
     label: "Mobile principal (uso com uma mão)",
     width: 390,
     height: 844,
+    inputMode: "ONE_HANDED_TOUCH",
   },
   {
     id: "secondary-desktop",
     label: "Desktop complementar",
     minWidth: 1280,
     minHeight: 720,
+    inputMode: "DESKTOP_POINTER_KEYBOARD",
   },
 ] as const;
 
@@ -82,6 +86,7 @@ export interface JourneyDefinition {
   readonly label: string;
   readonly operatorGoal: string;
   readonly requiredRouteKeys: readonly string[];
+  readonly requiredChecks: readonly string[];
   readonly relatedIssues: readonly number[];
 }
 
@@ -95,6 +100,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
     label: "Entender o que exige atenção hoje",
     operatorGoal: "Orientar-se em até três segundos e escolher a primeira ação segura.",
     requiredRouteKeys: ["destination:hoje"],
+    requiredChecks: ["orientation", "urgency", "next-safe-action"],
     relatedIssues: [106, 107, 110, 112, 113, 115, 116],
   },
   {
@@ -102,6 +108,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
     label: "Revisar a fila, aprovar e seguir para o próximo item",
     operatorGoal: "Concluir a revisão humana sem perder contexto entre itens.",
     requiredRouteKeys: ["warmbly:revisao"],
+    requiredChecks: ["open-review-queue", "approve-once", "advance-with-context"],
     relatedIssues: [110, 112, 113, 115],
   },
   {
@@ -109,6 +116,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
     label: "Ajustar, colocar em HOLD ou rejeitar",
     operatorGoal: "Distinguir as três decisões e confirmar seu efeito antes da mutação.",
     requiredRouteKeys: ["warmbly:revisao", "warmbly:operacao"],
+    requiredChecks: ["adjust", "hold", "reject"],
     relatedIssues: [110, 112, 113, 115],
   },
   {
@@ -116,6 +124,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
     label: "Triar o inbound sem inventar atribuição",
     operatorGoal: "Localizar sinal, proveniência e próxima ação do inbound.",
     requiredRouteKeys: ["destination:crescimento", "commercial:cohorts"],
+    requiredChecks: ["find-inbound", "read-provenance", "choose-next-action"],
     relatedIssues: [106, 107, 110, 116],
   },
   {
@@ -123,6 +132,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
     label: "Resolver uma exceção operacional",
     operatorGoal: "Compreender causa, autoridade e ação de recuperação segura.",
     requiredRouteKeys: ["commercial:excecoes"],
+    requiredChecks: ["find-exception", "understand-cause", "recover-safely"],
     relatedIssues: [107, 110, 112, 113, 114, 115],
   },
   {
@@ -134,6 +144,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
       "commercial:atividade",
       "commercial:pipeline",
     ],
+    requiredChecks: ["find-client-or-lead", "read-history", "return-with-context"],
     relatedIssues: [106, 107, 110, 116],
   },
   {
@@ -146,6 +157,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
       "destination:infra",
       "destination:agentes",
     ],
+    requiredChecks: ["finance", "engineering", "infrastructure", "agents", "no-internal-id-needed"],
     relatedIssues: [106, 107, 110, 116],
   },
   {
@@ -157,6 +169,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
       "warmbly:operacao",
       "warmbly:cohorts",
     ],
+    requiredChecks: ["read-outbound-state", "read-window-and-limits", "start-safe-pause"],
     relatedIssues: [107, 110, 112, 113, 115],
   },
   {
@@ -164,6 +177,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
     label: "Retomar a tarefa após voltar, recarregar ou reautenticar",
     operatorGoal: "Recuperar contexto e decisão sem depender de memória da arquitetura.",
     requiredRouteKeys: ["destination:memoria"],
+    requiredChecks: ["return", "reload", "reauthenticate"],
     relatedIssues: [106, 107, 110, 116],
   },
   {
@@ -175,6 +189,7 @@ export const LIVE_AUDIT_JOURNEYS: readonly JourneyDefinition[] = [
       "commercial:visao",
       "commercial:rascunhos",
     ],
+    requiredChecks: ["stale", "error", "permission-denied", "unknown-outcome"],
     relatedIssues: [106, 107, 110, 112, 113, 114, 115, 116],
   },
 ] as const;
@@ -197,6 +212,18 @@ export function auditPlanConsistencyErrors(): readonly string[] {
   const assigned = new Set<string>();
 
   for (const journey of LIVE_AUDIT_JOURNEYS) {
+    if (
+      journey.requiredRouteKeys.length === 0 ||
+      new Set(journey.requiredRouteKeys).size !== journey.requiredRouteKeys.length
+    ) {
+      errors.push(`Journey ${journey.id} must own at least one route, without duplicates.`);
+    }
+    if (
+      journey.requiredChecks.length === 0 ||
+      new Set(journey.requiredChecks).size !== journey.requiredChecks.length
+    ) {
+      errors.push(`Journey ${journey.id} must define at least one required check, without duplicates.`);
+    }
     for (const routeKey of journey.requiredRouteKeys) {
       if (!routeKeys.has(routeKey)) {
         errors.push(`Journey ${journey.id} references unknown route ${routeKey}.`);
@@ -213,6 +240,9 @@ export function auditPlanConsistencyErrors(): readonly string[] {
 
   if (new Set(LIVE_AUDIT_ROUTES.map((route) => route.path)).size !== LIVE_AUDIT_ROUTES.length) {
     errors.push("The live audit route inventory contains duplicate paths.");
+  }
+  if (new Set(LIVE_AUDIT_ROUTES.map((route) => route.key)).size !== LIVE_AUDIT_ROUTES.length) {
+    errors.push("The live audit route inventory contains duplicate keys.");
   }
   if (new Set(LIVE_AUDIT_JOURNEYS.map((journey) => journey.id)).size !== JOURNEY_IDS.length) {
     errors.push("The live audit journey inventory contains duplicate or missing IDs.");
@@ -237,7 +267,8 @@ export function buildLiveUxAuditPlan(): AuditPlan {
       "Execute every journey at 390x844 and repeat it on a complementary desktop viewport.",
       "Allow exactly three seconds for initial orientation.",
       "Use sanitized data; never send real email, issue GO, resume outbound, or perform an irreversible action.",
-      "Record video and screenshots plus orientation time, first-action time, steps, outcome, and immutable runtime SHA.",
+      "Copy the pinned production identities from /runtime-identity and /v1/runtime-identity; both must name the same release SHA and baseline.",
+      "Record distinct video and screenshot artifacts plus every required check, orientation time, first-action time, steps, and outcome.",
       "Open or complement an issue for every friction; a P0/P1 finding may not remain only in media, comments, or documents.",
     ],
   };
@@ -248,6 +279,7 @@ export type FrictionSeverity = "P0" | "P1" | "P2" | "P3";
 
 export interface AuditValidationResult {
   readonly valid: boolean;
+  readonly uxCriteriaPassed: boolean;
   readonly auditPassed: boolean;
   readonly errors: readonly string[];
   readonly gateFailures: readonly string[];
@@ -258,7 +290,11 @@ type JsonObject = Record<string, unknown>;
 const fullShaPattern = /^[0-9a-f]{40}$/;
 const sha256Pattern = /^[0-9a-f]{64}$/;
 const governanceIssuePattern = /^https:\/\/github\.com\/tjsasakifln\/Governance\/issues\/[1-9][0-9]*$/;
-const rfc3339Pattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const rfc3339Pattern = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;
+const emailPattern = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i;
+const cpfPattern = /\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/;
+const cnpjPattern = /\b\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2}\b/;
+const phonePattern = /(?:\+?55[\s().-]*)?(?:\(?\d{2}\)?[\s.-]*)?9?\d{4}[\s.-]*\d{4}/;
 
 function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -272,6 +308,62 @@ function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
+function unexpectedKeys(
+  value: JsonObject,
+  allowed: readonly string[],
+  path: string,
+  errors: string[],
+): void {
+  const allowedSet = new Set(allowed);
+  for (const key of Object.keys(value)) {
+    if (!allowedSet.has(key)) errors.push(`${path}.${key} is not allowed.`);
+  }
+}
+
+function isValidRfc3339(value: string): boolean {
+  const match = rfc3339Pattern.exec(value);
+  if (!match) return false;
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, , zone] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  if (
+    month < 1 || month > 12 || day < 1 ||
+    day > new Date(Date.UTC(year, month, 0)).getUTCDate() ||
+    hour > 23 || minute > 59 || second > 59
+  ) return false;
+  if (zone !== undefined && zone !== "Z") {
+    const offsetHour = Number(zone.slice(1, 3));
+    const offsetMinute = Number(zone.slice(4, 6));
+    if (offsetHour > 23 || offsetMinute > 59) return false;
+  }
+  return Number.isFinite(Date.parse(value));
+}
+
+function containsSensitiveLiteral(value: string): boolean {
+  return emailPattern.test(value) || cpfPattern.test(value) || cnpjPattern.test(value) || phonePattern.test(value);
+}
+
+function validateSanitizedText(
+  value: unknown,
+  path: string,
+  errors: string[],
+  maxLength = 500,
+): value is string {
+  if (!isNonEmptyString(value)) {
+    errors.push(`${path} is required.`);
+    return false;
+  }
+  if (value.length > maxLength) errors.push(`${path} exceeds ${maxLength} characters.`);
+  if (containsSensitiveLiteral(value)) {
+    errors.push(`${path} contains an email, CPF/CNPJ, or phone-like literal; use sanitized fixture language.`);
+  }
+  return true;
+}
+
 function stringArray(value: unknown): readonly string[] | null {
   if (!Array.isArray(value) || !value.every(isNonEmptyString)) return null;
   return value;
@@ -281,6 +373,47 @@ function exactMembers(actual: readonly string[], expected: readonly string[]): b
   return actual.length === expected.length &&
     new Set(actual).size === actual.length &&
     expected.every((item) => actual.includes(item));
+}
+
+function validateRuntimeIdentity(
+  value: unknown,
+  expectedService: "control-center-web" | "control-center-context",
+  runtimeSha: string,
+  path: string,
+  errors: string[],
+): string | null {
+  if (!isObject(value)) {
+    errors.push(`${path} must be an object copied from the live runtime identity endpoint.`);
+    return null;
+  }
+  unexpectedKeys(value, [
+    "schema_version",
+    "service",
+    "release_sha",
+    "required_baseline_sha",
+    "release_status",
+    "production_required",
+  ], path, errors);
+  if (value.schema_version !== RUNTIME_IDENTITY_SCHEMA) {
+    errors.push(`${path}.schema_version must be ${RUNTIME_IDENTITY_SCHEMA}.`);
+  }
+  if (value.service !== expectedService) errors.push(`${path}.service must be ${expectedService}.`);
+  if (value.release_sha !== runtimeSha || !isNonEmptyString(value.release_sha) || !fullShaPattern.test(value.release_sha)) {
+    errors.push(`${path}.release_sha must exactly match environment.runtimeSha.`);
+  }
+  if (value.release_status !== "PINNED") errors.push(`${path}.release_status must be PINNED.`);
+  if (value.production_required !== true) errors.push(`${path}.production_required must be true.`);
+  if (
+    !isNonEmptyString(value.required_baseline_sha) ||
+    !fullShaPattern.test(value.required_baseline_sha)
+  ) {
+    errors.push(`${path}.required_baseline_sha must be a full lowercase 40-character Git SHA.`);
+    return null;
+  }
+  if (value.required_baseline_sha !== LIVE_UX_REQUIRED_RUNTIME_BASELINE_SHA) {
+    errors.push(`${path}.required_baseline_sha must match the audit contract baseline.`);
+  }
+  return value.required_baseline_sha;
 }
 
 function validateViewport(
@@ -293,12 +426,16 @@ function validateViewport(
     errors.push(`${path} must be an object.`);
     return;
   }
+  unexpectedKeys(value, ["id", "width", "height", "inputMode"], path, errors);
   if (value.id !== expectedId) {
     errors.push(`${path}.id must be ${expectedId}.`);
   }
   if (expectedId === "primary-mobile") {
     if (value.width !== 390 || value.height !== 844) {
       errors.push(`${path} must record the exact 390x844 primary viewport.`);
+    }
+    if (value.inputMode !== "ONE_HANDED_TOUCH") {
+      errors.push(`${path}.inputMode must attest ONE_HANDED_TOUCH.`);
     }
     return;
   }
@@ -307,6 +444,9 @@ function validateViewport(
   }
   if (!isNonNegativeInteger(value.height) || value.height < 720) {
     errors.push(`${path}.height must be at least 720 for the complementary desktop run.`);
+  }
+  if (value.inputMode !== "DESKTOP_POINTER_KEYBOARD") {
+    errors.push(`${path}.inputMode must attest DESKTOP_POINTER_KEYBOARD.`);
   }
 }
 
@@ -319,19 +459,41 @@ function validateFriction(
     errors.push(`${path} must be an object.`);
     return;
   }
+  unexpectedKeys(value, ["severity", "summary", "issueUrl", "acceptanceCriteria"], path, errors);
   if (!["P0", "P1", "P2", "P3"].includes(String(value.severity))) {
     errors.push(`${path}.severity must be P0, P1, P2, or P3.`);
   }
-  if (!isNonEmptyString(value.summary)) {
-    errors.push(`${path}.summary is required.`);
-  }
+  validateSanitizedText(value.summary, `${path}.summary`, errors);
   if (!isNonEmptyString(value.issueUrl) || !governanceIssuePattern.test(value.issueUrl)) {
     errors.push(`${path}.issueUrl must point to a numbered Governance issue.`);
   }
   const acceptanceCriteria = stringArray(value.acceptanceCriteria);
   if (!acceptanceCriteria || acceptanceCriteria.length === 0) {
     errors.push(`${path}.acceptanceCriteria must contain at least one verifiable criterion.`);
+  } else {
+    if (acceptanceCriteria.length > 20) errors.push(`${path}.acceptanceCriteria may contain at most 20 items.`);
+    acceptanceCriteria.forEach((criterion, index) => {
+      validateSanitizedText(criterion, `${path}.acceptanceCriteria[${index}]`, errors);
+    });
   }
+}
+
+function registerMediaDigest(
+  value: unknown,
+  path: string,
+  errors: string[],
+  seenMediaDigests: Map<string, string>,
+): void {
+  if (!isNonEmptyString(value) || !sha256Pattern.test(value)) {
+    errors.push(`${path} must be a lowercase SHA-256 digest.`);
+    return;
+  }
+  const firstPath = seenMediaDigests.get(value);
+  if (firstPath) {
+    errors.push(`${path} reuses the media digest already recorded by ${firstPath}.`);
+    return;
+  }
+  seenMediaDigests.set(value, path);
 }
 
 function validateObservation(
@@ -342,11 +504,27 @@ function validateObservation(
   path: string,
   errors: string[],
   gateFailures: string[],
+  seenMediaDigests: Map<string, string>,
 ): void {
   if (!isObject(value)) {
     errors.push(`${path} must be an object.`);
     return;
   }
+  unexpectedKeys(value, [
+    "journeyId",
+    "viewport",
+    "routeKeys",
+    "checks",
+    "runtimeSha",
+    "sanitizedData",
+    "steps",
+    "orientationMs",
+    "firstActionMs",
+    "outcome",
+    "videoSha256",
+    "screenshotSha256s",
+    "frictions",
+  ], path, errors);
 
   if (value.journeyId !== journey.id) {
     errors.push(`${path}.journeyId must be ${journey.id}.`);
@@ -356,6 +534,36 @@ function validateObservation(
   const routeKeys = stringArray(value.routeKeys);
   if (!routeKeys || !exactMembers(routeKeys, journey.requiredRouteKeys)) {
     errors.push(`${path}.routeKeys must contain every route assigned to ${journey.id}, exactly once.`);
+  }
+
+  const checkOutcomes = new Map<string, AuditOutcome>();
+  if (!Array.isArray(value.checks)) {
+    errors.push(`${path}.checks must be an array.`);
+  } else {
+    value.checks.forEach((check, index) => {
+      const checkPath = `${path}.checks[${index}]`;
+      if (!isObject(check)) {
+        errors.push(`${checkPath} must be an object.`);
+        return;
+      }
+      unexpectedKeys(check, ["id", "outcome"], checkPath, errors);
+      if (!isNonEmptyString(check.id) || !journey.requiredChecks.includes(check.id)) {
+        errors.push(`${checkPath}.id must identify a required check for ${journey.id}.`);
+        return;
+      }
+      if (checkOutcomes.has(check.id)) {
+        errors.push(`${checkPath}.id duplicates ${check.id}.`);
+        return;
+      }
+      if (!["PASS", "FRICTION", "BLOCKED"].includes(String(check.outcome))) {
+        errors.push(`${checkPath}.outcome must be PASS, FRICTION, or BLOCKED.`);
+        return;
+      }
+      checkOutcomes.set(check.id, check.outcome as AuditOutcome);
+    });
+    if (!exactMembers([...checkOutcomes.keys()], journey.requiredChecks)) {
+      errors.push(`${path}.checks must report every required check for ${journey.id}, exactly once.`);
+    }
   }
   if (value.runtimeSha !== runtimeSha) {
     errors.push(`${path}.runtimeSha must match environment.runtimeSha.`);
@@ -367,6 +575,9 @@ function validateObservation(
   const steps = stringArray(value.steps);
   if (!steps || steps.length === 0) {
     errors.push(`${path}.steps must record at least one sanitized operator step.`);
+  } else {
+    if (steps.length > 100) errors.push(`${path}.steps may contain at most 100 items.`);
+    steps.forEach((step, index) => validateSanitizedText(step, `${path}.steps[${index}]`, errors));
   }
   if (!isNonNegativeInteger(value.orientationMs)) {
     errors.push(`${path}.orientationMs must be a non-negative integer.`);
@@ -379,6 +590,16 @@ function validateObservation(
     errors.push(`${path}.outcome must be PASS, FRICTION, or BLOCKED.`);
   } else if (outcome !== "PASS") {
     gateFailures.push(`${journey.id}/${viewportId} ended as ${String(outcome)}.`);
+  }
+  if (checkOutcomes.size === journey.requiredChecks.length) {
+    const expectedOutcome: AuditOutcome = [...checkOutcomes.values()].includes("BLOCKED")
+      ? "BLOCKED"
+      : [...checkOutcomes.values()].includes("FRICTION")
+        ? "FRICTION"
+        : "PASS";
+    if (outcome !== expectedOutcome) {
+      errors.push(`${path}.outcome must be ${expectedOutcome} to match its required check outcomes.`);
+    }
   }
 
   if (outcome === "BLOCKED") {
@@ -396,9 +617,7 @@ function validateObservation(
     errors.push(`${path}.firstActionMs may not be earlier than orientationMs.`);
   }
 
-  if (!isNonEmptyString(value.videoSha256) || !sha256Pattern.test(value.videoSha256)) {
-    errors.push(`${path}.videoSha256 must be a lowercase SHA-256 digest.`);
-  }
+  registerMediaDigest(value.videoSha256, `${path}.videoSha256`, errors, seenMediaDigests);
   const screenshotSha256s = stringArray(value.screenshotSha256s);
   if (
     !screenshotSha256s ||
@@ -406,6 +625,11 @@ function validateObservation(
     screenshotSha256s.some((digest) => !sha256Pattern.test(digest))
   ) {
     errors.push(`${path}.screenshotSha256s must contain lowercase SHA-256 digests.`);
+  } else {
+    if (screenshotSha256s.length > 20) errors.push(`${path}.screenshotSha256s may contain at most 20 items.`);
+    screenshotSha256s.forEach((digest, index) => {
+      registerMediaDigest(digest, `${path}.screenshotSha256s[${index}]`, errors, seenMediaDigests);
+    });
   }
 
   if (!Array.isArray(value.frictions)) {
@@ -428,18 +652,27 @@ function validateObservation(
  * A truthful FRICTION/BLOCKED manifest can be structurally valid, but it can
  * never make `auditPassed` true or close the live audit.
  */
-export function validateLiveUxAudit(value: unknown): AuditValidationResult {
+export function validateLiveUxAudit(value: unknown, nowMs = Date.now()): AuditValidationResult {
   const errors = [...auditPlanConsistencyErrors()];
   const gateFailures: string[] = [];
 
   if (!isObject(value)) {
     return {
       valid: false,
+      uxCriteriaPassed: false,
       auditPassed: false,
       errors: [...errors, "Audit evidence must be a JSON object."],
       gateFailures,
     };
   }
+  unexpectedKeys(value, [
+    "schemaVersion",
+    "executionMode",
+    "environment",
+    "operator",
+    "safety",
+    "observations",
+  ], "evidence", errors);
 
   if (value.schemaVersion !== LIVE_UX_AUDIT_SCHEMA) {
     errors.push(`schemaVersion must be ${LIVE_UX_AUDIT_SCHEMA}.`);
@@ -452,6 +685,13 @@ export function validateLiveUxAudit(value: unknown): AuditValidationResult {
   if (!isObject(value.environment)) {
     errors.push("environment must be an object.");
   } else {
+    unexpectedKeys(value.environment, [
+      "origin",
+      "runtimeSha",
+      "capturedAt",
+      "webRuntimeIdentity",
+      "contextRuntimeIdentity",
+    ], "environment", errors);
     if (value.environment.origin !== LIVE_UX_AUDIT_ORIGIN) {
       errors.push(`environment.origin must be ${LIVE_UX_AUDIT_ORIGIN}.`);
     }
@@ -460,24 +700,44 @@ export function validateLiveUxAudit(value: unknown): AuditValidationResult {
     } else {
       runtimeSha = value.environment.runtimeSha;
     }
-    if (!isNonEmptyString(value.environment.capturedAt) || !rfc3339Pattern.test(value.environment.capturedAt)) {
-      errors.push("environment.capturedAt must be an RFC 3339 timestamp with timezone.");
+    if (!isNonEmptyString(value.environment.capturedAt) || !isValidRfc3339(value.environment.capturedAt)) {
+      errors.push("environment.capturedAt must be a real RFC 3339 calendar timestamp with timezone.");
+    } else if (Date.parse(value.environment.capturedAt) > nowMs + 5 * 60 * 1_000) {
+      errors.push("environment.capturedAt may not be more than five minutes in the future.");
+    }
+    const webBaseline = validateRuntimeIdentity(
+      value.environment.webRuntimeIdentity,
+      "control-center-web",
+      runtimeSha,
+      "environment.webRuntimeIdentity",
+      errors,
+    );
+    const contextBaseline = validateRuntimeIdentity(
+      value.environment.contextRuntimeIdentity,
+      "control-center-context",
+      runtimeSha,
+      "environment.contextRuntimeIdentity",
+      errors,
+    );
+    if (webBaseline !== null && contextBaseline !== null && webBaseline !== contextBaseline) {
+      errors.push("web and context runtime identities must report the same required_baseline_sha.");
     }
   }
 
   if (!isObject(value.operator)) {
     errors.push("operator must be an object.");
   } else {
+    unexpectedKeys(value.operator, ["pseudonym", "role", "human", "independent"], "operator", errors);
     if (
       !isNonEmptyString(value.operator.pseudonym) ||
       value.operator.pseudonym.includes("@") ||
       value.operator.pseudonym.length > 80
     ) {
       errors.push("operator.pseudonym must be a non-email pseudonym of at most 80 characters.");
+    } else if (containsSensitiveLiteral(value.operator.pseudonym)) {
+      errors.push("operator.pseudonym contains a sensitive literal.");
     }
-    if (!isNonEmptyString(value.operator.role)) {
-      errors.push("operator.role is required.");
-    }
+    validateSanitizedText(value.operator.role, "operator.role", errors, 120);
     if (value.operator.human !== true || value.operator.independent !== true) {
       errors.push("operator must attest human=true and independent=true.");
     }
@@ -486,6 +746,13 @@ export function validateLiveUxAudit(value: unknown): AuditValidationResult {
   if (!isObject(value.safety)) {
     errors.push("safety must be an object.");
   } else {
+    unexpectedKeys(value.safety, [
+      "syntheticDataOnly",
+      "realEmailSent",
+      "goIssued",
+      "outboundResumed",
+      "irreversibleAction",
+    ], "safety", errors);
     if (value.safety.syntheticDataOnly !== true) {
       errors.push("safety.syntheticDataOnly must be true.");
     }
@@ -514,6 +781,7 @@ export function validateLiveUxAudit(value: unknown): AuditValidationResult {
   }
 
   const seenPairs = new Set<string>();
+  const seenMediaDigests = new Map<string, string>();
   observations.forEach((observation, index) => {
     const path = `observations[${index}]`;
     if (!isObject(observation)) {
@@ -541,6 +809,7 @@ export function validateLiveUxAudit(value: unknown): AuditValidationResult {
       path,
       errors,
       gateFailures,
+      seenMediaDigests,
     );
   });
 
@@ -551,10 +820,49 @@ export function validateLiveUxAudit(value: unknown): AuditValidationResult {
   }
 
   const valid = errors.length === 0;
+  const uxCriteriaPassed = valid && gateFailures.length === 0;
   return {
     valid,
-    auditPassed: valid && gateFailures.length === 0,
+    uxCriteriaPassed,
+    // Structural JSON alone cannot prove that its media digests resolve to
+    // recordings. Only the CLI gate may promote this to true after hashing the
+    // authorized evidence directory and resolving every finding issue.
+    auditPassed: false,
     errors,
     gateFailures,
   };
+}
+
+/** Returns the content identities that the CLI gate must resolve to real files. */
+export function liveUxAuditMediaDigests(value: unknown): readonly string[] {
+  if (!isObject(value) || !Array.isArray(value.observations)) return [];
+  const digests: string[] = [];
+  for (const observation of value.observations) {
+    if (!isObject(observation)) continue;
+    if (isNonEmptyString(observation.videoSha256) && sha256Pattern.test(observation.videoSha256)) {
+      digests.push(observation.videoSha256);
+    }
+    if (Array.isArray(observation.screenshotSha256s)) {
+      for (const digest of observation.screenshotSha256s) {
+        if (isNonEmptyString(digest) && sha256Pattern.test(digest)) digests.push(digest);
+      }
+    }
+  }
+  return digests;
+}
+
+/** Returns referenced findings so the CLI can prove they are real issues, not invented URLs. */
+export function liveUxAuditIssueNumbers(value: unknown): readonly number[] {
+  if (!isObject(value) || !Array.isArray(value.observations)) return [];
+  const issueNumbers = new Set<number>();
+  for (const observation of value.observations) {
+    if (!isObject(observation) || !Array.isArray(observation.frictions)) continue;
+    for (const friction of observation.frictions) {
+      if (!isObject(friction) || !isNonEmptyString(friction.issueUrl)) continue;
+      if (!governanceIssuePattern.test(friction.issueUrl)) continue;
+      const issueNumber = Number(friction.issueUrl.slice(friction.issueUrl.lastIndexOf("/") + 1));
+      if (Number.isSafeInteger(issueNumber) && issueNumber > 0) issueNumbers.add(issueNumber);
+    }
+  }
+  return [...issueNumbers].sort((left, right) => left - right);
 }

--- a/control-center/apps/web-shell/tests/live-ux-audit.test.ts
+++ b/control-center/apps/web-shell/tests/live-ux-audit.test.ts
@@ -6,19 +6,27 @@ import {
   LIVE_AUDIT_ROUTES,
   LIVE_UX_AUDIT_ORIGIN,
   LIVE_UX_AUDIT_SCHEMA,
+  LIVE_UX_REQUIRED_RUNTIME_BASELINE_SHA,
   VIEWPORTS,
   auditPlanConsistencyErrors,
   buildLiveUxAuditPlan,
+  liveUxAuditIssueNumbers,
+  liveUxAuditMediaDigests,
   validateLiveUxAudit,
 } from "../src/live-ux-audit";
 
 const runtimeSha = "a".repeat(40);
-const mediaSha = "b".repeat(64);
+const baselineSha = LIVE_UX_REQUIRED_RUNTIME_BASELINE_SHA;
+
+function mediaSha(index: number): string {
+  return index.toString(16).padStart(64, "0");
+}
 
 interface MutableObservation {
   journeyId: string;
-  viewport: { id: string; width: number; height: number };
+  viewport: { id: string; width: number; height: number; inputMode: string };
   routeKeys: string[];
+  checks: Array<{ id: string; outcome: string }>;
   runtimeSha: string;
   sanitizedData: boolean;
   steps: string[];
@@ -33,7 +41,13 @@ interface MutableObservation {
 interface MutableEvidence {
   schemaVersion: string;
   executionMode: string;
-  environment: { origin: string; runtimeSha: string; capturedAt: string };
+  environment: {
+    origin: string;
+    runtimeSha: string;
+    capturedAt: string;
+    webRuntimeIdentity: Record<string, unknown>;
+    contextRuntimeIdentity: Record<string, unknown>;
+  };
   operator: { pseudonym: string; role: string; human: boolean; independent: boolean };
   safety: {
     syntheticDataOnly: boolean;
@@ -52,7 +66,23 @@ function validEvidence(): MutableEvidence {
     environment: {
       origin: LIVE_UX_AUDIT_ORIGIN,
       runtimeSha,
-      capturedAt: "2026-08-25T14:30:00-03:00",
+      capturedAt: "2020-08-25T14:30:00-03:00",
+      webRuntimeIdentity: {
+        schema_version: "control-center.runtime-identity.v1",
+        service: "control-center-web",
+        release_sha: runtimeSha,
+        required_baseline_sha: baselineSha,
+        release_status: "PINNED",
+        production_required: true,
+      },
+      contextRuntimeIdentity: {
+        schema_version: "control-center.runtime-identity.v1",
+        service: "control-center-context",
+        release_sha: runtimeSha,
+        required_baseline_sha: baselineSha,
+        release_status: "PINNED",
+        production_required: true,
+      },
     },
     operator: {
       pseudonym: "external-operator-01",
@@ -67,24 +97,28 @@ function validEvidence(): MutableEvidence {
       outboundResumed: false,
       irreversibleAction: false,
     },
-    observations: LIVE_AUDIT_JOURNEYS.flatMap((journey) =>
-      VIEWPORTS.map((viewport): MutableObservation => ({
-        journeyId: journey.id,
-        viewport:
-          viewport.id === "primary-mobile"
-            ? { id: viewport.id, width: viewport.width, height: viewport.height }
-            : { id: viewport.id, width: viewport.minWidth, height: viewport.minHeight },
-        routeKeys: [...journey.requiredRouteKeys],
-        runtimeSha,
-        sanitizedData: true,
-        steps: ["Abrir a rota", "Identificar o estado", "Escolher a ação segura"],
-        orientationMs: 2_500,
-        firstActionMs: 4_000,
-        outcome: "PASS",
-        videoSha256: mediaSha,
-        screenshotSha256s: [mediaSha],
-        frictions: [],
-      })),
+    observations: LIVE_AUDIT_JOURNEYS.flatMap((journey, journeyIndex) =>
+      VIEWPORTS.map((viewport, viewportIndex): MutableObservation => {
+        const mediaIndex = journeyIndex * VIEWPORTS.length * 2 + viewportIndex * 2;
+        return {
+          journeyId: journey.id,
+          viewport:
+            viewport.id === "primary-mobile"
+              ? { id: viewport.id, width: viewport.width, height: viewport.height, inputMode: viewport.inputMode }
+              : { id: viewport.id, width: viewport.minWidth, height: viewport.minHeight, inputMode: viewport.inputMode },
+          routeKeys: [...journey.requiredRouteKeys],
+          checks: journey.requiredChecks.map((id) => ({ id, outcome: "PASS" })),
+          runtimeSha,
+          sanitizedData: true,
+          steps: ["Abrir a rota", "Identificar o estado", "Escolher a ação segura"],
+          orientationMs: 2_500,
+          firstActionMs: 4_000,
+          outcome: "PASS",
+          videoSha256: mediaSha(mediaIndex + 1),
+          screenshotSha256s: [mediaSha(mediaIndex + 2)],
+          frictions: [],
+        };
+      }),
     ),
   };
 }
@@ -109,11 +143,12 @@ test("generated plan is explicitly not executed evidence", () => {
   assert.equal(validateLiveUxAudit(plan).valid, false);
 });
 
-test("complete human live evidence passes provenance and UX gates", () => {
+test("complete manifest passes UX criteria but cannot self-approve without media", () => {
   const result = validateLiveUxAudit(validEvidence());
   assert.deepEqual(result, {
     valid: true,
-    auditPassed: true,
+    uxCriteriaPassed: true,
+    auditPassed: false,
     errors: [],
     gateFailures: [],
   });
@@ -135,11 +170,13 @@ test("primary mobile is pinned to 390x844 and desktop has a useful minimum", () 
   assert.ok(mobile);
   assert.ok(desktop);
   mobile.viewport.width = 391;
+  mobile.viewport.inputMode = "DESKTOP_POINTER_KEYBOARD";
   desktop.viewport.width = 1_024;
 
   const result = validateLiveUxAudit(evidence);
   assert.equal(result.valid, false);
   assert.ok(result.errors.some((error) => error.includes("exact 390x844")));
+  assert.ok(result.errors.some((error) => error.includes("ONE_HANDED_TOUCH")));
   assert.ok(result.errors.some((error) => error.includes("at least 1280")));
 });
 
@@ -171,6 +208,60 @@ test("immutable runtime identity must be full and identical in every observation
   evidence.environment.runtimeSha = "short";
   result = validateLiveUxAudit(evidence);
   assert.ok(result.errors.some((error) => error.includes("full lowercase 40-character")));
+});
+
+test("both production runtime identity endpoints must pin the audited release", () => {
+  const evidence = validEvidence();
+  evidence.environment.webRuntimeIdentity.release_sha = "d".repeat(40);
+  evidence.environment.contextRuntimeIdentity.production_required = false;
+  evidence.environment.contextRuntimeIdentity.required_baseline_sha = "e".repeat(40);
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("webRuntimeIdentity.release_sha")));
+  assert.ok(result.errors.some((error) => error.includes("production_required must be true")));
+  assert.ok(result.errors.some((error) => error.includes("same required_baseline_sha")));
+});
+
+test("capturedAt rejects normalized calendar dates and future evidence", () => {
+  const evidence = validEvidence();
+  evidence.environment.capturedAt = "2026-02-31T12:00:00Z";
+  let result = validateLiveUxAudit(evidence, Date.parse("2026-03-10T12:00:00Z"));
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("real RFC 3339 calendar")));
+
+  evidence.environment.capturedAt = "2026-03-10T12:06:00Z";
+  result = validateLiveUxAudit(evidence, Date.parse("2026-03-10T12:00:00Z"));
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("five minutes in the future")));
+});
+
+test("required scenario checks cannot be skipped or contradict the journey outcome", () => {
+  const evidence = validEvidence();
+  const recovery = evidence.observations.find(
+    (observation) =>
+      observation.journeyId === "recover-stale-error-permission-unknown" &&
+      observation.viewport.id === "primary-mobile",
+  );
+  assert.ok(recovery);
+  recovery.checks.pop();
+  recovery.checks[0]!.outcome = "BLOCKED";
+
+  let result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("must report every required check")));
+
+  const contradictoryEvidence = validEvidence();
+  const contradictoryRecovery = contradictoryEvidence.observations.find(
+    (observation) =>
+      observation.journeyId === "recover-stale-error-permission-unknown" &&
+      observation.viewport.id === "primary-mobile",
+  );
+  assert.ok(contradictoryRecovery);
+  contradictoryRecovery.checks[0]!.outcome = "BLOCKED";
+  result = validateLiveUxAudit(contradictoryEvidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("outcome must be BLOCKED")));
 });
 
 test("automation or a non-independent reviewer cannot impersonate the human gate", () => {
@@ -215,11 +306,54 @@ test("media is attested by digest without putting raw customer data in the manif
   assert.ok(result.errors.some((error) => error.includes("screenshotSha256s")));
 });
 
+test("one placeholder artifact cannot impersonate every recording and screenshot", () => {
+  const evidence = validEvidence();
+  const first = evidence.observations[0];
+  const second = evidence.observations[1];
+  assert.ok(first);
+  assert.ok(second);
+  second.videoSha256 = first.videoSha256;
+  second.screenshotSha256s = [first.screenshotSha256s[0]!];
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.equal(result.errors.filter((error) => error.includes("reuses the media digest")).length, 2);
+});
+
+test("the external gate receives every distinct media digest and finding issue", () => {
+  const evidence = validEvidence();
+  const observation = evidence.observations[0];
+  assert.ok(observation);
+  observation.outcome = "FRICTION";
+  observation.checks[0]!.outcome = "FRICTION";
+  observation.frictions = [{
+    severity: "P1",
+    summary: "A ação primária não fica distinguível no viewport principal.",
+    issueUrl: "https://github.com/tjsasakifln/Governance/issues/111",
+    acceptanceCriteria: ["A ação primária é identificada em até três segundos."],
+  }];
+
+  assert.equal(liveUxAuditMediaDigests(evidence).length, 40);
+  assert.deepEqual(liveUxAuditIssueNumbers(evidence), [111]);
+});
+
+test("unknown payload fields and obvious personal literals fail closed", () => {
+  const evidence = validEvidence() as MutableEvidence & { customerEmail?: string };
+  evidence.customerEmail = "real.person@example.com";
+  evidence.observations[0]!.steps = ["Ligar para (11) 99999-1234"];
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("evidence.customerEmail is not allowed")));
+  assert.ok(result.errors.some((error) => error.includes("phone-like literal")));
+});
+
 test("a linked friction is valid evidence but keeps the closure gate red", () => {
   const evidence = validEvidence();
   const observation = evidence.observations[0];
   assert.ok(observation);
   observation.outcome = "FRICTION";
+  observation.checks[0]!.outcome = "FRICTION";
   observation.frictions = [
     {
       severity: "P1",
@@ -231,6 +365,7 @@ test("a linked friction is valid evidence but keeps the closure gate red", () =>
 
   const result = validateLiveUxAudit(evidence);
   assert.equal(result.valid, true);
+  assert.equal(result.uxCriteriaPassed, false);
   assert.equal(result.auditPassed, false);
   assert.ok(result.gateFailures.some((failure) => failure.includes("ended as FRICTION")));
 });
@@ -240,6 +375,7 @@ test("frictions cannot remain only in comments or media", () => {
   const observation = evidence.observations[0];
   assert.ok(observation);
   observation.outcome = "BLOCKED";
+  observation.checks[0]!.outcome = "BLOCKED";
   observation.firstActionMs = null;
   observation.frictions = [
     {
@@ -265,6 +401,7 @@ test("three-second orientation budget is a closure gate, not forged evidence", (
 
   const result = validateLiveUxAudit(evidence);
   assert.equal(result.valid, true);
+  assert.equal(result.uxCriteriaPassed, false);
   assert.equal(result.auditPassed, false);
   assert.ok(result.gateFailures.some((failure) => failure.includes("exceeded the 3000ms")));
 });

--- a/control-center/apps/web-shell/tests/live-ux-audit.test.ts
+++ b/control-center/apps/web-shell/tests/live-ux-audit.test.ts
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  JOURNEY_IDS,
+  LIVE_AUDIT_JOURNEYS,
+  LIVE_AUDIT_ROUTES,
+  LIVE_UX_AUDIT_ORIGIN,
+  LIVE_UX_AUDIT_SCHEMA,
+  VIEWPORTS,
+  auditPlanConsistencyErrors,
+  buildLiveUxAuditPlan,
+  validateLiveUxAudit,
+} from "../src/live-ux-audit";
+
+const runtimeSha = "a".repeat(40);
+const mediaSha = "b".repeat(64);
+
+interface MutableObservation {
+  journeyId: string;
+  viewport: { id: string; width: number; height: number };
+  routeKeys: string[];
+  runtimeSha: string;
+  sanitizedData: boolean;
+  steps: string[];
+  orientationMs: number;
+  firstActionMs: number | null;
+  outcome: string;
+  videoSha256: string;
+  screenshotSha256s: string[];
+  frictions: Array<Record<string, unknown>>;
+}
+
+interface MutableEvidence {
+  schemaVersion: string;
+  executionMode: string;
+  environment: { origin: string; runtimeSha: string; capturedAt: string };
+  operator: { pseudonym: string; role: string; human: boolean; independent: boolean };
+  safety: {
+    syntheticDataOnly: boolean;
+    realEmailSent: boolean;
+    goIssued: boolean;
+    outboundResumed: boolean;
+    irreversibleAction: boolean;
+  };
+  observations: MutableObservation[];
+}
+
+function validEvidence(): MutableEvidence {
+  return {
+    schemaVersion: LIVE_UX_AUDIT_SCHEMA,
+    executionMode: "HUMAN_AUTHENTICATED_LIVE",
+    environment: {
+      origin: LIVE_UX_AUDIT_ORIGIN,
+      runtimeSha,
+      capturedAt: "2026-08-25T14:30:00-03:00",
+    },
+    operator: {
+      pseudonym: "external-operator-01",
+      role: "skeptical operations reviewer",
+      human: true,
+      independent: true,
+    },
+    safety: {
+      syntheticDataOnly: true,
+      realEmailSent: false,
+      goIssued: false,
+      outboundResumed: false,
+      irreversibleAction: false,
+    },
+    observations: LIVE_AUDIT_JOURNEYS.flatMap((journey) =>
+      VIEWPORTS.map((viewport): MutableObservation => ({
+        journeyId: journey.id,
+        viewport:
+          viewport.id === "primary-mobile"
+            ? { id: viewport.id, width: viewport.width, height: viewport.height }
+            : { id: viewport.id, width: viewport.minWidth, height: viewport.minHeight },
+        routeKeys: [...journey.requiredRouteKeys],
+        runtimeSha,
+        sanitizedData: true,
+        steps: ["Abrir a rota", "Identificar o estado", "Escolher a ação segura"],
+        orientationMs: 2_500,
+        firstActionMs: 4_000,
+        outcome: "PASS",
+        videoSha256: mediaSha,
+        screenshotSha256s: [mediaSha],
+        frictions: [],
+      })),
+    ),
+  };
+}
+
+test("live plan contains exactly the ten required journeys and every registered route", () => {
+  assert.equal(JOURNEY_IDS.length, 10);
+  assert.equal(LIVE_AUDIT_JOURNEYS.length, 10);
+  assert.equal(LIVE_AUDIT_ROUTES.length, 19);
+  assert.deepEqual(auditPlanConsistencyErrors(), []);
+
+  const assigned = new Set(LIVE_AUDIT_JOURNEYS.flatMap((journey) => journey.requiredRouteKeys));
+  assert.deepEqual(
+    [...assigned].sort(),
+    LIVE_AUDIT_ROUTES.map((route) => route.key).sort(),
+  );
+});
+
+test("generated plan is explicitly not executed evidence", () => {
+  const plan = buildLiveUxAuditPlan();
+  assert.equal(plan.status, "NOT_EXECUTED");
+  assert.match(plan.warning, /not evidence/i);
+  assert.equal(validateLiveUxAudit(plan).valid, false);
+});
+
+test("complete human live evidence passes provenance and UX gates", () => {
+  const result = validateLiveUxAudit(validEvidence());
+  assert.deepEqual(result, {
+    valid: true,
+    auditPassed: true,
+    errors: [],
+    gateFailures: [],
+  });
+});
+
+test("every journey must be observed on mobile and desktop", () => {
+  const evidence = validEvidence();
+  evidence.observations.pop();
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("Missing required observation")));
+});
+
+test("primary mobile is pinned to 390x844 and desktop has a useful minimum", () => {
+  const evidence = validEvidence();
+  const mobile = evidence.observations[0];
+  const desktop = evidence.observations[1];
+  assert.ok(mobile);
+  assert.ok(desktop);
+  mobile.viewport.width = 391;
+  desktop.viewport.width = 1_024;
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("exact 390x844")));
+  assert.ok(result.errors.some((error) => error.includes("at least 1280")));
+});
+
+test("an observation cannot silently skip a registry-derived route", () => {
+  const evidence = validEvidence();
+  const transversal = evidence.observations.find(
+    (observation) =>
+      observation.journeyId === "transversal-without-internal-ids" &&
+      observation.viewport.id === "primary-mobile",
+  );
+  assert.ok(transversal);
+  transversal.routeKeys.pop();
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("every route assigned")));
+});
+
+test("immutable runtime identity must be full and identical in every observation", () => {
+  const evidence = validEvidence();
+  const observation = evidence.observations[0];
+  assert.ok(observation);
+  observation.runtimeSha = "c".repeat(40);
+
+  let result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("must match environment.runtimeSha")));
+
+  evidence.environment.runtimeSha = "short";
+  result = validateLiveUxAudit(evidence);
+  assert.ok(result.errors.some((error) => error.includes("full lowercase 40-character")));
+});
+
+test("automation or a non-independent reviewer cannot impersonate the human gate", () => {
+  const evidence = validEvidence();
+  evidence.executionMode = "AUTOMATED";
+  evidence.operator.human = false;
+  evidence.operator.independent = false;
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("automation is not a substitute")));
+  assert.ok(result.errors.some((error) => error.includes("human=true")));
+});
+
+test("unsafe execution invalidates the evidence instead of normalizing it", () => {
+  const evidence = validEvidence();
+  evidence.safety.syntheticDataOnly = false;
+  evidence.safety.realEmailSent = true;
+  evidence.safety.goIssued = true;
+  evidence.safety.outboundResumed = true;
+  evidence.safety.irreversibleAction = true;
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("syntheticDataOnly")));
+  assert.ok(result.errors.some((error) => error.includes("realEmailSent")));
+  assert.ok(result.errors.some((error) => error.includes("goIssued")));
+  assert.ok(result.errors.some((error) => error.includes("outboundResumed")));
+  assert.ok(result.errors.some((error) => error.includes("irreversibleAction")));
+});
+
+test("media is attested by digest without putting raw customer data in the manifest", () => {
+  const evidence = validEvidence();
+  const observation = evidence.observations[0];
+  assert.ok(observation);
+  observation.videoSha256 = "https://example.invalid/video";
+  observation.screenshotSha256s = [];
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("videoSha256")));
+  assert.ok(result.errors.some((error) => error.includes("screenshotSha256s")));
+});
+
+test("a linked friction is valid evidence but keeps the closure gate red", () => {
+  const evidence = validEvidence();
+  const observation = evidence.observations[0];
+  assert.ok(observation);
+  observation.outcome = "FRICTION";
+  observation.frictions = [
+    {
+      severity: "P1",
+      summary: "A ação primária não fica distinguível no viewport principal.",
+      issueUrl: "https://github.com/tjsasakifln/Governance/issues/999",
+      acceptanceCriteria: ["A ação primária é identificada em até três segundos."],
+    },
+  ];
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, true);
+  assert.equal(result.auditPassed, false);
+  assert.ok(result.gateFailures.some((failure) => failure.includes("ended as FRICTION")));
+});
+
+test("frictions cannot remain only in comments or media", () => {
+  const evidence = validEvidence();
+  const observation = evidence.observations[0];
+  assert.ok(observation);
+  observation.outcome = "BLOCKED";
+  observation.firstActionMs = null;
+  observation.frictions = [
+    {
+      severity: "P0",
+      summary: "Operador não consegue autenticar.",
+      issueUrl: "video-only",
+      acceptanceCriteria: [],
+    },
+  ];
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("numbered Governance issue")));
+  assert.ok(result.errors.some((error) => error.includes("acceptanceCriteria")));
+});
+
+test("three-second orientation budget is a closure gate, not forged evidence", () => {
+  const evidence = validEvidence();
+  const observation = evidence.observations[0];
+  assert.ok(observation);
+  observation.orientationMs = 3_001;
+  observation.firstActionMs = 4_500;
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, true);
+  assert.equal(result.auditPassed, false);
+  assert.ok(result.gateFailures.some((failure) => failure.includes("exceeded the 3000ms")));
+});
+
+test("PASS cannot conceal recorded frictions or impossible timing", () => {
+  const evidence = validEvidence();
+  const observation = evidence.observations[0];
+  assert.ok(observation);
+  observation.firstActionMs = 1_000;
+  observation.frictions = [
+    {
+      severity: "P2",
+      summary: "Texto secundário ambíguo.",
+      issueUrl: "https://github.com/tjsasakifln/Governance/issues/998",
+      acceptanceCriteria: ["Texto secundário distingue estado e ação."],
+    },
+  ];
+
+  const result = validateLiveUxAudit(evidence);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.includes("may not be earlier")));
+  assert.ok(result.errors.some((error) => error.includes("cannot be PASS")));
+});

--- a/control-center/docs/LIVE-UX-AUDIT.md
+++ b/control-center/docs/LIVE-UX-AUDIT.md
@@ -1,0 +1,104 @@
+# Auditoria humana das jornadas autenticadas
+
+Este contrato operacional cobre a auditoria viva de UX de Governance #111. Ele
+mantém duas conclusões separadas:
+
+1. **evidência válida**: a execução humana é identificável, completa, sanitizada
+   e cobre todas as rotas e jornadas exigidas;
+2. **auditoria aprovada**: além de válida, toda observação terminou em `PASS` e a
+   orientação inicial ocorreu em até 3.000 ms.
+
+Gerar uma matriz, executar testes automatizados ou validar um JSON não substitui
+o operador humano externo no ambiente autenticado. O plano gerado sempre usa
+`status: NOT_EXECUTED` e nunca é aceito como evidência.
+
+## 1. Gerar a matriz atual
+
+Na raiz de `control-center`:
+
+```bash
+npm run --silent audit:ux --workspace=@confenge/control-center-web-shell -- plan > /tmp/live-ux-plan.json
+```
+
+As rotas vêm diretamente de `DESTINATIONS`, `COMMERCIAL_SURFACES` e
+`WARMBLY_SURFACES`. O teste de consistência falha quando uma rota registrada não
+é atribuída a uma jornada. O plano contém as dez jornadas mínimas, os dois
+viewports e as issues transversais relacionadas.
+
+## 2. Executar sem efeitos reais
+
+Use `https://ops.confenge.com.br`, dados sanitizados e um operador humano externo
+sem memória da arquitetura. Repita cada jornada:
+
+- no viewport principal exato de 390×844, simulando uso com uma mão;
+- em um desktop complementar de pelo menos 1280×720.
+
+O ensaio não pode enviar email real, emitir `GO`, retomar outbound ou executar
+ação irreversível. Para cada combinação jornada/viewport, registre:
+
+- SHA Git completo e imutável do runtime, idêntico ao SHA global da sessão;
+- rotas percorridas, passos sanitizados e resultado (`PASS`, `FRICTION` ou
+  `BLOCKED`);
+- tempo de orientação e tempo até a primeira ação, em milissegundos;
+- SHA-256 do vídeo e de ao menos uma captura de tela;
+- issue e critérios de aceite de toda fricção observada.
+
+O manifest só guarda hashes das mídias. Vídeos e capturas devem permanecer no
+repositório de evidências autorizado, já sanitizados; não inclua email, nome,
+telefone, payload ou segredo no JSON.
+
+## 3. Manifest de evidência
+
+O documento JSON tem esta forma (campos abreviados apenas nesta explicação):
+
+```json
+{
+  "schemaVersion": "confenge.live-ux-audit.v1",
+  "executionMode": "HUMAN_AUTHENTICATED_LIVE",
+  "environment": {
+    "origin": "https://ops.confenge.com.br",
+    "runtimeSha": "0123456789abcdef0123456789abcdef01234567",
+    "capturedAt": "2026-08-25T14:30:00-03:00"
+  },
+  "operator": {
+    "pseudonym": "external-operator-01",
+    "role": "skeptical operations reviewer",
+    "human": true,
+    "independent": true
+  },
+  "safety": {
+    "syntheticDataOnly": true,
+    "realEmailSent": false,
+    "goIssued": false,
+    "outboundResumed": false,
+    "irreversibleAction": false
+  },
+  "observations": []
+}
+```
+
+Use o plano gerado para preencher as 20 observações obrigatórias: dez jornadas
+vezes dois viewports. Cada observação repete o `runtimeSha`, lista exatamente as
+`routeKeys` atribuídas pelo plano e informa `sanitizedData: true`, `steps`,
+`orientationMs`, `firstActionMs`, `outcome`, `videoSha256`,
+`screenshotSha256s` e `frictions`.
+
+Uma fricção contém `severity`, `summary`, `issueUrl` numerada neste repositório e
+ao menos um item em `acceptanceCriteria`. Isso vale para todas as severidades;
+P0/P1 jamais podem ficar apenas em comentário, vídeo ou documento.
+
+## 4. Validar e decidir o gate
+
+```bash
+npm run audit:ux --workspace=@confenge/control-center-web-shell -- validate evidence.json
+npm run audit:ux --workspace=@confenge/control-center-web-shell -- gate evidence.json
+```
+
+`validate` retorna zero quando proveniência e completude são válidas, mesmo que
+o arquivo registre uma fricção real. `gate` só retorna zero quando
+`auditPassed: true`. Portanto, uma execução bloqueada pode ser preservada como
+evidência honesta sem permitir o fechamento indevido da auditoria.
+
+O resultado humano deve ser repetido após correções. A issue #111 permanece
+aberta enquanto qualquer jornada estiver bloqueada, tiver fricção, exceder três
+segundos de orientação ou não possuir ambas as observações.

--- a/control-center/docs/LIVE-UX-AUDIT.md
+++ b/control-center/docs/LIVE-UX-AUDIT.md
@@ -33,19 +33,32 @@ sem memória da arquitetura. Repita cada jornada:
 - no viewport principal exato de 390×844, simulando uso com uma mão;
 - em um desktop complementar de pelo menos 1280×720.
 
+O manifesto registra `inputMode: ONE_HANDED_TOUCH` no mobile e
+`inputMode: DESKTOP_POINTER_KEYBOARD` no desktop; apenas redimensionar uma
+janela de automação não satisfaz essa atestação.
+
 O ensaio não pode enviar email real, emitir `GO`, retomar outbound ou executar
 ação irreversível. Para cada combinação jornada/viewport, registre:
 
 - SHA Git completo e imutável do runtime, idêntico ao SHA global da sessão;
+- respostas completas e `PINNED` de `/runtime-identity` (web) e
+  `/v1/runtime-identity` (context), ambas em produção, no mesmo SHA e baseline;
 - rotas percorridas, passos sanitizados e resultado (`PASS`, `FRICTION` ou
   `BLOCKED`);
+- resultado individual de cada `requiredCheck` da jornada; stale, erro,
+  permissão negada e desfecho desconhecido são quatro verificações distintas;
 - tempo de orientação e tempo até a primeira ação, em milissegundos;
-- SHA-256 do vídeo e de ao menos uma captura de tela;
+- SHA-256 de um vídeo e de ao menos uma captura de tela exclusivos daquela
+  observação;
 - issue e critérios de aceite de toda fricção observada.
 
 O manifest só guarda hashes das mídias. Vídeos e capturas devem permanecer no
 repositório de evidências autorizado, já sanitizados; não inclua email, nome,
 telefone, payload ou segredo no JSON.
+
+O validador rejeita propriedades fora do contrato e literais óbvios de email,
+CPF/CNPJ e telefone. Isso reduz vazamento acidental, mas não substitui a revisão
+humana da sanitização das mídias.
 
 ## 3. Manifest de evidência
 
@@ -58,7 +71,23 @@ O documento JSON tem esta forma (campos abreviados apenas nesta explicação):
   "environment": {
     "origin": "https://ops.confenge.com.br",
     "runtimeSha": "0123456789abcdef0123456789abcdef01234567",
-    "capturedAt": "2026-08-25T14:30:00-03:00"
+    "capturedAt": "2026-08-25T14:30:00-03:00",
+    "webRuntimeIdentity": {
+      "schema_version": "control-center.runtime-identity.v1",
+      "service": "control-center-web",
+      "release_sha": "0123456789abcdef0123456789abcdef01234567",
+      "required_baseline_sha": "64ece7d38abacd3adeaa02735b4f22af66caab0f",
+      "release_status": "PINNED",
+      "production_required": true
+    },
+    "contextRuntimeIdentity": {
+      "schema_version": "control-center.runtime-identity.v1",
+      "service": "control-center-context",
+      "release_sha": "0123456789abcdef0123456789abcdef01234567",
+      "required_baseline_sha": "64ece7d38abacd3adeaa02735b4f22af66caab0f",
+      "release_status": "PINNED",
+      "production_required": true
+    }
   },
   "operator": {
     "pseudonym": "external-operator-01",
@@ -79,25 +108,30 @@ O documento JSON tem esta forma (campos abreviados apenas nesta explicação):
 
 Use o plano gerado para preencher as 20 observações obrigatórias: dez jornadas
 vezes dois viewports. Cada observação repete o `runtimeSha`, lista exatamente as
-`routeKeys` atribuídas pelo plano e informa `sanitizedData: true`, `steps`,
+`routeKeys` atribuídas pelo plano, registra cada `requiredCheck` uma vez em
+`checks` e informa `sanitizedData: true`, `steps`,
 `orientationMs`, `firstActionMs`, `outcome`, `videoSha256`,
 `screenshotSha256s` e `frictions`.
 
 Uma fricção contém `severity`, `summary`, `issueUrl` numerada neste repositório e
 ao menos um item em `acceptanceCriteria`. Isso vale para todas as severidades;
-P0/P1 jamais podem ficar apenas em comentário, vídeo ou documento.
+P0/P1 jamais podem ficar apenas em comentário, vídeo ou documento. A validação
+consulta o GitHub e falha se a URL não resolver para uma issue real (um PR com o
+mesmo número não conta).
 
 ## 4. Validar e decidir o gate
 
 ```bash
 npm run audit:ux --workspace=@confenge/control-center-web-shell -- validate evidence.json
-npm run audit:ux --workspace=@confenge/control-center-web-shell -- gate evidence.json
+npm run audit:ux --workspace=@confenge/control-center-web-shell -- gate evidence.json /caminho/para/midias-sanitizadas
 ```
 
-`validate` retorna zero quando proveniência e completude são válidas, mesmo que
-o arquivo registre uma fricção real. `gate` só retorna zero quando
-`auditPassed: true`. Portanto, uma execução bloqueada pode ser preservada como
-evidência honesta sem permitir o fechamento indevido da auditoria.
+`validate` retorna zero quando proveniência, completude e referências de issues
+são válidas, mesmo que o arquivo registre uma fricção real. `gate` recalcula o
+SHA-256 dos arquivos sob o diretório autorizado e só retorna zero quando todos
+os hashes existem e `auditPassed: true`. Portanto, uma execução bloqueada pode
+ser preservada como evidência honesta sem permitir o fechamento indevido da
+auditoria. Um JSON com hashes inventados nunca deixa o gate verde.
 
 O resultado humano deve ser repetido após correções. A issue #111 permanece
 aberta enquanto qualquer jornada estiver bloqueada, tiver fricção, exceder três


### PR DESCRIPTION
## Escopo

- deriva 19 rotas reais dos registries de navegação e exige que todas pertençam a uma das 10 jornadas mínimas
- materializa 33 verificações obrigatórias; stale, erro, permissão negada e desfecho desconhecido não podem ser resumidos em um único PASS
- exige execução humana autenticada em 390x844 com `ONE_HANDED_TOUCH` e desktop complementar com `DESKTOP_POINTER_KEYBOARD`
- vincula a sessão às identidades `PINNED` de `/runtime-identity` e `/v1/runtime-identity`, no mesmo SHA e baseline de produção
- separa manifesto estrutural, critérios de UX e auditoria aprovada; JSON sozinho nunca produz `auditPassed: true`
- recalcula os SHA-256 no diretório autorizado, proíbe reutilização de mídia e confirma no GitHub que achados apontam para issues reais, não PRs ou URLs inventadas
- rejeita propriedades fora do contrato, datas impossíveis/futuras, contradições entre checks e outcome e literais óbvios de email, CPF/CNPJ ou telefone
- falha fechado para automação disfarçada de operador, dados não sanitizados, email real, GO, retomada de outbound ou ação irreversível

## Verificação

- `npm run typecheck --workspace=@confenge/control-center-web-shell`
- `npm run build --workspace=@confenge/control-center-web-shell`
- web shell: 456 testes aprovados, incluindo 20 cenários focados da auditoria
- persistência com PostgreSQL real: 34 testes aprovados
- Python: 191 testes aprovados
- hardening: 25 testes aprovados
- cinco validadores de autoridade aprovados
- plano gerado com 10 jornadas, 19 rotas, 33 checks e zero inconsistências
- `npm audit`: zero vulnerabilidades

## Limite honesto

Este PR entrega a matriz viva e o gate de evidência, mas não afirma que a auditoria humana em `ops.confenge.com.br` já foi executada. A issue deve permanecer aberta até a repetição externa, com as mídias sanitizadas reais, produzir `auditPassed: true`.

Refs #111
