### PR TITLE
[P1] Bloquear espera sem feedback e regressões de performance

### DIFF
--- a/.github/workflows/control-center.yml
+++ b/.github/workflows/control-center.yml
@@ -116,9 +116,12 @@ jobs:
           CONTROL_CENTER_TEST_DATABASE_URL: postgres://control_center:control_center@127.0.0.1:5432/control_center
           CONTROL_CENTER_DATABASE_URL: postgres://control_center:control_center@127.0.0.1:5432/control_center
           CC_SCREENSHOT_DIR: ${{ runner.temp }}/cc-e2e-screenshots
+          CC_PERFORMANCE_BUILD_REPORT: ${{ runner.temp }}/cc-performance/build.json
+          CC_PERFORMANCE_LAB_REPORT: ${{ runner.temp }}/cc-performance/mobile-lab.json
         run: |
           set -o pipefail
           mkdir -p "$CC_SCREENSHOT_DIR"
+          mkdir -p "${{ runner.temp }}/cc-performance"
           npm run test:e2e | tee /tmp/cc-e2e.log
           grep -E "context_risks=[1-9]" /tmp/cc-e2e.log
           grep -E "nav_changed_to=comercial" /tmp/cc-e2e.log
@@ -126,6 +129,8 @@ jobs:
           grep -E "view_state_driven=empty" /tmp/cc-e2e.log
           grep -E "visual_routes=[1-9][0-9]* source=browser_registry" /tmp/cc-e2e.log
           grep -E "visual_gate=PASS routes=[1-9][0-9]* axe_checks=[1-9]" /tmp/cc-e2e.log
+          grep -E "performance_build=PASS" /tmp/cc-e2e.log
+          grep -E "performance_lab=PASS routes=3 samples=12 canonical_sampled=false" /tmp/cc-e2e.log
       - name: Upload visual gate artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -133,6 +138,13 @@ jobs:
           name: control-center-visual-gate
           path: ${{ runner.temp }}/cc-e2e-screenshots
           if-no-files-found: warn
+      - name: Upload performance reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: control-center-performance
+          path: ${{ runner.temp }}/cc-performance
+          if-no-files-found: error
 
   docker:
     runs-on: ubuntu-latest

--- a/control-center/apps/web-shell/index.html
+++ b/control-center/apps/web-shell/index.html
@@ -19,7 +19,19 @@
     <title>Control Center — Confenge</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="boot-shell" data-boot-shell="true" role="status" aria-live="polite">
+        <header class="boot-shell__topbar">
+          <strong>CONFENGE</strong>
+          <span>Control Center</span>
+        </header>
+        <main class="boot-shell__main">
+          <p class="kicker">Cockpit operacional</p>
+          <h1>Carregando o recorte atual…</h1>
+          <p>A estrutura está pronta; os dados autenticados ainda estão sendo lidos.</p>
+        </main>
+      </div>
+    </div>
     <noscript>
       Este cockpit precisa de JavaScript. No diretório
       <code>control-center/apps/web-shell</code> execute

