### PR TITLE
[P1] Padronizar orientação da primeira viewport

### DIFF
--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -79,6 +79,13 @@ function stringValue(record: Record<string, unknown>, key: string): string | und
 
 const REVIEW_PAGE_LIMIT = 100;
 
+class HttpReadError extends Error {
+  constructor(readonly status: number, path: string) {
+    super(`Backend operacional indisponível (${status} ${path}).`);
+    this.name = "HttpReadError";
+  }
+}
+
 function reviewOffsetOf(location: string | undefined): number {
   const raw = queryParamsOf(location ?? "").offset;
   if (typeof raw !== "string" || !/^\d+$/.test(raw)) return 0;
@@ -552,11 +559,12 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       const page = await this.loadPage(id, location);
       return { ok: true, loading: false, page };
     } catch (err) {
+      const denied = err instanceof HttpReadError && (err.status === 401 || err.status === 403);
       return {
         ok: false,
         loading: false,
         error: {
-          code: "CONTEXT_UNAVAILABLE",
+          code: denied ? "PERMISSION_DENIED" : "CONTEXT_UNAVAILABLE",
           message:
             err instanceof Error
               ? err.message
@@ -1388,7 +1396,7 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
     });
     if (response.status === 404) return undefined;
     if (!response.ok) {
-      throw new Error(`Backend operacional indisponível (${response.status} ${path}).`);
+      throw new HttpReadError(response.status, path);
     }
     try {
       return await response.json() as unknown;
@@ -1411,7 +1419,7 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       return undefined;
     }
     if (!response.ok) {
-      throw new Error(`Backend operacional indisponível (${response.status} ${path}).`);
+      throw new HttpReadError(response.status, path);
     }
     try {
       return JSON.parse(text) as unknown;

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -395,6 +395,103 @@ main {
   color: var(--fg-muted);
 }
 
+/* First-viewport cognitive contract (#106): every route answers the same three
+   questions before domain-specific cards begin. The compact mobile layout is
+   authored directly instead of being a squeezed desktop card grid. */
+.orientation-summary {
+  margin: 0.75rem 0 0.9rem;
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  border-radius: 0.45rem;
+  background: var(--bg-elev);
+  padding: 0.65rem 0.7rem;
+}
+
+.orientation-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  margin-bottom: 0.55rem;
+}
+
+.orientation-heading h2,
+.orientation-heading p,
+.orientation-field h2,
+.orientation-field p {
+  margin: 0;
+}
+
+.orientation-heading h2 {
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.orientation-heading p {
+  color: var(--fg-muted);
+  font-size: 0.76rem;
+  text-align: right;
+}
+
+.orientation-grid {
+  display: grid;
+  gap: 0;
+}
+
+.orientation-field {
+  min-width: 0;
+  padding: 0.5rem 0;
+  border-top: 1px solid var(--line);
+}
+
+.orientation-field h2 {
+  color: var(--fg-muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.orientation-value,
+.orientation-primary-action {
+  display: block;
+  margin-top: 0.15rem;
+  color: var(--fg);
+  font-size: 0.94rem;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.orientation-detail {
+  margin-top: 0.15rem !important;
+  color: var(--fg-muted);
+  font-size: 0.78rem;
+  line-height: 1.3;
+}
+
+.orientation-primary-action {
+  min-height: 44px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--accent);
+  border-radius: 0.35rem;
+  text-decoration: none;
+}
+
+.orientation-field[data-orientation-tone="critical"] .orientation-value {
+  color: var(--crit);
+}
+
+.orientation-field[data-orientation-tone="attention"] .orientation-value {
+  color: var(--high);
+}
+
+.orientation-field[data-orientation-tone="unknown"] .orientation-value {
+  color: var(--low);
+}
+
 .mock-lab {
   margin: 0.9rem 0;
   padding: 0.55rem 0.65rem;
@@ -801,6 +898,21 @@ h2 {
 
   .page-head h1 {
     font-size: 1.6rem;
+  }
+
+  .orientation-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .orientation-field {
+    padding: 0.25rem 0.85rem;
+    border-top: 0;
+    border-left: 1px solid var(--line);
+  }
+
+  .orientation-field:first-child {
+    padding-left: 0;
+    border-left: 0;
   }
 }
 

--- a/control-center/apps/web-shell/src/ui/orientation.ts
+++ b/control-center/apps/web-shell/src/ui/orientation.ts
@@ -1,0 +1,390 @@
+import type { DestinationPage } from "../adapters/contract";
+import { formatLocal, isUtcDateTime } from "../datetime";
+import type { DestinationId } from "../destinations";
+import { escapeHtml } from "../escape";
+import { collectProvenance } from "../page";
+import type { AttentionItem, FreshnessStatus, PriorityRecommendation } from "../types";
+import type { ViewKind, ViewState } from "../view-state";
+import { severityLabel } from "./labels";
+
+export const ORIENTATION_FIELDS = ["state", "risk", "next-action"] as const;
+
+export type OrientationField = (typeof ORIENTATION_FIELDS)[number];
+export type OrientationTone = "ok" | "attention" | "critical" | "unknown" | "neutral";
+export type OrientationActionKind = "act" | "recover" | "wait" | "none";
+
+export interface OrientationStatement {
+  readonly label: string;
+  readonly detail: string;
+  readonly tone: OrientationTone;
+}
+
+export interface OrientationAction {
+  readonly label: string;
+  readonly detail: string;
+  readonly kind: OrientationActionKind;
+  readonly href: string | null;
+}
+
+export interface OrientationSummary {
+  readonly destination: DestinationId;
+  readonly viewKind: ViewKind;
+  readonly state: OrientationStatement;
+  readonly risk: OrientationStatement;
+  readonly action: OrientationAction;
+  readonly observedAt: string | null;
+  readonly observedAtLabel: string;
+}
+
+interface OrientationInput {
+  readonly destination: DestinationId;
+  readonly view: ViewState<DestinationPage>;
+}
+
+const freshnessRank: Readonly<Record<FreshnessStatus, number>> = {
+  FRESH: 0,
+  STALE: 1,
+  UNKNOWN: 2,
+  ERROR: 3,
+};
+
+function worstFreshness(page: DestinationPage): FreshnessStatus | null {
+  const statuses = collectProvenance(page).map((item) => item.freshness_status);
+  if (statuses.length === 0) return null;
+  return statuses.reduce((worst, status) =>
+    freshnessRank[status] > freshnessRank[worst] ? status : worst,
+  );
+}
+
+function mostUrgentAttention(page: DestinationPage): AttentionItem | null {
+  const unresolved = page.attention.filter(
+    (item) => item.status === "open" || item.status === "acknowledged",
+  );
+  const rank: Readonly<Record<AttentionItem["severity"], number>> = {
+    critical: 0,
+    high: 1,
+    medium: 2,
+    low: 3,
+  };
+  return [...unresolved].sort((left, right) => {
+    const severity = rank[left.severity] - rank[right.severity];
+    if (severity !== 0) return severity;
+    return left.detected_at.localeCompare(right.detected_at);
+  })[0] ?? null;
+}
+
+function firstPriority(page: DestinationPage): PriorityRecommendation | null {
+  return [...page.priorities].sort((left, right) => left.rank - right.rank)[0] ?? null;
+}
+
+function errorOrientation(
+  destination: DestinationId,
+  view: Extract<ViewState<DestinationPage>, { kind: "error" }>,
+): OrientationSummary {
+  const denied = /(?:permission|forbidden|unauthori[sz]ed|access_denied|auth)/i.test(
+    `${view.code} ${view.message}`,
+  );
+  return {
+    destination,
+    viewKind: view.kind,
+    state: denied
+      ? {
+          label: "Sem permissão para este recorte",
+          detail: "A sessão atual não recebeu autoridade para ler esta área.",
+          tone: "unknown",
+        }
+      : {
+          label: "Leitura indisponível",
+          detail: "O Control Center não conseguiu montar este recorte.",
+          tone: "critical",
+        },
+    risk: {
+      label: "Risco desconhecido",
+      detail: "Sem uma leitura válida, nenhum estado operacional pode ser presumido.",
+      tone: "unknown",
+    },
+    action: denied
+      ? {
+          label: "Reautenticar ou pedir acesso",
+          detail: "Não tente contornar a autorização nem use outro recorte como prova.",
+          kind: "recover",
+          href: null,
+        }
+      : {
+          label: "Recarregar este endereço",
+          detail: "O recarregamento preserva a rota; confirme o estado antes de repetir uma ação.",
+          kind: "recover",
+          href: "",
+        },
+    observedAt: null,
+    observedAtLabel: "Atualização não disponível",
+  };
+}
+
+function reliabilityOrientation(
+  status: FreshnessStatus | null,
+): { state: OrientationStatement; risk: OrientationStatement; action: OrientationAction } {
+  switch (status) {
+    case "FRESH":
+      return {
+        state: {
+          label: "Leitura atual disponível",
+          detail: "As fontes observadas neste recorte foram classificadas como atualizadas.",
+          tone: "ok",
+        },
+        risk: {
+          label: "Nenhum risco acionável observado",
+          detail: "O recorte não retornou alerta ou prioridade que exija ação agora.",
+          tone: "ok",
+        },
+        action: {
+          label: "Nenhuma ação requerida agora",
+          detail: "Acompanhe uma nova leitura; não crie trabalho ornamental.",
+          kind: "none",
+          href: null,
+        },
+      };
+    case "STALE":
+      return {
+        state: {
+          label: "Há dados desatualizados",
+          detail: "Ao menos uma fonte ultrapassou a janela segura de atualização.",
+          tone: "attention",
+        },
+        risk: {
+          label: "Decisão pode usar estado antigo",
+          detail: "Dado defasado não prova a situação atual e nunca equivale a saudável.",
+          tone: "attention",
+        },
+        action: {
+          label: "Conferir a origem antes de agir",
+          detail: "Use a proveniência no conteúdo para obter uma leitura atual.",
+          kind: "recover",
+          href: "#orientacao-conteudo",
+        },
+      };
+    case "UNKNOWN":
+      return {
+        state: {
+          label: "Parte do estado é desconhecida",
+          detail: "Ao menos uma fonte não informou uma leitura confiável.",
+          tone: "unknown",
+        },
+        risk: {
+          label: "Risco não pode ser descartado",
+          detail: "Ausência de prova não é zero, sucesso ou estado saudável.",
+          tone: "unknown",
+        },
+        action: {
+          label: "Confirmar a fonte antes de decidir",
+          detail: "Consulte a proveniência e não execute mutação com estado desconhecido.",
+          kind: "recover",
+          href: "#orientacao-conteudo",
+        },
+      };
+    case "ERROR":
+      return {
+        state: {
+          label: "Leitura parcial com erro",
+          detail: "Ao menos uma coleta falhou; os demais dados continuam visíveis com cautela.",
+          tone: "critical",
+        },
+        risk: {
+          label: "O panorama pode estar incompleto",
+          detail: "Não interprete uma falha de coleta como ausência de ocorrências.",
+          tone: "critical",
+        },
+        action: {
+          label: "Investigar a coleta antes de agir",
+          detail: "Abra a proveniência e siga a recuperação indicada pela fonte.",
+          kind: "recover",
+          href: "#orientacao-conteudo",
+        },
+      };
+    case null:
+      return {
+        state: {
+          label: "Leitura disponível; atualidade não comprovada",
+          detail: "Este recorte não trouxe proveniência suficiente para avaliar atualização.",
+          tone: "unknown",
+        },
+        risk: {
+          label: "Risco não comprovado",
+          detail: "Sem proveniência, a ausência de alertas não autoriza concluir que está tudo bem.",
+          tone: "unknown",
+        },
+        action: {
+          label: "Confirmar a leitura antes de agir",
+          detail: "Use somente evidência com origem e horário observáveis.",
+          kind: "recover",
+          href: "#orientacao-conteudo",
+        },
+      };
+  }
+}
+
+export function buildOrientationSummary(input: OrientationInput): OrientationSummary {
+  const { destination, view } = input;
+
+  if (view.kind === "loading") {
+    return {
+      destination,
+      viewKind: view.kind,
+      state: {
+        label: "Carregando esta área",
+        detail: "A estrutura está disponível enquanto os dados são consultados.",
+        tone: "neutral",
+      },
+      risk: {
+        label: "Risco ainda não avaliado",
+        detail: "A leitura ainda não terminou; nenhum resultado foi presumido.",
+        tone: "unknown",
+      },
+      action: {
+        label: "Aguardar a leitura",
+        detail: "Não repita nem antecipe uma ação enquanto o estado está carregando.",
+        kind: "wait",
+        href: null,
+      },
+      observedAt: null,
+      observedAtLabel: "Atualização em andamento",
+    };
+  }
+
+  if (view.kind === "error") return errorOrientation(destination, view);
+
+  if (view.kind === "empty") {
+    return {
+      destination,
+      viewKind: view.kind,
+      state: {
+        label: "Recorte vazio",
+        detail: view.message,
+        tone: "neutral",
+      },
+      risk: {
+        label: "Nenhum item acionável foi retornado",
+        detail: "Vazio descreve este recorte; não transforma dado ausente em zero ou saudável.",
+        tone: "neutral",
+      },
+      action: {
+        label: "Nenhuma ação requerida neste recorte",
+        detail: "Mude o recorte somente se houver outra tarefa explícita.",
+        kind: "none",
+        href: null,
+      },
+      observedAt: null,
+      observedAtLabel: "Horário da leitura não informado",
+    };
+  }
+
+  const page = view.data;
+  const observedAt = isUtcDateTime(page.generated_at) ? page.generated_at : null;
+  const effectiveFreshness = view.kind === "stale" ? "STALE" : worstFreshness(page);
+  const reliability = reliabilityOrientation(effectiveFreshness);
+  const mayOfferDomainAction = effectiveFreshness === "FRESH";
+  const attention = mostUrgentAttention(page);
+  const priority = firstPriority(page);
+
+  if (attention) {
+    return {
+      destination,
+      viewKind: view.kind,
+      state: reliability.state,
+      risk: {
+        label: `Risco ${severityLabel(attention.severity)}: ${attention.title}`,
+        detail:
+          attention.status === "acknowledged"
+            ? "O alerta foi reconhecido, mas ainda não está resolvido."
+            : attention.summary,
+        tone: attention.severity === "critical" ? "critical" : "attention",
+      },
+      action: mayOfferDomainAction
+        ? {
+            label: attention.recommended_action?.trim() || "Revisar esta exceção antes de agir",
+            detail: "A ação abre o conteúdo operacional; autorização e confirmação continuam valendo.",
+            kind: "act",
+            href: "#orientacao-conteudo",
+          }
+        : reliability.action,
+      observedAt,
+      observedAtLabel: observedAt
+        ? `Leitura gerada em ${formatLocal(observedAt)}`
+        : "Horário da leitura inválido ou não informado",
+    };
+  }
+
+  if (priority) {
+    return {
+      destination,
+      viewKind: view.kind,
+      state: reliability.state,
+      risk: {
+        label: `Prioridade ${priority.rank}: ${priority.title}`,
+        detail: priority.rationale,
+        tone: "attention",
+      },
+      action: mayOfferDomainAction
+        ? {
+            label: priority.recommended_action?.trim() || "Revisar esta prioridade",
+            detail: "A ação abre o conteúdo operacional sem executar mutação.",
+            kind: "act",
+            href: "#orientacao-conteudo",
+          }
+        : reliability.action,
+      observedAt,
+      observedAtLabel: observedAt
+        ? `Leitura gerada em ${formatLocal(observedAt)}`
+        : "Horário da leitura inválido ou não informado",
+    };
+  }
+
+  return {
+    destination,
+    viewKind: view.kind,
+    state: reliability.state,
+    risk: reliability.risk,
+    action: reliability.action,
+    observedAt,
+    observedAtLabel: observedAt
+      ? `Leitura gerada em ${formatLocal(observedAt)}`
+      : "Horário da leitura inválido ou não informado",
+  };
+}
+
+function statement(
+  field: Exclude<OrientationField, "next-action">,
+  title: string,
+  value: OrientationStatement,
+): string {
+  return `<div class="orientation-field" data-orientation-field="${field}" data-orientation-tone="${value.tone}">
+    <h2>${title}</h2>
+    <p class="orientation-value">${escapeHtml(value.label)}</p>
+    <p class="orientation-detail">${escapeHtml(value.detail)}</p>
+  </div>`;
+}
+
+export function renderOrientationSummary(summary: OrientationSummary): string {
+  const actionBody = summary.action.href === null
+    ? `<p class="orientation-value">${escapeHtml(summary.action.label)}</p>`
+    : `<a class="orientation-primary-action" data-orientation-primary-action="true" href="${escapeHtml(summary.action.href)}">${escapeHtml(summary.action.label)}</a>`;
+  const observedAt = summary.observedAt === null
+    ? escapeHtml(summary.observedAtLabel)
+    : `<time datetime="${escapeHtml(summary.observedAt)}">${escapeHtml(summary.observedAtLabel)}</time>`;
+
+  return `<section class="orientation-summary" aria-labelledby="orientation-title" data-orientation-contract="v1" data-orientation-destination="${escapeHtml(summary.destination)}" data-orientation-view="${summary.viewKind}">
+    <header class="orientation-heading">
+      <h2 id="orientation-title">Orientação rápida</h2>
+      <p>${observedAt}</p>
+    </header>
+    <div class="orientation-grid">
+      ${statement("state", "Estado atual", summary.state)}
+      ${statement("risk", "Risco ou prioridade", summary.risk)}
+      <div class="orientation-field" data-orientation-field="next-action" data-orientation-action-kind="${summary.action.kind}">
+        <h2>Próxima ação</h2>
+        ${actionBody}
+        <p class="orientation-detail">${escapeHtml(summary.action.detail)}</p>
+      </div>
+    </div>
+  </section>`;
+}

--- a/control-center/apps/web-shell/src/ui/orientation.ts
+++ b/control-center/apps/web-shell/src/ui/orientation.ts
@@ -1,6 +1,6 @@
 import type { DestinationPage } from "../adapters/contract";
 import { formatLocal, isUtcDateTime } from "../datetime";
-import type { DestinationId } from "../destinations";
+import { getDestination, type DestinationId } from "../destinations";
 import { escapeHtml } from "../escape";
 import { collectProvenance } from "../page";
 import type { AttentionItem, FreshnessStatus, PriorityRecommendation } from "../types";
@@ -28,6 +28,7 @@ export interface OrientationAction {
 
 export interface OrientationSummary {
   readonly destination: DestinationId;
+  readonly locationLabel: string;
   readonly viewKind: ViewKind;
   readonly state: OrientationStatement;
   readonly risk: OrientationStatement;
@@ -39,6 +40,46 @@ export interface OrientationSummary {
 interface OrientationInput {
   readonly destination: DestinationId;
   readonly view: ViewState<DestinationPage>;
+  readonly surface?: string | null;
+  readonly currentHref?: string;
+}
+
+const commercialSurfaceLabels: Readonly<Record<string, string>> = {
+  visao: "Visão",
+  rascunhos: "Revisão editorial",
+  cohorts: "Coortes",
+  atividade: "Atividade",
+  pipeline: "Pipeline",
+  excecoes: "Exceções",
+};
+
+const warmblySurfaceLabels: Readonly<Record<string, string>> = {
+  operacao: "Operação",
+  cohorts: "Coortes",
+  revisao: "Revisão",
+};
+
+function locationLabel(destination: DestinationId, surface: string | null | undefined): string {
+  const root = getDestination(destination).label;
+  const labels = destination === "comercial"
+    ? commercialSurfaceLabels
+    : destination === "warmbly"
+      ? warmblySurfaceLabels
+      : null;
+  const child = labels && surface ? labels[surface] : undefined;
+  return child ? `${root} / ${child}` : root;
+}
+
+function safeCurrentHref(destination: DestinationId, value: string | undefined): string {
+  return value?.startsWith("#/") ? value : `#/${destination}`;
+}
+
+function conciseText(value: string, maxCharacters: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  const characters = [...normalized];
+  return characters.length <= maxCharacters
+    ? normalized
+    : `${characters.slice(0, maxCharacters - 1).join("")}…`;
 }
 
 const freshnessRank: Readonly<Record<FreshnessStatus, number>> = {
@@ -80,12 +121,14 @@ function firstPriority(page: DestinationPage): PriorityRecommendation | null {
 function errorOrientation(
   destination: DestinationId,
   view: Extract<ViewState<DestinationPage>, { kind: "error" }>,
+  location: string,
+  currentHref: string,
 ): OrientationSummary {
-  const denied = /(?:permission|forbidden|unauthori[sz]ed|access_denied|auth)/i.test(
-    `${view.code} ${view.message}`,
-  );
+  const denied = ["PERMISSION_DENIED", "FORBIDDEN", "UNAUTHORIZED", "HTTP_401", "HTTP_403"]
+    .includes(view.code.toUpperCase());
   return {
     destination,
+    locationLabel: location,
     viewKind: view.kind,
     state: denied
       ? {
@@ -114,7 +157,7 @@ function errorOrientation(
           label: "Recarregar este endereço",
           detail: "O recarregamento preserva a rota; confirme o estado antes de repetir uma ação.",
           kind: "recover",
-          href: "",
+          href: currentHref,
         },
     observedAt: null,
     observedAtLabel: "Atualização não disponível",
@@ -225,10 +268,13 @@ function reliabilityOrientation(
 
 export function buildOrientationSummary(input: OrientationInput): OrientationSummary {
   const { destination, view } = input;
+  const location = locationLabel(destination, input.surface);
+  const currentHref = safeCurrentHref(destination, input.currentHref);
 
   if (view.kind === "loading") {
     return {
       destination,
+      locationLabel: location,
       viewKind: view.kind,
       state: {
         label: "Carregando esta área",
@@ -251,11 +297,12 @@ export function buildOrientationSummary(input: OrientationInput): OrientationSum
     };
   }
 
-  if (view.kind === "error") return errorOrientation(destination, view);
+  if (view.kind === "error") return errorOrientation(destination, view, location, currentHref);
 
   if (view.kind === "empty") {
     return {
       destination,
+      locationLabel: location,
       viewKind: view.kind,
       state: {
         label: "Recorte vazio",
@@ -289,20 +336,23 @@ export function buildOrientationSummary(input: OrientationInput): OrientationSum
   if (attention) {
     return {
       destination,
+      locationLabel: location,
       viewKind: view.kind,
       state: reliability.state,
       risk: {
-        label: `Risco ${severityLabel(attention.severity)}: ${attention.title}`,
+        label: `Risco ${severityLabel(attention.severity)}: ${conciseText(attention.title, 96)}`,
         detail:
           attention.status === "acknowledged"
             ? "O alerta foi reconhecido, mas ainda não está resolvido."
-            : attention.summary,
+            : conciseText(attention.summary, 180),
         tone: attention.severity === "critical" ? "critical" : "attention",
       },
       action: mayOfferDomainAction
         ? {
-            label: attention.recommended_action?.trim() || "Revisar esta exceção antes de agir",
-            detail: "A ação abre o conteúdo operacional; autorização e confirmação continuam valendo.",
+            label: "Revisar esta exceção no conteúdo",
+            detail: attention.recommended_action?.trim()
+              ? `Recomendação observada: ${conciseText(attention.recommended_action, 140)} O link apenas abre o conteúdo; autorização e confirmação continuam valendo.`
+              : "O link apenas abre o conteúdo; autorização e confirmação continuam valendo.",
             kind: "act",
             href: "#orientacao-conteudo",
           }
@@ -317,17 +367,20 @@ export function buildOrientationSummary(input: OrientationInput): OrientationSum
   if (priority) {
     return {
       destination,
+      locationLabel: location,
       viewKind: view.kind,
       state: reliability.state,
       risk: {
-        label: `Prioridade ${priority.rank}: ${priority.title}`,
-        detail: priority.rationale,
+        label: `Prioridade ${priority.rank}: ${conciseText(priority.title, 96)}`,
+        detail: conciseText(priority.rationale, 180),
         tone: "attention",
       },
       action: mayOfferDomainAction
         ? {
-            label: priority.recommended_action?.trim() || "Revisar esta prioridade",
-            detail: "A ação abre o conteúdo operacional sem executar mutação.",
+            label: "Revisar esta prioridade no conteúdo",
+            detail: priority.recommended_action?.trim()
+              ? `Recomendação observada: ${conciseText(priority.recommended_action, 140)} O link não executa mutação.`
+              : "O link apenas abre o conteúdo operacional e não executa mutação.",
             kind: "act",
             href: "#orientacao-conteudo",
           }
@@ -341,6 +394,7 @@ export function buildOrientationSummary(input: OrientationInput): OrientationSum
 
   return {
     destination,
+    locationLabel: location,
     viewKind: view.kind,
     state: reliability.state,
     risk: reliability.risk,
@@ -374,7 +428,7 @@ export function renderOrientationSummary(summary: OrientationSummary): string {
 
   return `<section class="orientation-summary" aria-labelledby="orientation-title" data-orientation-contract="v1" data-orientation-destination="${escapeHtml(summary.destination)}" data-orientation-view="${summary.viewKind}">
     <header class="orientation-heading">
-      <h2 id="orientation-title">Orientação rápida</h2>
+      <h2 id="orientation-title">Orientação rápida — ${escapeHtml(summary.locationLabel)}</h2>
       <p>${observedAt}</p>
     </header>
     <div class="orientation-grid">

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -21,6 +21,7 @@ import { alertBody, alertDataAttributes } from "./alert-card";
 import { isOperationalClient } from "../client-identity";
 import { composeHoje } from "../hoje-compose";
 import { renderHoje } from "./hoje";
+import { buildOrientationSummary, renderOrientationSummary } from "./orientation";
 import {
   activityCard,
   clientCard,
@@ -391,6 +392,10 @@ export function renderShell(model: ShellModel): string {
           model.operatorResult,
         )
       : "";
+  const orientation = buildOrientationSummary({
+    destination: model.destination,
+    view: model.view,
+  });
 
   return `
     <a class="skip-link" href="#conteudo">Saltar para o conteúdo</a>
@@ -417,10 +422,11 @@ export function renderShell(model: ShellModel): string {
           <h1>${escapeHtml(label)}</h1>
           <p>${escapeHtml(headline)}</p>
         </header>
+        ${renderOrientationSummary(orientation)}
         ${model.adapterMode === "http" ? "" : mockLab(model.destination, model.viewKind)}
         ${viewBanner(model.view)}
         ${model.destination === "warmbly" ? "" : operatorBanner(model.operatorResult)}
-        ${body}
+        <div id="orientacao-conteudo">${body}</div>
       </main>
       <footer class="runtime-identity" data-runtime-identity="true" data-release-sha="${escapeHtml(model.releaseSha ?? "")}">
         Release em execução: <code data-runtime-release-sha="true">${escapeHtml(model.releaseSha ?? "não verificado")}</code>

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -5,7 +5,7 @@ import {
   BRAND_LOGO_SRC,
   BRAND_LOGO_WIDTH,
 } from "../brand";
-import { DESTINATIONS, hashFor, type DestinationId } from "../destinations";
+import { DESTINATIONS, hashFor, withQueryParams, type DestinationId } from "../destinations";
 import { escapeHtml } from "../escape";
 import { ownMapValue } from "../own-map";
 import { AUTH_URL, PRODUCTIVE_URL } from "../topology";
@@ -395,6 +395,13 @@ export function renderShell(model: ShellModel): string {
   const orientation = buildOrientationSummary({
     destination: model.destination,
     view: model.view,
+    ...(model.surface !== undefined ? { surface: model.surface } : {}),
+    currentHref: model.hash
+      ? withQueryParams(model.hash, { view: null })
+      : hashFor(model.destination, null, {
+          ...(model.surface ? { surface: model.surface } : {}),
+          ...(model.resource ? { resource: model.resource } : {}),
+        }),
   });
 
   return `

--- a/control-center/apps/web-shell/tests/orientation.test.ts
+++ b/control-center/apps/web-shell/tests/orientation.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 import type { DestinationPage } from "../src/adapters/contract";
+import { createHttpAdapter } from "../src/adapters/http";
 import {
   COMMERCIAL_SURFACES,
   DESTINATION_IDS,
@@ -68,6 +69,12 @@ test("every registered destination renders state, risk and next action before it
       });
       assert.match(html, /data-orientation-contract="v1"/);
       assert.equal([...html.matchAll(/data-orientation-field=/g)].length, 3);
+      if (destination === "comercial" && surface === "excecoes") {
+        assert.match(html, /Orientação rápida — Comercial \/ Exceções/);
+      }
+      if (destination === "warmbly" && surface === "revisao") {
+        assert.match(html, /Orientação rápida — Operação Warmbly \/ Revisão/);
+      }
     }
   }
 });
@@ -92,7 +99,8 @@ test("the most severe unresolved alert owns one unambiguous primary action", () 
     view: { kind: "ready", data },
   });
   assert.match(summary.risk.label, /^Risco crítico:/);
-  assert.equal(summary.action.label, "Inspecionar a coleta");
+  assert.equal(summary.action.label, "Revisar esta exceção no conteúdo");
+  assert.match(summary.action.detail, /Recomendação observada: Inspecionar a coleta/);
   assert.equal(summary.action.kind, "act");
 
   const html = renderOrientationSummary(summary);
@@ -209,11 +217,52 @@ test("loading, empty, generic error and permission denial have distinct recovery
 
   assert.equal(loading.action.kind, "wait");
   assert.equal(empty.action.kind, "none");
-  assert.equal(error.action.href, "");
+  assert.equal(error.action.href, "#/clientes");
   assert.match(error.action.label, /recarregar/i);
   assert.match(denied.state.label, /sem permissão/i);
   assert.equal(denied.action.href, null);
   assert.match(denied.action.detail, /não tente contornar/i);
+});
+
+test("permission state comes from an exact adapter code and generic authority prose is not misclassified", async () => {
+  const adapter = createHttpAdapter(
+    "https://ops.confenge.com.br",
+    async () => new Response("forbidden", { status: 403 }),
+  );
+  const read = await adapter.readDestination("memoria");
+  assert.equal(read.ok, false);
+  if (read.ok) return;
+  assert.equal(read.error.code, "PERMISSION_DENIED");
+
+  const denied = buildOrientationSummary({
+    destination: "memoria",
+    view: { kind: "error", code: read.error.code, message: read.error.message },
+  });
+  const unrelated = buildOrientationSummary({
+    destination: "memoria",
+    view: {
+      kind: "error",
+      code: "AUTHORITATIVE_SOURCE_ERROR",
+      message: "authoritative source failed",
+    },
+  });
+  assert.match(denied.state.label, /sem permissão/i);
+  assert.equal(unrelated.state.label, "Leitura indisponível");
+});
+
+test("error recovery preserves the current subroute and drops a synthetic view override", () => {
+  const html = renderShell({
+    destination: "warmbly",
+    surface: "revisao",
+    resource: "fixture-version",
+    hash: "#/warmbly/revisao?resource=fixture-version&view=error",
+    viewKind: "error",
+    adapterMode: "http",
+    mockScenario: "http",
+    view: { kind: "error", code: "CONTEXT_UNAVAILABLE", message: "falhou" },
+  });
+  assert.match(html, /href="#\/warmbly\/revisao\?resource=fixture-version"/);
+  assert.doesNotMatch(html, /orientation-primary-action[^>]+view=error/);
 });
 
 test("missing provenance remains unknown instead of becoming a healthy zero", () => {
@@ -236,7 +285,8 @@ test("priority is used only when no unresolved alert exists", () => {
     view: { kind: "ready", data },
   });
   assert.match(summary.risk.label, /^Prioridade 1:/);
-  assert.equal(summary.action.label, "Abrir a prioridade");
+  assert.equal(summary.action.label, "Revisar esta prioridade no conteúdo");
+  assert.match(summary.action.detail, /Recomendação observada: Abrir a prioridade/);
 });
 
 test("human update time is visible while the exact instant remains machine-readable", () => {
@@ -275,6 +325,30 @@ test("untrusted alert and action text is escaped in the first viewport", () => {
   assert.doesNotMatch(html, /<img/);
   assert.doesNotMatch(html, /onerror="/);
   assert.match(html, /&lt;img/);
+});
+
+test("untrusted domain prose is bounded so it cannot consume the first viewport", () => {
+  const data = page("hoje");
+  data.attention = [{
+    ...ATTENTION_FIXTURES[0]!,
+    title: `Título ${"muito longo ".repeat(80)}`,
+    summary: `Resumo ${"sem limite ".repeat(120)}`,
+    recommended_action: `Ação ${"enganosamente longa ".repeat(80)}`,
+    provenance: {
+      ...ATTENTION_FIXTURES[0]!.provenance,
+      freshness_status: "FRESH",
+    },
+  }];
+
+  const summary = buildOrientationSummary({
+    destination: "hoje",
+    view: { kind: "ready", data },
+  });
+  assert.ok([...summary.risk.label].length <= "Risco crítico: ".length + 96);
+  assert.ok([...summary.risk.detail].length <= 180);
+  assert.ok(summary.action.detail.length < 400);
+  assert.match(summary.risk.label, /…$/);
+  assert.match(summary.risk.detail, /…$/);
 });
 
 test("non-fresh evidence suppresses a domain action even when the source recommends it", () => {

--- a/control-center/apps/web-shell/tests/orientation.test.ts
+++ b/control-center/apps/web-shell/tests/orientation.test.ts
@@ -1,0 +1,307 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import type { DestinationPage } from "../src/adapters/contract";
+import {
+  COMMERCIAL_SURFACES,
+  DESTINATION_IDS,
+  WARMBLY_SURFACES,
+  type DestinationId,
+} from "../src/destinations";
+import { ATTENTION_FIXTURES, PRIORITY_FIXTURES } from "../src/fixtures/catalog";
+import {
+  ORIENTATION_FIELDS,
+  buildOrientationSummary,
+  renderOrientationSummary,
+} from "../src/ui/orientation";
+import { renderShell } from "../src/ui/render";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function page(destination: DestinationId): DestinationPage {
+  return {
+    id: destination,
+    label: destination,
+    scope: "company",
+    generated_at: "2026-08-20T18:00:00Z",
+    operator: { kind: "human", id: "human:operator" },
+    headline: "Recorte operacional",
+    attention: [],
+    priorities: [],
+  };
+}
+
+test("every registered destination renders state, risk and next action before its content", () => {
+  assert.deepEqual(ORIENTATION_FIELDS, ["state", "risk", "next-action"]);
+  for (const destination of DESTINATION_IDS) {
+    const html = renderShell({
+      destination,
+      viewKind: "ready",
+      adapterMode: "http",
+      mockScenario: "http",
+      view: { kind: "ready", data: page(destination) },
+    });
+    const orientationIndex = html.indexOf('data-orientation-contract="v1"');
+    const bodyIndex = html.indexOf('id="orientacao-conteudo"');
+    assert.ok(orientationIndex >= 0, `${destination} has orientation contract`);
+    assert.ok(bodyIndex > orientationIndex, `${destination} places orientation before content`);
+    for (const field of ORIENTATION_FIELDS) {
+      assert.match(html, new RegExp(`data-orientation-field="${field}"`));
+    }
+    assert.equal([...html.matchAll(/data-orientation-field=/g)].length, 3);
+  }
+
+  for (const [destination, surfaces] of [
+    ["comercial", COMMERCIAL_SURFACES],
+    ["warmbly", WARMBLY_SURFACES],
+  ] as const) {
+    for (const surface of surfaces) {
+      const html = renderShell({
+        destination,
+        surface,
+        viewKind: "ready",
+        adapterMode: "http",
+        mockScenario: "http",
+        view: { kind: "ready", data: page(destination) },
+      });
+      assert.match(html, /data-orientation-contract="v1"/);
+      assert.equal([...html.matchAll(/data-orientation-field=/g)].length, 3);
+    }
+  }
+});
+
+test("the most severe unresolved alert owns one unambiguous primary action", () => {
+  const data = page("hoje");
+  data.attention = [
+    { ...ATTENTION_FIXTURES[2]!, recommended_action: "Revisar o CI" },
+    {
+      ...ATTENTION_FIXTURES[0]!,
+      recommended_action: "Inspecionar a coleta",
+      provenance: {
+        ...ATTENTION_FIXTURES[0]!.provenance,
+        freshness_status: "FRESH",
+      },
+    },
+  ];
+  data.priorities = [PRIORITY_FIXTURES[0]!];
+
+  const summary = buildOrientationSummary({
+    destination: "hoje",
+    view: { kind: "ready", data },
+  });
+  assert.match(summary.risk.label, /^Risco crítico:/);
+  assert.equal(summary.action.label, "Inspecionar a coleta");
+  assert.equal(summary.action.kind, "act");
+
+  const html = renderOrientationSummary(summary);
+  assert.equal([...html.matchAll(/data-orientation-primary-action=/g)].length, 1);
+  assert.match(html, /href="#orientacao-conteudo"/);
+});
+
+test("acknowledging an alert does not misrepresent it as resolved", () => {
+  const data = page("infra");
+  data.attention = [
+    {
+      ...ATTENTION_FIXTURES[0]!,
+      status: "acknowledged",
+      provenance: {
+        ...ATTENTION_FIXTURES[0]!.provenance,
+        freshness_status: "FRESH",
+      },
+    },
+  ];
+
+  const summary = buildOrientationSummary({
+    destination: "infra",
+    view: { kind: "ready", data },
+  });
+  assert.match(summary.risk.detail, /ainda não está resolvido/i);
+  assert.equal(summary.action.kind, "act");
+});
+
+test("resolved alerts supply freshness but never re-enter the action queue", () => {
+  const data = page("engenharia");
+  data.attention = [
+    {
+      ...ATTENTION_FIXTURES[2]!,
+      status: "resolved",
+      provenance: {
+        ...ATTENTION_FIXTURES[2]!.provenance,
+        freshness_status: "FRESH",
+      },
+    },
+  ];
+
+  const summary = buildOrientationSummary({
+    destination: "engenharia",
+    view: { kind: "ready", data },
+  });
+  assert.equal(summary.risk.label, "Nenhum risco acionável observado");
+  assert.equal(summary.action.kind, "none");
+  assert.equal(summary.action.href, null);
+});
+
+test("worst provenance wins and partial failure is never painted healthy", () => {
+  const data = page("infra");
+  data.attention = [
+    {
+      ...ATTENTION_FIXTURES[2]!,
+      status: "resolved",
+      provenance: {
+        ...ATTENTION_FIXTURES[2]!.provenance,
+        freshness_status: "FRESH",
+      },
+    },
+    { ...ATTENTION_FIXTURES[0]!, status: "resolved" },
+  ];
+
+  const summary = buildOrientationSummary({
+    destination: "infra",
+    view: { kind: "ready", data },
+  });
+  assert.equal(summary.state.label, "Leitura parcial com erro");
+  assert.equal(summary.state.tone, "critical");
+  assert.match(summary.risk.detail, /não interprete.*ausência/i);
+  assert.equal(summary.action.kind, "recover");
+});
+
+test("a stale view overrides an otherwise fresh payload", () => {
+  const data = page("financeiro");
+  data.attention = [
+    {
+      ...ATTENTION_FIXTURES[2]!,
+      status: "resolved",
+      provenance: {
+        ...ATTENTION_FIXTURES[2]!.provenance,
+        freshness_status: "FRESH",
+      },
+    },
+  ];
+
+  const summary = buildOrientationSummary({
+    destination: "financeiro",
+    view: { kind: "stale", data, message: "Recorte defasado" },
+  });
+  assert.equal(summary.state.label, "Há dados desatualizados");
+  assert.equal(summary.state.tone, "attention");
+  assert.match(summary.action.label, /origem antes de agir/i);
+});
+
+test("loading, empty, generic error and permission denial have distinct recovery copy", () => {
+  const loading = buildOrientationSummary({
+    destination: "clientes",
+    view: { kind: "loading" },
+  });
+  const empty = buildOrientationSummary({
+    destination: "clientes",
+    view: { kind: "empty", message: "Nenhum cliente neste recorte." },
+  });
+  const error = buildOrientationSummary({
+    destination: "clientes",
+    view: { kind: "error", code: "UPSTREAM_ERROR", message: "falhou" },
+  });
+  const denied = buildOrientationSummary({
+    destination: "clientes",
+    view: { kind: "error", code: "PERMISSION_DENIED", message: "forbidden" },
+  });
+
+  assert.equal(loading.action.kind, "wait");
+  assert.equal(empty.action.kind, "none");
+  assert.equal(error.action.href, "");
+  assert.match(error.action.label, /recarregar/i);
+  assert.match(denied.state.label, /sem permissão/i);
+  assert.equal(denied.action.href, null);
+  assert.match(denied.action.detail, /não tente contornar/i);
+});
+
+test("missing provenance remains unknown instead of becoming a healthy zero", () => {
+  const summary = buildOrientationSummary({
+    destination: "memoria",
+    view: { kind: "ready", data: page("memoria") },
+  });
+  assert.equal(summary.state.tone, "unknown");
+  assert.match(summary.state.label, /atualidade não comprovada/i);
+  assert.match(summary.risk.detail, /ausência de alertas não autoriza/i);
+  assert.equal(summary.action.kind, "recover");
+});
+
+test("priority is used only when no unresolved alert exists", () => {
+  const data = page("comercial");
+  data.priorities = [{ ...PRIORITY_FIXTURES[0]!, recommended_action: "Abrir a prioridade" }];
+
+  const summary = buildOrientationSummary({
+    destination: "comercial",
+    view: { kind: "ready", data },
+  });
+  assert.match(summary.risk.label, /^Prioridade 1:/);
+  assert.equal(summary.action.label, "Abrir a prioridade");
+});
+
+test("human update time is visible while the exact instant remains machine-readable", () => {
+  const data = page("agentes");
+  data.attention = [{ ...ATTENTION_FIXTURES[2]!, status: "resolved" }];
+  const summary = buildOrientationSummary({
+    destination: "agentes",
+    view: { kind: "ready", data },
+  });
+  const html = renderOrientationSummary(summary);
+
+  assert.match(html, /datetime="2026-08-20T18:00:00Z"/);
+  assert.match(html, /20\/08\/2026/);
+  assert.match(html, /America\/Sao_Paulo/);
+});
+
+test("untrusted alert and action text is escaped in the first viewport", () => {
+  const payload = '<img src=x onerror="alert(1)">';
+  const data = page("hoje");
+  data.attention = [
+    {
+      ...ATTENTION_FIXTURES[0]!,
+      title: payload,
+      summary: payload,
+      recommended_action: payload,
+      provenance: {
+        ...ATTENTION_FIXTURES[0]!.provenance,
+        freshness_status: "FRESH",
+      },
+    },
+  ];
+  const html = renderOrientationSummary(
+    buildOrientationSummary({ destination: "hoje", view: { kind: "ready", data } }),
+  );
+
+  assert.doesNotMatch(html, /<img/);
+  assert.doesNotMatch(html, /onerror="/);
+  assert.match(html, /&lt;img/);
+});
+
+test("non-fresh evidence suppresses a domain action even when the source recommends it", () => {
+  const data = page("hoje");
+  data.attention = [
+    {
+      ...ATTENTION_FIXTURES[0]!,
+      recommended_action: "Executar uma ação de domínio",
+    },
+  ];
+  const summary = buildOrientationSummary({
+    destination: "hoje",
+    view: { kind: "ready", data },
+  });
+
+  assert.equal(summary.state.tone, "critical");
+  assert.equal(summary.action.kind, "recover");
+  assert.notEqual(summary.action.label, "Executar uma ação de domínio");
+  assert.match(summary.action.label, /coleta antes de agir/i);
+});
+
+test("mobile orientation is compact and its only actionable target is touch-sized", () => {
+  const css = readFileSync(join(rootDir, "src/styles.css"), "utf8");
+  assert.match(css, /\.orientation-grid\s*\{[^}]*display:\s*grid/s);
+  assert.match(css, /\.orientation-primary-action\s*\{[^}]*min-height:\s*44px/s);
+  assert.match(
+    css,
+    /@media \(min-width: 880px\)[\s\S]*\.orientation-grid\s*\{[^}]*grid-template-columns:\s*repeat\(3,/,
+  );
+});

--- a/control-center/docs/ORIENTATION-CONTRACT.md
+++ b/control-center/docs/ORIENTATION-CONTRACT.md
@@ -12,7 +12,9 @@ do domínio. Em leitura corrida, ele responde:
 
 O contrato é calculado em `ui/orientation.ts` a partir do mesmo `ViewState` e do
 mesmo `DestinationPage` que compõem a tela. Nenhum domínio mantém uma cópia
-manual do resumo.
+manual do resumo. O título também nomeia a subrota Comercial/Warmbly atual em
+linguagem operacional, para que “onde estou” não dependa de uma subnav abaixo da
+primeira viewport.
 
 ## Regras de verdade
 
@@ -27,11 +29,20 @@ manual do resumo.
 - Loading, vazio, erro e falta de permissão têm estado, risco e recuperação
   próprios. Uma negação de acesso nunca convida o operador a contorná-la.
 - O resumo cria no máximo uma ação primária. Ela apenas leva ao conteúdo ou
-  recarrega a rota; não altera autorização, não escreve e não pula confirmação.
+  recarrega a rota atual, preservando subrota, recurso e filtros; não altera
+  autorização, não escreve e não pula confirmação. Texto `recommended_action`
+  vindo da origem aparece como recomendação observada no detalhe, nunca como se
+  o link fosse executar a mutação descrita.
+- Falta de permissão só é declarada para códigos exatos de autorização. O
+  adaptador preserva 401/403 como `PERMISSION_DENIED`; palavras incidentais como
+  “authoritative” não viram uma falsa negação de acesso.
 - Uma recomendação do domínio só vira ação primária quando todas as fontes do
   recorte estão `FRESH`. Em `STALE`, `UNKNOWN` ou `ERROR`, recuperar a evidência
   sempre vence a recomendação.
 - Texto de alerta, prioridade e ação é tratado como não confiável e escapado.
+  Título, justificativa e recomendação também têm limites explícitos no resumo,
+  para que prosa longa da origem não expulse a decisão da primeira viewport; o
+  conteúdo integral continua disponível nos cartões do domínio.
 
 ## Validação humana ainda necessária
 

--- a/control-center/docs/ORIENTATION-CONTRACT.md
+++ b/control-center/docs/ORIENTATION-CONTRACT.md
@@ -1,0 +1,54 @@
+# Contrato de orientação da primeira viewport
+
+Todas as rotas do web shell mostram o mesmo bloco cognitivo antes do conteúdo
+do domínio. Em leitura corrida, ele responde:
+
+1. **Estado atual** — se a leitura está atual, parcial, defasada, desconhecida,
+   indisponível, vazia ou ainda carregando;
+2. **Risco ou prioridade** — o alerta não resolvido mais severo, a primeira
+   prioridade ou uma declaração explícita de que o risco não foi comprovado;
+3. **Próxima ação** — uma única ação segura, uma recuperação ou a afirmação de
+   que nenhuma ação é requerida agora.
+
+O contrato é calculado em `ui/orientation.ts` a partir do mesmo `ViewState` e do
+mesmo `DestinationPage` que compõem a tela. Nenhum domínio mantém uma cópia
+manual do resumo.
+
+## Regras de verdade
+
+- `ERROR`, `UNKNOWN` e `STALE` vencem `FRESH` no resumo; falha parcial nunca
+  vira panorama saudável.
+- Alerta `acknowledged` continua acionável. Apenas `resolved` ou `dismissed`
+  sai da fila cognitiva.
+- A falta de alertas sem proveniência não vira “tudo bem”; aparece como
+  atualidade e risco não comprovados.
+- O horário humano usa `America/Sao_Paulo`, enquanto o instante UTC exato
+  permanece no atributo `datetime`.
+- Loading, vazio, erro e falta de permissão têm estado, risco e recuperação
+  próprios. Uma negação de acesso nunca convida o operador a contorná-la.
+- O resumo cria no máximo uma ação primária. Ela apenas leva ao conteúdo ou
+  recarrega a rota; não altera autorização, não escreve e não pula confirmação.
+- Uma recomendação do domínio só vira ação primária quando todas as fontes do
+  recorte estão `FRESH`. Em `STALE`, `UNKNOWN` ou `ERROR`, recuperar a evidência
+  sempre vence a recomendação.
+- Texto de alerta, prioridade e ação é tratado como não confiável e escapado.
+
+## Validação humana ainda necessária
+
+Os testes automatizados impedem divergência estrutural entre rotas, verificam
+os estados adversariais e fixam o alvo de toque em 44 CSS px. Isso não prova que
+uma pessoa compreende a tela em três segundos.
+
+O fechamento de Governance #106 continua exigindo exposição de exatamente três
+segundos com pessoa externa à implementação, em 390×844 e nas superfícies
+inventariadas pela auditoria #111. Registrar por rota:
+
+- onde a pessoa acredita estar;
+- qual risco ou prioridade identificou;
+- qual próxima ação escolheria;
+- acerto/erro e tempo;
+- SHA do runtime e captura sanitizada.
+
+Uma resposta errada abre ou complementa a issue específica da jornada. O
+resumo comum é o contrato de produto; autoavaliação, fixture ou LLM não é prova
+de compreensão humana.


### PR DESCRIPTION
## Escopo

- coloca localização/subrota atual, estado, risco/prioridade e próxima ação antes do conteúdo em todos os 10 destinos e subrotas registradas
- deriva o maior risco acionável e a freshness mais fraca do mesmo payload que compõe a tela
- distingue loading, vazio, stale, parcial, erro e falta de permissão com recuperação própria
- preserva 401/403 como `PERMISSION_DENIED` e não confunde prosa incidental sobre autoridade com negação de acesso
- mantém no máximo uma ação primária, deixa explícito que ela apenas abre o conteúdo e suprime ação de domínio quando qualquer fonte não está `FRESH`
- preserva subrota, recurso e filtros ao recarregar; remove somente override sintético de view
- limita prosa não confiável do backend no resumo, mantendo horário humano em America/Sao_Paulo, UTC machine-readable, alvo de toque de 44px e escape de conteúdo hostil

## Verificação

- typecheck e build do web shell
- 472 testes do web shell, incluindo 16 provas focadas de orientação
- 191 testes Python
- 25 testes de hardening
- seis checks remotos serão exigidos novamente no SHA corrigido

## Limite honesto

Este PR implementa e testa o contrato cognitivo comum, mas não substitui a exposição humana de exatamente três segundos. #106 deve permanecer aberta até a validação externa em 390x844 cobrir a matriz viva ligada a #111.

Refs #106
