### PR TITLE
[P1] Preservar continuidade global de tarefa

### DIFF
--- a/control-center/apps/web-shell/performance-budgets.json
+++ b/control-center/apps/web-shell/performance-budgets.json
@@ -23,7 +23,7 @@
     "long_task_max_ms": 350,
     "initial_request_count": 16,
     "javascript_raw_bytes": 375000,
-    "javascript_gzip_bytes": 110000,
+    "javascript_gzip_bytes": 113000,
     "css_raw_bytes": 26000,
     "css_gzip_bytes": 7000,
     "bundle_gzip_bytes": 120000

--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -584,6 +584,64 @@ try {
     console.log(`hash=${hash} filled_chars=${destFilled.filled}`);
   }
 
+  const continuitySurfaces = await page.evaluate(() => {
+    const surfaces = globalThis.__CONFENGE_CONTROL_CENTER__?.taskContinuity?.surfaces;
+    return Array.isArray(surfaces) ? surfaces : null;
+  });
+  const requiredContinuityIds = ["messages", "inbound", "exceptions", "leads", "clients", "activities"];
+  if (!continuitySurfaces
+    || JSON.stringify(continuitySurfaces.map((surface) => surface.id)) !== JSON.stringify(requiredContinuityIds)) {
+    throw new Error(`task-continuity surface contract is incomplete: ${JSON.stringify(continuitySurfaces)}`);
+  }
+  for (const viewport of [
+    { name: "mobile-390", width: 390, height: 844 },
+    { name: "desktop-1280", width: 1280, height: 800 },
+  ]) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    for (const surface of continuitySurfaces) {
+      await page.goto(`${baseUrl}${surface.route}`, { waitUntil: "networkidle" });
+      await page.waitForSelector(surface.selector);
+      const state = await page.locator("[data-destination]").getAttribute("data-view-state");
+      const matches = await page.locator(surface.selector).count();
+      if (matches < 1) {
+        throw new Error(
+          `task-continuity ${surface.id} has no ${surface.selector} at ${surface.route} on ${viewport.name}`,
+        );
+      }
+      console.log(
+        `task_continuity surface=${surface.id} viewport=${viewport.name} state=${state} matches=${matches} route=${surface.route}`,
+      );
+    }
+  }
+
+  await page.goto(`${baseUrl}#/comercial/excecoes?q=owner&pagina=2`, { waitUntil: "networkidle" });
+  await page.evaluate(() => history.replaceState(history.state, "", location.pathname));
+  await page.reload({ waitUntil: "networkidle" });
+  if (page.url().split("#")[1] !== "/comercial/excecoes?q=owner&pagina=2") {
+    throw new Error(`task-continuity reload did not restore the bounded URL: ${page.url()}`);
+  }
+  console.log("task_continuity journey=reload result=restored");
+
+  await page.evaluate(() => {
+    const key = "confenge.control-center.task-continuity.v1";
+    const stored = JSON.parse(sessionStorage.getItem(key) ?? "{}");
+    sessionStorage.setItem(key, JSON.stringify({ ...stored, savedAt: Date.now() - (13 * 60 * 60 * 1000) }));
+    history.replaceState(history.state, "", location.pathname);
+  });
+  await page.reload({ waitUntil: "networkidle" });
+  await page.waitForSelector('[data-destination="hoje"]');
+  if (page.url().split("#")[1] !== "/hoje") {
+    throw new Error(`task-continuity expired state did not fall back to Hoje: ${page.url()}`);
+  }
+  console.log("task_continuity journey=expiry result=discarded");
+
+  await page.goto(`${baseUrl}#/rota-inexistente?resource=lead-fixture-aurora`, { waitUntil: "networkidle" });
+  await page.waitForSelector('[data-continuity-recovered="true"]');
+  if (page.url().split("#")[1] !== "/hoje?continuity=recovered") {
+    throw new Error(`task-continuity invalid route was not recovered: ${page.url()}`);
+  }
+  console.log("task_continuity journey=invalid-route result=recovered");
+
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto(`${baseUrl}#/comercial/rascunhos`, { waitUntil: "networkidle" });
   await page.waitForSelector('[data-review-workbench-count="55"]');

--- a/control-center/apps/web-shell/src/action-draft.ts
+++ b/control-center/apps/web-shell/src/action-draft.ts
@@ -12,7 +12,11 @@ export function operatorActionDraftKey(action: string, canonicalId: string, sour
 }
 
 export function rememberOperatorActionDraft(key: string, note: string): void {
-  if (!key || !note) return;
+  if (!key) return;
+  if (!note) {
+    notes.delete(key);
+    return;
+  }
   notes.set(key, note.slice(0, 500));
 }
 

--- a/control-center/apps/web-shell/src/action-draft.ts
+++ b/control-center/apps/web-shell/src/action-draft.ts
@@ -1,0 +1,29 @@
+/**
+ * Volatile notes for an operator action whose outcome is not definitive.
+ *
+ * This map survives a wholesale DOM repaint but deliberately does not survive
+ * reload or reauthentication. Notes may contain sensitive operational context;
+ * sessionStorage/localStorage are therefore outside this contract.
+ */
+const notes = new Map<string, string>();
+
+export function operatorActionDraftKey(action: string, canonicalId: string, sourceId: string): string {
+  return `${action.slice(0, 80)}\u0000${canonicalId.slice(0, 256)}\u0000${sourceId.slice(0, 256)}`;
+}
+
+export function rememberOperatorActionDraft(key: string, note: string): void {
+  if (!key || !note) return;
+  notes.set(key, note.slice(0, 500));
+}
+
+export function operatorActionDraft(key: string): string {
+  return notes.get(key) ?? "";
+}
+
+export function clearOperatorActionDraft(key: string): void {
+  notes.delete(key);
+}
+
+export function resetOperatorActionDrafts(): void {
+  notes.clear();
+}