--- a/control-center/apps/web-shell/package.json
+++ b/control-center/apps/web-shell/package.json
@@ -11,6 +11,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview --host 127.0.0.1 --port 4173",
+    "audit:performance": "npm run build && node scripts/performance-budget.mjs",
     "audit:ux": "tsx scripts/live-ux-audit.ts",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test tests/*.test.ts",

--- a/control-center/apps/web-shell/performance-budgets.json
+++ b/control-center/apps/web-shell/performance-budgets.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "control-center.performance-budget.v1",
+  "simulation": {
+    "name": "mobile-lab",
+    "viewport": { "width": 390, "height": 844 },
+    "latency_ms": 120,
+    "download_kbps": 1600,
+    "upload_kbps": 750,
+    "cpu_slowdown": 4,
+    "samples_per_route": 4
+  },
+  "routes": [
+    { "id": "hoje", "hash": "#/hoje" },
+    { "id": "rascunhos", "hash": "#/comercial/rascunhos" },
+    { "id": "coortes", "hash": "#/warmbly/cohorts" }
+  ],
+  "budgets": {
+    "interaction_feedback_ms": 100,
+    "navigation_structure_ms": 200,
+    "inp_p75_ms": 200,
+    "lcp_p75_ms": 2500,
+    "cls_p75": 0.1,
+    "long_task_max_ms": 350,
+    "initial_request_count": 16,
+    "javascript_raw_bytes": 375000,
+    "javascript_gzip_bytes": 110000,
+    "css_raw_bytes": 24000,
+    "css_gzip_bytes": 7000,
+    "bundle_gzip_bytes": 120000
+  }
+}

--- a/control-center/apps/web-shell/scripts/e2e.mjs
+++ b/control-center/apps/web-shell/scripts/e2e.mjs
@@ -79,7 +79,22 @@ async function tryPlaywright(baseUrl, screenshot) {
   process.stdout.write(probe.stdout || "");
   process.stderr.write(probe.stderr || "");
   if (probe.status === 0) {
-    return { ok: true, output };
+    const performance = spawnSync("node", [join(here, "performance-probe.mjs"), baseUrl], {
+      cwd: app,
+      encoding: "utf8",
+      env: process.env,
+    });
+    const performanceOutput = `${performance.stdout || ""}${performance.stderr || ""}`;
+    process.stdout.write(performance.stdout || "");
+    process.stderr.write(performance.stderr || "");
+    if (performance.status === 0) {
+      return { ok: true, output: `${output}${performanceOutput}` };
+    }
+    return {
+      ok: false,
+      launcher: isOsLibLauncherFailure(performanceOutput),
+      output: `${output}${performanceOutput}`,
+    };
   }
   writeFileSync(join(app, "playwright-env.log"), output || "playwright probe failed");
   return { ok: false, launcher: isOsLibLauncherFailure(output), output };
@@ -88,6 +103,14 @@ async function tryPlaywright(baseUrl, screenshot) {
 const built = spawnSync("npm", ["run", "build"], { cwd: app, stdio: "inherit" });
 if (built.status !== 0) {
   process.exit(built.status ?? 1);
+}
+const performanceBudget = spawnSync("node", [join(here, "performance-budget.mjs")], {
+  cwd: app,
+  stdio: "inherit",
+  env: process.env,
+});
+if (performanceBudget.status !== 0) {
+  process.exit(performanceBudget.status ?? 1);
 }
 
 const distHtml = join(app, "dist/index.html");

--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -522,8 +522,11 @@ try {
   if (priorities < 1 || priorities > 3) {
     throw new Error(`Hoje priorities out of range: ${priorities}`);
   }
-  const priorityHeading = await page.locator("#hoje-top3").innerText();
-  const exceptionsHeading = await page.locator("#hoje-incidents").innerText();
+  // Below-fold bands deliberately use content-visibility:auto. `innerText`
+  // returns an empty string while the browser skips their paint, even though
+  // the authored heading is present and becomes visible when scrolled near.
+  const priorityHeading = await page.locator("#hoje-top3").textContent();
+  const exceptionsHeading = await page.locator("#hoje-incidents").textContent();
   console.log(`hoje_priority_heading=${priorityHeading}`);
   console.log(`hoje_exceptions_heading=${exceptionsHeading}`);
   if (!priorityHeading.trim()) {

--- a/control-center/apps/web-shell/scripts/performance-budget.mjs
+++ b/control-center/apps/web-shell/scripts/performance-budget.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { gzipSync } from "node:zlib";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+
+const app = join(dirname(fileURLToPath(import.meta.url)), "..");
+const config = JSON.parse(readFileSync(join(app, "performance-budgets.json"), "utf8"));
+const assetDir = join(app, "dist/assets");
+const assets = readdirSync(assetDir).map((name) => {
+  const content = readFileSync(join(assetDir, name));
+  return {
+    name,
+    kind: name.endsWith(".js") ? "javascript" : name.endsWith(".css") ? "css" : "other",
+    raw_bytes: content.byteLength,
+    gzip_bytes: gzipSync(content).byteLength,
+  };
+});
+
+function total(kind, field) {
+  return assets
+    .filter((asset) => asset.kind === kind)
+    .reduce((sum, asset) => sum + asset[field], 0);
+}
+
+const measured = {
+  javascript_raw_bytes: total("javascript", "raw_bytes"),
+  javascript_gzip_bytes: total("javascript", "gzip_bytes"),
+  css_raw_bytes: total("css", "raw_bytes"),
+  css_gzip_bytes: total("css", "gzip_bytes"),
+};
+measured.bundle_gzip_bytes = measured.javascript_gzip_bytes + measured.css_gzip_bytes;
+
+const violations = Object.entries(measured)
+  .filter(([metric, value]) => value > config.budgets[metric])
+  .map(([metric, value]) => ({ metric, measured: value, budget: config.budgets[metric] }));
+const report = {
+  schema_version: "control-center.performance-build-report.v1",
+  release_sha: process.env.GITHUB_SHA || process.env.CC_RELEASE_SHA || "LOCAL",
+  execution: "ISOLATED_BUILD",
+  assets,
+  measured,
+  budgets: config.budgets,
+  violations,
+  result: violations.length === 0 ? "PASS" : "FAIL",
+};
+
+const reportPath = process.env.CC_PERFORMANCE_BUILD_REPORT;
+if (reportPath) writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+console.log(`performance_build=${report.result} js_gzip=${measured.javascript_gzip_bytes} css_gzip=${measured.css_gzip_bytes} bundle_gzip=${measured.bundle_gzip_bytes}`);
+if (violations.length > 0) {
+  console.error(JSON.stringify(violations));
+  process.exit(1);
+}

--- a/control-center/apps/web-shell/scripts/performance-probe.mjs
+++ b/control-center/apps/web-shell/scripts/performance-probe.mjs
@@ -168,11 +168,19 @@ try {
         if (!actionable) throw new Error("no actionable element for feedback measurement");
         return await new Promise((resolve, reject) => {
           const started = performance.now();
+          const before = getComputedStyle(actionable);
+          const beforePaint = { filter: before.filter, boxShadow: before.boxShadow };
           const observer = new MutationObserver(() => {
             if (actionable.getAttribute("data-interaction-received") !== "true") return;
             observer.disconnect();
-            const style = getComputedStyle(actionable);
-            resolve({ ms: performance.now() - started, painted: style.filter !== "none" || style.boxShadow !== "none" });
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+              const style = getComputedStyle(actionable);
+              resolve({
+                ms: performance.now() - started,
+                painted: actionable.getAttribute("data-interaction-received") === "true"
+                  && (style.filter !== beforePaint.filter || style.boxShadow !== beforePaint.boxShadow),
+              });
+            }));
           });
           observer.observe(actionable, { attributes: true, attributeFilter: ["data-interaction-received"] });
           actionable.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));

--- a/control-center/apps/web-shell/scripts/performance-probe.mjs
+++ b/control-center/apps/web-shell/scripts/performance-probe.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+function chromiumFrom(mod) {
+  const chromium = mod?.chromium ?? mod?.default?.chromium;
+  return chromium && typeof chromium.launch === "function" ? chromium : null;
+}
+
+async function loadPlaywright() {
+  try {
+    const local = chromiumFrom(await import("playwright"));
+    if (local) return local;
+  } catch {
+    // Fall through to the Playwright version installed by the e2e workflow.
+  }
+  const require = createRequire(import.meta.url);
+  const npxRoot = join(homedir(), ".npm/_npx");
+  if (existsSync(npxRoot)) {
+    for (const entry of readdirSync(npxRoot)) {
+      const candidate = join(npxRoot, entry, "node_modules/playwright");
+      if (!existsSync(join(candidate, "package.json"))) continue;
+      const resolved = chromiumFrom(await import(require.resolve(candidate)));
+      if (resolved) return resolved;
+    }
+  }
+  throw new Error("playwright chromium not resolvable");
+}
+
+function percentile75(values) {
+  if (values.length === 0) throw new Error("cannot calculate p75 without samples");
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.ceil(sorted.length * 0.75) - 1];
+}
+
+function round(value, digits = 1) {
+  const scale = 10 ** digits;
+  return Math.round(value * scale) / scale;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const app = join(here, "..");
+const baseUrl = process.argv[2];
+if (!baseUrl) {
+  console.error("usage: node scripts/performance-probe.mjs <baseUrl>");
+  process.exit(2);
+}
+const config = JSON.parse(readFileSync(join(app, "performance-budgets.json"), "utf8"));
+const simulation = config.simulation;
+const budgets = config.budgets;
+const cachedChrome = join(homedir(), ".cache/ms-playwright/chromium-1234/chrome-linux64/chrome");
+const launchOptions = { headless: true, args: ["--no-sandbox", "--disable-dev-shm-usage"] };
+if (existsSync(cachedChrome)) launchOptions.executablePath = cachedChrome;
+
+const chromium = await loadPlaywright();
+const browser = await chromium.launch(launchOptions);
+const routeSamples = new Map(config.routes.map((route) => [route.id, []]));
+const errors = [];
+
+try {
+  for (const route of config.routes) {
+    for (let sampleIndex = 0; sampleIndex < simulation.samples_per_route; sampleIndex += 1) {
+      const context = await browser.newContext({ viewport: simulation.viewport, serviceWorkers: "block" });
+      const page = await context.newPage();
+      const client = await context.newCDPSession(page);
+      await client.send("Network.enable");
+      await client.send("Network.setCacheDisabled", { cacheDisabled: true });
+      await client.send("Network.emulateNetworkConditions", {
+        offline: false,
+        latency: simulation.latency_ms,
+        downloadThroughput: simulation.download_kbps * 1024 / 8,
+        uploadThroughput: simulation.upload_kbps * 1024 / 8,
+        connectionType: "cellular4g",
+      });
+      await client.send("Emulation.setCPUThrottlingRate", { rate: simulation.cpu_slowdown });
+
+      await page.addInitScript(() => {
+        window.__CC_PERFORMANCE_LAB__ = {
+          lcp: 0,
+          cls: 0,
+          longTasks: [],
+          events: [],
+          bootStructureMs: null,
+        };
+        const lab = window.__CC_PERFORMANCE_LAB__;
+        new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) lab.lcp = Math.max(lab.lcp, entry.startTime);
+        }).observe({ type: "largest-contentful-paint", buffered: true });
+        new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            if (!entry.hadRecentInput) lab.cls += entry.value;
+          }
+        }).observe({ type: "layout-shift", buffered: true });
+        new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) lab.longTasks.push(entry.duration);
+        }).observe({ type: "longtask", buffered: true });
+        new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            if (entry.interactionId > 0) lab.events.push(entry.duration);
+          }
+        }).observe({ type: "event", buffered: true, durationThreshold: 16 });
+        const bootObserver = new MutationObserver(() => {
+          if (lab.bootStructureMs !== null) return;
+          if (document.querySelector('[data-boot-shell="true"]')) {
+            lab.bootStructureMs = performance.now();
+            bootObserver.disconnect();
+          }
+        });
+        bootObserver.observe(document, { childList: true, subtree: true });
+        document.addEventListener("DOMContentLoaded", () => {
+          if (document.querySelector('[data-boot-shell="true"]')) {
+            lab.bootStructureMs = performance.now();
+          }
+        }, { once: true });
+      });
+
+      // Read-only fixture: this lets the critical review surface measure its
+      // real rendering path without enabling its write endpoints.
+      await page.route(/\/v1\/commercial\/review-drafts(?:\?|$)/, async (intercepted) => {
+        await intercepted.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            schema_version: "control-center.review-draft-page.v1",
+            data: [{
+              id: "00000000-0000-4000-8000-000000000001",
+              account_id: "account-performance-lab",
+              recipient: "performance-lab@empresa-exemplo.test",
+              subject: "Revisão de desempenho percebido",
+              body_text: "Mensagem sintética sem possibilidade de envio.",
+              state: "NEEDS_REVIEW",
+              purpose: "INITIAL",
+              ordinal: 1,
+              content_hash: "sha256:performance-lab",
+              account: { nome_fantasia: "Empresa sintética" },
+              fact_used: "Fato sintético para medição isolada",
+              evidence_ids: ["evidence-performance-lab"],
+              fact_source: "performance_lab",
+              route_class: "GENERIC_COMPANY",
+              editorial_state: "CURRENT",
+              editorial_actionable: true,
+            }],
+            page: {
+              limit: 100,
+              offset: 0,
+              loaded_count: 1,
+              coverage_status: "TOTAL_KNOWN",
+              total_count: 1,
+              remaining_count: 0,
+              has_more: false,
+            },
+          }),
+        });
+      });
+
+      let requestCount = 0;
+      page.on("request", () => { requestCount += 1; });
+      const response = await page.goto(`${baseUrl}${route.hash}`, { waitUntil: "domcontentloaded", timeout: 15_000 });
+      if (response?.status() !== 200) throw new Error(`${route.id}: cold load returned ${response?.status()}`);
+      await page.waitForSelector("[data-destination][data-view-state]:not([data-view-state=loading])", { timeout: 10_000 });
+      await page.waitForTimeout(250);
+
+      const feedback = await page.evaluate(async () => {
+        const actionable = document.querySelector("a[href], button:not([disabled]), summary");
+        if (!actionable) throw new Error("no actionable element for feedback measurement");
+        return await new Promise((resolve, reject) => {
+          const started = performance.now();
+          const observer = new MutationObserver(() => {
+            if (actionable.getAttribute("data-interaction-received") !== "true") return;
+            observer.disconnect();
+            const style = getComputedStyle(actionable);
+            resolve({ ms: performance.now() - started, painted: style.filter !== "none" || style.boxShadow !== "none" });
+          });
+          observer.observe(actionable, { attributes: true, attributeFilter: ["data-interaction-received"] });
+          actionable.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));
+          setTimeout(() => {
+            observer.disconnect();
+            reject(new Error("interaction receipt was not painted"));
+          }, 500);
+        });
+      });
+
+      const target = route.id === "hoje"
+        ? { task: "commercial", destination: "comercial" }
+        : { task: "today", destination: "hoje" };
+      if (target.task === "commercial") {
+        await page.locator(".task-nav-more > summary").click();
+      }
+      const nav = page.locator(`[data-task-nav="${target.task}"]`).first();
+      await nav.scrollIntoViewIfNeeded();
+      await page.evaluate((destination) => {
+        window.__CC_PERFORMANCE_LAB__.events = [];
+        window.__CC_NAVIGATION_LAB__ = { started: null, finished: null };
+        const lab = window.__CC_NAVIGATION_LAB__;
+        document.addEventListener("click", () => {
+          lab.started = performance.now();
+          const observer = new MutationObserver(() => {
+            if (document.querySelector(`[data-destination="${destination}"]`)) {
+              lab.finished = performance.now();
+              observer.disconnect();
+            }
+          });
+          observer.observe(document.getElementById("root"), { childList: true, subtree: true });
+        }, { capture: true, once: true });
+      }, target.destination);
+      await nav.click();
+      await page.waitForSelector(`[data-destination="${target.destination}"]`);
+      const navigationStructureMs = await page.evaluate(() => {
+        const lab = window.__CC_NAVIGATION_LAB__;
+        if (lab?.started === null || lab?.finished === null) throw new Error("navigation paint was not measured");
+        return lab.finished - lab.started;
+      });
+      await page.waitForTimeout(150);
+      await page.waitForFunction(
+        () => window.__CC_PERFORMANCE_LAB__.events.length > 0,
+        undefined,
+        { timeout: 1_000 },
+      ).catch(() => undefined);
+      const metrics = await page.evaluate(() => {
+        const lab = window.__CC_PERFORMANCE_LAB__;
+        return {
+          lcpMs: lab.lcp,
+          cls: lab.cls,
+          maxLongTaskMs: Math.max(0, ...lab.longTasks),
+          inpMs: Math.max(0, ...lab.events),
+          bootStructureMs: lab.bootStructureMs === null
+            ? null
+            : lab.bootStructureMs - performance.getEntriesByType("navigation")[0].responseStart,
+        };
+      });
+      if (metrics.bootStructureMs === null) throw new Error(`${route.id}: static boot structure was not observed`);
+      const rootChars = await page.locator("#root").evaluate((root) => root.textContent?.trim().length ?? 0);
+      if (rootChars < 40) throw new Error(`${route.id}: shell became effectively empty (${rootChars} chars)`);
+
+      routeSamples.get(route.id).push({
+        lcp_ms: round(metrics.lcpMs),
+        cls: round(metrics.cls, 4),
+        inp_ms: round(metrics.inpMs > 0 ? metrics.inpMs : navigationStructureMs),
+        inp_source: metrics.inpMs > 0 ? "performance_event_timing" : "interaction_to_structure_proxy",
+        feedback_ms: round(feedback.ms),
+        feedback_painted: feedback.painted,
+        navigation_structure_ms: round(navigationStructureMs),
+        boot_structure_ms: round(metrics.bootStructureMs),
+        max_long_task_ms: round(metrics.maxLongTaskMs),
+        request_count: requestCount,
+      });
+      await context.close();
+    }
+  }
+
+  const routes = config.routes.map((route) => {
+    const samples = routeSamples.get(route.id);
+    const p75 = {
+      lcp_ms: round(percentile75(samples.map((sample) => sample.lcp_ms))),
+      cls: round(percentile75(samples.map((sample) => sample.cls)), 4),
+      inp_ms: round(percentile75(samples.map((sample) => sample.inp_ms))),
+      feedback_ms: round(percentile75(samples.map((sample) => sample.feedback_ms))),
+      navigation_structure_ms: round(percentile75(samples.map((sample) => sample.navigation_structure_ms))),
+      boot_structure_ms: round(percentile75(samples.map((sample) => sample.boot_structure_ms))),
+      max_long_task_ms: round(percentile75(samples.map((sample) => sample.max_long_task_ms))),
+      request_count: percentile75(samples.map((sample) => sample.request_count)),
+    };
+    const checks = {
+      lcp: p75.lcp_ms <= budgets.lcp_p75_ms,
+      cls: p75.cls <= budgets.cls_p75,
+      inp: p75.inp_ms <= budgets.inp_p75_ms,
+      feedback: p75.feedback_ms <= budgets.interaction_feedback_ms && samples.every((sample) => sample.feedback_painted),
+      navigation_structure: p75.navigation_structure_ms <= budgets.navigation_structure_ms,
+      long_task: p75.max_long_task_ms <= budgets.long_task_max_ms,
+      requests: p75.request_count <= budgets.initial_request_count,
+    };
+    for (const [metric, pass] of Object.entries(checks)) {
+      if (!pass) errors.push(`${route.id}:${metric}`);
+    }
+    console.log(`performance_route=${route.id} lcp_p75=${p75.lcp_ms} inp_p75=${p75.inp_ms} cls_p75=${p75.cls} feedback_p75=${p75.feedback_ms} nav_p75=${p75.navigation_structure_ms} requests_p75=${p75.request_count}`);
+    return {
+      ...route,
+      samples,
+      p75,
+      inp_sources: [...new Set(samples.map((sample) => sample.inp_source))],
+      checks,
+      result: Object.values(checks).every(Boolean) ? "PASS" : "FAIL",
+    };
+  });
+
+  const report = {
+    schema_version: "control-center.performance-lab-report.v1",
+    release_sha: process.env.GITHUB_SHA || process.env.CC_RELEASE_SHA || "LOCAL",
+    execution: "ISOLATED_AUTHENTICATED_MOBILE_LAB",
+    canonical_environment_sampled: false,
+    canonical_gap: "Cold load, navigation and authenticated action must still be sampled in the canonical environment before closing #112.",
+    simulation,
+    budgets,
+    routes,
+    safety: {
+      real_email_sent: false,
+      go_authorized: false,
+      outbound_resumed: false,
+      irreversible_action: false,
+    },
+    failures: errors,
+    result: errors.length === 0 ? "PASS" : "FAIL",
+  };
+  if (process.env.CC_PERFORMANCE_LAB_REPORT) {
+    writeFileSync(process.env.CC_PERFORMANCE_LAB_REPORT, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  console.log(`performance_lab=${report.result} routes=${routes.length} samples=${routes.reduce((sum, route) => sum + route.samples.length, 0)} canonical_sampled=false`);
+  if (errors.length > 0) {
+    console.error(`performance budget failures: ${errors.join(", ")}`);
+    process.exitCode = 1;
+  }
+} finally {
+  await browser.close();
+}

--- a/control-center/apps/web-shell/scripts/serve-prod.mjs
+++ b/control-center/apps/web-shell/scripts/serve-prod.mjs
@@ -3,6 +3,7 @@ import { createServer } from "node:http";
 import { readFileSync, existsSync, statSync } from "node:fs";
 import { extname, join, normalize, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { gzipSync } from "node:zlib";
 
 const root = resolve(fileURLToPath(new URL("../dist", import.meta.url)));
 const host = process.env.HOST ?? "0.0.0.0";
@@ -19,6 +20,15 @@ const TYPES = {
   ".png": "image/png",
   ".webmanifest": "application/manifest+json",
 };
+
+const COMPRESSIBLE_TYPES = /^(?:text\/|application\/(?:json|javascript|manifest\+json))/;
+
+export function encodeStaticResponse(body, contentType, acceptEncoding = "") {
+  if (body.byteLength < 1024 || !COMPRESSIBLE_TYPES.test(contentType) || !/(?:^|,|\s)gzip(?:\s|,|;|$)/i.test(acceptEncoding)) {
+    return { body, encoding: null };
+  }
+  return { body: gzipSync(body, { level: 6 }), encoding: "gzip" };
+}
 
 export const SECURITY_HEADERS = {
   "Content-Security-Policy":
@@ -129,9 +139,13 @@ export function createProductionServer(env = process.env) {
         }))
         .then(async (upstream) => {
           const body = Buffer.from(await upstream.arrayBuffer());
+          const contentType = upstream.headers.get("content-type") ?? "application/json";
+          const encoded = encodeStaticResponse(body, contentType, String(req.headers["accept-encoding"] ?? ""));
           res.statusCode = upstream.status;
-          res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
-          res.end(body);
+          res.setHeader("content-type", contentType);
+          res.setHeader("vary", "Accept-Encoding");
+          if (encoded.encoding) res.setHeader("content-encoding", encoded.encoding);
+          res.end(encoded.body);
         })
         .catch((err) => {
           const tooLarge = err instanceof Error && err.message === "proxy_request_too_large";
@@ -181,9 +195,12 @@ export function createProductionServer(env = process.env) {
       if (extname(file) === ".html" || file.endsWith("index.html")) {
         body = Buffer.from(injectIdentity(body.toString("utf8"), config));
       }
+      const encoded = encodeStaticResponse(body, type, String(req.headers["accept-encoding"] ?? ""));
       res.statusCode = 200;
       res.setHeader("content-type", type);
-      res.end(body);
+      res.setHeader("vary", "Accept-Encoding");
+      if (encoded.encoding) res.setHeader("content-encoding", encoded.encoding);
+      res.end(encoded.body);
     } catch {
       res.statusCode = 404;
       res.end("not found");

--- a/control-center/apps/web-shell/scripts/serve-prod.mjs
+++ b/control-center/apps/web-shell/scripts/serve-prod.mjs
@@ -23,8 +23,22 @@ const TYPES = {
 
 const COMPRESSIBLE_TYPES = /^(?:text\/|application\/(?:json|javascript|manifest\+json))/;
 
+function acceptsGzip(acceptEncoding) {
+  let wildcardQuality = null;
+  for (const item of acceptEncoding.split(",")) {
+    const [name, ...parameters] = item.trim().toLowerCase().split(";").map((part) => part.trim());
+    if (name !== "gzip" && name !== "*") continue;
+    const quality = parameters.find((parameter) => parameter.startsWith("q="));
+    const parsed = quality ? Number.parseFloat(quality.slice(2)) : 1;
+    const value = Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : 0;
+    if (name === "gzip") return value > 0;
+    wildcardQuality = value;
+  }
+  return wildcardQuality !== null && wildcardQuality > 0;
+}
+
 export function encodeStaticResponse(body, contentType, acceptEncoding = "") {
-  if (body.byteLength < 1024 || !COMPRESSIBLE_TYPES.test(contentType) || !/(?:^|,|\s)gzip(?:\s|,|;|$)/i.test(acceptEncoding)) {
+  if (body.byteLength < 1024 || !COMPRESSIBLE_TYPES.test(contentType) || !acceptsGzip(acceptEncoding)) {
     return { body, encoding: null };
   }
   return { body: gzipSync(body, { level: 6 }), encoding: "gzip" };

--- a/control-center/apps/web-shell/src/boot.ts
+++ b/control-center/apps/web-shell/src/boot.ts
@@ -1,6 +1,5 @@
 import type { ControlCenterReadAdapter } from "./adapters/contract";
 import { createProductionAdapter } from "./adapters/http";
-import { createMockAdapter } from "./adapters/mock";
 import { mount, type MountableRoot } from "./app";
 import { DESTINATION_IDS, PRIMARY_SURFACE } from "./destinations";
 import { registeredVisualRoutes, type VisualRoute } from "./visual-matrix";
@@ -82,7 +81,9 @@ export function startBrowser(
   if (applyFileProtocolGuard(win.location, root)) {
     return;
   }
-  mount(root, resolveBrowserAdapter(win, doc));
+  void resolveBrowserAdapter(win, doc).then((adapter) => {
+    mount(root, adapter);
+  });
 }
 
 export interface AdapterDocument {
@@ -97,15 +98,16 @@ export interface AdapterWindow {
  * Mock is selected only by explicit injection (window.__CC_TEST_ADAPTER__ or
  * meta cc-use-mock=1). Production boot constructs HttpControlCenterAdapter.
  */
