### PR TITLE
[P1] Trocar abas móveis por tarefas explícitas

### DIFF
--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -424,7 +424,17 @@ try {
   await page.screenshot({ path: screenshotPath, fullPage: true });
   console.log(`screenshot=${screenshotPath}`);
 
-  await page.locator("nav[aria-label='Áreas do Control Center'] a", { hasText: "Comercial" }).click();
+  const desktopCommercial = page.locator(
+    "nav[aria-label='Áreas do Control Center'] a",
+    { hasText: "Comercial" },
+  );
+  if (await desktopCommercial.isVisible()) {
+    await desktopCommercial.click();
+  } else {
+    const moreTasks = page.locator(".task-nav-more > summary");
+    await moreTasks.click();
+    await page.locator("[data-task-nav='commercial']").click();
+  }
   await page.waitForSelector('[data-destination="comercial"]');
   const after = await page.locator("[data-destination]").getAttribute("data-destination");
   if (after !== "comercial") throw new Error(`nav did not change destination: ${after}`);

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -167,21 +167,14 @@ a {
 
 .nav {
   grid-area: nav;
-  display: flex;
-  gap: 0.25rem;
-  overflow-x: auto;
-  overscroll-behavior-x: contain;
-  -webkit-overflow-scrolling: touch;
-  padding: 0.4rem 0.5rem calc(0.4rem + env(safe-area-inset-bottom));
-  background: var(--bg-elev);
-  border-top: 1px solid var(--line);
+  display: none;
 }
 
 .subnav {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.35rem;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
+  overflow: visible;
   margin: 0 0 0.85rem;
   position: sticky;
   top: 0;
@@ -199,7 +192,9 @@ a {
   border-radius: 999px;
   color: var(--fg);
   text-decoration: none;
-  white-space: nowrap;
+  justify-content: center;
+  text-align: center;
+  white-space: normal;
 }
 
 .subnav a[aria-current="page"] {
@@ -218,6 +213,133 @@ a {
   position: static;
   margin: 0.5rem 0 0.2rem;
   padding: 0;
+}
+
+/* Mobile global navigation is a task launcher, not a sideways list of the
+   repository's ten domains. Four frequent/risky tasks remain visible; the
+   native details panel exposes every other area without swipe, hover or JS. */
+.task-nav {
+  grid-area: nav;
+  position: relative;
+  z-index: 12;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  align-items: stretch;
+  gap: 0.2rem;
+  min-width: 0;
+  padding: 0.35rem 0.35rem calc(0.35rem + env(safe-area-inset-bottom));
+  border-top: 1px solid var(--line);
+  background: var(--bg-elev);
+}
+
+.task-nav > a,
+.task-nav-more > summary {
+  min-width: 0;
+  min-height: 44px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.05rem;
+  padding: 0.35rem 0.15rem;
+  border: 1px solid transparent;
+  border-radius: 0.35rem;
+  color: var(--fg);
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.task-nav > a[aria-current="page"],
+.task-nav-more > summary[data-contains-current="true"] {
+  border-color: var(--accent);
+  background: #2a2620;
+}
+
+.task-nav-label,
+.task-nav-context {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.task-nav-label {
+  font-size: 0.74rem;
+  font-weight: 650;
+  line-height: 1.1;
+}
+
+.task-nav-context {
+  color: var(--fg-muted);
+  font-size: 0.61rem;
+  line-height: 1.05;
+}
+
+.task-nav-more {
+  position: static;
+  min-width: 0;
+}
+
+.task-nav-more > summary {
+  list-style: none;
+}
+
+.task-nav-more > summary::-webkit-details-marker {
+  display: none;
+}
+
+.task-nav-more-panel {
+  position: absolute;
+  left: 0.35rem;
+  right: 0.35rem;
+  bottom: calc(100% + 0.35rem);
+  max-height: min(65dvh, 30rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.35rem;
+  padding: 0.55rem;
+  border: 1px solid var(--accent);
+  border-radius: 0.5rem;
+  background: var(--bg-elev);
+  box-shadow: 0 -0.5rem 2rem rgb(0 0 0 / 35%);
+}
+
+.task-nav-more-title {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.task-nav-more-panel a {
+  min-height: 44px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 0.35rem;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.task-nav-more-panel a[aria-current="page"] {
+  border-color: var(--accent);
+  background: #2a2620;
+}
+
+.task-nav-more-panel .task-nav-label {
+  font-size: 0.86rem;
+}
+
+.task-nav-more-panel .task-nav-context {
+  margin-top: 0.12rem;
+  font-size: 0.72rem;
 }
 
 .operator-form {
@@ -874,8 +996,8 @@ h2 {
   }
 
   .nav {
+    display: flex;
     flex-direction: column;
-    overflow-x: hidden;
     /* Stretches to its grid row instead of a hardcoded calc(100dvh - 3rem)
        that never matched the real topbar height and pushed the shell past the
        viewport. Scrolls internally when the link list is taller than the row. */
@@ -884,6 +1006,16 @@ h2 {
     border-right: 1px solid var(--line);
     padding: 0.8rem 0.55rem;
     min-height: 0;
+  }
+
+  .task-nav {
+    display: none;
+  }
+
+  .subnav {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: visible;
   }
 
   .nav a {

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -342,6 +342,18 @@ a {
   font-size: 0.72rem;
 }
 
+/* At 200% zoom a 360px phone exposes roughly 180 CSS px. Five columns would
+   shrink below the 44px target contract, so the launcher wraps into two rows. */
+@media (max-width: 300px) {
+  .task-nav {
+    grid-template-columns: repeat(3, minmax(44px, 1fr));
+  }
+
+  .task-nav-more-panel {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 .operator-form {
   display: grid;
   gap: 0.45rem;

--- a/control-center/apps/web-shell/src/ui/navigation.ts
+++ b/control-center/apps/web-shell/src/ui/navigation.ts
@@ -1,0 +1,221 @@
+import {
+  DESTINATIONS,
+  hashFor,
+  type DestinationId,
+} from "../destinations";
+import { escapeHtml } from "../escape";
+import type { ViewKind } from "../view-state";
+
+export interface NavigationLocation {
+  readonly destination: DestinationId;
+  readonly surface?: string | null;
+}
+
+export interface MobileTaskTarget {
+  readonly key: string;
+  readonly label: string;
+  readonly context: string;
+  readonly destination: DestinationId;
+  readonly path: string;
+}
+
+export const MOBILE_PRIMARY_TASKS: readonly MobileTaskTarget[] = [
+  {
+    key: "today",
+    label: "Hoje",
+    context: "atenção",
+    destination: "hoje",
+    path: hashFor("hoje"),
+  },
+  {
+    key: "review",
+    label: "Revisar",
+    context: "mensagens",
+    destination: "warmbly",
+    path: hashFor("warmbly", null, { surface: "revisao" }),
+  },
+  {
+    key: "exceptions",
+    label: "Exceções",
+    context: "resolver",
+    destination: "comercial",
+    path: hashFor("comercial", null, { surface: "excecoes" }),
+  },
+  {
+    key: "clients",
+    label: "Clientes",
+    context: "inspecionar",
+    destination: "clientes",
+    path: hashFor("clientes"),
+  },
+] as const;
+
+export const MOBILE_MORE_TASKS: readonly MobileTaskTarget[] = [
+  {
+    key: "inbound",
+    label: "Tratar inbound",
+    context: "Crescimento",
+    destination: "crescimento",
+    path: hashFor("crescimento"),
+  },
+  {
+    key: "outbound",
+    label: "Pausar outbound",
+    context: "estado e controles seguros",
+    destination: "warmbly",
+    path: hashFor("warmbly", null, { surface: "operacao" }),
+  },
+  {
+    key: "infra",
+    label: "Checar incidente de infra",
+    context: "serviços e recuperação",
+    destination: "infra",
+    path: hashFor("infra"),
+  },
+  {
+    key: "commercial",
+    label: "Operar comercial",
+    context: "visão, rascunhos e pipeline",
+    destination: "comercial",
+    path: hashFor("comercial"),
+  },
+  {
+    key: "cohorts",
+    label: "Ver coortes outbound",
+    context: "Operação Warmbly",
+    destination: "warmbly",
+    path: hashFor("warmbly", null, { surface: "cohorts" }),
+  },
+  {
+    key: "finance",
+    label: "Consultar financeiro",
+    context: "somente leitura",
+    destination: "financeiro",
+    path: hashFor("financeiro"),
+  },
+  {
+    key: "engineering",
+    label: "Checar engenharia",
+    context: "repos e CI",
+    destination: "engenharia",
+    path: hashFor("engenharia"),
+  },
+  {
+    key: "memory",
+    label: "Consultar decisões",
+    context: "Memória",
+    destination: "memoria",
+    path: hashFor("memoria"),
+  },
+  {
+    key: "agents",
+    label: "Ver atividade de agentes",
+    context: "sessões e resultados",
+    destination: "agentes",
+    path: hashFor("agentes"),
+  },
+] as const;
+
+export const MOBILE_TASKS: readonly MobileTaskTarget[] = [
+  ...MOBILE_PRIMARY_TASKS,
+  ...MOBILE_MORE_TASKS,
+];
+
+function withView(path: string, viewKind: ViewKind): string {
+  if (viewKind === "ready") return path;
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}view=${encodeURIComponent(viewKind)}`;
+}
+
+/**
+ * Chooses one conceptual mobile task for the current deep route. The page
+ * header and contextual subnav retain the exact sub-surface; this mapping only
+ * prevents two global entries from both claiming aria-current.
+ */
+export function currentMobileTaskKey(location: NavigationLocation): string {
+  switch (location.destination) {
+    case "hoje":
+      return "today";
+    case "clientes":
+      return "clients";
+    case "crescimento":
+      return "inbound";
+    case "infra":
+      return "infra";
+    case "financeiro":
+      return "finance";
+    case "engenharia":
+      return "engineering";
+    case "memoria":
+      return "memory";
+    case "agentes":
+      return "agents";
+    case "comercial":
+      return location.surface === "excecoes" ? "exceptions" : "commercial";
+    case "warmbly":
+      if (location.surface === "revisao") return "review";
+      if (location.surface === "cohorts") return "cohorts";
+      return "outbound";
+  }
+}
+
+function mobileTaskLink(
+  task: MobileTaskTarget,
+  currentKey: string,
+  viewKind: ViewKind,
+): string {
+  const current = task.key === currentKey;
+  return `<a href="${escapeHtml(withView(task.path, viewKind))}" data-task-nav="${escapeHtml(task.key)}" aria-current="${current ? "page" : "false"}">
+    <span class="task-nav-label">${escapeHtml(task.label)}</span>
+    <span class="task-nav-context">${escapeHtml(task.context)}</span>
+    ${current ? '<span class="sr-only"> — tarefa atual</span>' : ""}
+  </a>`;
+}
+
+export function renderMobileTaskNavigation(
+  location: NavigationLocation,
+  viewKind: ViewKind,
+): string {
+  const currentKey = currentMobileTaskKey(location);
+  const primaryKeys = new Set(MOBILE_PRIMARY_TASKS.map((task) => task.key));
+  const moreCurrent = !primaryKeys.has(currentKey);
+  const primary = MOBILE_PRIMARY_TASKS.map((task) =>
+    mobileTaskLink(task, currentKey, viewKind),
+  ).join("");
+  const more = MOBILE_MORE_TASKS.map((task) =>
+    mobileTaskLink(task, currentKey, viewKind),
+  ).join("");
+
+  return `<nav class="task-nav" aria-label="Tarefas principais">
+    ${primary}
+    <details class="task-nav-more"${moreCurrent ? " open" : ""}>
+      <summary aria-label="Abrir mais tarefas" data-contains-current="${moreCurrent ? "true" : "false"}">
+        <span class="task-nav-label">Mais</span>
+        <span class="task-nav-context">tarefas</span>
+        ${moreCurrent ? '<span class="sr-only"> — contém a tarefa atual</span>' : ""}
+      </summary>
+      <div class="task-nav-more-panel" aria-label="Mais tarefas do Control Center">
+        <p class="task-nav-more-title">Mais tarefas</p>
+        ${more}
+      </div>
+    </details>
+  </nav>`;
+}
+
+export function renderDesktopNavigation(
+  location: NavigationLocation,
+  viewKind: ViewKind,
+): string {
+  const links = DESTINATIONS.map((item) => {
+    const current = item.id === location.destination;
+    return `<a
+      href="${escapeHtml(withView(hashFor(item.id), viewKind))}"
+      data-nav="${item.id}"
+      aria-current="${current ? "page" : "false"}"
+    >${escapeHtml(item.label)}</a>`;
+  }).join("");
+
+  return `<nav class="nav" aria-label="Áreas do Control Center">
+    ${links}
+  </nav>`;
+}

--- a/control-center/apps/web-shell/src/ui/navigation.ts
+++ b/control-center/apps/web-shell/src/ui/navigation.ts
@@ -1,6 +1,7 @@
 import {
   DESTINATIONS,
   hashFor,
+  withQueryParams,
   type DestinationId,
 } from "../destinations";
 import { escapeHtml } from "../escape";
@@ -9,6 +10,8 @@ import type { ViewKind } from "../view-state";
 export interface NavigationLocation {
   readonly destination: DestinationId;
   readonly surface?: string | null;
+  /** Exact current hash, including deep resource and list-filter context. */
+  readonly currentHref?: string;
 }
 
 export interface MobileTaskTarget {
@@ -60,7 +63,7 @@ export const MOBILE_MORE_TASKS: readonly MobileTaskTarget[] = [
   },
   {
     key: "outbound",
-    label: "Pausar outbound",
+    label: "Abrir pausa outbound",
     context: "estado e controles seguros",
     destination: "warmbly",
     path: hashFor("warmbly", null, { surface: "operacao" }),
@@ -121,10 +124,17 @@ export const MOBILE_TASKS: readonly MobileTaskTarget[] = [
   ...MOBILE_MORE_TASKS,
 ];
 
-function withView(path: string, viewKind: ViewKind): string {
-  if (viewKind === "ready") return path;
-  const separator = path.includes("?") ? "&" : "?";
-  return `${path}${separator}view=${encodeURIComponent(viewKind)}`;
+function navigationHref(
+  canonicalPath: string,
+  current: boolean,
+  location: NavigationLocation,
+  viewKind: ViewKind,
+  preserveViewState: boolean,
+): string {
+  const path = current && location.currentHref ? location.currentHref : canonicalPath;
+  return withQueryParams(path, {
+    view: preserveViewState && viewKind !== "ready" ? viewKind : null,
+  });
 }
 
 /**
@@ -162,10 +172,13 @@ export function currentMobileTaskKey(location: NavigationLocation): string {
 function mobileTaskLink(
   task: MobileTaskTarget,
   currentKey: string,
+  location: NavigationLocation,
   viewKind: ViewKind,
+  preserveViewState: boolean,
 ): string {
   const current = task.key === currentKey;
-  return `<a href="${escapeHtml(withView(task.path, viewKind))}" data-task-nav="${escapeHtml(task.key)}" aria-current="${current ? "page" : "false"}">
+  const href = navigationHref(task.path, current, location, viewKind, preserveViewState);
+  return `<a href="${escapeHtml(href)}" data-task-nav="${escapeHtml(task.key)}" aria-current="${current ? "page" : "false"}">
     <span class="task-nav-label">${escapeHtml(task.label)}</span>
     <span class="task-nav-context">${escapeHtml(task.context)}</span>
     ${current ? '<span class="sr-only"> — tarefa atual</span>' : ""}
@@ -175,23 +188,29 @@ function mobileTaskLink(
 export function renderMobileTaskNavigation(
   location: NavigationLocation,
   viewKind: ViewKind,
+  preserveViewState = false,
 ): string {
   const currentKey = currentMobileTaskKey(location);
   const primaryKeys = new Set(MOBILE_PRIMARY_TASKS.map((task) => task.key));
   const moreCurrent = !primaryKeys.has(currentKey);
+  const currentMoreTask = MOBILE_MORE_TASKS.find((task) => task.key === currentKey);
   const primary = MOBILE_PRIMARY_TASKS.map((task) =>
-    mobileTaskLink(task, currentKey, viewKind),
+    mobileTaskLink(task, currentKey, location, viewKind, preserveViewState),
   ).join("");
   const more = MOBILE_MORE_TASKS.map((task) =>
-    mobileTaskLink(task, currentKey, viewKind),
+    mobileTaskLink(task, currentKey, location, viewKind, preserveViewState),
   ).join("");
+  const moreSummaryLabel = currentMoreTask
+    ? `Abrir mais tarefas; tarefa atual: ${currentMoreTask.label}`
+    : "Abrir mais tarefas";
+  const moreSummaryContext = currentMoreTask?.label ?? "tarefas";
 
   return `<nav class="task-nav" aria-label="Tarefas principais">
     ${primary}
-    <details class="task-nav-more"${moreCurrent ? " open" : ""}>
-      <summary aria-label="Abrir mais tarefas" data-contains-current="${moreCurrent ? "true" : "false"}">
+    <details class="task-nav-more">
+      <summary aria-label="${escapeHtml(moreSummaryLabel)}" data-contains-current="${moreCurrent ? "true" : "false"}">
         <span class="task-nav-label">Mais</span>
-        <span class="task-nav-context">tarefas</span>
+        <span class="task-nav-context">${escapeHtml(moreSummaryContext)}</span>
         ${moreCurrent ? '<span class="sr-only"> — contém a tarefa atual</span>' : ""}
       </summary>
       <div class="task-nav-more-panel" aria-label="Mais tarefas do Control Center">
@@ -205,11 +224,19 @@ export function renderMobileTaskNavigation(
 export function renderDesktopNavigation(
   location: NavigationLocation,
   viewKind: ViewKind,
+  preserveViewState = false,
 ): string {
   const links = DESTINATIONS.map((item) => {
     const current = item.id === location.destination;
+    const href = navigationHref(
+      hashFor(item.id),
+      current,
+      location,
+      viewKind,
+      preserveViewState,
+    );
     return `<a
-      href="${escapeHtml(withView(hashFor(item.id), viewKind))}"
+      href="${escapeHtml(href)}"
       data-nav="${item.id}"
       aria-current="${current ? "page" : "false"}"
     >${escapeHtml(item.label)}</a>`;

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -367,7 +367,9 @@ export function renderShell(model: ShellModel): string {
   const navigationLocation = {
     destination: model.destination,
     ...(model.surface !== undefined ? { surface: model.surface } : {}),
+    ...(model.hash !== undefined ? { currentHref: model.hash } : {}),
   };
+  const preserveNavigationViewState = model.adapterMode !== "http";
 
   const page =
     model.view.kind === "ready" || model.view.kind === "stale" ? model.view.data : null;
@@ -416,8 +418,8 @@ export function renderShell(model: ShellModel): string {
         </a>
         <p class="operator" title="${escapeHtml(operatorId)}">${escapeHtml(operator)}${model.adapterMode === "http" ? "" : " · modo mock"}</p>
       </header>
-      ${renderMobileTaskNavigation(navigationLocation, model.viewKind)}
-      ${renderDesktopNavigation(navigationLocation, model.viewKind)}
+      ${renderMobileTaskNavigation(navigationLocation, model.viewKind, preserveNavigationViewState)}
+      ${renderDesktopNavigation(navigationLocation, model.viewKind, preserveNavigationViewState)}
       <main id="conteudo" tabindex="-1">
         <header class="page-head">
           <h1>${escapeHtml(label)}</h1>

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -35,6 +35,7 @@ import {
   memoriaGroups,
 } from "./domains";
 import { warmblyBlock } from "./warmbly";
+import { renderDesktopNavigation, renderMobileTaskNavigation } from "./navigation";
 import {
   pendingResumeConfirmation,
   resumeObservationFingerprint,
@@ -363,16 +364,10 @@ function mockLab(destination: DestinationId, current: ViewKind): string {
 export function renderShell(model: ShellModel): string {
   const dest = DESTINATIONS.find((item) => item.id === model.destination);
   const label = dest?.label ?? model.destination;
-  const nav = DESTINATIONS.map((item) => {
-    const current = item.id === model.destination;
-    return `
-      <a
-        href="${hashFor(item.id, model.viewKind === "ready" ? null : model.viewKind)}"
-        data-nav="${item.id}"
-        aria-current="${current ? "page" : "false"}"
-      >${escapeHtml(item.label)}</a>
-    `;
-  }).join("");
+  const navigationLocation = {
+    destination: model.destination,
+    ...(model.surface !== undefined ? { surface: model.surface } : {}),
+  };
 
   const page =
     model.view.kind === "ready" || model.view.kind === "stale" ? model.view.data : null;
@@ -421,9 +416,8 @@ export function renderShell(model: ShellModel): string {
         </a>
         <p class="operator" title="${escapeHtml(operatorId)}">${escapeHtml(operator)}${model.adapterMode === "http" ? "" : " · modo mock"}</p>
       </header>
-      <nav class="nav" aria-label="Áreas do Control Center">
-        ${nav}
-      </nav>
+      ${renderMobileTaskNavigation(navigationLocation, model.viewKind)}
+      ${renderDesktopNavigation(navigationLocation, model.viewKind)}
       <main id="conteudo" tabindex="-1">
         <header class="page-head">
           <h1>${escapeHtml(label)}</h1>

--- a/control-center/apps/web-shell/tests/navigation.test.ts
+++ b/control-center/apps/web-shell/tests/navigation.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { DESTINATION_IDS } from "../src/destinations";
+import {
+  MOBILE_MORE_TASKS,
+  MOBILE_PRIMARY_TASKS,
+  MOBILE_TASKS,
+  currentMobileTaskKey,
+  renderDesktopNavigation,
+  renderMobileTaskNavigation,
+} from "../src/ui/navigation";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("mobile exposes exactly four primary destinations plus an explicit task panel", () => {
+  assert.equal(MOBILE_PRIMARY_TASKS.length, 4);
+  assert.equal(MOBILE_MORE_TASKS.length, 9);
+  assert.deepEqual(
+    MOBILE_PRIMARY_TASKS.map((task) => task.key),
+    ["today", "review", "exceptions", "clients"],
+  );
+  assert.equal(new Set(MOBILE_TASKS.map((task) => task.key)).size, MOBILE_TASKS.length);
+  assert.equal(new Set(MOBILE_TASKS.map((task) => task.path)).size, MOBILE_TASKS.length);
+
+  const html = renderMobileTaskNavigation({ destination: "hoje", surface: null }, "ready");
+  const primaryMarkup = html.split('<details class="task-nav-more"')[0] ?? "";
+  assert.equal([...primaryMarkup.matchAll(/data-task-nav=/g)].length, 4);
+  assert.match(html, /<details class="task-nav-more">/);
+  assert.match(html, /<summary aria-label="Abrir mais tarefas"/);
+  assert.match(html, />Mais tarefas</);
+  assert.doesNotMatch(html, /hamburger|☰/i);
+});
+
+test("every registered destination remains reachable without swipe or hover", () => {
+  const represented = new Set(MOBILE_TASKS.map((task) => task.destination));
+  assert.deepEqual([...represented].sort(), [...DESTINATION_IDS].sort());
+
+  const html = renderMobileTaskNavigation({ destination: "hoje" }, "ready");
+  for (const task of MOBILE_TASKS) {
+    assert.match(html, new RegExp(`data-task-nav="${task.key}"`));
+    assert.match(html, new RegExp(`href="${task.path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`));
+  }
+});
+
+test("the six named high-frequency or high-risk tasks have direct deep links", () => {
+  const byKey = new Map(MOBILE_TASKS.map((task) => [task.key, task]));
+  assert.equal(byKey.get("review")?.path, "#/warmbly/revisao");
+  assert.equal(byKey.get("inbound")?.path, "#/crescimento");
+  assert.equal(byKey.get("exceptions")?.path, "#/comercial/excecoes");
+  assert.equal(byKey.get("outbound")?.path, "#/warmbly/operacao");
+  assert.equal(byKey.get("clients")?.path, "#/clientes");
+  assert.equal(byKey.get("infra")?.path, "#/infra");
+});
+
+test("deep routes map to one conceptual current task", () => {
+  assert.equal(currentMobileTaskKey({ destination: "warmbly", surface: "revisao" }), "review");
+  assert.equal(currentMobileTaskKey({ destination: "warmbly", surface: "cohorts" }), "cohorts");
+  assert.equal(currentMobileTaskKey({ destination: "warmbly", surface: null }), "outbound");
+  assert.equal(currentMobileTaskKey({ destination: "comercial", surface: "excecoes" }), "exceptions");
+  assert.equal(currentMobileTaskKey({ destination: "comercial", surface: "pipeline" }), "commercial");
+  assert.equal(currentMobileTaskKey({ destination: "clientes" }), "clients");
+});
+
+test("the current task is unique and secondary routes open the panel that contains it", () => {
+  const primary = renderMobileTaskNavigation(
+    { destination: "warmbly", surface: "revisao" },
+    "ready",
+  );
+  assert.equal([...primary.matchAll(/aria-current="page"/g)].length, 1);
+  assert.match(primary, /data-task-nav="review" aria-current="page"/);
+  assert.doesNotMatch(primary, /<details class="task-nav-more" open>/);
+
+  const secondary = renderMobileTaskNavigation({ destination: "financeiro" }, "ready");
+  assert.equal([...secondary.matchAll(/aria-current="page"/g)].length, 1);
+  assert.match(secondary, /<details class="task-nav-more" open>/);
+  assert.match(secondary, /data-contains-current="true"/);
+  assert.match(secondary, /data-task-nav="finance" aria-current="page"/);
+});
+
+test("mock view state survives every task link without weakening deep URLs", () => {
+  const html = renderMobileTaskNavigation({ destination: "hoje" }, "error");
+  assert.equal([...html.matchAll(/data-task-nav=/g)].length, MOBILE_TASKS.length);
+  assert.equal([...html.matchAll(/\?view=error/g)].length, MOBILE_TASKS.length);
+  assert.match(html, /href="#\/warmbly\/revisao\?view=error"/);
+});
+
+test("desktop keeps the complete registry and one current area", () => {
+  const html = renderDesktopNavigation({ destination: "infra" }, "ready");
+  assert.equal([...html.matchAll(/data-nav=/g)].length, DESTINATION_IDS.length);
+  assert.equal([...html.matchAll(/aria-current="page"/g)].length, 1);
+  assert.match(html, /data-nav="infra"[\s\S]*aria-current="page"/);
+});
+
+test("mobile task targets, contextual tabs and long labels wrap instead of scrolling sideways", () => {
+  const css = readFileSync(join(rootDir, "src/styles.css"), "utf8");
+  assert.doesNotMatch(css, /\.nav\s*\{[^}]*overflow-x:\s*auto/s);
+  assert.doesNotMatch(css, /\.subnav\s*\{[^}]*overflow-x:\s*auto/s);
+  assert.match(css, /\.task-nav\s*\{[^}]*grid-template-columns:\s*repeat\(5,/s);
+  assert.match(css, /\.task-nav\s*>\s*a,[\s\S]*min-height:\s*44px/);
+  assert.match(css, /\.task-nav-label,[\s\S]*overflow-wrap:\s*anywhere/);
+  assert.match(css, /\.subnav a\s*\{[^}]*white-space:\s*normal/s);
+  assert.match(css, /\.task-nav-more-panel\s*\{[^}]*overflow-y:\s*auto/s);
+});
+
+test("safe-area padding and vertical task panel avoid the system gesture edge", () => {
+  const css = readFileSync(join(rootDir, "src/styles.css"), "utf8");
+  assert.match(css, /\.task-nav\s*\{[^}]*env\(safe-area-inset-bottom\)/s);
+  assert.match(css, /\.task-nav-more-panel\s*\{[^}]*bottom:\s*calc\(100%/s);
+  assert.match(css, /max-height:\s*min\(65dvh,/);
+  assert.doesNotMatch(css, /\.task-nav-more-panel\s*\{[^}]*overflow-x/s);
+});

--- a/control-center/apps/web-shell/tests/navigation.test.ts
+++ b/control-center/apps/web-shell/tests/navigation.test.ts
@@ -64,7 +64,7 @@ test("deep routes map to one conceptual current task", () => {
   assert.equal(currentMobileTaskKey({ destination: "clientes" }), "clients");
 });
 
-test("the current task is unique and secondary routes open the panel that contains it", () => {
+test("the current task is unique and a closed secondary panel names the task it contains", () => {
   const primary = renderMobileTaskNavigation(
     { destination: "warmbly", surface: "revisao" },
     "ready",
@@ -75,16 +75,36 @@ test("the current task is unique and secondary routes open the panel that contai
 
   const secondary = renderMobileTaskNavigation({ destination: "financeiro" }, "ready");
   assert.equal([...secondary.matchAll(/aria-current="page"/g)].length, 1);
-  assert.match(secondary, /<details class="task-nav-more" open>/);
+  assert.doesNotMatch(secondary, /<details class="task-nav-more" open>/);
   assert.match(secondary, /data-contains-current="true"/);
+  assert.match(secondary, /aria-label="Abrir mais tarefas; tarefa atual: Consultar financeiro"/);
+  assert.match(secondary, /<span class="task-nav-context">Consultar financeiro<\/span>/);
   assert.match(secondary, /data-task-nav="finance" aria-current="page"/);
 });
 
 test("mock view state survives every task link without weakening deep URLs", () => {
-  const html = renderMobileTaskNavigation({ destination: "hoje" }, "error");
+  const html = renderMobileTaskNavigation({ destination: "hoje" }, "error", true);
   assert.equal([...html.matchAll(/data-task-nav=/g)].length, MOBILE_TASKS.length);
   assert.equal([...html.matchAll(/\?view=error/g)].length, MOBILE_TASKS.length);
   assert.match(html, /href="#\/warmbly\/revisao\?view=error"/);
+});
+
+test("production navigation drops synthetic view state and preserves exact current context", () => {
+  const location = {
+    destination: "clientes" as const,
+    currentHref: "#/clientes/cli-1?status=open&sort=name&view=error",
+  };
+  const mobile = renderMobileTaskNavigation(location, "error", false);
+  assert.doesNotMatch(mobile, /view=error/);
+  assert.match(
+    mobile,
+    /href="#\/clientes\/cli-1\?status=open&amp;sort=name" data-task-nav="clients" aria-current="page"/,
+  );
+  assert.doesNotMatch(mobile, /#\/hoje\?status=open/);
+
+  const desktop = renderDesktopNavigation(location, "error", false);
+  assert.doesNotMatch(desktop, /view=error/);
+  assert.match(desktop, /href="#\/clientes\/cli-1\?status=open&amp;sort=name"[\s\S]*data-nav="clientes"/);
 });
 
 test("desktop keeps the complete registry and one current area", () => {
@@ -103,6 +123,14 @@ test("mobile task targets, contextual tabs and long labels wrap instead of scrol
   assert.match(css, /\.task-nav-label,[\s\S]*overflow-wrap:\s*anywhere/);
   assert.match(css, /\.subnav a\s*\{[^}]*white-space:\s*normal/s);
   assert.match(css, /\.task-nav-more-panel\s*\{[^}]*overflow-y:\s*auto/s);
+  assert.match(
+    css,
+    /@media \(max-width:\s*300px\)[\s\S]*\.task-nav\s*\{[^}]*grid-template-columns:\s*repeat\(3,\s*minmax\(44px,\s*1fr\)\)/s,
+  );
+  assert.match(
+    css,
+    /@media \(max-width:\s*300px\)[\s\S]*\.task-nav-more-panel\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)/s,
+  );
 });
 
 test("safe-area padding and vertical task panel avoid the system gesture edge", () => {

--- a/control-center/apps/web-shell/tests/navigation.test.ts
+++ b/control-center/apps/web-shell/tests/navigation.test.ts
@@ -112,3 +112,10 @@ test("safe-area padding and vertical task panel avoid the system gesture edge", 
   assert.match(css, /max-height:\s*min\(65dvh,/);
   assert.doesNotMatch(css, /\.task-nav-more-panel\s*\{[^}]*overflow-x/s);
 });
+
+test("the browser probe navigates through the visible mobile task launcher", () => {
+  const probe = readFileSync(join(rootDir, "scripts/launch-probe.mjs"), "utf8");
+  assert.match(probe, /desktopCommercial\.isVisible\(\)/);
+  assert.match(probe, /\.task-nav-more > summary/);
+  assert.match(probe, /\[data-task-nav='commercial'\]/);
+});

--- a/control-center/apps/web-shell/tests/ux.test.ts
+++ b/control-center/apps/web-shell/tests/ux.test.ts
@@ -110,11 +110,13 @@ test("loading, empty, stale and error remain distinct view states", () => {
   }
 });
 
-test("viewport overflow is confined to nav/subnav; html/body clip accidental horizontal scroll", () => {
+test("global and contextual navigation need no horizontal discovery", () => {
   const css = readFileSync(join(rootDir, "src/styles.css"), "utf8");
   assert.match(css, /html,\s*body\s*\{[^}]*overflow-x:\s*hidden/s);
-  assert.match(css, /\.nav\s*\{[^}]*overflow-x:\s*auto/s);
-  assert.match(css, /\.subnav\s*\{[^}]*overflow-x:\s*auto/s);
+  assert.doesNotMatch(css, /\.nav\s*\{[^}]*overflow-x:\s*auto/s);
+  assert.doesNotMatch(css, /\.subnav\s*\{[^}]*overflow-x:\s*auto/s);
+  assert.match(css, /\.task-nav\s*\{[^}]*grid-template-columns:\s*repeat\(5,/s);
+  assert.match(css, /\.subnav\s*\{[^}]*grid-template-columns:\s*repeat\(2,/s);
   assert.match(css, /min-height:\s*44px/);
 });
 

--- a/control-center/docs/MOBILE-TASK-NAVIGATION.md
+++ b/control-center/docs/MOBILE-TASK-NAVIGATION.md
@@ -1,0 +1,49 @@
+# Navegação móvel orientada às tarefas
+
+No mobile, o Control Center não apresenta as dez áreas como um trilho horizontal.
+Quatro tarefas ficam sempre visíveis:
+
+- entender a atenção de **Hoje**;
+- **Revisar** mensagens;
+- tratar **Exceções**;
+- inspecionar **Clientes**.
+
+`Mais tarefas` é um painel nativo `details/summary`, identificado por texto e
+operável sem JavaScript. Ele torna diretamente alcançáveis tratar inbound,
+pausar outbound e checar incidente de infraestrutura, além das demais áreas do
+produto. Não é um menu hambúrguer indiferenciado: cada entrada usa verbo,
+objeto e contexto operacional.
+
+O desktop continua mostrando o registro completo de áreas. Ambos os modos usam
+links hash reais, portanto preservam deep links, histórico, back/forward,
+teclado e semântica de `aria-current`.
+
+## Regras de interação
+
+- Existem exatamente quatro destinos primários móveis e uma entrada explícita
+  para as demais tarefas.
+- A rota atual corresponde a uma única tarefa global. Quando ela está no painel
+  secundário, o painel inicia aberto e a entrada atual fica visível.
+- Toda área em `DESTINATIONS` possui ao menos uma entrada móvel; nenhuma depende
+  de swipe, hover ou memória.
+- Alvos de toque têm no mínimo 44 CSS px e a barra respeita
+  `safe-area-inset-bottom`.
+- Textos longos quebram linha. O painel secundário rola verticalmente dentro de
+  um limite, nunca lateralmente.
+- Subnavegações contextuais usam grid no mobile e `flex-wrap` no desktop. Um
+  segundo trilho horizontal não é permitido.
+- O painel apenas navega. Não envia email, não emite GO, não retoma outbound e
+  não executa mutação.
+
+## Validação pendente
+
+Os testes automatizados verificam cobertura do registro, links profundos,
+estado atual único, semântica nativa, ausência de overflow horizontal, zoom
+estrutural e alvos de toque. O fechamento de Governance #107 ainda exige uma
+pessoa externa à implementação nos viewports 360×800, 390×844, 430×932 e
+desktop, incluindo textos longos e zoom de 200%.
+
+Registrar se, em três segundos, a pessoa identifica a área atual e inicia sem
+instrução prévia cada uma destas tarefas: revisão, inbound, exceção, pausa de
+outbound, cliente e incidente de infraestrutura. Fixture, autoavaliação ou LLM
+não substitui essa evidência humana.

--- a/control-center/docs/MOBILE-TASK-NAVIGATION.md
+++ b/control-center/docs/MOBILE-TASK-NAVIGATION.md
@@ -10,9 +10,9 @@ Quatro tarefas ficam sempre visíveis:
 
 `Mais tarefas` é um painel nativo `details/summary`, identificado por texto e
 operável sem JavaScript. Ele torna diretamente alcançáveis tratar inbound,
-pausar outbound e checar incidente de infraestrutura, além das demais áreas do
-produto. Não é um menu hambúrguer indiferenciado: cada entrada usa verbo,
-objeto e contexto operacional.
+abrir os controles de pausa outbound e checar incidente de infraestrutura,
+além das demais áreas do produto. Não é um menu hambúrguer indiferenciado:
+cada entrada usa verbo, objeto e contexto operacional.
 
 O desktop continua mostrando o registro completo de áreas. Ambos os modos usam
 links hash reais, portanto preservam deep links, histórico, back/forward,
@@ -23,17 +23,22 @@ teclado e semântica de `aria-current`.
 - Existem exatamente quatro destinos primários móveis e uma entrada explícita
   para as demais tarefas.
 - A rota atual corresponde a uma única tarefa global. Quando ela está no painel
-  secundário, o painel inicia aberto e a entrada atual fica visível.
+  secundário, `Mais` identifica pelo nome a tarefa atual sem abrir e cobrir o
+  conteúdo; ao abrir, a entrada atual fica marcada.
 - Toda área em `DESTINATIONS` possui ao menos uma entrada móvel; nenhuma depende
   de swipe, hover ou memória.
 - Alvos de toque têm no mínimo 44 CSS px e a barra respeita
-  `safe-area-inset-bottom`.
+  `safe-area-inset-bottom`. Abaixo de 300 CSS px (incluindo um telefone a 200%
+  de zoom), os cinco lançadores quebram em duas linhas para manter esse mínimo.
 - Textos longos quebram linha. O painel secundário rola verticalmente dentro de
   um limite, nunca lateralmente.
 - Subnavegações contextuais usam grid no mobile e `flex-wrap` no desktop. Um
   segundo trilho horizontal não é permitido.
 - O painel apenas navega. Não envia email, não emite GO, não retoma outbound e
   não executa mutação.
+- Em produção, a navegação nunca propaga o parâmetro sintético `view`; na
+  fixture mock ele é preservado para permitir percorrer o mesmo cenário.
+- O link da tarefa/área atual preserva subrota, recurso e filtros da URL atual.
 
 ## Validação pendente
 


### PR DESCRIPTION
## Escopo

- substitui o trilho horizontal de dez áreas por quatro tarefas móveis primárias e um painel textual de demais tarefas
- expõe deep links diretos para revisão, inbound, exceções, controles de pausa outbound, cliente e incidente de infra
- mantém todas as áreas de `DESTINATIONS` alcançáveis e um único `aria-current`
- identifica no lançador `Mais` a tarefa secundária atual sem abrir automaticamente um painel sobre o conteúdo
- transforma subnavs móveis em grid e desktop em wrap, removendo a segunda descoberta horizontal
- preserva o hash exato da tarefa/área atual, incluindo subrota, recurso, filtros e posição
- restringe o parâmetro sintético `view` ao modo mock; falhas reais não contaminam os demais destinos
- mantém alvos de 44px em viewports estreitos e zoom de 200% ao quebrar o lançador em duas linhas abaixo de 300 CSS px
- preserva histórico, teclado, leitor de tela, safe area e quebra de textos longos

## Verificação local

- 483 testes do web shell
- 11 testes focados de navegação móvel
- typecheck e build Vite do web shell
- 12 testes E2E/fallback
- 25 testes de hardening
- 188 testes Python de autoridade, oferta, delivery e prova de lote

## Limite honesto

A sonda Chromium local continua sujeita às bibliotecas do ambiente; o CI instala as dependências Playwright e executa a prova real. Este PR não declara o teste humano de três segundos concluído: #107 deve permanecer aberta até validação externa em 360×800, 390×844, 430×932, desktop, textos longos e zoom de 200%.

Refs #107