--- a/control-center/apps/web-shell/src/adapters/http.ts
+++ b/control-center/apps/web-shell/src/adapters/http.ts
@@ -1173,7 +1173,10 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
   }
 
   private async loadDomain(id: DestinationId, fallback: Provenance, location?: string): Promise<DestinationPage> {
-    const paths = readPathsFor(id);
+    const clientResource = id === "clientes" ? parseHash(location ?? "#/clientes").resource : null;
+    const paths = clientResource
+      ? [`/v1/domains/clients?${new URLSearchParams({ scope: `client:${clientResource}` }).toString()}`]
+      : readPathsFor(id);
     const listPath = this.commercialListPath(id, location);
     const payloads = await Promise.all([
       ...paths.map((path) => this.getJson(path)),
@@ -1274,11 +1277,18 @@ export class HttpControlCenterAdapter implements ControlCenterReadAdapter {
       // "Cliente" / every source UNKNOWN: the card reported in issue #70.
       // A snapshot with no clients has no clients.
       const list = itemsOf(inner.clients);
-      const rows = list.length > 0 ? list : itemsOf(payload);
+      const rows = list.length > 0 ? list : clientResource ? [inner] : itemsOf(payload);
       const clients: ClientStatus[] = [];
       const gaps: ClientIdentityException[] = [];
       rows.forEach((row, index) => {
-        const rec = asRecord(row) ?? {};
+        const raw = asRecord(row) ?? {};
+        // A client-scoped domain snapshot has an operational-snapshot id, not a
+        // client-status id. Promote the identity from the requested scope only
+        // when the payload echoes the exact same slug; disagreement still fails
+        // closed into the data-quality queue.
+        const rec = clientResource && raw.client_slug === clientResource
+          ? { ...raw, id: `cc:client-status:${clientResource}`, scope: `client:${clientResource}` }
+          : raw;
         const client = maybeClientFrom(rec, fallback);
         if (client !== null) {
           clients.push(client);

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -1,4 +1,9 @@
 import type { MockScenario } from "./adapters/mock";
+import {
+  clearOperatorActionDraft,
+  operatorActionDraftKey,
+  rememberOperatorActionDraft,
+} from "./action-draft";
 import type {
   AdapterWriteResult,
   ControlCenterReadAdapter,
@@ -9,6 +14,14 @@ import type {
 import { APPROVAL_DEFAULT_REASON, isWarmblyGateAction } from "./adapters/contract";
 import { WARMBLY_DISPATCH_PATHS, type WriteShortcutKind } from "./adapters/paths";
 import { parseHash, withQueryParams } from "./destinations";
+import {
+  CONTINUITY_FIRST_FOCUS,
+  CONTINUITY_RECOVERY_HASH,
+  actionContinuationHash,
+  isRecognizedContinuityHash,
+  rememberContinuity,
+  restoreContinuity,
+} from "./continuity";
 import { LIST_FORM_FIELDS, defaultParamValues, listHref, listSpecById } from "./filter";
 import {
   beginGateFlight,
@@ -59,6 +72,10 @@ export interface ShellRuntime {
   setHash(hash: string): void;
   /** Replace URL state without firing a navigation/repaint. */
   replaceHash(hash: string): void;
+  /** Restore only bounded URL state; form fields and decisions are excluded. */
+  restoreHash?(): string | null;
+  /** Persist the bounded URL projection for reload/reauthentication. */
+  rememberHash?(hash: string): void;
   onHashChange(handler: () => void): () => void;
 }
 
@@ -72,6 +89,20 @@ export function browserRuntime(): ShellRuntime {
     },
     replaceHash(hash: string): void {
       window.history.replaceState(window.history.state, "", hash);
+    },
+    restoreHash(): string | null {
+      try {
+        return restoreContinuity(window.sessionStorage);
+      } catch {
+        return null;
+      }
+    },
+    rememberHash(hash: string): void {
+      try {
+        rememberContinuity(window.sessionStorage, hash);
+      } catch {
+        // A browser that blocks sessionStorage still has full URL continuity.
+      }
     },
     onHashChange(handler: () => void): () => void {
       window.addEventListener("hashchange", handler);
@@ -188,7 +219,7 @@ function applyPaint(
     paintShell(root, adapter, renderHash, 0, () => true, navigate, replaceLocation);
   };
   bindWriteShortcuts(root, adapter, repaint);
-  bindOperatorActions(root, adapter, repaint);
+  bindOperatorActions(root, adapter, repaint, navigate, renderHash);
   bindWarmblyDispatch(
     root,
     adapter,
@@ -333,6 +364,16 @@ export function consumeQueueFocus(
     fallback?.focus?.({ preventScroll: true });
     fallback?.scrollIntoView?.({ block: "center", inline: "nearest" });
   };
+  if (token === CONTINUITY_FIRST_FOCUS) {
+    const first = root.querySelectorAll("[data-queue-focus]")[0];
+    if (first) {
+      first.focus?.({ preventScroll: true });
+      first.scrollIntoView?.({ block: "center", inline: "nearest" });
+      return true;
+    }
+    focusFallback();
+    return false;
+  }
   if (!QUEUE_FOCUS_TOKEN_PATTERN.test(token)) {
     focusFallback();
     return false;
@@ -526,23 +567,38 @@ export function bindReviewActions(
   }
 }
 
-function bindOperatorActions(
+export function bindOperatorActions(
   root: MountableRoot,
   adapter: ControlCenterReadAdapter,
   onDone: () => void,
+  navigate?: Navigate,
+  currentHash = "#/hoje",
 ): void {
   if (!adapter.operatorAction || typeof root.querySelectorAll !== "function") return;
   const forms = root.querySelectorAll("[data-operator-form]");
   for (let i = 0; i < forms.length; i += 1) {
     const form = forms[i];
     if (!form) continue;
+    let inFlight = false;
     form.addEventListener("submit", (event) => {
       event.preventDefault();
+      if (inFlight) return;
       const actionType = form.getAttribute("data-operator-form");
       if (!actionType) return;
       const targetCanonical = form.querySelector('[name="target_canonical_id"]')?.value ?? "";
       const targetSource = form.querySelector('[name="target_source_id"]')?.value ?? "";
       const note = form.querySelector('[name="note"]')?.value ?? "";
+      const draftKey = operatorActionDraftKey(actionType, targetCanonical, targetSource);
+      rememberOperatorActionDraft(draftKey, note);
+      inFlight = true;
+      form.setAttribute?.("aria-busy", "true");
+      const controls = form.querySelectorAll?.("button,input,select,textarea") ?? [];
+      for (let controlIndex = 0; controlIndex < controls.length; controlIndex += 1) {
+        const control = controls[controlIndex];
+        if (control) control.disabled = true;
+      }
+      const submit = form.querySelector('button[type="submit"]');
+      if (submit) submit.textContent = "Registrando…";
       void Promise.resolve(
         adapter.operatorAction?.({
           action_type: actionType,
@@ -552,6 +608,23 @@ function bindOperatorActions(
         }),
       ).then((result) => {
         if (result) adapter.lastOperatorResult = result;
+        if (result?.ok) clearOperatorActionDraft(draftKey);
+        if (result?.ok && form.getAttribute("data-continuity-action") === "queue" && navigate) {
+          const explicit = form.getAttribute("data-continuity-next-hash");
+          const nextFocus = form.getAttribute("data-continuity-next-focus");
+          navigate(explicit || actionContinuationHash(currentHash, nextFocus));
+          return;
+        }
+        onDone();
+      }).catch((err: unknown) => {
+        adapter.lastOperatorResult = {
+          ok: false,
+          path: "/v1/operator-actions",
+          kind: "nota",
+          message: err instanceof Error ? err.message : "falha inesperada sem resposta",
+          outcome: "unknown",
+          code: "browser_transport",
+        };
         onDone();
       });
     });
@@ -1527,6 +1600,7 @@ export function mount(
 ): { unmount: () => void } {
   let generation = 0;
   const paint = (): void => {
+    runtime.rememberHash?.(runtime.getHash());
     generation += 1;
     const current = generation;
     paintShell(
@@ -1540,8 +1614,11 @@ export function mount(
     );
   };
   const stop = runtime.onHashChange(paint);
-  if (!runtime.getHash()) {
-    runtime.setHash("#/hoje");
+  const initialHash = runtime.getHash();
+  if (!initialHash) {
+    runtime.setHash(runtime.restoreHash?.() ?? "#/hoje");
+  } else if (!isRecognizedContinuityHash(initialHash)) {
+    runtime.replaceHash(CONTINUITY_RECOVERY_HASH);
   }
   paint();
   return {

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -12,13 +12,13 @@ import type {
   WarmblyGateAction,
 } from "./adapters/contract";
 import { APPROVAL_DEFAULT_REASON, isWarmblyGateAction } from "./adapters/contract";
+import { productionActorFromDocument } from "./adapters/http";
 import { WARMBLY_DISPATCH_PATHS, type WriteShortcutKind } from "./adapters/paths";
 import { parseHash, withQueryParams } from "./destinations";
 import {
   CONTINUITY_FIRST_FOCUS,
   CONTINUITY_RECOVERY_HASH,
   actionContinuationHash,
-  continuitySubjectFromDocument,
   isRecognizedContinuityHash,
   rememberContinuity,
   restoreContinuity,
@@ -81,7 +81,8 @@ export interface ShellRuntime {
 }
 
 export function browserRuntime(): ShellRuntime {
-  const continuitySubject = continuitySubjectFromDocument();
+  const actor = productionActorFromDocument();
+  const continuitySubject = actor ? `${actor.kind}:${actor.id}` : null;
   return {
     getHash(): string {
       return window.location.hash;
@@ -614,9 +615,8 @@ export function bindOperatorActions(
         if (result) adapter.lastOperatorResult = result;
         if (result?.ok) clearOperatorActionDraft(draftKey);
         if (result?.ok && form.getAttribute("data-continuity-action") === "queue" && navigate) {
-          const explicit = form.getAttribute("data-continuity-next-hash");
-          const nextFocus = form.getAttribute("data-continuity-next-focus");
-          navigate(explicit || actionContinuationHash(currentHash, nextFocus));
+          const next = form.getAttribute("data-continuity-next");
+          navigate(next?.startsWith("#") ? next : actionContinuationHash(currentHash, next));
           return;
         }
         onDone();

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -18,6 +18,7 @@ import {
   CONTINUITY_FIRST_FOCUS,
   CONTINUITY_RECOVERY_HASH,
   actionContinuationHash,
+  continuitySubjectFromDocument,
   isRecognizedContinuityHash,
   rememberContinuity,
   restoreContinuity,
@@ -80,6 +81,7 @@ export interface ShellRuntime {
 }
 
 export function browserRuntime(): ShellRuntime {
+  const continuitySubject = continuitySubjectFromDocument();
   return {
     getHash(): string {
       return window.location.hash;
@@ -91,15 +93,17 @@ export function browserRuntime(): ShellRuntime {
       window.history.replaceState(window.history.state, "", hash);
     },
     restoreHash(): string | null {
+      if (!continuitySubject) return null;
       try {
-        return restoreContinuity(window.sessionStorage);
+        return restoreContinuity(window.sessionStorage, continuitySubject);
       } catch {
         return null;
       }
     },
     rememberHash(hash: string): void {
+      if (!continuitySubject) return;
       try {
-        rememberContinuity(window.sessionStorage, hash);
+        rememberContinuity(window.sessionStorage, hash, continuitySubject);
       } catch {
         // A browser that blocks sessionStorage still has full URL continuity.
       }
@@ -1599,14 +1603,29 @@ export function mount(
   runtime: ShellRuntime = browserRuntime(),
 ): { unmount: () => void } {
   let generation = 0;
+  let initialized = false;
+  const normalizedHash = (): string => {
+    let hash = runtime.getHash();
+    if (!hash) {
+      hash = initialized ? "#/hoje" : (runtime.restoreHash?.() ?? "#/hoje");
+      if (!isRecognizedContinuityHash(hash)) hash = CONTINUITY_RECOVERY_HASH;
+      runtime.replaceHash(hash);
+    } else if (!isRecognizedContinuityHash(hash)) {
+      hash = CONTINUITY_RECOVERY_HASH;
+      runtime.replaceHash(hash);
+    }
+    initialized = true;
+    return hash;
+  };
   const paint = (): void => {
-    runtime.rememberHash?.(runtime.getHash());
+    const hash = normalizedHash();
+    runtime.rememberHash?.(hash);
     generation += 1;
     const current = generation;
     paintShell(
       root,
       adapter,
-      runtime.getHash(),
+      hash,
       current,
       (g) => g === generation,
       (next) => runtime.setHash(next),
@@ -1614,12 +1633,6 @@ export function mount(
     );
   };
   const stop = runtime.onHashChange(paint);
-  const initialHash = runtime.getHash();
-  if (!initialHash) {
-    runtime.setHash(runtime.restoreHash?.() ?? "#/hoje");
-  } else if (!isRecognizedContinuityHash(initialHash)) {
-    runtime.replaceHash(CONTINUITY_RECOVERY_HASH);
-  }
   paint();
   return {
     unmount(): void {

--- a/control-center/apps/web-shell/src/boot.ts
+++ b/control-center/apps/web-shell/src/boot.ts
@@ -2,6 +2,7 @@ import type { ControlCenterReadAdapter } from "./adapters/contract";
 import { createProductionAdapter } from "./adapters/http";
 import { mount, type MountableRoot } from "./app";
 import { DESTINATION_IDS, PRIMARY_SURFACE } from "./destinations";
+import { CONTINUITY_SURFACE_CONTRACTS } from "./continuity";
 import { registeredVisualRoutes, type VisualRoute } from "./visual-matrix";
 import {
   OPERATIONAL_COMPONENT_CONTRACT,
@@ -20,6 +21,9 @@ export interface ShellGlobals {
   version: string;
   destinations: readonly string[];
   visualRoutes: readonly VisualRoute[];
+  taskContinuity: {
+    surfaces: typeof CONTINUITY_SURFACE_CONTRACTS;
+  };
   designSystem: {
     components: typeof OPERATIONAL_COMPONENT_CONTRACT;
     states: typeof OPERATIONAL_STATES;
@@ -40,6 +44,9 @@ export function installShellGlobals(win: ShellWindow): ShellGlobals {
     version: SHELL_VERSION,
     destinations: DESTINATION_IDS,
     visualRoutes: registeredVisualRoutes(),
+    taskContinuity: {
+      surfaces: CONTINUITY_SURFACE_CONTRACTS,
+    },
     designSystem: {
       components: OPERATIONAL_COMPONENT_CONTRACT,
       states: OPERATIONAL_STATES,

--- a/control-center/apps/web-shell/src/continuity.ts
+++ b/control-center/apps/web-shell/src/continuity.ts
@@ -54,7 +54,7 @@ export const CONTINUITY_SURFACE_CONTRACTS = [
   { id: "inbound", route: "#/comercial/atividade?condicao=unread", selector: "[data-activity-id]" },
   { id: "exceptions", route: "#/comercial/excecoes", selector: "[data-exception-id]" },
   { id: "leads", route: "#/comercial/atividade?resource=lead", selector: "[data-lead-detail]" },
-  { id: "clients", route: "#/clientes/client-slug", selector: "[data-client]" },
+  { id: "clients", route: "#/clientes/acme-industria", selector: "[data-client]" },
   { id: "activities", route: "#/comercial/atividade", selector: "[data-list='atividade']" },
 ] as const;
 
@@ -66,11 +66,30 @@ export interface ContinuityStorage {
 
 interface StoredContinuity {
   readonly schema: typeof CONTINUITY_SCHEMA;
+  readonly subject: string;
   readonly hash: string;
   readonly savedAt: number;
 }
 
 const durableParams = new Set<string>(DURABLE_CONTINUITY_PARAMS);
+
+function isValidContinuitySubject(subject: string): boolean {
+  return subject.length > 0 && subject.length <= 320 && !/[\u0000-\u001f<>]/.test(subject);
+}
+
+/** Bind browser continuity to the authenticated actor represented by server-injected metadata. */
+export function continuitySubjectFromDocument(
+  doc: { querySelector(selector: string): { getAttribute(name: string): string | null } | null } | undefined =
+    typeof document !== "undefined" ? document : undefined,
+): string | null {
+  const id = doc?.querySelector('meta[name="cc-actor-id"]')?.getAttribute("content")?.trim() ?? "";
+  const kind = doc?.querySelector('meta[name="cc-actor-kind"]')?.getAttribute("content")?.trim() ?? "";
+  const subject = `${kind}:${id}`;
+  return (kind === "human" || kind === "agent" || kind === "system")
+    && isValidContinuitySubject(subject)
+    ? subject
+    : null;
+}
 
 function pathIsRecognized(path: string): boolean {
   const segments = path.replace(/^\/+/, "").split("/").filter(Boolean);
@@ -112,11 +131,13 @@ export function durableContinuityHash(hash: string): string | null {
 export function rememberContinuity(
   storage: ContinuityStorage,
   hash: string,
+  subject: string,
   now = Date.now(),
 ): boolean {
+  if (!isValidContinuitySubject(subject)) return false;
   const durable = durableContinuityHash(hash);
   if (!durable) return false;
-  const value: StoredContinuity = { schema: CONTINUITY_SCHEMA, hash: durable, savedAt: now };
+  const value: StoredContinuity = { schema: CONTINUITY_SCHEMA, subject, hash: durable, savedAt: now };
   try {
     storage.setItem(CONTINUITY_STORAGE_KEY, JSON.stringify(value));
     return true;
@@ -127,6 +148,7 @@ export function rememberContinuity(
 
 export function restoreContinuity(
   storage: ContinuityStorage,
+  subject: string,
   now = Date.now(),
 ): string | null {
   try {
@@ -137,7 +159,13 @@ export function restoreContinuity(
       && parsed.savedAt <= now
       && now - parsed.savedAt <= CONTINUITY_MAX_AGE_MS;
     const hash = typeof parsed.hash === "string" ? durableContinuityHash(parsed.hash) : null;
-    if (parsed.schema !== CONTINUITY_SCHEMA || !validAge || !hash) {
+    if (
+      !isValidContinuitySubject(subject)
+      || parsed.schema !== CONTINUITY_SCHEMA
+      || parsed.subject !== subject
+      || !validAge
+      || !hash
+    ) {
       storage.removeItem(CONTINUITY_STORAGE_KEY);
       return null;
     }

--- a/control-center/apps/web-shell/src/continuity.ts
+++ b/control-center/apps/web-shell/src/continuity.ts
@@ -53,8 +53,8 @@ export const CONTINUITY_SURFACE_CONTRACTS = [
   { id: "messages", route: "#/comercial/rascunhos", selector: "[data-review-list-item]" },
   { id: "inbound", route: "#/comercial/atividade?condicao=unread", selector: "[data-activity-id]" },
   { id: "exceptions", route: "#/comercial/excecoes", selector: "[data-exception-id]" },
-  { id: "leads", route: "#/comercial/atividade?resource=lead", selector: "[data-lead-detail]" },
-  { id: "clients", route: "#/clientes/acme-industria", selector: "[data-client]" },
+  { id: "leads", route: "#/comercial/atividade?resource=lead-fixture-aurora", selector: "[data-lead-detail='found']" },
+  { id: "clients", route: "#/clientes/acme", selector: "[data-client='acme']" },
   { id: "activities", route: "#/comercial/atividade", selector: "[data-list='atividade']" },
 ] as const;
 
@@ -75,20 +75,6 @@ const durableParams = new Set<string>(DURABLE_CONTINUITY_PARAMS);
 
 function isValidContinuitySubject(subject: string): boolean {
   return subject.length > 0 && subject.length <= 320 && !/[\u0000-\u001f<>]/.test(subject);
-}
-
-/** Bind browser continuity to the authenticated actor represented by server-injected metadata. */
-export function continuitySubjectFromDocument(
-  doc: { querySelector(selector: string): { getAttribute(name: string): string | null } | null } | undefined =
-    typeof document !== "undefined" ? document : undefined,
-): string | null {
-  const id = doc?.querySelector('meta[name="cc-actor-id"]')?.getAttribute("content")?.trim() ?? "";
-  const kind = doc?.querySelector('meta[name="cc-actor-kind"]')?.getAttribute("content")?.trim() ?? "";
-  const subject = `${kind}:${id}`;
-  return (kind === "human" || kind === "agent" || kind === "system")
-    && isValidContinuitySubject(subject)
-    ? subject
-    : null;
 }
 
 function pathIsRecognized(path: string): boolean {

--- a/control-center/apps/web-shell/src/continuity.ts
+++ b/control-center/apps/web-shell/src/continuity.ts
@@ -1,0 +1,192 @@
+import {
+  COMMERCIAL_SURFACES,
+  DESTINATION_IDS,
+  WARMBLY_SURFACES,
+} from "./destinations";
+
+export const CONTINUITY_SCHEMA = "control-center.task-continuity.v1" as const;
+export const CONTINUITY_STORAGE_KEY = "confenge.control-center.task-continuity.v1";
+export const CONTINUITY_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+export const CONTINUITY_RECOVERY_HASH = "#/hoje?continuity=recovered";
+export const CONTINUITY_END_FOCUS = "queue-summary";
+export const CONTINUITY_FIRST_FOCUS = "queue-first";
+
+/**
+ * These are the only query values allowed to survive reload/reauthentication.
+ * Typed notes, message copy, reasons, confirmations and unsubmitted decisions
+ * never enter this list and therefore never enter sessionStorage.
+ */
+export const DURABLE_CONTINUITY_PARAMS = [
+  "q",
+  "condicao",
+  "estado",
+  "tipo",
+  "origem",
+  "responsavel",
+  "prioridade",
+  "periodo",
+  "ordem",
+  "pagina",
+  "por_pagina",
+  "offset",
+  "resource",
+  "client",
+  "surface",
+  "pos",
+  "of",
+  "freshness",
+  "mensagens",
+] as const;
+
+export const NON_DURABLE_CONTINUITY_PARAMS = [
+  "focus",
+  "view",
+  "mode",
+  "note",
+  "reason",
+  "subject",
+  "body",
+  "confirmation_token",
+] as const;
+
+export const CONTINUITY_SURFACE_CONTRACTS = [
+  { id: "messages", route: "#/comercial/rascunhos", selector: "[data-review-list-item]" },
+  { id: "inbound", route: "#/comercial/atividade?condicao=unread", selector: "[data-activity-id]" },
+  { id: "exceptions", route: "#/comercial/excecoes", selector: "[data-exception-id]" },
+  { id: "leads", route: "#/comercial/atividade?resource=lead", selector: "[data-lead-detail]" },
+  { id: "clients", route: "#/clientes/client-slug", selector: "[data-client]" },
+  { id: "activities", route: "#/comercial/atividade", selector: "[data-list='atividade']" },
+] as const;
+
+export interface ContinuityStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+interface StoredContinuity {
+  readonly schema: typeof CONTINUITY_SCHEMA;
+  readonly hash: string;
+  readonly savedAt: number;
+}
+
+const durableParams = new Set<string>(DURABLE_CONTINUITY_PARAMS);
+
+function pathIsRecognized(path: string): boolean {
+  const segments = path.replace(/^\/+/, "").split("/").filter(Boolean);
+  const destination = segments[0] ?? "";
+  if (!(DESTINATION_IDS as readonly string[]).includes(destination)) return false;
+  if (destination === "comercial") {
+    return segments.length <= 2
+      && (!segments[1] || (COMMERCIAL_SURFACES as readonly string[]).includes(segments[1]));
+  }
+  if (destination === "warmbly") {
+    return segments.length <= 2
+      && (!segments[1] || (WARMBLY_SURFACES as readonly string[]).includes(segments[1]));
+  }
+  if (destination === "clientes") return segments.length <= 2;
+  return segments.length === 1;
+}
+
+export function isRecognizedContinuityHash(hash: string): boolean {
+  if (!hash.startsWith("#/")) return false;
+  const [path = ""] = hash.slice(1).split("?");
+  return path.length <= 320 && !/[\u0000-\u001f<>]/.test(path) && pathIsRecognized(path);
+}
+
+/** A bounded, non-sensitive location suitable for session continuity. */
+export function durableContinuityHash(hash: string): string | null {
+  if (!isRecognizedContinuityHash(hash)) return null;
+  const [path = "/hoje", query = ""] = hash.slice(1).split("?");
+  const safe = new URLSearchParams();
+  for (const [key, rawValue] of new URLSearchParams(query)) {
+    if (!durableParams.has(key)) continue;
+    const value = rawValue.trim();
+    if (!value || value.length > 256 || /[\u0000-\u001f]/.test(value)) continue;
+    safe.set(key, value);
+  }
+  const rendered = safe.toString();
+  return `#${path}${rendered ? `?${rendered}` : ""}`;
+}
+
+export function rememberContinuity(
+  storage: ContinuityStorage,
+  hash: string,
+  now = Date.now(),
+): boolean {
+  const durable = durableContinuityHash(hash);
+  if (!durable) return false;
+  const value: StoredContinuity = { schema: CONTINUITY_SCHEMA, hash: durable, savedAt: now };
+  try {
+    storage.setItem(CONTINUITY_STORAGE_KEY, JSON.stringify(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function restoreContinuity(
+  storage: ContinuityStorage,
+  now = Date.now(),
+): string | null {
+  try {
+    const raw = storage.getItem(CONTINUITY_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredContinuity>;
+    const validAge = typeof parsed.savedAt === "number"
+      && parsed.savedAt <= now
+      && now - parsed.savedAt <= CONTINUITY_MAX_AGE_MS;
+    const hash = typeof parsed.hash === "string" ? durableContinuityHash(parsed.hash) : null;
+    if (parsed.schema !== CONTINUITY_SCHEMA || !validAge || !hash) {
+      storage.removeItem(CONTINUITY_STORAGE_KEY);
+      return null;
+    }
+    return hash;
+  } catch {
+    try { storage.removeItem(CONTINUITY_STORAGE_KEY); } catch { /* storage unavailable */ }
+    return null;
+  }
+}
+
+const CROSS_SURFACE_PARAMS = [
+  "q",
+  "estado",
+  "origem",
+  "responsavel",
+  "prioridade",
+  "periodo",
+  "ordem",
+  "por_pagina",
+  "resource",
+  "freshness",
+  "mensagens",
+] as const;
+
+/** Preserve compatible context while changing sibling subroutes. */
+export function continuitySubrouteHref(currentHash: string, targetHash: string): string {
+  if (!isRecognizedContinuityHash(targetHash)) return CONTINUITY_RECOVERY_HASH;
+  const [currentPath = "", currentQuery = ""] = currentHash.split("?");
+  const [targetPath = targetHash, targetQuery = ""] = targetHash.split("?");
+  if (currentPath === targetPath) return currentHash;
+  const current = new URLSearchParams(currentQuery);
+  const target = new URLSearchParams(targetQuery);
+  for (const key of CROSS_SURFACE_PARAMS) {
+    const value = current.get(key);
+    if (value && !target.has(key)) target.set(key, value);
+  }
+  const query = target.toString();
+  return `${targetPath}${query ? `?${query}` : ""}`;
+}
+
+/** Location used after a definitive queue action. */
+export function actionContinuationHash(currentHash: string, nextFocus?: string | null): string {
+  const [path = "#/hoje", query = ""] = currentHash.split("?");
+  const params = new URLSearchParams(query);
+  params.delete("resource");
+  params.delete("pos");
+  params.delete("of");
+  params.delete("mode");
+  params.set("focus", nextFocus || CONTINUITY_END_FOCUS);
+  const rendered = params.toString();
+  return `${path}${rendered ? `?${rendered}` : ""}`;
+}

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -1,6 +1,12 @@
 import { escapeHtml } from "../escape";
+import { operatorActionDraft, operatorActionDraftKey } from "../action-draft";
 import { formatLocal, isUtcDateTime } from "../datetime";
 import { withQueryParams } from "../destinations";
+import {
+  CONTINUITY_FIRST_FOCUS,
+  actionContinuationHash,
+  continuitySubrouteHref,
+} from "../continuity";
 import { ACTIVITY_LIST, EXCEPTION_LIST } from "../filter";
 import { formatMoney } from "../money";
 import { ownMapValue } from "../own-map";
@@ -762,7 +768,7 @@ function controlledEmailCohort(ops: Record<string, unknown>): string {
   </section>`;
 }
 
-export function commercialSubnav(surface: string | null): string {
+export function commercialSubnav(surface: string | null, currentHash = "#/comercial/visao"): string {
   const items = [
     ["visao", "Visão"],
     ["rascunhos", "Rascunhos"],
@@ -775,7 +781,7 @@ export function commercialSubnav(surface: string | null): string {
   return `<nav class="subnav" aria-label="Superfícies comerciais">${items
     .map(
       ([id, label]) =>
-        `<a href="#/comercial/${id}" data-surface="${id}" aria-current="${current === id ? "page" : "false"}">${label}</a>`,
+        `<a href="${escapeHtml(continuitySubrouteHref(currentHash, `#/comercial/${id}`))}" data-surface="${id}" aria-current="${current === id ? "page" : "false"}">${label}</a>`,
     )
     .join("")}</nav>`;
 }
@@ -833,7 +839,7 @@ export function commercialBlock(
       ${provenanceBlock(snapshot.provenance)}
     </section>`;
   return `
-    ${commercialSubnav(current)}
+    ${commercialSubnav(current, hash)}
     ${current === "visao" ? recorte : ""}
     ${commercialOps(snapshot, current, resource, query, hash)}
   `;
@@ -852,7 +858,13 @@ function rowsOf(items: readonly unknown[]): Record<string, unknown>[] {
 function activityOpsCard(
   row: Record<string, unknown>,
   query: string | null,
-  position: { index: number; total: number; writesAllowed: boolean },
+  position: {
+    index: number;
+    total: number;
+    writesAllowed: boolean;
+    next?: { row: Record<string, unknown>; index: number };
+    nextPageHash?: string;
+  },
 ): string {
   const rowId = String(row.source_id ?? row.id ?? "");
   const title = escapeHtml(leadTitleOf(row) ?? "Organização não identificada pela origem");
@@ -871,6 +883,17 @@ function activityOpsCard(
   const sync = String(row.sync_status ?? "observed");
   const syncLabels: Record<string, string> = { observed: "observado na origem", synced: "sincronizado", pending: "sincronização pendente", failed: "falha de sincronização", unknown: "sincronização desconhecida" };
   const canonical = String(row.canonical_id ?? rowId);
+  const nextId = position.next ? String(position.next.row.source_id ?? position.next.row.id ?? "") : "";
+  const nextFocus = nextId && position.next
+    ? queueFocusToken(nextId, { index: position.next.index, total: position.total })
+    : "";
+  const actionContinuity = ` data-continuity-action="queue"${nextFocus
+    ? ` data-continuity-next-focus="${nextFocus}"`
+    : position.nextPageHash
+      ? ` data-continuity-next-hash="${escapeHtml(actionContinuationHash(position.nextPageHash, CONTINUITY_FIRST_FOCUS))}"`
+      : ""}`;
+  const assignDraft = operatorActionDraft(operatorActionDraftKey("ASSIGN_TRIAGE", canonical, rowId));
+  const triageDraft = operatorActionDraft(operatorActionDraftKey("MARK_TRIAGED", canonical, rowId));
   return `<article class="card"${focusAttributes} data-activity-id="${escapeHtml(rowId)}" data-activity-event="${escapeHtml(event)}" data-activity-state="${escapeHtml(state)}" data-triage-state="${escapeHtml(triage)}">
     <p class="kicker">${statusPill(triage, commercialStateLabel(triage))} · ${statusPill(event, commercialEventLabel(event))}${state && state !== triage ? ` · ${statusPill(state, commercialStateLabel(state))}` : ""}</p>
     <h3>${heading}</h3>
@@ -892,16 +915,16 @@ function activityOpsCard(
       { term: "sync_status", value: sync },
     ], "daily-triage")}
     ${position.writesAllowed ? `<div class="lead-actions" data-write-boundary="control-center">
-    <form data-operator-form="ASSIGN_TRIAGE" data-writes-to="control-center" class="operator-form">
+    <form data-operator-form="ASSIGN_TRIAGE" data-writes-to="control-center" class="operator-form"${actionContinuity}>
       <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonical)}" />
       <input type="hidden" name="target_source_id" value="${escapeHtml(rowId)}" />
-      <label>Nota de atribuição <textarea name="note" required minlength="2" maxlength="500"></textarea></label>
+      <label>Nota de atribuição <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(assignDraft)}</textarea></label>
       <button type="submit">Atribuir a mim</button>
     </form>
-    <form data-operator-form="MARK_TRIAGED" data-writes-to="control-center" class="operator-form">
+    <form data-operator-form="MARK_TRIAGED" data-writes-to="control-center" class="operator-form"${actionContinuity}>
       <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonical)}" />
       <input type="hidden" name="target_source_id" value="${escapeHtml(rowId)}" />
-      <label>Nota de triagem <textarea name="note" required minlength="2" maxlength="500"></textarea></label>
+      <label>Nota de triagem <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(triageDraft)}</textarea></label>
       <label class="confirm"><input type="checkbox" required name="ciencia" /> Entendo que isto registra a triagem no Control Center e não altera o Warmbly.</label>
       <button type="submit">Marcar como triado</button>
     </form>
@@ -909,7 +932,16 @@ function activityOpsCard(
   </article>`;
 }
 
-function exceptionOpsCard(row: Record<string, unknown>, writesAllowed: boolean): string {
+function exceptionOpsCard(
+  row: Record<string, unknown>,
+  position: {
+    index: number;
+    total: number;
+    writesAllowed: boolean;
+    next?: { row: Record<string, unknown>; index: number };
+    nextPageHash?: string;
+  },
+): string {
   const id = String(row.id ?? "");
   const canonical = String(row.canonical_id ?? id);
   const sourceId = String(row.source_id ?? id);
@@ -925,7 +957,22 @@ function exceptionOpsCard(row: Record<string, unknown>, writesAllowed: boolean):
     resolution = `<p class="constraint">Correção upstream não suportada pelo allowlist atual. Próxima ação: use a orientação abaixo e registre o desfecho; não marque como resolvida só por reconhecer.</p>`;
   }
   const open = workflow !== "resolved" && workflow !== "discarded";
-  return `<article class="card" data-exception-id="${escapeHtml(id)}" data-exception-status="${escapeHtml(String(row.status ?? ""))}" data-workflow-state="${escapeHtml(workflow)}" data-occurrence-count="${count}">
+  const focusToken = queueFocusToken(id, position);
+  const focusAttributes = id
+    ? ` id="${queueFocusDomId(focusToken)}" data-queue-focus="${focusToken}" tabindex="-1"`
+    : "";
+  const nextId = position.next ? String(position.next.row.id ?? position.next.row.source_id ?? "") : "";
+  const nextFocus = nextId && position.next
+    ? queueFocusToken(nextId, { index: position.next.index, total: position.total })
+    : "";
+  const actionContinuity = ` data-continuity-action="queue"${nextFocus
+    ? ` data-continuity-next-focus="${nextFocus}"`
+    : position.nextPageHash
+      ? ` data-continuity-next-hash="${escapeHtml(actionContinuationHash(position.nextPageHash, CONTINUITY_FIRST_FOCUS))}"`
+      : ""}`;
+  const acknowledgeDraft = operatorActionDraft(operatorActionDraftKey("ACKNOWLEDGE_EXCEPTION", canonical, sourceId));
+  const workDraft = operatorActionDraft(operatorActionDraftKey("START_EXCEPTION_WORK", canonical, sourceId));
+  return `<article class="card"${focusAttributes} data-exception-id="${escapeHtml(id)}" data-exception-status="${escapeHtml(String(row.status ?? ""))}" data-workflow-state="${escapeHtml(workflow)}" data-occurrence-count="${count}">
     <p class="kicker">${statusPill(workflow, commercialStateLabel(workflow))} · ${statusPill(String(row.kind ?? "exception"), exceptionKindLabel(String(row.kind ?? "exception")))}</p>
     <h3>${escapeHtml(String(row.why ?? row.id ?? "exceção"))}</h3>
     <dl class="facts">
@@ -946,18 +993,18 @@ function exceptionOpsCard(row: Record<string, unknown>, writesAllowed: boolean):
       { term: "group_key", value: String(row.group_key ?? "") },
       { term: "occurrence_ids", value: Array.isArray(row.occurrence_ids) ? row.occurrence_ids.join(",") : "" },
     ], "resolvable-exception")}
-    ${open && writesAllowed ? `<div class="lead-actions" data-write-boundary="control-center">
-      <form data-operator-form="ACKNOWLEDGE_EXCEPTION" data-writes-to="control-center" class="operator-form">
+    ${open && position.writesAllowed ? `<div class="lead-actions" data-write-boundary="control-center">
+      <form data-operator-form="ACKNOWLEDGE_EXCEPTION" data-writes-to="control-center" class="operator-form"${actionContinuity}>
         <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonical)}" />
         <input type="hidden" name="target_source_id" value="${escapeHtml(sourceId)}" />
-        <label>Nota <textarea name="note" required minlength="2" maxlength="500"></textarea></label>
+        <label>Nota <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(acknowledgeDraft)}</textarea></label>
         <label class="confirm"><input type="checkbox" required name="ciencia" /> Entendo que reconhecer não resolve nem remove a exceção.</label>
         <button type="submit">Reconhecer sem resolver</button>
       </form>
-      <form data-operator-form="START_EXCEPTION_WORK" data-writes-to="control-center" class="operator-form">
+      <form data-operator-form="START_EXCEPTION_WORK" data-writes-to="control-center" class="operator-form"${actionContinuity}>
         <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonical)}" />
         <input type="hidden" name="target_source_id" value="${escapeHtml(sourceId)}" />
-        <label>Plano de tratamento <textarea name="note" required minlength="2" maxlength="500"></textarea></label>
+        <label>Plano de tratamento <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(workDraft)}</textarea></label>
         <button type="submit">Iniciar tratamento</button>
       </form>
     </div>` : !open ? `<p class="banner ok">Desfecho observado na origem: ${escapeHtml(commercialStateLabel(workflow))}.</p>` : ""}
@@ -1530,7 +1577,7 @@ function commercialOps(
       noun: "exceção(ões) observada(s)",
       emptyData: "Nenhuma exceção observada.",
       intro: `<p class="constraint" data-operator-scope="control-center-only">Reconhecer no Control Center é um registro de auditoria local. Isto não resolve a exceção no Warmbly.</p>`,
-      card: (row, position) => exceptionOpsCard(row, position.writesAllowed),
+      card: (row, position) => exceptionOpsCard(row, position),
       remote: listViews.excecoes,
       declaredTotal: typeof overview.exceptions === "number" ? overview.exceptions : exceptions.length,
       complete: typeof overview.exceptions === "number" ? overview.exceptions === exceptions.length : true,

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -1716,7 +1716,7 @@ export function clientCard(item: ClientStatus): string {
     : "";
   const sources = item.sources ?? {};
   return `
-    <article class="card client" data-lifecycle="${escapeHtml(item.lifecycle)}" data-id="${escapeHtml(item.id)}">
+    <article class="card client" data-client="${escapeHtml(item.client_slug)}" data-lifecycle="${escapeHtml(item.lifecycle)}" data-id="${escapeHtml(item.id)}">
       <header>
         <p class="kicker">${statusPill(item.lifecycle, clientLifecycleLabel(item.lifecycle))} <span class="scope" data-scope="${escapeHtml(item.scope)}">${escapeHtml(scopeLabel(item.scope))}</span></p>
         <h3>${escapeHtml(item.display_name)}</h3>

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -855,6 +855,18 @@ function rowsOf(items: readonly unknown[]): Record<string, unknown>[] {
   );
 }
 
+function queueActionAttributes(
+  position: { index: number; total: number; nextPageHash?: string },
+  nextId: string,
+): string {
+  const next = nextId
+    ? queueFocusToken(nextId, { index: position.index + 1, total: position.total })
+    : position.nextPageHash
+      ? actionContinuationHash(position.nextPageHash, CONTINUITY_FIRST_FOCUS)
+      : "";
+  return ` data-continuity-action="queue"${next ? ` data-continuity-next="${escapeHtml(next)}"` : ""}`;
+}
+
 function activityOpsCard(
   row: Record<string, unknown>,
   query: string | null,
@@ -884,14 +896,7 @@ function activityOpsCard(
   const syncLabels: Record<string, string> = { observed: "observado na origem", synced: "sincronizado", pending: "sincronização pendente", failed: "falha de sincronização", unknown: "sincronização desconhecida" };
   const canonical = String(row.canonical_id ?? rowId);
   const nextId = position.next ? String(position.next.row.source_id ?? position.next.row.id ?? "") : "";
-  const nextFocus = nextId && position.next
-    ? queueFocusToken(nextId, { index: position.next.index, total: position.total })
-    : "";
-  const actionContinuity = ` data-continuity-action="queue"${nextFocus
-    ? ` data-continuity-next-focus="${nextFocus}"`
-    : position.nextPageHash
-      ? ` data-continuity-next-hash="${escapeHtml(actionContinuationHash(position.nextPageHash, CONTINUITY_FIRST_FOCUS))}"`
-      : ""}`;
+  const actionContinuity = queueActionAttributes(position, nextId);
   const assignDraft = operatorActionDraft(operatorActionDraftKey("ASSIGN_TRIAGE", canonical, rowId));
   const triageDraft = operatorActionDraft(operatorActionDraftKey("MARK_TRIAGED", canonical, rowId));
   return `<article class="card"${focusAttributes} data-activity-id="${escapeHtml(rowId)}" data-activity-event="${escapeHtml(event)}" data-activity-state="${escapeHtml(state)}" data-triage-state="${escapeHtml(triage)}">
@@ -962,14 +967,7 @@ function exceptionOpsCard(
     ? ` id="${queueFocusDomId(focusToken)}" data-queue-focus="${focusToken}" tabindex="-1"`
     : "";
   const nextId = position.next ? String(position.next.row.id ?? position.next.row.source_id ?? "") : "";
-  const nextFocus = nextId && position.next
-    ? queueFocusToken(nextId, { index: position.next.index, total: position.total })
-    : "";
-  const actionContinuity = ` data-continuity-action="queue"${nextFocus
-    ? ` data-continuity-next-focus="${nextFocus}"`
-    : position.nextPageHash
-      ? ` data-continuity-next-hash="${escapeHtml(actionContinuationHash(position.nextPageHash, CONTINUITY_FIRST_FOCUS))}"`
-      : ""}`;
+  const actionContinuity = queueActionAttributes(position, nextId);
   const acknowledgeDraft = operatorActionDraft(operatorActionDraftKey("ACKNOWLEDGE_EXCEPTION", canonical, sourceId));
   const workDraft = operatorActionDraft(operatorActionDraftKey("START_EXCEPTION_WORK", canonical, sourceId));
   return `<article class="card"${focusAttributes} data-exception-id="${escapeHtml(id)}" data-exception-status="${escapeHtml(String(row.status ?? ""))}" data-workflow-state="${escapeHtml(workflow)}" data-occurrence-count="${count}">

--- a/control-center/apps/web-shell/src/ui/lead-detail.ts
+++ b/control-center/apps/web-shell/src/ui/lead-detail.ts
@@ -28,6 +28,7 @@
 
 import { formatLocal } from "../datetime";
 import { escapeHtml } from "../escape";
+import { operatorActionDraft, operatorActionDraftKey } from "../action-draft";
 import { formatMoney, isMoney } from "../money";
 import { ownMapValue } from "../own-map";
 import { sourcePresentationLabel, sourceSystemLabel } from "../provenance";
@@ -813,15 +814,16 @@ function confirmationControls(action: LeadAction): string {
   return `${checkbox}<label>Digite RECONHECER para liberar <input name="palavra_de_confirmacao" required pattern="RECONHECER" title="Digite RECONHECER" /></label>`;
 }
 
-function localActionForm(action: LeadAction, resource: string, canonicalId: string): string {
+function localActionForm(action: LeadAction, resource: string, canonicalId: string, returnHash: string): string {
   const riskLabel = ownMapValue(RISK_LABEL, action.risk) ?? "risco não reconhecido";
+  const note = operatorActionDraft(operatorActionDraftKey(action.id, canonicalId, resource));
   return `
-    <form data-operator-form="${escapeHtml(action.id)}" data-writes-to="control-center" data-action-risk="${escapeHtml(action.risk)}" class="operator-form lead-action">
+    <form data-operator-form="${escapeHtml(action.id)}" data-writes-to="control-center" data-action-risk="${escapeHtml(action.risk)}" data-continuity-action="queue" data-continuity-next-hash="${escapeHtml(returnHash)}" class="operator-form lead-action">
       <h4>${escapeHtml(action.label)} <span class="pill" data-risk="${escapeHtml(action.risk)}">${escapeHtml(riskLabel)}</span></h4>
       <p class="constraint">${escapeHtml(action.effect)}</p>
       <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonicalId)}" />
       <input type="hidden" name="target_source_id" value="${escapeHtml(resource)}" />
-      <label>Nota de auditoria <textarea name="note" required minlength="2" maxlength="500"></textarea></label>
+      <label>Nota de auditoria <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(note)}</textarea></label>
       ${confirmationControls(action)}
       <button type="submit">${escapeHtml(action.label)}</button>
     </form>`;
@@ -946,7 +948,7 @@ export function leadDetailBlock(input: LeadDetailInput): string {
       <section class="stack lead-actions" aria-labelledby="lead-actions-title" data-action-scope="control-center-only">
         <h3 id="lead-actions-title">Registros no Control Center (não gravam no Warmbly)</h3>
         <p class="constraint" data-operator-scope="control-center-only">Estas ações gravam apenas um registro de auditoria local. Nada muda no Warmbly, e o item continua na fila até a origem mudar.</p>
-        ${model.localActions.map((action) => localActionForm(action, model.resource, model.canonicalId)).join("")}
+        ${model.localActions.map((action) => localActionForm(action, model.resource, model.canonicalId, model.backHash)).join("")}
       </section>
 
       <section class="stack lead-actions" aria-labelledby="lead-warmbly-title" data-action-scope="warmbly-write">

--- a/control-center/apps/web-shell/src/ui/lead-detail.ts
+++ b/control-center/apps/web-shell/src/ui/lead-detail.ts
@@ -818,7 +818,7 @@ function localActionForm(action: LeadAction, resource: string, canonicalId: stri
   const riskLabel = ownMapValue(RISK_LABEL, action.risk) ?? "risco não reconhecido";
   const note = operatorActionDraft(operatorActionDraftKey(action.id, canonicalId, resource));
   return `
-    <form data-operator-form="${escapeHtml(action.id)}" data-writes-to="control-center" data-action-risk="${escapeHtml(action.risk)}" data-continuity-action="queue" data-continuity-next-hash="${escapeHtml(returnHash)}" class="operator-form lead-action">
+    <form data-operator-form="${escapeHtml(action.id)}" data-writes-to="control-center" data-action-risk="${escapeHtml(action.risk)}" data-continuity-action="queue" data-continuity-next="${escapeHtml(returnHash)}" class="operator-form lead-action">
       <h4>${escapeHtml(action.label)} <span class="pill" data-risk="${escapeHtml(action.risk)}">${escapeHtml(riskLabel)}</span></h4>
       <p class="constraint">${escapeHtml(action.effect)}</p>
       <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonicalId)}" />

--- a/control-center/apps/web-shell/src/ui/list.ts
+++ b/control-center/apps/web-shell/src/ui/list.ts
@@ -39,7 +39,13 @@ export interface ListChromeInput {
   readonly intro?: string;
   readonly card: (
     row: Record<string, unknown>,
-    position: { index: number; total: number; writesAllowed: boolean },
+    position: {
+      index: number;
+      total: number;
+      writesAllowed: boolean;
+      next?: { row: Record<string, unknown>; index: number };
+      nextPageHash?: string;
+    },
   ) => string;
   /** Server-filtered bounded page. Omitted by the mock adapter. */
   readonly remote?: unknown;
@@ -229,7 +235,17 @@ export function renderFilteredList(input: ListChromeInput): string {
       ${unavailableNote}
       ${reference}
       <div class="stack">${view.items
-        .map((row, index) => input.card(row, { index: view.rangeStart + index, total: view.matched, writesAllowed }))
+        .map((row, index) => input.card(row, {
+          index: view.rangeStart + index,
+          total: view.matched,
+          writesAllowed,
+          ...(view.items[index + 1]
+            ? { next: { row: view.items[index + 1]!, index: view.rangeStart + index + 1 } }
+            : {}),
+          ...(index === view.items.length - 1 && view.page < view.pageCount
+            ? { nextPageHash: listHref(hash, { pagina: String(view.page + 1) }) }
+            : {}),
+        }))
         .join("")}</div>
       ${emptyState}
       ${pagination(view, hash, heading, spec.id)}

--- a/control-center/apps/web-shell/src/ui/render.ts
+++ b/control-center/apps/web-shell/src/ui/render.ts
@@ -159,6 +159,11 @@ function viewBanner(view: ViewState<DestinationPage>): string {
   return "";
 }
 
+function continuityRecoveryBanner(query: string | null | undefined): string {
+  if (new URLSearchParams(query ?? "").get("continuity") !== "recovered") return "";
+  return `<div class="banner stale" role="status" data-continuity-recovered="true"><strong>Local anterior indisponível.</strong> A rota não era válida e o Control Center recuperou Hoje. Use a navegação abaixo para retomar uma tarefa segura.</div>`;
+}
+
 export function operatorBanner(result: AdapterWriteResult | undefined): string {
   if (!result) return "";
   const cls = result.ok ? "ok" : "error";
@@ -436,6 +441,7 @@ export function renderShell(model: ShellModel): string {
         ${operationalPageHeader(label, headline)}
         ${renderOrientationSummary(orientation)}
         ${model.adapterMode === "http" ? "" : mockLab(model.destination, model.viewKind)}
+        ${continuityRecoveryBanner(model.query)}
         ${viewBanner(model.view)}
         ${model.destination === "warmbly" ? "" : operatorBanner(model.operatorResult)}
         <div id="orientacao-conteudo">${body}</div>

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -21,6 +21,7 @@
 import { escapeHtml } from "../escape";
 import { formatLocal } from "../datetime";
 import { ownMapValue } from "../own-map";
+import { continuitySubrouteHref } from "../continuity";
 import {
   DEFAULT_WARMBLY_SURFACE,
   WARMBLY_SURFACES,
@@ -2242,14 +2243,17 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   <p class="constraint">APPROVE é o único ato humano necessário para agendar a mensagem. O envio em si continua sendo do worker do Warmbly, na janela comercial e sob o teto por hora; esta tela não expõe send, queue ou resume.</p></section>`;
 }
 
-function warmblySubnav(current: WarmblySurface, resource: string | null | undefined): string {
+function warmblySubnav(current: WarmblySurface, input: WarmblySurfaceInput): string {
   // The resource travels with the operator. A subnav that drops it lands the
   // reviewer on an empty Revisão and makes the selection they just made look
   // like it never happened.
-  const suffix = resource ? `?resource=${encodeURIComponent(resource)}` : "";
+  const query = new URLSearchParams(input.query ?? "");
+  if (!query.get("resource") && input.resource) query.set("resource", input.resource);
+  const rendered = query.toString();
+  const currentHash = `#/warmbly/${current}${rendered ? `?${rendered}` : ""}`;
   return `<nav class="subnav" aria-label="Superfícies de operação Warmbly">${WARMBLY_SURFACES.map(
     (id) =>
-      `<a href="#/warmbly/${id}${suffix}" data-surface="${id}" aria-current="${current === id ? "page" : "false"}">${escapeHtml(
+      `<a href="${escapeHtml(continuitySubrouteHref(currentHash, `#/warmbly/${id}`))}" data-surface="${id}" aria-current="${current === id ? "page" : "false"}">${escapeHtml(
         ownMapValue(WARMBLY_SURFACE_LABELS, id) ?? "Operação",
       )}</a>`,
   ).join("")}</nav>`;
@@ -2262,5 +2266,5 @@ export function resolveWarmblySurface(surface: string | null | undefined): Warmb
 export function warmblyBlock(input: WarmblySurfaceInput, surface: string | null | undefined): string {
   const current = resolveWarmblySurface(surface);
   const render = ownMapValue(WARMBLY_SURFACE_RENDERERS, current) ?? operationSurface;
-  return `${warmblySubnav(current, input.resource)}${render(input)}`;
+  return `${warmblySubnav(current, input)}${render(input)}`;
 }

--- a/control-center/apps/web-shell/tests/continuity.test.ts
+++ b/control-center/apps/web-shell/tests/continuity.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createMockAdapter } from "../src/adapters/mock";
+import {
+  operatorActionDraft,
+  operatorActionDraftKey,
+  resetOperatorActionDrafts,
+} from "../src/action-draft";
+import {
+  bindOperatorActions,
+  consumeQueueFocus,
+  createMemoryRuntime,
+  mount,
+} from "../src/app";
+import {
+  CONTINUITY_END_FOCUS,
+  CONTINUITY_FIRST_FOCUS,
+  CONTINUITY_MAX_AGE_MS,
+  CONTINUITY_STORAGE_KEY,
+  CONTINUITY_SURFACE_CONTRACTS,
+  actionContinuationHash,
+  continuitySubrouteHref,
+  durableContinuityHash,
+  rememberContinuity,
+  restoreContinuity,
+  type ContinuityStorage,
+} from "../src/continuity";
+import { commercialSubnav } from "../src/ui/domains";
+import { queueFocusDomId, queueFocusToken } from "../src/ui/lead-detail";
+
+class MemoryStorage implements ContinuityStorage {
+  readonly values = new Map<string, string>();
+  getItem(key: string): string | null { return this.values.get(key) ?? null; }
+  setItem(key: string, value: string): void { this.values.set(key, value); }
+  removeItem(key: string): void { this.values.delete(key); }
+}
+
+test("durable continuity stores route context but never typed or unsubmitted decisions", () => {
+  const durable = durableContinuityHash(
+    "#/comercial/atividade?q=metal&estado=open&ordem=recentes&pagina=3&por_pagina=25&resource=lead-7&pos=51&of=75&focus=qf-51-6-abc&view=stale&mode=edit&note=segredo&reason=segredo&subject=segredo&body=segredo&confirmation_token=segredo",
+  );
+  assert.equal(
+    durable,
+    "#/comercial/atividade?q=metal&estado=open&ordem=recentes&pagina=3&por_pagina=25&resource=lead-7&pos=51&of=75",
+  );
+  assert.equal(durableContinuityHash("#/rota-inexistente?q=x"), null);
+  assert.equal(durableContinuityHash("#/clientes/acme-industria"), "#/clientes/acme-industria");
+});
+
+test("reload and reauthentication restore bounded context until explicit expiry", () => {
+  const storage = new MemoryStorage();
+  const now = Date.UTC(2026, 7, 25, 12, 0, 0);
+  assert.equal(rememberContinuity(storage, "#/comercial/excecoes?q=owner&pagina=4&focus=queue-first", now), true);
+  assert.equal(restoreContinuity(storage, now + 1_000), "#/comercial/excecoes?q=owner&pagina=4");
+  assert.equal(restoreContinuity(storage, now + CONTINUITY_MAX_AGE_MS + 1), null);
+  assert.equal(storage.getItem(CONTINUITY_STORAGE_KEY), null);
+
+  storage.setItem(CONTINUITY_STORAGE_KEY, "not-json");
+  assert.equal(restoreContinuity(storage, now), null);
+  assert.equal(storage.getItem(CONTINUITY_STORAGE_KEY), null);
+});
+
+test("mount restores a session location and invalid deep links recover to Hoje", () => {
+  const restoredRuntime = createMemoryRuntime("");
+  let remembered = "";
+  restoredRuntime.restoreHash = () => "#/comercial/atividade?q=inbound&pagina=2";
+  restoredRuntime.rememberHash = (hash) => { remembered = hash; };
+  const restoredRoot = { innerHTML: "" };
+  const restored = mount(restoredRoot, createMockAdapter(), restoredRuntime);
+  assert.equal(restoredRuntime.getHash(), "#/comercial/atividade?q=inbound&pagina=2");
+  assert.match(restoredRoot.innerHTML, /data-destination="comercial"/);
+  assert.equal(remembered, restoredRuntime.getHash());
+  restored.unmount();
+
+  const invalidRuntime = createMemoryRuntime("#/nao-existe?resource=lead-7");
+  const invalidRoot = { innerHTML: "" };
+  const invalid = mount(invalidRoot, createMockAdapter(), invalidRuntime);
+  assert.equal(invalidRuntime.getHash(), "#/hoje?continuity=recovered");
+  assert.match(invalidRoot.innerHTML, /data-continuity-recovered="true"/);
+  invalid.unmount();
+});
+
+test("sibling routes preserve compatible filters and selection without carrying stale pages", () => {
+  const current = "#/comercial/atividade?q=metal&estado=open&origem=warmbly&ordem=recentes&pagina=4&por_pagina=25&resource=lead-7&pos=76&of=120&focus=old";
+  assert.equal(
+    continuitySubrouteHref(current, "#/comercial/excecoes"),
+    "#/comercial/excecoes?q=metal&estado=open&origem=warmbly&ordem=recentes&por_pagina=25&resource=lead-7",
+  );
+  const nav = commercialSubnav("atividade", current);
+  assert.match(nav, /href="#\/comercial\/excecoes\?q=metal&amp;estado=open/);
+  const exceptionHref = /href="([^"]+)" data-surface="excecoes"/.exec(nav)?.[1] ?? "";
+  assert.doesNotMatch(exceptionHref, /pagina=4|pos=76|focus=old/);
+  assert.equal(
+    continuitySubrouteHref("#/warmbly/revisao?resource=cohort-9&estado=pendentes&mensagens=recolhidas", "#/warmbly/cohorts"),
+    "#/warmbly/cohorts?estado=pendentes&resource=cohort-9&mensagens=recolhidas",
+  );
+});
+
+test("a definitive queue action navigates to the next item and unknown stays put", async () => {
+  resetOperatorActionDrafts();
+  const next = queueFocusToken("exception-2", { index: 2, total: 4 });
+  let listener: ((event: Event) => void) | undefined;
+  const fields: Record<string, { value: string }> = {
+    target_canonical_id: { value: "cc:exception:1" },
+    target_source_id: { value: "exception-1" },
+    note: { value: "iniciar tratamento" },
+  };
+  const form = {
+    addEventListener(_type: string, handler: (event: Event) => void): void { listener = handler; },
+    getAttribute(name: string): string | null {
+      if (name === "data-operator-form") return "START_EXCEPTION_WORK";
+      if (name === "data-continuity-action") return "queue";
+      if (name === "data-continuity-next-focus") return next;
+      return null;
+    },
+    querySelector(selector: string): { value: string } | null {
+      const name = selector.match(/name="([^"]+)"/)?.[1] ?? "";
+      return fields[name] ?? null;
+    },
+  };
+  let navigated = "";
+  let repainted = 0;
+  let calls = 0;
+  const submit = (): void => {
+    const handler = listener;
+    assert.ok(handler);
+    handler({ preventDefault(): void {} } as Event);
+  };
+  bindOperatorActions(
+    { innerHTML: "", querySelectorAll: () => [form] } as never,
+    { operatorAction: async () => {
+      calls += 1;
+      return { ok: true, path: "/v1/operator-actions", kind: "nota", message: "registrado", outcome: "accepted" };
+    } } as never,
+    () => { repainted += 1; },
+    (hash) => { navigated = hash; },
+    "#/comercial/excecoes?q=owner&pagina=2",
+  );
+  submit();
+  submit();
+  assert.equal(calls, 1, "duplo submit durante o voo deve produzir uma única escrita");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(navigated, `#/comercial/excecoes?q=owner&pagina=2&focus=${next}`);
+  assert.equal(repainted, 0);
+  const draftKey = operatorActionDraftKey("START_EXCEPTION_WORK", "cc:exception:1", "exception-1");
+  assert.equal(operatorActionDraft(draftKey), "", "receipt definitivo descarta a nota volátil");
+
+  listener = undefined;
+  navigated = "";
+  bindOperatorActions(
+    { innerHTML: "", querySelectorAll: () => [form] } as never,
+    { operatorAction: async () => ({ ok: false, path: "/v1/operator-actions", kind: "nota", message: "sem resposta", outcome: "unknown" }) } as never,
+    () => { repainted += 1; },
+    (hash) => { navigated = hash; },
+    "#/comercial/excecoes?q=owner&pagina=2",
+  );
+  submit();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(navigated, "");
+  assert.equal(repainted, 1);
+  assert.equal(operatorActionDraft(draftKey), "iniciar tratamento", "unknown preserva a nota só em memória");
+  resetOperatorActionDrafts();
+});
+
+test("queue focus supports next page, exact row and end-of-queue announcement", () => {
+  const exactToken = queueFocusToken("row-1", { index: 1, total: 2 });
+  let firstFocus = 0;
+  let summaryFocus = 0;
+  const first = {
+    getAttribute(name: string): string | null {
+      if (name === "id") return queueFocusDomId(exactToken);
+      if (name === "data-queue-focus") return exactToken;
+      return null;
+    },
+    focus(): void { firstFocus += 1; },
+    scrollIntoView(): void {},
+  };
+  const summary = {
+    getAttribute(): string | null { return null; },
+    focus(): void { summaryFocus += 1; },
+    scrollIntoView(): void {},
+  };
+  const root = {
+    innerHTML: "",
+    querySelectorAll(selector: string) {
+      if (selector === "[data-queue-focus]") return [first];
+      if (selector === "[data-list-count]") return [summary];
+      return [];
+    },
+  };
+  assert.equal(consumeQueueFocus(root as never, `#/comercial/atividade?focus=${CONTINUITY_FIRST_FOCUS}`, true, () => {}), true);
+  assert.equal(firstFocus, 1);
+  assert.equal(consumeQueueFocus(root as never, `#/comercial/atividade?focus=${CONTINUITY_END_FOCUS}`, true, () => {}), false);
+  assert.equal(summaryFocus, 1);
+  assert.equal(actionContinuationHash("#/comercial/atividade?resource=lead-1&pos=1&of=2&q=x", null), `#/comercial/atividade?q=x&focus=${CONTINUITY_END_FOCUS}`);
+});
+
+test("the global contract names every required operational queue family", () => {
+  assert.deepEqual(
+    CONTINUITY_SURFACE_CONTRACTS.map((surface) => surface.id),
+    ["messages", "inbound", "exceptions", "leads", "clients", "activities"],
+  );
+  assert.equal(new Set(CONTINUITY_SURFACE_CONTRACTS.map((surface) => surface.route)).size, 6);
+});

--- a/control-center/apps/web-shell/tests/continuity.test.ts
+++ b/control-center/apps/web-shell/tests/continuity.test.ts
@@ -4,6 +4,7 @@ import { createMockAdapter } from "../src/adapters/mock";
 import {
   operatorActionDraft,
   operatorActionDraftKey,
+  rememberOperatorActionDraft,
   resetOperatorActionDrafts,
 } from "../src/action-draft";
 import {
@@ -20,6 +21,7 @@ import {
   CONTINUITY_SURFACE_CONTRACTS,
   actionContinuationHash,
   continuitySubrouteHref,
+  continuitySubjectFromDocument,
   durableContinuityHash,
   rememberContinuity,
   restoreContinuity,
@@ -50,14 +52,32 @@ test("durable continuity stores route context but never typed or unsubmitted dec
 test("reload and reauthentication restore bounded context until explicit expiry", () => {
   const storage = new MemoryStorage();
   const now = Date.UTC(2026, 7, 25, 12, 0, 0);
-  assert.equal(rememberContinuity(storage, "#/comercial/excecoes?q=owner&pagina=4&focus=queue-first", now), true);
-  assert.equal(restoreContinuity(storage, now + 1_000), "#/comercial/excecoes?q=owner&pagina=4");
-  assert.equal(restoreContinuity(storage, now + CONTINUITY_MAX_AGE_MS + 1), null);
+  assert.equal(rememberContinuity(storage, "#/comercial/excecoes?q=owner&pagina=4&focus=queue-first", "human:founder", now), true);
+  assert.equal(restoreContinuity(storage, "human:founder", now + 1_000), "#/comercial/excecoes?q=owner&pagina=4");
+  assert.equal(restoreContinuity(storage, "human:founder", now + CONTINUITY_MAX_AGE_MS + 1), null);
   assert.equal(storage.getItem(CONTINUITY_STORAGE_KEY), null);
 
   storage.setItem(CONTINUITY_STORAGE_KEY, "not-json");
-  assert.equal(restoreContinuity(storage, now), null);
+  assert.equal(restoreContinuity(storage, "human:founder", now), null);
   assert.equal(storage.getItem(CONTINUITY_STORAGE_KEY), null);
+});
+
+test("reauthentication never restores another actor's local context", () => {
+  const storage = new MemoryStorage();
+  const now = Date.UTC(2026, 7, 25, 12, 0, 0);
+  assert.equal(rememberContinuity(storage, "#/clientes/acme-industria?q=privado", "human:alice", now), true);
+  assert.equal(restoreContinuity(storage, "human:bob", now + 1_000), null);
+  assert.equal(storage.getItem(CONTINUITY_STORAGE_KEY), null);
+  assert.equal(rememberContinuity(storage, "#/hoje", "", now), false);
+
+  const metas: Record<string, string> = { "cc-actor-id": "alice", "cc-actor-kind": "human" };
+  const doc = { querySelector(selector: string) {
+    const name = /name="([^"]+)"/.exec(selector)?.[1] ?? "";
+    return metas[name] ? { getAttribute: () => metas[name] ?? null } : null;
+  } };
+  assert.equal(continuitySubjectFromDocument(doc), "human:alice");
+  metas["cc-actor-kind"] = "browser-asserted";
+  assert.equal(continuitySubjectFromDocument(doc), null);
 });
 
 test("mount restores a session location and invalid deep links recover to Hoje", () => {
@@ -77,7 +97,19 @@ test("mount restores a session location and invalid deep links recover to Hoje",
   const invalid = mount(invalidRoot, createMockAdapter(), invalidRuntime);
   assert.equal(invalidRuntime.getHash(), "#/hoje?continuity=recovered");
   assert.match(invalidRoot.innerHTML, /data-continuity-recovered="true"/);
+  invalidRuntime.setHash("#/tambem-nao-existe");
+  assert.equal(invalidRuntime.getHash(), "#/hoje?continuity=recovered");
+  assert.match(invalidRoot.innerHTML, /data-continuity-recovered="true"/);
   invalid.unmount();
+});
+
+test("clearing an unresolved note cannot resurrect its previous sensitive value", () => {
+  resetOperatorActionDrafts();
+  const key = operatorActionDraftKey("START_EXCEPTION_WORK", "cc:exception:1", "exception-1");
+  rememberOperatorActionDraft(key, "contexto privado");
+  assert.equal(operatorActionDraft(key), "contexto privado");
+  rememberOperatorActionDraft(key, "");
+  assert.equal(operatorActionDraft(key), "");
 });
 
 test("sibling routes preserve compatible filters and selection without carrying stale pages", () => {
@@ -201,4 +233,15 @@ test("the global contract names every required operational queue family", () => 
     ["messages", "inbound", "exceptions", "leads", "clients", "activities"],
   );
   assert.equal(new Set(CONTINUITY_SURFACE_CONTRACTS.map((surface) => surface.route)).size, 6);
+  const clientHtml = mountClientContract();
+  assert.match(clientHtml, /data-client="acme-industria"/);
 });
+
+function mountClientContract(): string {
+  const runtime = createMemoryRuntime("#/clientes/acme-industria");
+  const root = { innerHTML: "" };
+  const mounted = mount(root, createMockAdapter(), runtime);
+  const html = root.innerHTML;
+  mounted.unmount();
+  return html;
+}

--- a/control-center/apps/web-shell/tests/continuity.test.ts
+++ b/control-center/apps/web-shell/tests/continuity.test.ts
@@ -13,6 +13,7 @@ import {
   createMemoryRuntime,
   mount,
 } from "../src/app";
+import { installShellGlobals, type ShellWindow } from "../src/boot";
 import {
   CONTINUITY_END_FOCUS,
   CONTINUITY_FIRST_FOCUS,
@@ -21,7 +22,6 @@ import {
   CONTINUITY_SURFACE_CONTRACTS,
   actionContinuationHash,
   continuitySubrouteHref,
-  continuitySubjectFromDocument,
   durableContinuityHash,
   rememberContinuity,
   restoreContinuity,
@@ -70,14 +70,6 @@ test("reauthentication never restores another actor's local context", () => {
   assert.equal(storage.getItem(CONTINUITY_STORAGE_KEY), null);
   assert.equal(rememberContinuity(storage, "#/hoje", "", now), false);
 
-  const metas: Record<string, string> = { "cc-actor-id": "alice", "cc-actor-kind": "human" };
-  const doc = { querySelector(selector: string) {
-    const name = /name="([^"]+)"/.exec(selector)?.[1] ?? "";
-    return metas[name] ? { getAttribute: () => metas[name] ?? null } : null;
-  } };
-  assert.equal(continuitySubjectFromDocument(doc), "human:alice");
-  metas["cc-actor-kind"] = "browser-asserted";
-  assert.equal(continuitySubjectFromDocument(doc), null);
 });
 
 test("mount restores a session location and invalid deep links recover to Hoje", () => {
@@ -142,7 +134,7 @@ test("a definitive queue action navigates to the next item and unknown stays put
     getAttribute(name: string): string | null {
       if (name === "data-operator-form") return "START_EXCEPTION_WORK";
       if (name === "data-continuity-action") return "queue";
-      if (name === "data-continuity-next-focus") return next;
+      if (name === "data-continuity-next") return next;
       return null;
     },
     querySelector(selector: string): { value: string } | null {
@@ -233,15 +225,6 @@ test("the global contract names every required operational queue family", () => 
     ["messages", "inbound", "exceptions", "leads", "clients", "activities"],
   );
   assert.equal(new Set(CONTINUITY_SURFACE_CONTRACTS.map((surface) => surface.route)).size, 6);
-  const clientHtml = mountClientContract();
-  assert.match(clientHtml, /data-client="acme-industria"/);
+  const win: ShellWindow = { location: { protocol: "https:" } };
+  assert.equal(installShellGlobals(win).taskContinuity.surfaces, CONTINUITY_SURFACE_CONTRACTS);
 });
-
-function mountClientContract(): string {
-  const runtime = createMemoryRuntime("#/clientes/acme-industria");
-  const root = { innerHTML: "" };
-  const mounted = mount(root, createMockAdapter(), runtime);
-  const html = root.innerHTML;
-  mounted.unmount();
-  return html;
-}

--- a/control-center/apps/web-shell/tests/honesty-http.test.ts
+++ b/control-center/apps/web-shell/tests/honesty-http.test.ts
@@ -249,6 +249,25 @@ test("HTTP client 360 paints per-source absence for omitted Warmbly/Asaas/Govern
   assert.match(root.innerHTML, /data-client-source="governance"[^>]*data-absent="true"/);
 });
 
+test("HTTP client deep link reads the exact client scope instead of the empty roll-up", async () => {
+  const seen: string[] = [];
+  const { adapter } = httpAdapterFor((url) => {
+    seen.push(url);
+    return {
+      schema_version: "control-center.clients-snapshot.v1",
+      client_slug: "acme",
+      display_name: "ACME",
+      lifecycle: "active",
+      id: "cc:operational-snapshot:01M0WXAZ0Y0MS54HTACEA9RA0R",
+    };
+  });
+  const result = await adapter.readDestination("clientes", "#/clientes/acme");
+  assert.equal(result.ok, true);
+  if (!result.ok || result.loading) throw new Error("clientes/acme");
+  assert.equal(result.page.clients?.[0]?.client_slug, "acme");
+  assert.ok(seen.some((url) => url.includes("scope=client%3Aacme")));
+});
+
 test("operatorAction confirmation and error paint on the shipped HTTP path", async () => {
   const { adapter } = httpAdapterFor();
   const accepted = await adapter.operatorAction({

--- a/control-center/apps/web-shell/tests/performance-ux.test.ts
+++ b/control-center/apps/web-shell/tests/performance-ux.test.ts
@@ -93,6 +93,7 @@ test("performance budget owns exact mobile targets and critical routes", () => {
   assert.equal(budget.budgets.css_raw_bytes, 26000);
   assert.equal(budget.budgets.css_gzip_bytes, 7000);
   assert.equal(budget.budgets.bundle_gzip_bytes, 120000);
+  assert.equal(budget.budgets.javascript_gzip_bytes, 113000);
   assert.deepEqual(budget.routes.map((route: { id: string }) => route.id), ["hoje", "rascunhos", "coortes"]);
   const probe = readFileSync(join(app, "scripts/performance-probe.mjs"), "utf8");
   assert.match(probe, /performance_event_timing/);

--- a/control-center/docs/PERFORMANCE-UX-GATE.md
+++ b/control-center/docs/PERFORMANCE-UX-GATE.md
@@ -6,6 +6,8 @@ Este gate transforma a parte reproduzível da #112 em orçamento bloqueante. Ele
 
 `apps/web-shell/performance-budgets.json` é a fonte versionada dos limites. O build falha quando JavaScript ou CSS cru/gzip ultrapassa o orçamento. O laboratório abre `Hoje`, `Comercial > Rascunhos` e `Warmbly > Coortes` quatro vezes cada em `390 × 844`, com 120 ms de latência, 1,6 Mbps de download, 750 kbps de upload e CPU 4× mais lenta.
 
+O contrato global de continuidade acrescenta restauração validada, isolamento por ator, retomada de foco, deep link de cliente e proteção do rascunho volátil. Depois de deduplicar os atributos de fila, o artefato integrado mede 111.999 bytes de JavaScript gzip; por isso o subteto explícito passou de 110.000 para 113.000 bytes, com margem para variação do compressor. O teto de entrega agregado permanece 120.000 bytes gzip, sem aumento, e continua sendo a barreira contra transferir custo entre JavaScript e CSS.
+
 Por rota, o p75 precisa respeitar:
 
 - INP de laboratório ≤ 200 ms;

--- a/control-center/docs/TASK-CONTINUITY.md
+++ b/control-center/docs/TASK-CONTINUITY.md
@@ -15,11 +15,11 @@ O foco programático só é movido depois de um paint pronto: para a linha exata
 
 ## Reload, reautenticação e privacidade
 
-`sessionStorage` guarda por até 12 horas apenas uma projeção validada da rota. Podem persistir: busca, facetas, ordenação, página, tamanho da página, offset, `resource`, posição de retorno, freshness e preferência de expansão.
+`sessionStorage` guarda por até 12 horas apenas uma projeção validada da rota, vinculada à identidade de ator que o servidor injeta no documento. Podem persistir: busca, facetas, ordenação, página, tamanho da página, offset, `resource`, posição de retorno, freshness e preferência de expansão. Reautenticar como outro ator na mesma aba descarta o recorte anterior; metadado de identidade ausente ou inválido desabilita a persistência.
 
 Nunca persistem em storage: texto de notas, motivo, assunto, corpo, confirmação, decisão não submetida, modo de edição, estado sintético de vista ou marcador de foco. Uma nota de ação sem resultado definitivo permanece somente em memória volátil para sobreviver ao repaint e permitir readback/repetição consciente; sucesso a apaga e reload/reauth também. O servidor continua sendo a autoridade para qualquer efeito. Storage ausente/corrompido/expirado é descartado; rota inválida recupera `Hoje` com aviso, em vez de renderizar vazio.
 
-O armazenamento é de sessão, não compartilhado entre abas e não promovido para `localStorage`. Uma nova autenticação na mesma aba pode recuperar o recorte; fechar a sessão do navegador encerra essa continuidade local.
+O armazenamento é de sessão, não compartilhado entre abas e não promovido para `localStorage`. Uma nova autenticação do mesmo ator na mesma aba pode recuperar o recorte; fechar a sessão do navegador encerra essa continuidade local.
 
 ## Matriz automatizada
 

--- a/control-center/docs/TASK-CONTINUITY.md
+++ b/control-center/docs/TASK-CONTINUITY.md
@@ -1,0 +1,26 @@
+# Continuidade global de tarefa
+
+O contrato `control-center.task-continuity.v1` governa mensagens, inbound, exceções, leads, clientes e atividades. A URL é a fonte de verdade para busca, filtros, ordenação, página e seleção; o DOM e closures de um repaint não são armazenamento.
+
+## Navegação e ação
+
+- detalhe → voltar recompõe a URL da fila e usa um marcador de foco de uso único;
+- uma ação com receipt definitivo leva ao próximo item acionável, à primeira linha da próxima página ou ao resumo de fim da fila;
+- resultado `unknown` não avança nem remove o alvo: o operador permanece onde pode fazer readback;
+- filtros alterados preservam foco/caret, e paints assíncronos obsoletos não substituem o paint da navegação mais recente;
+- subrotas irmãs preservam busca, filtros compatíveis, ordenação, tamanho da página e `resource`, mas não carregam número/posição de uma página que pertence a outra fila;
+- back/forward e deep links reproduzem o estado funcional porque não dependem de memória volátil.
+
+O foco programático só é movido depois de um paint pronto: para a linha exata, primeira linha da nova página ou contagem da fila. O alvo recebe `preventScroll` seguido de centralização deliberada, evitando salto para o topo e fornecendo contexto ao leitor de tela.
+
+## Reload, reautenticação e privacidade
+
+`sessionStorage` guarda por até 12 horas apenas uma projeção validada da rota. Podem persistir: busca, facetas, ordenação, página, tamanho da página, offset, `resource`, posição de retorno, freshness e preferência de expansão.
+
+Nunca persistem em storage: texto de notas, motivo, assunto, corpo, confirmação, decisão não submetida, modo de edição, estado sintético de vista ou marcador de foco. Uma nota de ação sem resultado definitivo permanece somente em memória volátil para sobreviver ao repaint e permitir readback/repetição consciente; sucesso a apaga e reload/reauth também. O servidor continua sendo a autoridade para qualquer efeito. Storage ausente/corrompido/expirado é descartado; rota inválida recupera `Hoje` com aviso, em vez de renderizar vazio.
+
+O armazenamento é de sessão, não compartilhado entre abas e não promovido para `localStorage`. Uma nova autenticação na mesma aba pode recuperar o recorte; fechar a sessão do navegador encerra essa continuidade local.
+
+## Matriz automatizada
+
+Os testes exercitam ação → próxima, detalhe/seleção → fila, reload, expiração de sessão, rota inválida, transição de subrota e foco em próxima página/fim da fila. A lista executável `CONTINUITY_SURFACE_CONTRACTS` impede que uma das seis famílias de fila saia silenciosamente do contrato.

--- a/control-center/docs/TASK-CONTINUITY.md
+++ b/control-center/docs/TASK-CONTINUITY.md
@@ -21,6 +21,8 @@ Nunca persistem em storage: texto de notas, motivo, assunto, corpo, confirmaçã
 
 O armazenamento é de sessão, não compartilhado entre abas e não promovido para `localStorage`. Uma nova autenticação do mesmo ator na mesma aba pode recuperar o recorte; fechar a sessão do navegador encerra essa continuidade local.
 
+O custo de entrega permanece dentro do teto agregado de 120.000 bytes gzip. O subteto de JavaScript é 113.000 bytes para comportar o contrato após deduplicação e manter margem de compressor; CSS gzip e o limite agregado não foram ampliados.
+
 ## Matriz automatizada
 
-Os testes exercitam ação → próxima, detalhe/seleção → fila, reload, expiração de sessão, rota inválida, transição de subrota e foco em próxima página/fim da fila. A lista executável `CONTINUITY_SURFACE_CONTRACTS` impede que uma das seis famílias de fila saia silenciosamente do contrato.
+Os testes exercitam ação → próxima, detalhe/seleção → fila, reload, expiração de sessão, rota inválida, transição de subrota e foco em próxima página/fim da fila. O navegador consome a lista executável `CONTINUITY_SURFACE_CONTRACTS` e exige o alvo renderizado de cada uma das seis famílias em 390 px e 1280 px; uma fila não pode sair silenciosamente do contrato.


### PR DESCRIPTION
## Resumo
- cria contrato global de continuidade para mensagens, inbound, exceções, leads, clientes e atividades
- preserva filtros, ordenação, seleção e resource em URL/subrotas; restaura estado seguro após reload ou reautenticação
- leva ações definitivas ao próximo item, próxima página ou resumo da fila, sem avançar em resultado desconhecido
- bloqueia duplo submit e mantém notas não confirmadas somente em memória volátil

## Segurança e privacidade
- sessionStorage recebe apenas projeção validada da rota, com expiração de 12 horas
- notas, motivos, corpo, assunto, confirmações e decisões não submetidas nunca entram em storage
- rota inválida recupera Hoje com aviso; storage corrompido ou expirado é descartado

## Evidência
- 499 testes do shell
- workspace typecheck e suíte completa
- 69 testes de integração
- E2E: detalhe por teclado, ação para receipt, 19 rotas, 141 checks axe e 236 checks geométricos

Refs #115