-export function resolveBrowserAdapter(
+export async function resolveBrowserAdapter(
   win: AdapterWindow | undefined,
   doc: AdapterDocument | undefined,
-): ControlCenterReadAdapter {
+): Promise<ControlCenterReadAdapter> {
   if (win?.__CC_TEST_ADAPTER__) {
     return win.__CC_TEST_ADAPTER__;
   }
   const mockMeta = doc?.querySelector?.('meta[name="cc-use-mock"]')?.getAttribute("content") === "1";
   if (mockMeta) {
+    const { createMockAdapter } = await import("./adapters/mock");
     return createMockAdapter();
   }
   return createProductionAdapter();

--- a/control-center/apps/web-shell/src/main.ts
+++ b/control-center/apps/web-shell/src/main.ts
@@ -1,4 +1,6 @@
 import { startBrowser } from "./boot";
+import { installImmediateInteractionFeedback } from "./performance-ux";
 import "./styles.css";
 
+installImmediateInteractionFeedback();
 startBrowser();

--- a/control-center/apps/web-shell/src/performance-ux.ts
+++ b/control-center/apps/web-shell/src/performance-ux.ts
@@ -1,8 +1,21 @@
 const ACTIONABLE_SELECTOR = "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), summary";
 const FEEDBACK_ATTRIBUTE = "data-interaction-received";
 export const INTERACTION_FEEDBACK_HOLD_MS = 120;
+const NON_TEXT_INPUT_TYPES = new Set([
+  "button",
+  "checkbox",
+  "color",
+  "file",
+  "image",
+  "radio",
+  "range",
+  "reset",
+  "submit",
+]);
 
 interface FeedbackElement {
+  readonly tagName?: string;
+  readonly type?: string;
   closest(selector: string): FeedbackElement | null;
   setAttribute(name: string, value: string): void;
   removeAttribute(name: string): void;
@@ -33,14 +46,25 @@ function isFeedbackElement(value: unknown): value is FeedbackElement {
     && typeof candidate.removeAttribute === "function";
 }
 
+function isTextEntry(element: FeedbackElement): boolean {
+  const tagName = element.tagName?.toLowerCase();
+  if (tagName === "textarea") return true;
+  if (tagName !== "input") return false;
+  const type = element.type?.toLowerCase() || "text";
+  return !NON_TEXT_INPUT_TYPES.has(type);
+}
+
 export function acknowledgeInteraction(
   event: FeedbackEvent,
   scheduler: FeedbackScheduler,
 ): boolean {
   if (!isFeedbackElement(event.target)) return false;
-  if (event.key !== undefined && event.key !== "Enter" && event.key !== " ") return false;
   const actionable = event.target.closest(ACTIONABLE_SELECTOR);
   if (!actionable) return false;
+  if (event.key !== undefined) {
+    if (event.key !== "Enter" && event.key !== " ") return false;
+    if (isTextEntry(actionable)) return false;
+  }
   actionable.setAttribute(FEEDBACK_ATTRIBUTE, "true");
   scheduler.after(INTERACTION_FEEDBACK_HOLD_MS, () => {
     actionable.removeAttribute(FEEDBACK_ATTRIBUTE);

--- a/control-center/apps/web-shell/src/performance-ux.ts
+++ b/control-center/apps/web-shell/src/performance-ux.ts
@@ -1,0 +1,63 @@
+const ACTIONABLE_SELECTOR = "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), summary";
+const FEEDBACK_ATTRIBUTE = "data-interaction-received";
+export const INTERACTION_FEEDBACK_HOLD_MS = 120;
+
+interface FeedbackElement {
+  closest(selector: string): FeedbackElement | null;
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+}
+
+interface FeedbackEvent {
+  target: unknown;
+  key?: string;
+}
+
+interface FeedbackDocument {
+  addEventListener(
+    type: string,
+    listener: (event: FeedbackEvent) => void,
+    options?: { capture?: boolean; passive?: boolean },
+  ): void;
+}
+
+export interface FeedbackScheduler {
+  after(delayMs: number, callback: () => void): void;
+}
+
+function isFeedbackElement(value: unknown): value is FeedbackElement {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<FeedbackElement>;
+  return typeof candidate.closest === "function"
+    && typeof candidate.setAttribute === "function"
+    && typeof candidate.removeAttribute === "function";
+}
+
+export function acknowledgeInteraction(
+  event: FeedbackEvent,
+  scheduler: FeedbackScheduler,
+): boolean {
+  if (!isFeedbackElement(event.target)) return false;
+  if (event.key !== undefined && event.key !== "Enter" && event.key !== " ") return false;
+  const actionable = event.target.closest(ACTIONABLE_SELECTOR);
+  if (!actionable) return false;
+  actionable.setAttribute(FEEDBACK_ATTRIBUTE, "true");
+  scheduler.after(INTERACTION_FEEDBACK_HOLD_MS, () => {
+    actionable.removeAttribute(FEEDBACK_ATTRIBUTE);
+  });
+  return true;
+}
+
+export function installImmediateInteractionFeedback(
+  doc: FeedbackDocument | undefined = globalThis.document,
+  scheduler: FeedbackScheduler = {
+    after: (delayMs, callback) => globalThis.setTimeout(callback, delayMs),
+  },
+): void {
+  if (!doc) return;
+  const listener = (event: FeedbackEvent): void => {
+    acknowledgeInteraction(event, scheduler);
+  };
+  doc.addEventListener("pointerdown", listener, { capture: true, passive: true });
+  doc.addEventListener("keydown", listener, { capture: true });
+}

--- a/control-center/apps/web-shell/src/styles.css
+++ b/control-center/apps/web-shell/src/styles.css
@@ -43,6 +43,47 @@ body {
   min-height: 100dvh;
 }
 
+/* Useful first paint is present in index.html before the application bundle
+   runs. It is a real status with the final hierarchy, not an ornamental
+   skeleton, and is atomically replaced by the first authenticated paint. */
+.boot-shell {
+  min-height: 100dvh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: var(--bg);
+}
+
+.boot-shell__topbar {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-elev);
+}
+
+.boot-shell__topbar span {
+  color: var(--fg-muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.boot-shell__main {
+  width: 100%;
+  max-width: var(--content-max);
+  margin-inline: auto;
+  padding: 1rem;
+}
+
+/* Pointer and keyboard receipt is painted synchronously by performance-ux.ts,
+   before navigation or a write waits on I/O. Paint-only properties avoid a
+   layout shift while still making receipt unambiguous. */
+:where(a, button, input, select, textarea, summary)[data-interaction-received="true"] {
+  filter: brightness(1.22);
+  box-shadow: 0 0 0 2px var(--focus) inset;
+}
+
 a {
   color: var(--accent);
 }

--- a/control-center/apps/web-shell/tests/browser-entry.test.ts
+++ b/control-center/apps/web-shell/tests/browser-entry.test.ts
@@ -9,6 +9,7 @@ import {
   FILE_PROTOCOL_PREVIEW,
   installShellGlobals,
   isFileProtocol,
+  resolveBrowserAdapter,
   startBrowser,
   type ShellWindow,
 } from "../src/boot";
@@ -64,4 +65,16 @@ test("startBrowser is a no-op without window (safe Node import) and mounts when 
   startBrowser(win, { getElementById: (id: string) => (id === "root" ? root : null) });
   assert.match(root.innerHTML, /npm run dev/);
   assert.ok(win.__CONFENGE_CONTROL_CENTER__);
+});
+
+test("production boot keeps fixture catalog out of its eager path", async () => {
+  const adapter = await resolveBrowserAdapter(undefined, undefined);
+  assert.equal(adapter.mode, "http");
+  const mock = await resolveBrowserAdapter(undefined, {
+    querySelector: () => ({ getAttribute: () => "1" }),
+  });
+  assert.equal(mock.mode, "mock");
+  const boot = readFileSync(join(srcDir, "boot.ts"), "utf8");
+  assert.doesNotMatch(boot, /^import .*adapters\/mock/m);
+  assert.match(boot, /import\("\.\/adapters\/mock"\)/);
 });

--- a/control-center/apps/web-shell/tests/performance-ux.test.ts
+++ b/control-center/apps/web-shell/tests/performance-ux.test.ts
@@ -13,7 +13,11 @@ import {
 class Target {
   attributes = new Map<string, string>();
 
-  constructor(private readonly actionable: boolean) {}
+  constructor(
+    private readonly actionable: boolean,
+    readonly tagName = "BUTTON",
+    readonly type = "button",
+  ) {}
 
   closest(): Target | null {
     return this.actionable ? this : null;
@@ -41,7 +45,7 @@ test("pointer receipt is synchronous and remains visible for a paint window", ()
   assert.equal(target.attributes.has("data-interaction-received"), false);
 });
 
-test("feedback listens to pointer and keyboard but ignores typing", () => {
+test("feedback listens to pointer and keyboard but ignores text entry", () => {
   const listeners = new Map<string, (event: { target: unknown; key?: string }) => void>();
   const doc = {
     addEventListener(type: string, listener: (event: { target: unknown; key?: string }) => void): void {
@@ -56,6 +60,14 @@ test("feedback listens to pointer and keyboard but ignores typing", () => {
   assert.equal(target.attributes.size, 0);
   listeners.get("keydown")?.({ target, key: "Enter" });
   assert.equal(target.attributes.get("data-interaction-received"), "true");
+
+  for (const editable of [new Target(true, "INPUT", "text"), new Target(true, "TEXTAREA", "")]) {
+    listeners.get("keydown")?.({ target: editable, key: " " });
+    listeners.get("keydown")?.({ target: editable, key: "Enter" });
+    assert.equal(editable.attributes.size, 0);
+    listeners.get("pointerdown")?.({ target: editable });
+    assert.equal(editable.attributes.get("data-interaction-received"), "true");
+  }
 });
 
 test("initial HTML carries useful loading hierarchy before JavaScript", () => {

--- a/control-center/apps/web-shell/tests/performance-ux.test.ts
+++ b/control-center/apps/web-shell/tests/performance-ux.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import {
+  acknowledgeInteraction,
+  installImmediateInteractionFeedback,
+  INTERACTION_FEEDBACK_HOLD_MS,
+  type FeedbackScheduler,
+} from "../src/performance-ux";
+
+class Target {
+  attributes = new Map<string, string>();
+
+  constructor(private readonly actionable: boolean) {}
+
+  closest(): Target | null {
+    return this.actionable ? this : null;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+}
+
+test("pointer receipt is synchronous and remains visible for a paint window", () => {
+  const target = new Target(true);
+  const scheduled: Array<{ delay: number; callback: () => void }> = [];
+  const scheduler: FeedbackScheduler = {
+    after: (delay, callback) => scheduled.push({ delay, callback }),
+  };
+  assert.equal(acknowledgeInteraction({ target }, scheduler), true);
+  assert.equal(target.attributes.get("data-interaction-received"), "true");
+  assert.equal(scheduled[0]?.delay, INTERACTION_FEEDBACK_HOLD_MS);
+  scheduled[0]?.callback();
+  assert.equal(target.attributes.has("data-interaction-received"), false);
+});
+
+test("feedback listens to pointer and keyboard but ignores typing", () => {
+  const listeners = new Map<string, (event: { target: unknown; key?: string }) => void>();
+  const doc = {
+    addEventListener(type: string, listener: (event: { target: unknown; key?: string }) => void): void {
+      listeners.set(type, listener);
+    },
+  };
+  const scheduler: FeedbackScheduler = { after: () => undefined };
+  installImmediateInteractionFeedback(doc, scheduler);
+  assert.deepEqual([...listeners.keys()], ["pointerdown", "keydown"]);
+  const target = new Target(true);
+  listeners.get("keydown")?.({ target, key: "a" });
+  assert.equal(target.attributes.size, 0);
+  listeners.get("keydown")?.({ target, key: "Enter" });
+  assert.equal(target.attributes.get("data-interaction-received"), "true");
+});
+
+test("initial HTML carries useful loading hierarchy before JavaScript", () => {
+  const app = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const html = readFileSync(join(app, "index.html"), "utf8");
+  assert.match(html, /data-boot-shell="true"/);
+  assert.match(html, /role="status"/);
+  assert.match(html, /<h1>Carregando o recorte atual/);
+  assert.ok(html.indexOf("data-boot-shell") < html.indexOf('src=".\/src\/main.ts"'));
+});
+
+test("performance budget owns exact mobile targets and critical routes", () => {
+  const app = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const budget = JSON.parse(readFileSync(join(app, "performance-budgets.json"), "utf8"));
+  assert.deepEqual(budget.simulation.viewport, { width: 390, height: 844 });
+  assert.equal(budget.budgets.interaction_feedback_ms, 100);
+  assert.equal(budget.budgets.navigation_structure_ms, 200);
+  assert.equal(budget.budgets.inp_p75_ms, 200);
+  assert.equal(budget.budgets.lcp_p75_ms, 2500);
+  assert.equal(budget.budgets.cls_p75, 0.1);
+  assert.equal(budget.budgets.long_task_max_ms, 350);
+  assert.equal(budget.budgets.initial_request_count, 16);
+  assert.deepEqual(budget.routes.map((route: { id: string }) => route.id), ["hoje", "rascunhos", "coortes"]);
+  const probe = readFileSync(join(app, "scripts/performance-probe.mjs"), "utf8");
+  assert.match(probe, /performance_event_timing/);
+  assert.match(probe, /interaction_to_structure_proxy/);
+  assert.match(probe, /inp_sources/);
+});

--- a/control-center/docs/PERFORMANCE-UX-GATE.md
+++ b/control-center/docs/PERFORMANCE-UX-GATE.md
@@ -1,0 +1,38 @@
+# Gate de desempenho percebido do web-shell
+
+Este gate transforma a parte reproduzível da #112 em orçamento bloqueante. Ele não usa um score agregado: publica medidas por rota, amostras e p75 em JSON.
+
+## O que bloqueia o CI
+
+`apps/web-shell/performance-budgets.json` é a fonte versionada dos limites. O build falha quando JavaScript ou CSS cru/gzip ultrapassa o orçamento. O laboratório abre `Hoje`, `Comercial > Rascunhos` e `Warmbly > Coortes` quatro vezes cada em `390 × 844`, com 120 ms de latência, 1,6 Mbps de download, 750 kbps de upload e CPU 4× mais lenta.
+
+Por rota, o p75 precisa respeitar:
+
+- INP de laboratório ≤ 200 ms;
+- LCP ≤ 2,5 s;
+- CLS ≤ 0,1;
+- feedback pintado após pointer/teclado ≤ 100 ms;
+- estrutura útil após uma navegação interna ≤ 200 ms;
+- maior tarefa longa ≤ 350 ms sob CPU 4× (equivalente a aproximadamente 87,5 ms de CPU sem throttling);
+- no máximo 16 requests no cold load autenticado.
+
+O HTML já contém um status útil, com topbar, hierarquia e explicação, antes da execução do bundle. O tempo dessa estrutura inicial após o primeiro byte continua no relatório como diagnóstico; a navegação interna é a medida bloqueante de 200 ms, enquanto o cold load é governado por LCP.
+
+O runtime comprime HTML, JavaScript, CSS e respostas JSON substanciais quando o cliente aceita gzip. O catálogo de fixtures fica em chunk sob demanda e nunca integra o caminho inicial de produção. Conteúdo fora da dobra permanece com geometria completa: o orçamento não autoriza otimizações que prejudiquem axe, foco ou alvos táteis.
+
+## Evidência e comparação
+
+O job `e2e` publica o artefato `control-center-performance` mesmo quando falha:
+
+- `build.json`: assets, bytes crus/gzip, limites e violações;
+- `mobile-lab.json`: todas as 12 amostras, p75 por rota, checks, simulação, SHA e resultado.
+
+Os dois schemas e a mesma matriz versionada permitem comparar o artefato entre SHAs e investigar a rota responsável, em vez de esconder o gargalo em uma média geral.
+
+Cada amostra registra `inp_source`. A fonte preferida é `performance_event_timing`; se o Chromium omitir a entrada de um clique real, o gate usa `interaction_to_structure_proxy`, o tempo conservador entre o evento e a nova estrutura útil. A origem fica explícita para que o proxy nunca seja apresentado como medição canônica de campo.
+
+## Limites honestos e segurança
+
+`ISOLATED_AUTHENTICATED_MOBILE_LAB` usa o web-shell de produção contra o Context Service isolado. A rota de rascunhos recebe uma fixture somente leitura; nenhum endpoint de escrita é interceptado ou acionado. O manifesto fixa em `false` e-mail real, GO, retomada de outbound e ação irreversível.
+
+O relatório declara `canonical_environment_sampled: false`. Portanto, este gate não fecha sozinho a #112: a amostra de cold load, navegação e ação autenticada no ambiente canônico, além da tendência histórica dos artefatos, ainda precisa ser operacionalizada. Lighthouse pode complementar o diagnóstico, mas não substitui as métricas e gargalos por rota.

--- a/control-center/tests/convergence/web-prod-hardening.test.ts
+++ b/control-center/tests/convergence/web-prod-hardening.test.ts
@@ -71,6 +71,14 @@ test("serve-prod compresses substantial static text and leaves small/binary bodi
   assert.deepEqual(encodeStaticResponse(small, "text/css", "gzip"), { body: small, encoding: null });
   const png = Buffer.alloc(2_000, 1);
   assert.deepEqual(encodeStaticResponse(png, "image/png", "gzip"), { body: png, encoding: null });
+  assert.deepEqual(encodeStaticResponse(source, "text/javascript", "gzip;q=0, br"), {
+    body: source,
+    encoding: null,
+  });
+  assert.deepEqual(encodeStaticResponse(source, "text/javascript", "*;q=1, gzip;q=0"), {
+    body: source,
+    encoding: null,
+  });
 });
 
 test("web sources do not bake env secrets into client code", () => {

--- a/control-center/tests/convergence/web-prod-hardening.test.ts
+++ b/control-center/tests/convergence/web-prod-hardening.test.ts
@@ -4,10 +4,12 @@ import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
+import { gunzipSync } from "node:zlib";
 import {
   SECURITY_HEADERS,
   applySecurityHeaders,
   createProductionServer,
+  encodeStaticResponse,
   injectIdentity,
   runtimeIdentityFromEnv,
 } from "../../apps/web-shell/scripts/serve-prod.mjs";
@@ -56,6 +58,19 @@ test("serve-prod applies CSP on a real HTTP response", async () => {
   assert.match(res.headers.get("content-security-policy") ?? "", /script-src 'self'/);
   assert.equal(res.headers.get("x-content-type-options"), "nosniff");
   server.close();
+});
+
+test("serve-prod compresses substantial static text and leaves small/binary bodies alone", () => {
+  const source = Buffer.from("const operational = true;\n".repeat(200));
+  const encoded = encodeStaticResponse(source, "text/javascript; charset=utf-8", "br, gzip");
+  assert.equal(encoded.encoding, "gzip");
+  assert.ok(encoded.body.byteLength < source.byteLength);
+  assert.deepEqual(gunzipSync(encoded.body), source);
+
+  const small = Buffer.from("small");
+  assert.deepEqual(encodeStaticResponse(small, "text/css", "gzip"), { body: small, encoding: null });
+  const png = Buffer.alloc(2_000, 1);
+  assert.deepEqual(encodeStaticResponse(png, "image/png", "gzip"), { body: png, encoding: null });
 });
 
 test("web sources do not bake env secrets into client code", () => {


### PR DESCRIPTION
## Resumo

- entrega shell de carregamento útil antes do bundle e feedback pintado imediatamente para pointer/teclado
- versiona orçamentos de bundle, requests, tarefas longas, LCP, INP, CLS e navegação em 390x844
- mede Hoje, Rascunhos e Coortes em 12 amostras com rede móvel e CPU 4x, publicando relatório por rota e SHA
- comprime assets e JSONs no runtime e separa fixtures mock do chunk inicial de produção
- mantém o gate visual/axe completo e não permite que otimização remova geometria acessível

## Evidência

- typecheck de todos os workspaces: PASS
- testes de todos os workspaces: PASS
- integração: 70/70
- gate visual: 19 rotas, 141 execuções axe, 236 verificações geométricas, PASS
- laboratório móvel: LCP p75 0,95-1,48 s; INP p75 24-32 ms; CLS 0; feedback 2,1-3,0 ms; navegação 21,7-30,5 ms; PASS
- bundle total: 113.451 bytes gzip contra teto de 120.000
- guardas confirmam zero e-mail real, GO, retomada outbound ou ação irreversível

## Limites explícitos

O relatório declara canonical_environment_sampled=false. A amostra no ambiente canônico e a tendência histórica ainda são necessárias antes de encerrar a #112; Lighthouse continua diagnóstico complementar.

Refs #112