### PR TITLE
[P1] Aplicar uma decisão humana por ação

### DIFF
--- a/.github/workflows/control-center.yml
+++ b/.github/workflows/control-center.yml
@@ -128,6 +128,9 @@ jobs:
           grep -E "launch-probe ok" /tmp/cc-e2e.log
           grep -E "view_state_driven=empty" /tmp/cc-e2e.log
           grep -E "visual_routes=[1-9][0-9]* source=browser_registry" /tmp/cc-e2e.log
+          grep -E "interaction_contract=PASS actions=[1-9][0-9]* journeys=[1-9]" /tmp/cc-e2e.log
+          grep -E "interaction_feedback=PASS budget_ms=100" /tmp/cc-e2e.log
+          grep -E "interaction_mobile=PASS viewport=390x844" /tmp/cc-e2e.log
           grep -E "visual_gate=PASS routes=[1-9][0-9]* axe_checks=[1-9]" /tmp/cc-e2e.log
           grep -E "performance_build=PASS" /tmp/cc-e2e.log
           grep -E "performance_lab=PASS routes=3 samples=12 canonical_sampled=false" /tmp/cc-e2e.log

--- a/control-center/apps/web-shell/performance-budgets.json
+++ b/control-center/apps/web-shell/performance-budgets.json
@@ -23,7 +23,7 @@
     "long_task_max_ms": 350,
     "initial_request_count": 16,
     "javascript_raw_bytes": 375000,
-    "javascript_gzip_bytes": 113000,
+    "javascript_gzip_bytes": 113500,
     "css_raw_bytes": 26000,
     "css_gzip_bytes": 7000,
     "bundle_gzip_bytes": 120000

--- a/control-center/apps/web-shell/scripts/launch-probe.mjs
+++ b/control-center/apps/web-shell/scripts/launch-probe.mjs
@@ -511,6 +511,27 @@ try {
   visualManifest.routes = routeInventory;
   console.log(`visual_routes=${routeInventory.length} source=browser_registry`);
 
+  const interactionContract = await page.evaluate(() => {
+    const contract = globalThis.__CONFENGE_CONTROL_CENTER__?.interactionContract;
+    return contract && Array.isArray(contract.actionIds) && Array.isArray(contract.journeys)
+      ? contract
+      : null;
+  });
+  if (!interactionContract || interactionContract.actionIds.length !== 27
+    || interactionContract.journeys.length !== 5
+    || interactionContract.feedbackBudgetMs !== 100) {
+    throw new Error("browser did not expose the complete mutable-interaction contract");
+  }
+  if (new Set(interactionContract.actionIds).size !== interactionContract.actionIds.length) {
+    throw new Error("mutable-interaction contract lost an action identity");
+  }
+  if (interactionContract.journeys.some((journey) => journey.after >= journey.before)) {
+    throw new Error("a critical interaction journey did not reduce its human steps");
+  }
+  console.log(
+    `interaction_contract=PASS actions=${interactionContract.actionIds.length} journeys=${interactionContract.journeys.length} feedback_budget_ms=100 double_submit=blocked readback=required`,
+  );
+
   for (const { label } of destinationRoutes) {
     const nav = page.locator("nav[aria-label='Áreas do Control Center'] a", { hasText: label });
     const count = await nav.count();
@@ -744,8 +765,80 @@ try {
   const grouped = await page.locator('[data-exception-id="exception-fixture-owner"]').getAttribute("data-occurrence-count");
   if (grouped !== "2") throw new Error(`grouped duplicate evidence lost: ${grouped}`);
   const action = page.locator('[data-operator-form="START_EXCEPTION_WORK"]');
+
+  // A 390x844 phone with a reduced visual area stands in for an open virtual
+  // keyboard. Native inline validation must retain the entered value, and the
+  // field plus CTA must remain above the task launcher.
+  await page.setViewportSize({ width: 390, height: 844 });
+  const redundantFields = await page.locator(
+    '[data-one-decision="true"] input:not([type="hidden"]), [data-one-decision="true"] textarea, [data-one-decision="true"] select',
+  ).count();
+  if (redundantFields !== 0) {
+    throw new Error(`one-decision actions reintroduced ${redundantFields} redundant field(s)`);
+  }
+  const note = action.locator('textarea[name="note"]');
+  const actionButton = action.locator('button[type="submit"]');
+  await note.fill("x");
+  await actionButton.click();
+  const inlineValidation = await note.evaluate((field) => ({
+    value: field.value,
+    valid: field.checkValidity(),
+    message: field.validationMessage,
+  }));
+  if (inlineValidation.valid || inlineValidation.value !== "x" || inlineValidation.message.length === 0) {
+    throw new Error(`inline validation did not retain the invalid draft: ${JSON.stringify(inlineValidation)}`);
+  }
+  await page.setViewportSize({ width: 390, height: 520 });
+  await note.focus();
+  await actionButton.scrollIntoViewIfNeeded();
+  const keyboardGeometry = await action.evaluate((form) => {
+    const field = form.querySelector('textarea[name="note"]')?.getBoundingClientRect();
+    const button = form.querySelector('button[type="submit"]')?.getBoundingClientRect();
+    const nav = document.querySelector(".task-nav")?.getBoundingClientRect();
+    const bottom = Math.min(globalThis.visualViewport?.height ?? innerHeight, nav?.top ?? innerHeight);
+    return {
+      field: field ? { top: field.top, bottom: field.bottom } : null,
+      button: button ? { top: button.top, bottom: button.bottom } : null,
+      usableBottom: bottom,
+    };
+  });
+  if (!keyboardGeometry.field || !keyboardGeometry.button
+    || keyboardGeometry.field.top < 0
+    || keyboardGeometry.button.bottom > keyboardGeometry.usableBottom + 1) {
+    throw new Error(`virtual-keyboard layout hides field or action: ${JSON.stringify(keyboardGeometry)}`);
+  }
+  await page.setViewportSize({ width: 390, height: 844 });
+  console.log(
+    `interaction_mobile=PASS viewport=390x844 keyboard_simulated_height=520 redundant_fields=${redundantFields} validation=inline draft=preserved action=unobscured`,
+  );
+
+  await action.evaluate((form) => {
+    globalThis.__CC_INTERACTION_PROBE__ = {};
+    const probe = globalThis.__CC_INTERACTION_PROBE__;
+    form.addEventListener("submit", () => {
+      probe.submittedAt = performance.now();
+    }, { capture: true, once: true });
+    const observer = new MutationObserver(() => {
+      if (form.getAttribute("aria-busy") !== "true" || probe.feedbackAt !== undefined) return;
+      observer.disconnect();
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          probe.feedbackAt = performance.now();
+        });
+      });
+    });
+    observer.observe(form, { attributes: true, attributeFilter: ["aria-busy"] });
+  });
   await action.locator('textarea[name="note"]').fill("Fixture e2e: atribuir responsável e validar a origem");
-  await action.locator('button[type="submit"]').click();
+  await actionButton.click();
+  await page.waitForFunction(() => globalThis.__CC_INTERACTION_PROBE__?.feedbackAt !== undefined);
+  const feedbackMs = await page.evaluate(() => {
+    const probe = globalThis.__CC_INTERACTION_PROBE__;
+    return probe.feedbackAt - probe.submittedAt;
+  });
+  if (!Number.isFinite(feedbackMs) || feedbackMs > 100) {
+    throw new Error(`interaction feedback exceeded 100ms: ${feedbackMs}`);
+  }
   await page.waitForSelector('.operator-result');
   if ((await page.locator('[data-action-receipt="true"]').count()) !== 1) {
     throw new Error(`authorized fixture action returned no receipt: ${await page.locator('.operator-result').innerText()}`);
@@ -756,6 +849,7 @@ try {
   }
   const criticalShot = screenshotPath.replace(/(\.[a-z]+)$/i, "-critical-path$1");
   await page.screenshot({ path: criticalShot, fullPage: true });
+  console.log(`interaction_feedback=PASS budget_ms=100 measured_ms=${feedbackMs.toFixed(2)} double_submit=blocked readback=confirmed`);
   console.log(`critical_path=exception_to_receipt outcome=accepted screenshot=${criticalShot}`);
 
   async function overflowPx() {

--- a/control-center/apps/web-shell/src/action-draft.ts
+++ b/control-center/apps/web-shell/src/action-draft.ts
@@ -1,11 +1,11 @@
-/**
- * Volatile notes for an operator action whose outcome is not definitive.
- *
- * This map survives a wholesale DOM repaint but deliberately does not survive
- * reload or reauthentication. Notes may contain sensitive operational context;
- * sessionStorage/localStorage are therefore outside this contract.
- */
-const notes = new Map<string, string>();
+import {
+  clearInteractionDraft,
+  interactionDraftValue,
+  rememberInteractionDraft,
+  resetInteractionDrafts,
+} from "./interaction-draft";
+
+const NOTE_FIELD = "note";
 
 export function operatorActionDraftKey(action: string, canonicalId: string, sourceId: string): string {
   return `${action.slice(0, 80)}\u0000${canonicalId.slice(0, 256)}\u0000${sourceId.slice(0, 256)}`;
@@ -14,20 +14,20 @@ export function operatorActionDraftKey(action: string, canonicalId: string, sour
 export function rememberOperatorActionDraft(key: string, note: string): void {
   if (!key) return;
   if (!note) {
-    notes.delete(key);
+    clearInteractionDraft(key);
     return;
   }
-  notes.set(key, note.slice(0, 500));
+  rememberInteractionDraft(key, { [NOTE_FIELD]: note.slice(0, 500) });
 }
 
 export function operatorActionDraft(key: string): string {
-  return notes.get(key) ?? "";
+  return interactionDraftValue(key, NOTE_FIELD);
 }
 
 export function clearOperatorActionDraft(key: string): void {
-  notes.delete(key);
+  clearInteractionDraft(key);
 }
 
 export function resetOperatorActionDrafts(): void {
-  notes.clear();
+  resetInteractionDrafts();
 }

--- a/control-center/apps/web-shell/src/app.ts
+++ b/control-center/apps/web-shell/src/app.ts
@@ -1,9 +1,4 @@
 import type { MockScenario } from "./adapters/mock";
-import {
-  clearOperatorActionDraft,
-  operatorActionDraftKey,
-  rememberOperatorActionDraft,
-} from "./action-draft";
 import type {
   AdapterWriteResult,
   ControlCenterReadAdapter,
@@ -43,6 +38,7 @@ import {
   resumeObservationFingerprint,
 } from "./warmbly-confirmation";
 import { pageIsEmpty, pageIsStale } from "./page";
+import { clearInteractionDraft, rememberInteractionDraft } from "./interaction-draft";
 import {
   confirmReviewDecided,
   markReviewDecided,
@@ -153,12 +149,14 @@ export interface MountableRoot {
       checked?: boolean;
       disabled?: boolean;
       textContent?: string | null;
+      getAttribute?(name: string): string | null;
     } | null;
     querySelectorAll?(selector: string): ArrayLike<{
       value: string;
       checked?: boolean;
       disabled?: boolean;
       textContent?: string | null;
+      getAttribute?(name: string): string | null;
       setAttribute?(name: string, value: string): void;
     }>;
     focus?(options?: { preventScroll?: boolean }): void;
@@ -223,6 +221,7 @@ function applyPaint(
   const repaint = (): void => {
     paintShell(root, adapter, renderHash, 0, () => true, navigate, replaceLocation);
   };
+  bindInteractionDraftCapture(root);
   bindWriteShortcuts(root, adapter, repaint);
   bindOperatorActions(root, adapter, repaint, navigate, renderHash);
   bindWarmblyDispatch(
@@ -490,6 +489,7 @@ export function bindReviewActions(
   for (let i = 0; i < forms.length; i += 1) {
     const form = forms[i];
     if (!form) continue;
+    bindExplicitSubmitKey(form);
     let inFlight = false;
     form.addEventListener("submit", (event) => {
       event.preventDefault();
@@ -503,6 +503,7 @@ export function bindReviewActions(
       const bodyText = form.querySelector('[name="body_text"]')?.value ?? "";
       const originalSubject = form.querySelector('[name="original_subject"]')?.value ?? subject;
       const originalBodyText = form.querySelector('[name="original_body_text"]')?.value ?? bodyText;
+      const draftKey = form.getAttribute("data-draft-key") ?? "";
       if (action !== "SAVE_ADJUSTMENT" && (subject !== originalSubject || bodyText !== originalBodyText)) {
         adapter.lastOperatorResult = {
           ok: false,
@@ -516,6 +517,11 @@ export function bindReviewActions(
         return;
       }
       inFlight = true;
+      rememberInteractionDraft(draftKey, {
+        subject,
+        body_text: bodyText,
+        reason: form.querySelector('[name="reason"]')?.value ?? "",
+      });
       form.setAttribute?.("aria-busy", "true");
       const controls = form.querySelectorAll?.("button,input,select,textarea") ?? [];
       for (let controlIndex = 0; controlIndex < controls.length; controlIndex += 1) {
@@ -545,6 +551,7 @@ export function bindReviewActions(
           if (result) {
             adapter.lastOperatorResult = result;
             if (result.ok) {
+              clearInteractionDraft(draftKey);
               const destinationId = action === "SAVE_ADJUSTMENT" ? id : nextReviewId;
               completionHash = withQueryParams(currentHash ?? "#/comercial/rascunhos", {
                 resource: destinationId || null,
@@ -572,6 +579,93 @@ export function bindReviewActions(
   }
 }
 
+type InteractiveForm = {
+  setAttribute?(name: string, value: string): void;
+  querySelector(selector: string): {
+    value: string;
+    checked?: boolean;
+    disabled?: boolean;
+    textContent?: string | null;
+  } | null;
+  querySelectorAll?(selector: string): ArrayLike<{
+    value: string;
+    checked?: boolean;
+    disabled?: boolean;
+    textContent?: string | null;
+  }>;
+};
+
+/** Paints the sub-100ms acknowledgement before any network promise can run. */
+function markInteractionPending(form: InteractiveForm, label: string): void {
+  form.setAttribute?.("aria-busy", "true");
+  const controls = form.querySelectorAll?.("button,input,select,textarea") ?? [];
+  for (let index = 0; index < controls.length; index += 1) {
+    const control = controls[index];
+    if (control) control.disabled = true;
+  }
+  const submit = form.querySelector('button[type="submit"]');
+  if (submit) submit.textContent = label;
+}
+
+/** Enter in a text field must not impersonate a deliberate risky-button press. */
+export function bindExplicitSubmitKey(form: {
+  getAttribute(name: string): string | null;
+  addEventListener(type: string, listener: (event: Event) => void): void;
+}): void {
+  if (form.getAttribute("data-explicit-submit") !== "true") return;
+  form.addEventListener("keydown", (event) => {
+    const keyboard = event as KeyboardEvent;
+    if (keyboard.key !== "Enter") return;
+    const target = keyboard.target as { matches?(selector: string): boolean } | null;
+    if (target?.matches?.('button[type="submit"], textarea')) return;
+    event.preventDefault();
+  });
+}
+
+/**
+ * Keeps human-authored input across any whole-shell repaint, including a
+ * repaint caused by another form before this form has been submitted.
+ */
+export function bindInteractionDraftCapture(root: MountableRoot): void {
+  if (typeof root.querySelectorAll !== "function") return;
+  const forms = root.querySelectorAll("[data-draft-key]");
+  for (let index = 0; index < forms.length; index += 1) {
+    const form = forms[index];
+    const key = form?.getAttribute("data-draft-key") ?? "";
+    if (!form || !key) continue;
+    const capture = (): void => {
+      const controls = form.querySelectorAll?.("input[name],select[name],textarea[name]") ?? [];
+      const values = new Map<string, string[]>();
+      for (let controlIndex = 0; controlIndex < controls.length; controlIndex += 1) {
+        const control = controls[controlIndex];
+        const name = control?.getAttribute?.("name") ?? "";
+        if (!control || !name) continue;
+        const type = control.getAttribute?.("type")?.toLowerCase() ?? "";
+        if ((type === "checkbox" || type === "radio") && control.checked !== true) continue;
+        const selected = values.get(name) ?? [];
+        selected.push(control.value ?? "");
+        values.set(name, selected);
+      }
+      rememberInteractionDraft(
+        key,
+        Object.fromEntries(Array.from(values, ([name, selected]) => [name, selected.join("|")])),
+      );
+    };
+    form.addEventListener("input", capture);
+    form.addEventListener("change", capture);
+  }
+}
+
+function browserWriteUnknown(path: string, err: unknown): AdapterWriteResult {
+  return {
+    ok: false,
+    path,
+    kind: "nota",
+    message: `Resultado não confirmado. Não repita ainda: ${err instanceof Error ? err.message : "falha inesperada"}.`,
+    outcome: "unknown",
+    code: "browser_transport",
+  };
+}
 export function bindOperatorActions(
   root: MountableRoot,
   adapter: ControlCenterReadAdapter,
@@ -584,6 +678,7 @@ export function bindOperatorActions(
   for (let i = 0; i < forms.length; i += 1) {
     const form = forms[i];
     if (!form) continue;
+    bindExplicitSubmitKey(form);
     let inFlight = false;
     form.addEventListener("submit", (event) => {
       event.preventDefault();
@@ -593,44 +688,42 @@ export function bindOperatorActions(
       const targetCanonical = form.querySelector('[name="target_canonical_id"]')?.value ?? "";
       const targetSource = form.querySelector('[name="target_source_id"]')?.value ?? "";
       const note = form.querySelector('[name="note"]')?.value ?? "";
-      const draftKey = operatorActionDraftKey(actionType, targetCanonical, targetSource);
-      rememberOperatorActionDraft(draftKey, note);
+      const draftKey = form.getAttribute("data-draft-key") ?? "";
       inFlight = true;
-      form.setAttribute?.("aria-busy", "true");
-      const controls = form.querySelectorAll?.("button,input,select,textarea") ?? [];
-      for (let controlIndex = 0; controlIndex < controls.length; controlIndex += 1) {
-        const control = controls[controlIndex];
-        if (control) control.disabled = true;
-      }
-      const submit = form.querySelector('button[type="submit"]');
-      if (submit) submit.textContent = "Registrando…";
-      void Promise.resolve(
-        adapter.operatorAction?.({
+      rememberInteractionDraft(draftKey, { note });
+      markInteractionPending(form, "Registrando…");
+      let continuation: string | null = null;
+      let request: AdapterWriteResult | Promise<AdapterWriteResult> | undefined;
+      try {
+        request = adapter.operatorAction?.({
           action_type: actionType,
           target_canonical_id: targetCanonical,
           target_source_id: targetSource,
           note,
-        }),
-      ).then((result) => {
-        if (result) adapter.lastOperatorResult = result;
-        if (result?.ok) clearOperatorActionDraft(draftKey);
-        if (result?.ok && form.getAttribute("data-continuity-action") === "queue" && navigate) {
-          const next = form.getAttribute("data-continuity-next");
-          navigate(next?.startsWith("#") ? next : actionContinuationHash(currentHash, next));
-          return;
-        }
+        });
+      } catch (err: unknown) {
+        adapter.lastOperatorResult = browserWriteUnknown("/v1/operator-actions", err);
         onDone();
-      }).catch((err: unknown) => {
-        adapter.lastOperatorResult = {
-          ok: false,
-          path: "/v1/operator-actions",
-          kind: "nota",
-          message: err instanceof Error ? err.message : "falha inesperada sem resposta",
-          outcome: "unknown",
-          code: "browser_transport",
-        };
-        onDone();
-      });
+        return;
+      }
+      void Promise.resolve(request)
+        .then((result) => {
+          if (result) adapter.lastOperatorResult = result;
+          if (result?.ok) {
+            clearInteractionDraft(draftKey);
+            if (form.getAttribute("data-continuity-action") === "queue" && navigate) {
+              const next = form.getAttribute("data-continuity-next");
+              continuation = next?.startsWith("#") ? next : actionContinuationHash(currentHash, next);
+            }
+          }
+        })
+        .catch((err: unknown) => {
+          adapter.lastOperatorResult = browserWriteUnknown("/v1/operator-actions", err);
+        })
+        .finally(() => {
+          if (continuation && navigate) navigate(continuation);
+          else onDone();
+        });
     });
   }
 }
@@ -650,7 +743,7 @@ export { clearPendingResumeConfirmation, pendingResumeConfirmation } from "./war
  * challenge drops the token, so a failed or spent confirmation always costs a
  * new deliberate act.
  */
-function bindWarmblyDispatch(
+export function bindWarmblyDispatch(
   root: MountableRoot,
   adapter: ControlCenterReadAdapter,
   onDone: () => void,
@@ -661,72 +754,86 @@ function bindWarmblyDispatch(
   for (let i = 0; i < forms.length; i += 1) {
     const form = forms[i];
     if (!form) continue;
+    bindExplicitSubmitKey(form);
+    let inFlight = false;
     form.addEventListener("submit", (event) => {
       event.preventDefault();
+      if (inFlight) return;
+      const requested = form.getAttribute("data-warmbly-dispatch");
+      if (requested !== "pause" && requested !== "resume" && requested !== "acknowledge") return;
+      inFlight = true;
+      const draftKey = form.getAttribute("data-draft-key") ?? "";
+      rememberInteractionDraft(draftKey, {
+        reason: form.querySelector('[name="reason"]')?.value ?? "",
+      });
+      markInteractionPending(form, "Confirmando no servidor…");
       void (async () => {
-        const requested = form.getAttribute("data-warmbly-dispatch");
-        if (requested !== "pause" && requested !== "resume" && requested !== "acknowledge") return;
-        const reason = form.querySelector('[name="reason"]')?.value ?? "";
-        const normalizedReason = reason.trim();
-        const targetId = form.querySelector('[name="target_id"]')?.value ?? "";
+        try {
+          const reason = form.querySelector('[name="reason"]')?.value ?? "";
+          const normalizedReason = reason.trim();
+          const targetId = form.querySelector('[name="target_id"]')?.value ?? "";
 
-        let action: "pause" | "resume_confirm" | "resume" | "acknowledge" = requested;
-        let confirmationToken: string | undefined;
-        const pending = readPendingResume();
+          let action: "pause" | "resume_confirm" | "resume" | "acknowledge" = requested;
+          let confirmationToken: string | undefined;
+          const pending = readPendingResume();
 
-        if (requested === "resume") {
-          const matchesPending =
-            pending !== undefined &&
-            pending.reason === normalizedReason &&
-            pending.observation_fingerprint === observationFingerprint;
-          if (matchesPending) {
-            // Take the token before the asynchronous freshness check. It is
-            // single-use in this client even if the read or the write fails.
-            confirmationToken = pending.token;
-            clearPendingResume();
-            const latestObservation = await latestResumeObservation(adapter);
-            if (latestObservation !== observationFingerprint) {
-              adapter.lastOperatorResult = staleResumeConfirmation();
-              onDone();
-              return;
+          if (requested === "resume") {
+            const matchesPending =
+              pending !== undefined &&
+              pending.reason === normalizedReason &&
+              pending.observation_fingerprint === observationFingerprint;
+            if (matchesPending) {
+              // Take the token before the asynchronous freshness check. It is
+              // single-use in this client even if the read or the write fails.
+              confirmationToken = pending.token;
+              clearPendingResume();
+              const latestObservation = await latestResumeObservation(adapter);
+              if (latestObservation !== observationFingerprint) {
+                adapter.lastOperatorResult = staleResumeConfirmation();
+                return;
+              }
+              action = "resume";
+            } else {
+              // A changed reason or changed rendered observation cannot inherit
+              // the old challenge. This submit starts a fresh first step.
+              clearPendingResume();
+              action = "resume_confirm";
             }
-            action = "resume";
           } else {
-            // A changed reason or changed rendered observation cannot inherit
-            // the old challenge. This submit starts a fresh first step.
+            // Pause and acknowledge are interventions. Even a refused attempt
+            // invalidates a prior resume decision before it can be reused.
             clearPendingResume();
-            action = "resume_confirm";
           }
-        } else {
-          // Pause and acknowledge are interventions. Even a refused attempt
-          // invalidates a prior resume decision before it can be reused.
-          clearPendingResume();
-        }
 
-        const result = await Promise.resolve(
-          adapter.warmblyDispatch?.({
-            action,
-            reason,
-            ...(action === "resume" && confirmationToken
-              ? { confirmation_token: confirmationToken }
-              : {}),
-            ...(requested === "acknowledge" ? { target_id: targetId } : {}),
-          }),
-        );
-        if (result) {
-          adapter.lastOperatorResult = result;
-          // Arm the following resume only when this call actually minted a
-          // challenge. A refusal arms nothing, and the challenge is bound to
-          // the same reason and observation the operator just reviewed.
-          if (action === "resume_confirm" && result.ok && result.confirmationToken) {
-            armPendingResumeConfirmation({
-              token: result.confirmationToken,
-              reason: normalizedReason,
-              observation_fingerprint: observationFingerprint,
-            });
+          const result = await Promise.resolve(
+            adapter.warmblyDispatch?.({
+              action,
+              reason,
+              ...(action === "resume" && confirmationToken
+                ? { confirmation_token: confirmationToken }
+                : {}),
+              ...(requested === "acknowledge" ? { target_id: targetId } : {}),
+            }),
+          );
+          if (result) {
+            adapter.lastOperatorResult = result;
+            if (result.ok) clearInteractionDraft(draftKey);
+            // Arm the following resume only when this call actually minted a
+            // challenge. A refusal arms nothing, and the challenge is bound to
+            // the same reason and observation the operator just reviewed.
+            if (action === "resume_confirm" && result.ok && result.confirmationToken) {
+              armPendingResumeConfirmation({
+                token: result.confirmationToken,
+                reason: normalizedReason,
+                observation_fingerprint: observationFingerprint,
+              });
+            }
           }
+        } catch (err: unknown) {
+          adapter.lastOperatorResult = browserWriteUnknown("/api/warmbly/dispatch", err);
+        } finally {
+          onDone();
         }
-        onDone();
       })();
     });
   }
@@ -763,6 +870,7 @@ function bindWarmblyHumanGate(
     if (!form) continue;
     const raw = form.getAttribute("data-human-gate");
     if (!isWarmblyGateAction(raw)) continue;
+    bindExplicitSubmitKey(form);
     form.addEventListener("submit", (event) => {
       event.preventDefault();
       const versionId = form.getAttribute("data-version") ?? "";
@@ -785,8 +893,14 @@ function bindWarmblyHumanGate(
         .map((entry) => entry.value)
         .filter(Boolean)
         .sort();
-      const confirmation = form.querySelector('[name="confirmation"]')?.value?.trim() ?? "";
+      // The rendered cohort version is already the frozen subject of this
+      // action. Requiring the operator to copy it into an input adds no new
+      // decision; derive the exact token while preserving the backend gate.
+      const confirmation = raw === "adjust"
+        ? `v${form.getAttribute("data-cohort-version") ?? ""}`
+        : "";
       const reason = form.querySelector('[name="reason"]')?.value ?? "";
+      const draftKey = form.getAttribute("data-draft-key") ?? "";
 
       if (raw === "adjust") {
         const subject = form.querySelector('[name="subject"]')?.value ?? "";
@@ -814,6 +928,11 @@ function bindWarmblyHumanGate(
       }
 
       if (!beginGateFlight(key)) return;
+      rememberInteractionDraft(draftKey, {
+        reason,
+        decision: decision ?? "",
+        recover_version_ids: recoverVersionIds.join("|"),
+      });
       const isApprove = raw === "review" && decision === "APPROVE";
       const intent: HumanGateIntent = {
         action: raw,
@@ -838,8 +957,8 @@ function bindWarmblyHumanGate(
         // to the trail: actor, instant, version, frozen hash and recipient are
         // all recorded already.
         ...(isApprove ? { acknowledged: true } : {}),
-        // Adjust costs a typed version confirmation so an edit cannot clobber
-        // a version the operator was not looking at.
+        // The backend still receives the exact version confirmation. Its value
+        // is derived from the immutable card the operator previewed.
         ...(raw === "adjust" && confirmation
           ? { confirmation }
           : {}),
@@ -897,7 +1016,8 @@ function bindWarmblyHumanGate(
           if (confirmedApplication(result)) confirmReviewDecided(versionId, candidateId);
           else rollbackReviewDecided(versionId, candidateId);
         }
-        if (raw === "adjust" && result.ok) clearAdjustDraft(candidateId);
+        if (raw === "adjust" && confirmedApplication(result)) clearAdjustDraft(candidateId);
+        if (confirmedApplication(result)) clearInteractionDraft(draftKey);
         // The reviewer's hands stay where they were: the next pending card
         // takes the focus so the following approval needs no scroll and no
         // pointer hunt.
@@ -987,7 +1107,11 @@ async function settleGateIntent(
   settleHumanGateIntent(intent, settledOutcome);
   const settled: AdapterWriteResult = {
     ...result,
-    ...(settledOutcome === "executed" ? { ok: true, outcome: "executed" } : {}),
+    ...(settledOutcome === "executed"
+      ? { ok: true, outcome: "executed" }
+      : settledOutcome === "refused"
+        ? { ok: false, outcome: "refused" }
+        : { ok: false, outcome: "unknown" }),
     readback,
   };
   adapter.lastOperatorResult = settled;
@@ -1264,7 +1388,7 @@ function gateNavigation(
   action: WarmblyGateAction,
   result: AdapterWriteResult | undefined,
 ): string | null {
-  if (!result?.ok) return null;
+  if (!result || !confirmedApplication(result)) return null;
   if (action !== "create" && action !== "reproduce" && action !== "adjust") return null;
   const cohortId = result.gateResource?.cohort_id;
   // No id in the response is not a reason to guess one: a version this screen
@@ -1545,7 +1669,7 @@ function staleResumeConfirmation(): AdapterWriteResult {
   };
 }
 
-function bindWriteShortcuts(
+export function bindWriteShortcuts(
   root: MountableRoot,
   adapter: ControlCenterReadAdapter,
   onDone: () => void,
@@ -1555,13 +1679,28 @@ function bindWriteShortcuts(
   for (let i = 0; i < forms.length; i += 1) {
     const form = forms[i];
     if (!form) continue;
+    let inFlight = false;
     form.addEventListener("submit", (event) => {
       event.preventDefault();
+      if (inFlight) return;
       const kind = form.getAttribute("data-shortcut-form") as WriteShortcutKind | null;
       if (!kind) return;
       const title = form.querySelector('[name="title"]')?.value ?? "";
       const body = form.querySelector('[name="body"]')?.value ?? "";
-      void Promise.resolve(adapter.writeShortcut?.(kind, { title, body })).then(onDone);
+      const draftKey = form.getAttribute("data-draft-key") ?? "";
+      inFlight = true;
+      rememberInteractionDraft(draftKey, { title, body });
+      markInteractionPending(form, "Registrando…");
+      void Promise.resolve()
+        .then(() => adapter.writeShortcut?.(kind, { title, body }))
+        .then((result) => {
+          if (result) adapter.lastOperatorResult = result;
+          if (result?.ok) clearInteractionDraft(draftKey);
+        })
+        .catch((err: unknown) => {
+          adapter.lastOperatorResult = browserWriteUnknown("/v1/directives", err);
+        })
+        .finally(onDone);
     });
   }
 }

--- a/control-center/apps/web-shell/src/boot.ts
+++ b/control-center/apps/web-shell/src/boot.ts
@@ -9,6 +9,11 @@ import {
   OPERATIONAL_STATES,
   renderOperationalComponentCatalog,
 } from "./ui/design-system";
+import {
+  CRITICAL_INTERACTION_JOURNEYS,
+  INTERACTION_FEEDBACK_BUDGET_MS,
+  MUTABLE_INTERACTION_IDS,
+} from "./interaction-runtime";
 
 export const SHELL_VERSION = "0.1.0";
 export const SHELL_GLOBAL_KEY = "__CONFENGE_CONTROL_CENTER__";
@@ -28,6 +33,11 @@ export interface ShellGlobals {
     components: typeof OPERATIONAL_COMPONENT_CONTRACT;
     states: typeof OPERATIONAL_STATES;
     renderCatalog: typeof renderOperationalComponentCatalog;
+  };
+  interactionContract: {
+    actionIds: typeof MUTABLE_INTERACTION_IDS;
+    journeys: typeof CRITICAL_INTERACTION_JOURNEYS;
+    feedbackBudgetMs: typeof INTERACTION_FEEDBACK_BUDGET_MS;
   };
   primarySurface: typeof PRIMARY_SURFACE;
   mount: typeof mount;
@@ -51,6 +61,11 @@ export function installShellGlobals(win: ShellWindow): ShellGlobals {
       components: OPERATIONAL_COMPONENT_CONTRACT,
       states: OPERATIONAL_STATES,
       renderCatalog: renderOperationalComponentCatalog,
+    },
+    interactionContract: {
+      actionIds: MUTABLE_INTERACTION_IDS,
+      journeys: CRITICAL_INTERACTION_JOURNEYS,
+      feedbackBudgetMs: INTERACTION_FEEDBACK_BUDGET_MS,
     },
     primarySurface: PRIMARY_SURFACE,
     mount,

--- a/control-center/apps/web-shell/src/interaction-contract.ts
+++ b/control-center/apps/web-shell/src/interaction-contract.ts
@@ -1,0 +1,75 @@
+import { INTERACTION_FEEDBACK_BUDGET_MS } from "./interaction-runtime";
+export {
+  CRITICAL_INTERACTION_JOURNEYS,
+  INTERACTION_FEEDBACK_BUDGET_MS,
+  MUTABLE_INTERACTION_IDS,
+} from "./interaction-runtime";
+
+export const INTERACTION_CONTRACT_SCHEMA = "control-center.interaction.v1" as const;
+
+export type InteractionRisk = "low" | "medium" | "high";
+export type HumanDecision = "one-tap" | "content" | "reason" | "selection" | "two-step";
+export type ConfirmationKind = "none" | "consequence" | "two-step";
+
+export interface MutableInteraction {
+  readonly id: string;
+  readonly route: string;
+  readonly action: string;
+  readonly risk: InteractionRisk;
+  readonly reversible: boolean;
+  readonly authority: "context-service" | "warmbly";
+  readonly consequence: string;
+  readonly humanDecision: HumanDecision;
+  readonly confirmation: ConfirmationKind;
+  readonly derived: readonly string[];
+  readonly stepsBefore: number;
+  readonly stepsAfter: number;
+  readonly readback: true;
+  readonly blocksDoubleSubmit: true;
+  readonly feedbackBudgetMs: typeof INTERACTION_FEEDBACK_BUDGET_MS;
+}
+
+function interaction(
+  input: Omit<MutableInteraction, "readback" | "blocksDoubleSubmit" | "feedbackBudgetMs">,
+): MutableInteraction {
+  return {
+    ...input,
+    readback: true,
+    blocksDoubleSubmit: true,
+    feedbackBudgetMs: INTERACTION_FEEDBACK_BUDGET_MS,
+  };
+}
+
+export const MUTABLE_INTERACTIONS: readonly MutableInteraction[] = [
+  interaction({ id: "today.directive", route: "#/hoje", action: "CREATE_DIRECTIVE", risk: "low", reversible: true, authority: "context-service", consequence: "Registra conteúdo autoral na memória operacional.", humanDecision: "content", confirmation: "none", derived: ["operator", "date", "directive_kind"], stepsBefore: 3, stepsAfter: 3 }),
+  interaction({ id: "today.acknowledge", route: "#/hoje", action: "ACKNOWLEDGE_EXCEPTION", risk: "low", reversible: true, authority: "context-service", consequence: "Registra reconhecimento local sem resolver a origem.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "target_ids", "note"], stepsBefore: 2, stepsAfter: 1 }),
+  interaction({ id: "activity.assign", route: "#/comercial/atividade", action: "ASSIGN_TRIAGE", risk: "low", reversible: true, authority: "context-service", consequence: "Atribui a triagem ao operador autenticado.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "target_ids", "note"], stepsBefore: 2, stepsAfter: 1 }),
+  interaction({ id: "activity.mark-triaged", route: "#/comercial/atividade", action: "MARK_TRIAGED", risk: "low", reversible: true, authority: "context-service", consequence: "Registra triagem local; não altera Warmbly.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "target_ids", "note"], stepsBefore: 3, stepsAfter: 1 }),
+  interaction({ id: "exceptions.acknowledge", route: "#/comercial/excecoes", action: "ACKNOWLEDGE_EXCEPTION", risk: "low", reversible: true, authority: "context-service", consequence: "Reconhece localmente; a exceção continua aberta.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "target_ids", "note"], stepsBefore: 3, stepsAfter: 1 }),
+  interaction({ id: "exceptions.start-work", route: "#/comercial/excecoes", action: "START_EXCEPTION_WORK", risk: "low", reversible: true, authority: "context-service", consequence: "Registra o plano que orientará o tratamento.", humanDecision: "content", confirmation: "none", derived: ["operator", "target_ids"], stepsBefore: 2, stepsAfter: 2 }),
+  interaction({ id: "lead.record-note", route: "#/comercial/atividade?resource=:id", action: "RECORD_NOTE", risk: "low", reversible: true, authority: "context-service", consequence: "Grava a nota digitada somente no Control Center.", humanDecision: "content", confirmation: "none", derived: ["operator", "target_ids"], stepsBefore: 2, stepsAfter: 2 }),
+  interaction({ id: "lead.mark-reviewed", route: "#/comercial/atividade?resource=:id", action: "MARK_REVIEWED", risk: "low", reversible: true, authority: "context-service", consequence: "Registra que o item foi revisto; não altera a origem.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "target_ids", "note"], stepsBefore: 2, stepsAfter: 1 }),
+  interaction({ id: "lead.review-activity", route: "#/comercial/atividade?resource=:id", action: "REVIEW_ACTIVITY", risk: "low", reversible: true, authority: "context-service", consequence: "Valida a leitura local da atividade.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "target_ids", "note"], stepsBefore: 2, stepsAfter: 1 }),
+  interaction({ id: "lead.confirm-next", route: "#/comercial/atividade?resource=:id", action: "CONFIRM_NEXT_ACTION", risk: "low", reversible: true, authority: "context-service", consequence: "Concorda com o próximo passo sem executá-lo.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "target_ids", "note"], stepsBefore: 2, stepsAfter: 1 }),
+  interaction({ id: "lead.reject-next", route: "#/comercial/atividade?resource=:id", action: "REJECT_NEXT_ACTION", risk: "medium", reversible: true, authority: "context-service", consequence: "Registra por que o próximo passo observado está errado.", humanDecision: "reason", confirmation: "none", derived: ["operator", "target_ids"], stepsBefore: 3, stepsAfter: 2 }),
+  interaction({ id: "lead.acknowledge-exception", route: "#/comercial/excecoes?resource=:id", action: "ACKNOWLEDGE_EXCEPTION", risk: "low", reversible: true, authority: "context-service", consequence: "Reconhece localmente e mantém a exceção aberta.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "target_ids", "note"], stepsBefore: 3, stepsAfter: 1 }),
+  interaction({ id: "lead.reopen-exception", route: "#/comercial/excecoes?resource=:id", action: "REOPEN_EXCEPTION", risk: "medium", reversible: true, authority: "context-service", consequence: "Registra a justificativa para reabrir o trabalho local.", humanDecision: "reason", confirmation: "none", derived: ["operator", "target_ids"], stepsBefore: 3, stepsAfter: 2 }),
+  interaction({ id: "lead.warmbly-acknowledge", route: "#/comercial/atividade?resource=:id", action: "acknowledge", risk: "medium", reversible: false, authority: "warmbly", consequence: "Marca o alerta provado como visto; não responde nem envia.", humanDecision: "one-tap", confirmation: "consequence", derived: ["operator", "target_id", "reason"], stepsBefore: 4, stepsAfter: 1 }),
+  interaction({ id: "draft.save", route: "#/comercial/rascunhos", action: "SAVE_ADJUSTMENT", risk: "low", reversible: true, authority: "context-service", consequence: "Salva assunto/corpo editados e relê o hash.", humanDecision: "content", confirmation: "none", derived: ["operator", "draft_id", "expected_hash"], stepsBefore: 3, stepsAfter: 3 }),
+  interaction({ id: "draft.approve", route: "#/comercial/rascunhos", action: "APPROVE", risk: "high", reversible: false, authority: "context-service", consequence: "Aprova e agenda o destinatário nomeado no botão.", humanDecision: "one-tap", confirmation: "consequence", derived: ["operator", "draft_id", "recipient", "expected_hash"], stepsBefore: 1, stepsAfter: 1 }),
+  interaction({ id: "draft.reject", route: "#/comercial/rascunhos", action: "REJECT", risk: "medium", reversible: true, authority: "context-service", consequence: "Solicita reescrita com o motivo digitado.", humanDecision: "reason", confirmation: "none", derived: ["operator", "draft_id", "expected_hash"], stepsBefore: 2, stepsAfter: 2 }),
+  interaction({ id: "dispatch.pause", route: "#/warmbly/operacao", action: "pause", risk: "medium", reversible: true, authority: "warmbly", consequence: "Interrompe o outbound; nada é enviado durante a pausa.", humanDecision: "one-tap", confirmation: "consequence", derived: ["operator", "reason"], stepsBefore: 2, stepsAfter: 1 }),
+  interaction({ id: "dispatch.resume", route: "#/warmbly/operacao", action: "resume", risk: "high", reversible: false, authority: "warmbly", consequence: "Libera e-mail frio sujeito à fila, janela e teto mostrados.", humanDecision: "two-step", confirmation: "two-step", derived: ["operator", "observation", "confirmation_token"], stepsBefore: 3, stepsAfter: 3 }),
+  interaction({ id: "gate.create", route: "#/warmbly/cohorts", action: "create", risk: "low", reversible: true, authority: "warmbly", consequence: "Cria a próxima cohort com 1 a 10 candidatos escolhidos pelo operador.", humanDecision: "selection", confirmation: "none", derived: ["operator", "selection_mode"], stepsBefore: 2, stepsAfter: 2 }),
+  interaction({ id: "gate.recover", route: "#/warmbly/cohorts", action: "create:recover", risk: "medium", reversible: true, authority: "warmbly", consequence: "Recompõe somente as versões selecionadas com dados atuais.", humanDecision: "selection", confirmation: "consequence", derived: ["operator", "limit", "selection_mode"], stepsBefore: 2, stepsAfter: 2 }),
+  interaction({ id: "gate.validate", route: "#/warmbly/revisao", action: "validate", risk: "low", reversible: true, authority: "warmbly", consequence: "Verifica destinatário sem enviar mensagem.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "version", "candidate"], stepsBefore: 1, stepsAfter: 1 }),
+  interaction({ id: "gate.approve", route: "#/warmbly/revisao", action: "review:APPROVE", risk: "high", reversible: false, authority: "warmbly", consequence: "Aprova e agenda a mensagem exata para a próxima janela.", humanDecision: "one-tap", confirmation: "consequence", derived: ["operator", "version", "candidate", "recipient", "reason", "acknowledgement"], stepsBefore: 2, stepsAfter: 1 }),
+  interaction({ id: "gate.hold-reject", route: "#/warmbly/revisao", action: "review:HOLD|REJECT", risk: "medium", reversible: true, authority: "warmbly", consequence: "Segura/rejeita e registra o motivo excepcional.", humanDecision: "reason", confirmation: "none", derived: ["operator", "version", "candidate"], stepsBefore: 3, stepsAfter: 3 }),
+  interaction({ id: "gate.adjust", route: "#/warmbly/revisao", action: "adjust", risk: "medium", reversible: true, authority: "warmbly", consequence: "Cria uma nova versão após mostrar o diff; a anterior permanece.", humanDecision: "content", confirmation: "consequence", derived: ["operator", "version_confirmation", "frozen_hash"], stepsBefore: 6, stepsAfter: 5 }),
+  interaction({ id: "gate.reproduce", route: "#/warmbly/revisao", action: "reproduce", risk: "low", reversible: true, authority: "warmbly", consequence: "Reproduz a versão imutável sem enviar.", humanDecision: "one-tap", confirmation: "none", derived: ["operator", "version"], stepsBefore: 1, stepsAfter: 1 }),
+  interaction({ id: "gate.reconcile", route: "#/warmbly/revisao", action: "reconcile", risk: "high", reversible: false, authority: "warmbly", consequence: "Reprocessa aprovações já registradas de forma idempotente.", humanDecision: "one-tap", confirmation: "consequence", derived: ["operator", "approved_bindings"], stepsBefore: 1, stepsAfter: 1 }),
+] as const;
+
+export function mutableInteraction(id: string): MutableInteraction | undefined {
+  return MUTABLE_INTERACTIONS.find((item) => item.id === id);
+}

--- a/control-center/apps/web-shell/src/interaction-draft.ts
+++ b/control-center/apps/web-shell/src/interaction-draft.ts
@@ -1,0 +1,40 @@
+/**
+ * Volatile form memory for recoverable write failures.
+ *
+ * This intentionally never touches localStorage/sessionStorage: operational
+ * notes and message bodies can be sensitive. A full reload clears the map,
+ * while a shell repaint after a refused or unknown response can restore what
+ * the operator typed.
+ */
+export type InteractionDraft = Readonly<Record<string, string>>;
+
+const drafts = new Map<string, InteractionDraft>();
+
+export function rememberInteractionDraft(key: string, fields: Record<string, string>): void {
+  if (!key) return;
+  const boundedKey = key.slice(0, 768);
+  const bounded = Object.fromEntries(
+    Object.entries(fields)
+      .slice(0, 24)
+      .map(([field, value]) => [field.slice(0, 80), String(value).slice(0, 8000)]),
+  );
+  drafts.set(boundedKey, bounded);
+}
+
+export function interactionDraft(key: string): InteractionDraft | undefined {
+  const draft = drafts.get(key.slice(0, 768));
+  return draft ? { ...draft } : undefined;
+}
+
+export function interactionDraftValue(key: string, field: string, fallback = ""): string {
+  return drafts.get(key.slice(0, 768))?.[field.slice(0, 80)] ?? fallback;
+}
+
+export function clearInteractionDraft(key: string): void {
+  if (key) drafts.delete(key.slice(0, 768));
+}
+
+/** Test seam. Production drafts otherwise live until success or reload. */
+export function resetInteractionDrafts(): void {
+  drafts.clear();
+}

--- a/control-center/apps/web-shell/src/interaction-runtime.ts
+++ b/control-center/apps/web-shell/src/interaction-runtime.ts
@@ -1,0 +1,40 @@
+/** Compact interaction evidence intentionally shipped to the browser. */
+export const INTERACTION_FEEDBACK_BUDGET_MS = 100 as const;
+
+export const MUTABLE_INTERACTION_IDS = [
+  "today.directive",
+  "today.acknowledge",
+  "activity.assign",
+  "activity.mark-triaged",
+  "exceptions.acknowledge",
+  "exceptions.start-work",
+  "lead.record-note",
+  "lead.mark-reviewed",
+  "lead.review-activity",
+  "lead.confirm-next",
+  "lead.reject-next",
+  "lead.acknowledge-exception",
+  "lead.reopen-exception",
+  "lead.warmbly-acknowledge",
+  "draft.save",
+  "draft.approve",
+  "draft.reject",
+  "dispatch.pause",
+  "dispatch.resume",
+  "gate.create",
+  "gate.recover",
+  "gate.validate",
+  "gate.approve",
+  "gate.hold-reject",
+  "gate.adjust",
+  "gate.reproduce",
+  "gate.reconcile",
+] as const;
+
+export const CRITICAL_INTERACTION_JOURNEYS = [
+  { id: "daily-triage", before: 3, after: 1 },
+  { id: "exception-acknowledge", before: 3, after: 1 },
+  { id: "inbound-acknowledge", before: 4, after: 1 },
+  { id: "approve-and-queue", before: 2, after: 1 },
+  { id: "adjust-version", before: 6, after: 5 },
+] as const;

--- a/control-center/apps/web-shell/src/ui/alert-card.ts
+++ b/control-center/apps/web-shell/src/ui/alert-card.ts
@@ -32,10 +32,9 @@ function acknowledgeForm(alert: AlertPresentation): string {
   const ack = alert.acknowledge;
   if (!ack) return "";
   return `
-        <form data-operator-form="${escapeHtml(ack.action_type)}" class="operator-form alert-ack">
+        <form data-operator-form="${escapeHtml(ack.action_type)}" data-interaction="today.acknowledge" data-one-decision="true" class="operator-form alert-ack">
           <input type="hidden" name="target_canonical_id" value="${escapeHtml(ack.target_canonical_id)}" />
           <input type="hidden" name="target_source_id" value="${escapeHtml(ack.target_source_id)}" />
-          <label>Nota do reconhecimento <textarea name="note" required minlength="2" rows="2"></textarea></label>
           <button type="submit">Reconhecer sem resolver</button>
           <p class="hint" data-ack-effect="control-center-only">${escapeHtml(ack.effect)}</p>
         </form>`;

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -1,5 +1,4 @@
 import { escapeHtml } from "../escape";
-import { operatorActionDraft, operatorActionDraftKey } from "../action-draft";
 import { formatLocal, isUtcDateTime } from "../datetime";
 import { withQueryParams } from "../destinations";
 import {
@@ -8,6 +7,7 @@ import {
   continuitySubrouteHref,
 } from "../continuity";
 import { ACTIVITY_LIST, EXCEPTION_LIST } from "../filter";
+import { interactionDraftValue } from "../interaction-draft";
 import { formatMoney } from "../money";
 import { ownMapValue } from "../own-map";
 import { sourceSystemLabel } from "../provenance";
@@ -897,8 +897,6 @@ function activityOpsCard(
   const canonical = String(row.canonical_id ?? rowId);
   const nextId = position.next ? String(position.next.row.source_id ?? position.next.row.id ?? "") : "";
   const actionContinuity = queueActionAttributes(position, nextId);
-  const assignDraft = operatorActionDraft(operatorActionDraftKey("ASSIGN_TRIAGE", canonical, rowId));
-  const triageDraft = operatorActionDraft(operatorActionDraftKey("MARK_TRIAGED", canonical, rowId));
   return `<article class="card"${focusAttributes} data-activity-id="${escapeHtml(rowId)}" data-activity-event="${escapeHtml(event)}" data-activity-state="${escapeHtml(state)}" data-triage-state="${escapeHtml(triage)}">
     <p class="kicker">${statusPill(triage, commercialStateLabel(triage))} · ${statusPill(event, commercialEventLabel(event))}${state && state !== triage ? ` · ${statusPill(state, commercialStateLabel(state))}` : ""}</p>
     <h3>${heading}</h3>
@@ -920,18 +918,16 @@ function activityOpsCard(
       { term: "sync_status", value: sync },
     ], "daily-triage")}
     ${position.writesAllowed ? `<div class="lead-actions" data-write-boundary="control-center">
-    <form data-operator-form="ASSIGN_TRIAGE" data-writes-to="control-center" class="operator-form"${actionContinuity}>
+    <form data-operator-form="ASSIGN_TRIAGE" data-writes-to="control-center" data-interaction="activity.assign" data-one-decision="true" class="operator-form"${actionContinuity}>
       <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonical)}" />
       <input type="hidden" name="target_source_id" value="${escapeHtml(rowId)}" />
-      <label>Nota de atribuição <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(assignDraft)}</textarea></label>
       <button type="submit">Atribuir a mim</button>
     </form>
-    <form data-operator-form="MARK_TRIAGED" data-writes-to="control-center" class="operator-form"${actionContinuity}>
+    <form data-operator-form="MARK_TRIAGED" data-writes-to="control-center" data-interaction="activity.mark-triaged" data-one-decision="true" class="operator-form"${actionContinuity}>
       <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonical)}" />
       <input type="hidden" name="target_source_id" value="${escapeHtml(rowId)}" />
-      <label>Nota de triagem <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(triageDraft)}</textarea></label>
-      <label class="confirm"><input type="checkbox" required name="ciencia" /> Entendo que isto registra a triagem no Control Center e não altera o Warmbly.</label>
       <button type="submit">Marcar como triado</button>
+      <p class="constraint">Registra a triagem neste Control Center; não altera o Warmbly.</p>
     </form>
     </div>` : ""}
   </article>`;
@@ -950,6 +946,7 @@ function exceptionOpsCard(
   const id = String(row.id ?? "");
   const canonical = String(row.canonical_id ?? id);
   const sourceId = String(row.source_id ?? id);
+  const startDraftKey = `operator:START_EXCEPTION_WORK:${canonical}:${sourceId}`;
   const workflow = String(row.workflow_state ?? "new");
   const owner = typeof row.owner === "string" && row.owner ? row.owner : "sem responsável";
   const age = typeof row.age_seconds === "number" ? `${Math.max(0, Math.floor(row.age_seconds / 3600))} h` : "não informada";
@@ -968,8 +965,6 @@ function exceptionOpsCard(
     : "";
   const nextId = position.next ? String(position.next.row.id ?? position.next.row.source_id ?? "") : "";
   const actionContinuity = queueActionAttributes(position, nextId);
-  const acknowledgeDraft = operatorActionDraft(operatorActionDraftKey("ACKNOWLEDGE_EXCEPTION", canonical, sourceId));
-  const workDraft = operatorActionDraft(operatorActionDraftKey("START_EXCEPTION_WORK", canonical, sourceId));
   return `<article class="card"${focusAttributes} data-exception-id="${escapeHtml(id)}" data-exception-status="${escapeHtml(String(row.status ?? ""))}" data-workflow-state="${escapeHtml(workflow)}" data-occurrence-count="${count}">
     <p class="kicker">${statusPill(workflow, commercialStateLabel(workflow))} · ${statusPill(String(row.kind ?? "exception"), exceptionKindLabel(String(row.kind ?? "exception")))}</p>
     <h3>${escapeHtml(String(row.why ?? row.id ?? "exceção"))}</h3>
@@ -992,17 +987,16 @@ function exceptionOpsCard(
       { term: "occurrence_ids", value: Array.isArray(row.occurrence_ids) ? row.occurrence_ids.join(",") : "" },
     ], "resolvable-exception")}
     ${open && position.writesAllowed ? `<div class="lead-actions" data-write-boundary="control-center">
-      <form data-operator-form="ACKNOWLEDGE_EXCEPTION" data-writes-to="control-center" class="operator-form"${actionContinuity}>
+      <form data-operator-form="ACKNOWLEDGE_EXCEPTION" data-writes-to="control-center" data-interaction="exceptions.acknowledge" data-one-decision="true" class="operator-form"${actionContinuity}>
         <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonical)}" />
         <input type="hidden" name="target_source_id" value="${escapeHtml(sourceId)}" />
-        <label>Nota <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(acknowledgeDraft)}</textarea></label>
-        <label class="confirm"><input type="checkbox" required name="ciencia" /> Entendo que reconhecer não resolve nem remove a exceção.</label>
         <button type="submit">Reconhecer sem resolver</button>
+        <p class="constraint">Registra o reconhecimento local; não resolve nem remove a exceção.</p>
       </form>
-      <form data-operator-form="START_EXCEPTION_WORK" data-writes-to="control-center" class="operator-form"${actionContinuity}>
+      <form data-operator-form="START_EXCEPTION_WORK" data-writes-to="control-center" data-draft-key="${escapeHtml(startDraftKey)}" data-interaction="exceptions.start-work" class="operator-form"${actionContinuity}>
         <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonical)}" />
         <input type="hidden" name="target_source_id" value="${escapeHtml(sourceId)}" />
-        <label>Plano de tratamento <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(workDraft)}</textarea></label>
+        <label>Plano de tratamento <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(interactionDraftValue(startDraftKey, "note"))}</textarea></label>
         <button type="submit">Iniciar tratamento</button>
       </form>
     </div>` : !open ? `<p class="banner ok">Desfecho observado na origem: ${escapeHtml(commercialStateLabel(workflow))}.</p>` : ""}
@@ -1311,6 +1305,11 @@ function reviewDraftInspector(
     : ` data-reason-codes="${escapeHtml(editorial.reasonCodes.join(" "))}"`;
   const subjectRows = reviewRows(subject, 2, 4);
   const bodyRows = reviewRows(bodyText, 12, 40);
+  const editDraftKey = `review:${id}:SAVE_ADJUSTMENT`;
+  const rejectDraftKey = `review:${id}:REJECT`;
+  const editSubject = interactionDraftValue(editDraftKey, "subject", subject);
+  const editBodyText = interactionDraftValue(editDraftKey, "body_text", bodyText);
+  const rejectReason = interactionDraftValue(rejectDraftKey, "reason");
   const factUsed = reviewText(row.fact_used);
   const provenance = reviewProvenance(row);
   const targetFit = reviewTargetFit(row.target_fit);
@@ -1365,29 +1364,29 @@ function reviewDraftInspector(
   const decision = !actionable
     ? `<div class="review-readonly" data-review-readonly="${escapeHtml(id)}">${readOnlyMessage}</div>`
     : mode === "edit"
-      ? `<form data-review-form="${escapeHtml(id)}" data-review-mode="edit" class="operator-form review-decision-form">
+      ? `<form data-review-form="${escapeHtml(id)}" data-review-mode="edit" data-draft-key="${escapeHtml(editDraftKey)}" data-interaction="draft.save" class="operator-form review-decision-form">
                 ${commonHidden}
                 <input type="hidden" name="action" value="SAVE_ADJUSTMENT" />
-                <label>Assunto <textarea name="subject" rows="${subjectRows}">${escapeHtml(subject)}</textarea></label>
-                <label>Corpo <textarea name="body_text" rows="${bodyRows}">${escapeHtml(bodyText)}</textarea></label>
+                <label>Assunto <textarea name="subject" rows="${subjectRows}">${escapeHtml(editSubject)}</textarea></label>
+                <label>Corpo <textarea name="body_text" rows="${bodyRows}">${escapeHtml(editBodyText)}</textarea></label>
                 <div class="review-actions">
                   <button type="submit" data-review-save="true">Salvar ajuste</button>
                   <a class="button" href="${escapeHtml(reviewDraftHref(id, "inspect", hash))}">Cancelar edição</a>
                 </div>
               </form>`
       : mode === "reject"
-        ? `${readOnlyMessage}<form data-review-form="${escapeHtml(id)}" data-review-mode="reject" class="operator-form review-decision-form">
+        ? `${readOnlyMessage}<form data-review-form="${escapeHtml(id)}" data-review-mode="reject" data-draft-key="${escapeHtml(rejectDraftKey)}" data-interaction="draft.reject" class="operator-form review-decision-form">
                 ${commonHidden}
                 <input type="hidden" name="action" value="REJECT" />
                 <textarea name="subject" hidden>${escapeHtml(subject)}</textarea>
                 <textarea name="body_text" hidden>${escapeHtml(bodyText)}</textarea>
-                <label>Motivo para reescrita <textarea name="reason" rows="4" required></textarea></label>
+                <label>Motivo para reescrita <textarea name="reason" rows="4" required>${escapeHtml(rejectReason)}</textarea></label>
                 <div class="review-actions">
                   <button type="submit" data-review-reject="true">Rejeitar e solicitar reescrita</button>
                   <a class="button" href="${escapeHtml(reviewDraftHref(id, "inspect", hash))}">Cancelar rejeição</a>
                 </div>
               </form>`
-        : `${readOnlyMessage}<form data-review-form="${escapeHtml(id)}" data-review-mode="approve" class="operator-form review-decision-form approve-form">
+        : `${readOnlyMessage}<form data-review-form="${escapeHtml(id)}" data-review-mode="approve" data-interaction="draft.approve" data-one-decision="true" class="operator-form review-decision-form approve-form">
                 ${commonHidden}
                 <input type="hidden" name="action" value="APPROVE" />
                 <textarea name="subject" hidden>${escapeHtml(subject)}</textarea>

--- a/control-center/apps/web-shell/src/ui/hoje.ts
+++ b/control-center/apps/web-shell/src/ui/hoje.ts
@@ -6,6 +6,7 @@ import { ownMapValue } from "../own-map";
 import type { HojeSection, HojeViewModel } from "../hoje-compose";
 import { WRITE_SHORTCUT_LABELS } from "../adapters/paths";
 import { freshnessTone } from "../freshness-tone";
+import { interactionDraftValue } from "../interaction-draft";
 import {
   CONFIDENCE_HELP,
   confidenceWord,
@@ -88,17 +89,18 @@ function shortcutForm(section: HojeSection): string {
   return section.shortcuts
     .map((shortcut) => {
       const label = ownMapValue(WRITE_SHORTCUT_LABELS, shortcut.kind) ?? "Atalho operacional";
+      const draftKey = `shortcut:${shortcut.kind}`;
       return `
-        <form class="shortcut-form" data-shortcut-form="${escapeHtml(shortcut.kind)}" data-write-path="/v1/directives">
+        <form class="shortcut-form" data-shortcut-form="${escapeHtml(shortcut.kind)}" data-draft-key="${escapeHtml(draftKey)}" data-interaction="today.directive" data-write-path="/v1/directives">
           <h3>${escapeHtml(label)}</h3>
           <p class="hint">${escapeHtml(shortcut.hint)}</p>
           <label>
             Título
-            <input name="title" type="text" required maxlength="200" autocomplete="off" />
+            <input name="title" type="text" required maxlength="200" autocomplete="off" value="${escapeHtml(interactionDraftValue(draftKey, "title"))}" />
           </label>
           <label>
             Corpo
-            <textarea name="body" required maxlength="8000" rows="3"></textarea>
+            <textarea name="body" required maxlength="8000" rows="3">${escapeHtml(interactionDraftValue(draftKey, "body"))}</textarea>
           </label>
           <button type="submit">${escapeHtml(label)}</button>
           ${technicalDetails(

--- a/control-center/apps/web-shell/src/ui/lead-detail.ts
+++ b/control-center/apps/web-shell/src/ui/lead-detail.ts
@@ -28,9 +28,9 @@
 
 import { formatLocal } from "../datetime";
 import { escapeHtml } from "../escape";
-import { operatorActionDraft, operatorActionDraftKey } from "../action-draft";
 import { formatMoney, isMoney } from "../money";
 import { ownMapValue } from "../own-map";
+import { interactionDraftValue } from "../interaction-draft";
 import { sourcePresentationLabel, sourceSystemLabel } from "../provenance";
 import type { CommercialSnapshot } from "../types";
 import {
@@ -382,8 +382,9 @@ export interface LeadAction {
   risk: ActionRisk;
   writes: ActionWriteTarget;
   effect: string;
-  /** Extra confirmation beyond the mandatory audit note. */
-  confirmation: "nota" | "nota-e-ciencia" | "nota-ciencia-e-palavra";
+  /** Only content that changes the meaning of this particular decision. */
+  humanInput: "none" | "note" | "reason";
+  confirmation: "none" | "consequence";
 }
 
 export interface LeadDetailModel {
@@ -493,7 +494,8 @@ function localActionsFor(opts: {
       risk: "baixo",
       writes: "control-center",
       effect: "Grava uma nota de auditoria no Control Center. Nada muda no Warmbly.",
-      confirmation: "nota",
+      humanInput: "note",
+      confirmation: "none",
     },
     {
       id: "MARK_REVIEWED",
@@ -501,7 +503,8 @@ function localActionsFor(opts: {
       risk: "baixo",
       writes: "control-center",
       effect: "Registra que um humano olhou este item. Não altera o estágio no Warmbly.",
-      confirmation: "nota",
+      humanInput: "none",
+      confirmation: "none",
     },
   ];
   if (opts.hasActivity) {
@@ -511,7 +514,8 @@ function localActionsFor(opts: {
       risk: "baixo",
       writes: "control-center",
       effect: "Confirma que a atividade observada confere com a realidade. Registro local.",
-      confirmation: "nota",
+      humanInput: "none",
+      confirmation: "none",
     });
   }
   if (opts.hasNextStep) {
@@ -521,7 +525,8 @@ function localActionsFor(opts: {
       risk: "baixo",
       writes: "control-center",
       effect: "Concorda com o próximo passo sugerido pela origem. Não o executa.",
-      confirmation: "nota",
+      humanInput: "none",
+      confirmation: "none",
     });
     out.push({
       id: "REJECT_NEXT_ACTION",
@@ -530,7 +535,8 @@ function localActionsFor(opts: {
       writes: "control-center",
       effect:
         "Registra que o próximo passo sugerido está errado. O Warmbly continua sugerindo até alguém corrigir lá.",
-      confirmation: "nota-e-ciencia",
+      humanInput: "reason",
+      confirmation: "consequence",
     });
   }
   if (opts.hasOpenException) {
@@ -541,7 +547,8 @@ function localActionsFor(opts: {
       writes: "control-center",
       effect:
         "Registro de auditoria local. A exceção continua aberta no Warmbly e continua nesta fila.",
-      confirmation: "nota-e-ciencia",
+      humanInput: "none",
+      confirmation: "consequence",
     });
   }
   if (opts.hasClosedException) {
@@ -551,7 +558,8 @@ function localActionsFor(opts: {
       risk: "medio",
       writes: "control-center",
       effect: "Desfaz o reconhecimento local. Não reabre nada no Warmbly.",
-      confirmation: "nota-e-ciencia",
+      humanInput: "reason",
+      confirmation: "consequence",
     });
   }
   return out;
@@ -742,11 +750,12 @@ export function leadDetailView(input: LeadDetailInput): LeadDetailModel {
         {
           id: "acknowledge_inbound_alert",
           label: "Reconhecer alerta no Warmbly",
-          risk: "alto",
+          risk: "medio",
           writes: "warmbly",
           effect:
             "Escreve no Warmbly: marca este alerta de inbound como visto por um humano. Não responde, não envia e não dispara nada.",
-          confirmation: "nota-ciencia-e-palavra",
+          humanInput: "none",
+          confirmation: "consequence",
         },
       ]
     : [];
@@ -803,28 +812,31 @@ function timeCell(at: string | null): string {
   return `<time datetime="${escapeHtml(at)}">${escapeHtml(formatLocal(at))}</time><span class="sr-only">UTC ${escapeHtml(at)}</span>`;
 }
 
-function confirmationControls(action: LeadAction): string {
-  if (action.confirmation === "nota") return "";
-  const ciencia =
-    action.writes === "warmbly"
-      ? "Entendo que esta ação grava no Warmbly."
-      : "Entendo que este é um registro local e que nada muda no Warmbly.";
-  const checkbox = `<label class="confirm"><input type="checkbox" name="ciencia" required /> ${escapeHtml(ciencia)}</label>`;
-  if (action.confirmation === "nota-e-ciencia") return checkbox;
-  return `${checkbox}<label>Digite RECONHECER para liberar <input name="palavra_de_confirmacao" required pattern="RECONHECER" title="Digite RECONHECER" /></label>`;
-}
-
 function localActionForm(action: LeadAction, resource: string, canonicalId: string, returnHash: string): string {
   const riskLabel = ownMapValue(RISK_LABEL, action.risk) ?? "risco não reconhecido";
-  const note = operatorActionDraft(operatorActionDraftKey(action.id, canonicalId, resource));
+  const interactionIds: Record<string, string> = {
+    RECORD_NOTE: "lead.record-note",
+    MARK_REVIEWED: "lead.mark-reviewed",
+    REVIEW_ACTIVITY: "lead.review-activity",
+    CONFIRM_NEXT_ACTION: "lead.confirm-next",
+    REJECT_NEXT_ACTION: "lead.reject-next",
+    ACKNOWLEDGE_EXCEPTION: "lead.acknowledge-exception",
+    REOPEN_EXCEPTION: "lead.reopen-exception",
+  };
+  const draftKey = `operator:${action.id}:${canonicalId}:${resource}`;
+  const draftNote = interactionDraftValue(draftKey, "note");
+  const field = action.humanInput === "note"
+    ? `<label>Nota de auditoria <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(draftNote)}</textarea></label>`
+    : action.humanInput === "reason"
+      ? `<label>Motivo operacional <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(draftNote)}</textarea></label>`
+      : "";
   return `
-    <form data-operator-form="${escapeHtml(action.id)}" data-writes-to="control-center" data-action-risk="${escapeHtml(action.risk)}" data-continuity-action="queue" data-continuity-next="${escapeHtml(returnHash)}" class="operator-form lead-action">
+    <form data-operator-form="${escapeHtml(action.id)}" data-writes-to="control-center" data-draft-key="${escapeHtml(draftKey)}" data-action-risk="${escapeHtml(action.risk)}" data-human-input="${escapeHtml(action.humanInput)}" data-interaction="${escapeHtml(interactionIds[action.id] ?? action.id)}" data-continuity-action="queue" data-continuity-next="${escapeHtml(returnHash)}"${action.humanInput === "none" ? ` data-one-decision="true"` : ""} class="operator-form lead-action">
       <h4>${escapeHtml(action.label)} <span class="pill" data-risk="${escapeHtml(action.risk)}">${escapeHtml(riskLabel)}</span></h4>
       <p class="constraint">${escapeHtml(action.effect)}</p>
       <input type="hidden" name="target_canonical_id" value="${escapeHtml(canonicalId)}" />
       <input type="hidden" name="target_source_id" value="${escapeHtml(resource)}" />
-      <label>Nota de auditoria <textarea name="note" required minlength="2" maxlength="500">${escapeHtml(note)}</textarea></label>
-      ${confirmationControls(action)}
+      ${field}
       <button type="submit">${escapeHtml(action.label)}</button>
     </form>`;
 }
@@ -832,12 +844,10 @@ function localActionForm(action: LeadAction, resource: string, canonicalId: stri
 function warmblyActionForm(action: LeadAction, targetId: string): string {
   const riskLabel = ownMapValue(RISK_LABEL, action.risk) ?? "risco não reconhecido";
   return `
-    <form data-warmbly-dispatch="acknowledge" data-writes-to="warmbly" data-action-risk="${escapeHtml(action.risk)}" class="operator-form lead-action">
+    <form data-warmbly-dispatch="acknowledge" data-writes-to="warmbly" data-action-risk="${escapeHtml(action.risk)}" data-interaction="lead.warmbly-acknowledge" data-one-decision="true" class="operator-form lead-action">
       <h4>${escapeHtml(action.label)} <span class="pill" data-risk="${escapeHtml(action.risk)}">${escapeHtml(riskLabel)}</span></h4>
       <p class="constraint">${escapeHtml(action.effect)}</p>
       <input type="hidden" name="target_id" value="${escapeHtml(targetId)}" />
-      <label>Motivo <input name="reason" required minlength="2" maxlength="200" placeholder="por que está reconhecendo" /></label>
-      ${confirmationControls(action)}
       <button type="submit">${escapeHtml(action.label)}</button>
     </form>`;
 }

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -22,13 +22,14 @@ import { escapeHtml } from "../escape";
 import { formatLocal } from "../datetime";
 import { ownMapValue } from "../own-map";
 import { continuitySubrouteHref } from "../continuity";
+import { interactionDraft, interactionDraftValue } from "../interaction-draft";
 import {
   DEFAULT_WARMBLY_SURFACE,
   WARMBLY_SURFACES,
   isWarmblySurface,
   type WarmblySurface,
 } from "../destinations";
-import { APPROVAL_DEFAULT_REASON, type AdapterWriteResult } from "../adapters/contract";
+import type { AdapterWriteResult } from "../adapters/contract";
 import {
   adjustDraft,
   adjustRouteMissing,
@@ -845,6 +846,8 @@ function controlsBlock(
   confirmation: PendingResumeConfirmation | undefined,
 ): string {
   const confirmationArmed = confirmation !== undefined;
+  const resumeDraftKey = "dispatch:resume";
+  const resumeReason = confirmation?.reason ?? interactionDraftValue(resumeDraftKey, "reason");
   return `
     <section class="stack" aria-labelledby="warmbly-controles" data-resume-armed="${confirmationArmed ? "true" : "false"}">
       <h2 id="warmbly-controles">Controles</h2>
@@ -853,8 +856,8 @@ function controlsBlock(
       <article class="card">
         <h3>Pausar o outbound</h3>
         <p>Um passo. Interrompe o disparo; nada é enviado enquanto durar a pausa.</p>
-        <form data-warmbly-dispatch="pause" class="operator-form">
-          <label>Motivo <input name="reason" required minlength="2" maxlength="200" placeholder="por que está pausando" /></label>
+        <form data-warmbly-dispatch="pause" data-interaction="dispatch.pause" data-one-decision="true" class="operator-form">
+          <input type="hidden" name="reason" value="Pausa solicitada manualmente no Control Center" />
           <button type="submit">Pausar disparos</button>
         </form>
       </article>
@@ -867,19 +870,15 @@ function controlsBlock(
             ? `<p class="banner stale" role="status" data-confirmation-pending="true">Confirmação pendente e ainda não executada. O próximo envio deste formulário executa a retomada. O token é de uso único, vence sozinho e vale só para quem o pediu; recarregar a página o descarta.</p>`
             : `<p class="constraint">Enviar uma vez pede a confirmação; enviar de novo, com o mesmo motivo, executa.</p>`
         }
-        <form data-warmbly-dispatch="resume" class="operator-form" data-two-step="true">
-          <label>Motivo <input name="reason" required minlength="2" maxlength="200" placeholder="por que está retomando"${confirmation ? ` value="${escapeHtml(confirmation.reason)}" readonly` : ""} /></label>
+        <form data-warmbly-dispatch="resume" data-draft-key="${escapeHtml(resumeDraftKey)}" data-interaction="dispatch.resume" data-explicit-submit="true" class="operator-form" data-two-step="true">
+          <label>Motivo <input name="reason" required minlength="2" maxlength="200" placeholder="por que está retomando" value="${escapeHtml(resumeReason)}"${confirmation ? " readonly" : ""} /></label>
           <button type="submit">${confirmationArmed ? "Confirmar retomada (passo 2 de 2)" : "Retomar disparos (passo 1 de 2)"}</button>
         </form>
       </article>
       <article class="card">
         <h3>Reconhecer alerta de inbound</h3>
-        <p>Um passo. Escreve o reconhecimento no Warmbly; não resolve a exceção no Control Center.</p>
-        <form data-warmbly-dispatch="acknowledge" class="operator-form">
-          <label>Alerta <input name="target_id" required minlength="1" maxlength="128" placeholder="id do lead" /></label>
-          <label>Motivo <input name="reason" maxlength="200" placeholder="opcional" /></label>
-          <button type="submit">Reconhecer alerta</button>
-        </form>
+        <p>Escolha primeiro o alerta na fila. O detalhe prova o alvo e então oferece uma única ação de reconhecimento; esta tela não pede que você copie um identificador.</p>
+        <p><a class="button" href="#/comercial/atividade?condicao=unread">Abrir alertas de inbound não lidos</a></p>
       </article>
     </section>`;
 }
@@ -1514,12 +1513,18 @@ function cohortSurface(input: WarmblySurfaceInput): string {
     seenRoots.add(root);
     return textOf(cohort.id) !== null;
   });
+  const recoverKey = "create:recover-prior";
+  const recoveredSelection = new Set(
+    (interactionDraft(`gate:${recoverKey}`)?.recover_version_ids ?? "")
+      .split("|")
+      .filter(Boolean),
+  );
   const recoveryChoices = recoverable.map((cohort) => {
     const id = textOf(cohort.id) ?? "";
-    return `<label class="check-row"><input type="checkbox" name="recover_version_ids" value="${escapeHtml(id)}"><span>v${escapeHtml(show(cohort.version))} · ${escapeHtml(show(cohort.created_at))}</span></label>`;
+    return `<label class="check-row"><input type="checkbox" name="recover_version_ids" value="${escapeHtml(id)}"${recoveredSelection.has(id) ? " checked" : ""}><span>v${escapeHtml(show(cohort.version))} · ${escapeHtml(show(cohort.created_at))}</span></label>`;
   }).join("");
   const createKey = "create:next-unclaimed";
-  const recoverKey = "create:recover-prior";
+  const createLimit = interactionDraftValue(`gate:${createKey}`, "limit", "10");
   const createPending = gateInFlight(createKey);
   const recoverPending = gateInFlight(recoverKey);
   return `<section class="stack" aria-labelledby="cohorts-title"><h2 id="cohorts-title">Cohorts versionadas</h2><p class="constraint">Denominadores vêm do preview Warmbly: considerados = elegíveis + excluídos e destinatários finais nunca são recalculados nesta tela. A automação global permanece desligada; cada APPROVE agenda somente sua mensagem com <code>auto_send=true</code>.</p>
@@ -1529,12 +1534,12 @@ function cohortSurface(input: WarmblySurfaceInput): string {
   ${selectionProgress}
   <form class="filters" data-human-gate-filters="cohorts"><label>Freshness<select name="freshness"><option value="all">Todos</option><option value="FRESH"${freshness === "FRESH" ? " selected" : ""}>FRESH</option><option value="STALE"${freshness === "STALE" ? " selected" : ""}>STALE</option></select></label></form>
   ${createPending ? pendingBlock("Criando a cohort congelada") : ""}
-  <form class="operator-form" data-human-gate="create" data-gate-key="${escapeHtml(createKey)}"><input type="hidden" name="selection_mode" value="NEXT_UNCLAIMED"><label>Próxima cohort (1–10)<input name="limit" type="number" min="1" max="10" value="10" required></label><button type="submit"${createPending || !authority.canReview ? " disabled" : ""}>${createPending ? "Enviando…" : "Criar próxima cohort sem repetição"}</button>${
+  <form class="operator-form" data-human-gate="create" data-draft-key="gate:${escapeHtml(createKey)}" data-interaction="gate.create" data-gate-key="${escapeHtml(createKey)}"><input type="hidden" name="selection_mode" value="NEXT_UNCLAIMED"><label>Quantidade de fornecedores<input name="limit" type="number" min="1" max="10" step="1" required value="${escapeHtml(createLimit)}"></label><button type="submit"${createPending || !authority.canReview ? " disabled" : ""}>${createPending ? "Enviando…" : "Criar próxima cohort sem repetição"}</button>${
     authority.canReview
-      ? `<p class="constraint">O servidor reserva os próximos fornecedores elegíveis de forma transacional. Repetições de CNPJ-raiz, destinatário ou histórico anterior são excluídas.</p>`
+      ? `<p class="constraint">Escolha entre 1 e 10. O servidor reserva essa quantidade dos próximos fornecedores elegíveis de forma transacional; repetições de CNPJ-raiz, destinatário ou histórico anterior são excluídas.</p>`
       : `<p class="constraint" data-blocked-reason="create">Criar cohort exige o grupo <code>operators</code> no Authelia.</p>`
   }</form>
-  ${recoverable.length > 0 ? `${recoverPending ? pendingBlock("Recuperando fornecedores anteriores na fonte atual") : ""}<form class="operator-form" data-human-gate="create" data-gate-key="${escapeHtml(recoverKey)}"><input type="hidden" name="selection_mode" value="RECOVER_PRIOR"><input type="hidden" name="limit" value="10"><fieldset><legend>Recuperar versões anteriores</legend>${recoveryChoices}</fieldset><button type="submit"${recoverPending || !authority.canReview ? " disabled" : ""}>${recoverPending ? "Enviando…" : "Recompor fornecedores selecionados com a fonte atual"}</button><p class="constraint">A recuperação deduplica fornecedores, relê a fonte vigente e cria textos e hashes novos. Aprovação ou agendamento anteriores não são herdados.</p></form>` : ""}
+  ${recoverable.length > 0 ? `${recoverPending ? pendingBlock("Recuperando fornecedores anteriores na fonte atual") : ""}<form class="operator-form" data-human-gate="create" data-draft-key="gate:${escapeHtml(recoverKey)}" data-interaction="gate.recover" data-gate-key="${escapeHtml(recoverKey)}"><input type="hidden" name="selection_mode" value="RECOVER_PRIOR"><input type="hidden" name="limit" value="10"><fieldset><legend>Recuperar versões anteriores</legend>${recoveryChoices}</fieldset><button type="submit"${recoverPending || !authority.canReview ? " disabled" : ""}>${recoverPending ? "Enviando…" : "Recompor fornecedores selecionados com a fonte atual"}</button><p class="constraint">A recuperação deduplica fornecedores, relê a fonte vigente e cria textos e hashes novos. Aprovação ou agendamento anteriores não são herdados.</p></form>` : ""}
   <p class="table-scroll-hint" id="cohorts-table-hint">Tabela larga: deslize horizontalmente ou use as setas para ver todas as colunas.</p>
   <div class="table-wrap" role="region" tabindex="0" aria-labelledby="cohorts-title" aria-describedby="cohorts-table-hint"><table><thead><tr><th>Versão</th><th>Freshness</th><th>Considerados</th><th>Elegíveis</th><th>Excluídos</th><th>Finais</th><th>Revisão</th></tr></thead><tbody>${rows || `<tr><td colspan="7">Nenhuma cohort ${list.status === "read" ? "listada pelo servidor" : "pôde ser lida"}.</td></tr>`}</tbody></table></div></section>`;
 }
@@ -1758,6 +1763,9 @@ function candidateCard(
   const approveKey = `review:${cohortId}:${candidateId}:APPROVE`;
   const holdKey = `review:${cohortId}:${candidateId}:HOLD_REJECT`;
   const adjustKey = `adjust:${cohortId}:${candidateId}:`;
+  const holdDraftKey = `gate:${holdKey}`;
+  const holdDraft = interactionDraft(holdDraftKey);
+  const holdDecision = holdDraft?.decision === "REJECT" ? "REJECT" : "HOLD";
 
   const copyQaFailures = Array.isArray(copyQa.failures)
     ? copyQa.failures.filter((entry): entry is string => typeof entry === "string")
@@ -1773,7 +1781,7 @@ function candidateCard(
     gate.needsValidation || !gate.allowed
       ? `
     ${gateInFlight(validateKey) ? pendingBlock("Pedindo a verificação do destinatário") : ""}
-    <form class="operator-form" data-human-gate="validate" data-gate-key="${escapeHtml(validateKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
+    <form class="operator-form" data-human-gate="validate" data-interaction="gate.validate" data-one-decision="true" data-gate-key="${escapeHtml(validateKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
       <p class="constraint">Pede ao Warmbly que verifique agora se este endereço aceita entrega. Não envia mensagem nenhuma${gate.needsValidation ? ", e aprovar já faz isso sozinho" : ""}.</p>
       <button type="submit"${gateInFlight(validateKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(validateKey) ? "Enviando…" : "Verificar o destinatário agora"}</button>
     </form>
@@ -1795,7 +1803,7 @@ function candidateCard(
 `
       : `
     ${gateInFlight(approveKey) ? pendingBlock("Registrando a aprovação") : ""}
-    <form class="operator-form approve-form" data-human-gate="review" data-gate-key="${escapeHtml(approveKey)}" data-decision="APPROVE" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}"${gate.needsValidation ? ` data-auto-validate="true"` : ""}>
+    <form class="operator-form approve-form" data-human-gate="review" data-interaction="gate.approve" data-one-decision="true" data-explicit-submit="true" data-gate-key="${escapeHtml(approveKey)}" data-decision="APPROVE" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}"${gate.needsValidation ? ` data-auto-validate="true"` : ""}>
       <h4>Aprovar e enfileirar este candidato</h4>
       <p class="constraint" data-approve-meaning="true">Clicar em Aprovar e enfileirar é a ciência e a autoridade de agendamento: a trilha grava sua identidade do Authelia, o instante, esta versão v${escapeHtml(version)}, o hash congelado, o destinatário exato e a decisão; a mesma operação cria a mensagem com <code>auto_send=true</code> e <code>due_at</code> na próxima janela comercial. Não há GO, segunda caixa ou passo de entrega.</p>
       ${
@@ -1804,11 +1812,6 @@ function candidateCard(
           : ""
       }
       <button type="submit" data-approve-submit="true"${gate.allowed && authority.canReview && !gateInFlight(approveKey) ? "" : " disabled"}>${gateInFlight(approveKey) ? "Enviando…" : "Aprovar e enfileirar para envio"}</button>
-      <details data-approve-comment="true">
-        <summary>Comentário para a trilha (opcional)</summary>
-        <label>Observação<input name="reason" maxlength="200"></label>
-        <p class="constraint">Em branco, a trilha grava <code>${escapeHtml(APPROVAL_DEFAULT_REASON)}</code>. Aprovação comum não exige texto.</p>
-      </details>
       ${
         gate.allowed
           ? ""
@@ -1842,10 +1845,10 @@ function candidateCard(
     ? `
     ${approveControl}
     ${gateInFlight(holdKey) ? pendingBlock("Registrando HOLD/REJECT") : ""}
-    <form class="operator-form" data-human-gate="review" data-gate-key="${escapeHtml(holdKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
+    <form class="operator-form" data-human-gate="review" data-draft-key="${escapeHtml(holdDraftKey)}" data-interaction="gate.hold-reject" data-explicit-submit="true" data-gate-key="${escapeHtml(holdKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}">
       <h4>Segurar ou rejeitar</h4>
-      <label>Decisão<select name="decision"><option value="HOLD">HOLD</option><option value="REJECT">REJECT</option></select></label>
-      <label>Motivo<input name="reason" required minlength="3"></label>
+      <label>Decisão<select name="decision"><option value="HOLD"${holdDraft && holdDecision === "HOLD" ? " selected" : ""}>HOLD</option><option value="REJECT"${holdDecision === "REJECT" ? " selected" : ""}>REJECT</option></select></label>
+      <label>Motivo<input name="reason" required minlength="3" value="${escapeHtml(holdDraft?.reason ?? "")}"></label>
       <p class="constraint" data-no-ack-required="true">HOLD e REJECT exigem motivo escrito: segurar ou rejeitar é a exceção, e o texto é o que explica a exceção depois.</p>
       <button type="submit"${authority.canReview && !gateInFlight(holdKey) ? "" : " disabled"}>${gateInFlight(holdKey) ? "Enviando…" : "Registrar HOLD/REJECT"}</button>
     </form>
@@ -1988,11 +1991,10 @@ function adjustBlock(args: {
       }
       ${pending ? pendingBlock("Enviando o ajuste") : ""}
       ${diff}
-      <form class="operator-form" data-human-gate="adjust" data-gate-key="${escapeHtml(adjustKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}" data-cohort-version="${escapeHtml(version)}" data-frozen-hash="${escapeHtml(frozenHash)}" data-before-subject="${escapeHtml(subject)}" data-before-body="${escapeHtml(body)}" data-adjust-step="${draft ? "confirm" : "preview"}">
+      <form class="operator-form" data-human-gate="adjust" data-interaction="gate.adjust" data-explicit-submit="true" data-gate-key="${escapeHtml(adjustKey)}" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}" data-cohort-version="${escapeHtml(version)}" data-frozen-hash="${escapeHtml(frozenHash)}" data-before-subject="${escapeHtml(subject)}" data-before-body="${escapeHtml(body)}" data-adjust-step="${draft ? "confirm" : "preview"}">
         <label>Assunto<input name="subject" required minlength="3" maxlength="200" value="${escapeHtml(draft?.subject ?? subject)}"></label>
         <label>Corpo<textarea name="body_text" required minlength="3" rows="8">${escapeHtml(draft?.body_text ?? body)}</textarea></label>
         <label>Motivo do ajuste<input name="reason" required minlength="3" value="${escapeHtml(draft?.reason ?? "")}"></label>
-        <label>Confirme digitando <code>v${escapeHtml(version)}</code><input name="confirmation" required pattern="v${escapeHtml(version)}" value="${escapeHtml(draft ? `v${version}` : "")}"></label>
         <button type="submit"${pending || unavailable || !authority.canReview ? " disabled" : ""}>${
           pending ? "Enviando…" : draft ? `Confirmar e criar a versão seguinte a partir da v${escapeHtml(version)}` : "Pré-visualizar a mudança"
         }</button>
@@ -2129,7 +2131,7 @@ function reconcileBlock(authority: OperatorAuthority): string {
     <p data-reconcile-meaning="true">Este não é um passo normal depois da revisão. APPROVE já agenda sozinho. Use o reparo somente para aprovações antigas ou para um APPROVE cujo card mostre “sem agendamento confirmado”.</p>
     <p class="constraint" data-reconcile-repeat="true">A operação percorre o histórico pelo mesmo caminho de código do APPROVE, deduplica candidatos repetidos entre cohorts e é idempotente: executar de novo não cria outra mensagem nem reenvia o que já saiu.</p>
     <p class="constraint">O resultado mostra quantos registros, vínculos e candidatos únicos foram encontrados e quantos ficaram agendados. Isto não transporta e-mail; o worker continua sob janela comercial, teto por hora, pausa e kill switch.</p>
-    <form class="operator-form" data-human-gate="reconcile" data-gate-key="${escapeHtml(reconcileKey)}">
+    <form class="operator-form" data-human-gate="reconcile" data-interaction="gate.reconcile" data-one-decision="true" data-explicit-submit="true" data-gate-key="${escapeHtml(reconcileKey)}">
       <button type="submit" data-reconcile-submit="true"${authority.canReconcile && !pending ? "" : " disabled"}>${pending ? "Enviando…" : "Reprocessar aprovações já registradas"}</button>
       ${
         authority.canReconcile
@@ -2209,7 +2211,7 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   const reproduceControl = editorial.actionable
     ? `
   ${gateInFlight(reproduceKey) ? pendingBlock("Reproduzindo a versão imutável") : ""}
-  <form class="operator-form" data-human-gate="reproduce" data-gate-key="${escapeHtml(reproduceKey)}" data-version="${escapeHtml(cohortId)}"><button type="submit"${gateInFlight(reproduceKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(reproduceKey) ? "Enviando…" : "Reproduzir versão imutável"}</button></form>
+  <form class="operator-form" data-human-gate="reproduce" data-interaction="gate.reproduce" data-one-decision="true" data-gate-key="${escapeHtml(reproduceKey)}" data-version="${escapeHtml(cohortId)}"><button type="submit"${gateInFlight(reproduceKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(reproduceKey) ? "Enviando…" : "Reproduzir versão imutável"}</button></form>
 `
     : "";
   return `<section class="stack" aria-labelledby="review-title" data-review-cohort="${escapeHtml(cohortId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}"><h2 id="review-title">Revisão v${escapeHtml(version)}</h2>

--- a/control-center/apps/web-shell/tests/continuity.test.ts
+++ b/control-center/apps/web-shell/tests/continuity.test.ts
@@ -135,6 +135,9 @@ test("a definitive queue action navigates to the next item and unknown stays put
       if (name === "data-operator-form") return "START_EXCEPTION_WORK";
       if (name === "data-continuity-action") return "queue";
       if (name === "data-continuity-next") return next;
+      if (name === "data-draft-key") {
+        return operatorActionDraftKey("START_EXCEPTION_WORK", "cc:exception:1", "exception-1");
+      }
       return null;
     },
     querySelector(selector: string): { value: string } | null {

--- a/control-center/apps/web-shell/tests/interaction-contract.test.ts
+++ b/control-center/apps/web-shell/tests/interaction-contract.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  bindExplicitSubmitKey,
+  bindInteractionDraftCapture,
+  bindOperatorActions,
+} from "../src/app";
+import {
+  CRITICAL_INTERACTION_JOURNEYS,
+  INTERACTION_FEEDBACK_BUDGET_MS,
+  MUTABLE_INTERACTION_IDS,
+  MUTABLE_INTERACTIONS,
+} from "../src/interaction-contract";
+import {
+  interactionDraft,
+  resetInteractionDrafts,
+} from "../src/interaction-draft";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = (name: string): string => readFileSync(join(here, "../src/ui", name), "utf8");
+
+test("every mutable route is inventoried with consequence, derivation and recovery guarantees", () => {
+  assert.equal(MUTABLE_INTERACTIONS.length, 27);
+  assert.deepEqual(MUTABLE_INTERACTIONS.map((item) => item.id), MUTABLE_INTERACTION_IDS);
+  assert.equal(new Set(MUTABLE_INTERACTIONS.map((item) => item.id)).size, MUTABLE_INTERACTIONS.length);
+  for (const item of MUTABLE_INTERACTIONS) {
+    assert.match(item.route, /^#\//, `${item.id} has no route`);
+    assert.ok(item.action.length > 0, `${item.id} has no action`);
+    assert.ok(item.consequence.length >= 20, `${item.id} has no concrete consequence`);
+    assert.ok(item.derived.length > 0, `${item.id} derives no bookkeeping`);
+    assert.ok(item.stepsAfter <= item.stepsBefore, `${item.id} adds steps`);
+    assert.equal(item.feedbackBudgetMs, INTERACTION_FEEDBACK_BUDGET_MS);
+    assert.equal(item.blocksDoubleSubmit, true);
+    assert.equal(item.readback, true);
+  }
+});
+
+test("irreversible actions keep proportional confirmation", () => {
+  const irreversible = MUTABLE_INTERACTIONS.filter((item) => !item.reversible);
+  assert.deepEqual(
+    irreversible.map((item) => item.id),
+    [
+      "lead.warmbly-acknowledge",
+      "draft.approve",
+      "dispatch.resume",
+      "gate.approve",
+      "gate.reconcile",
+    ],
+  );
+  assert.ok(irreversible.every((item) => item.confirmation !== "none"));
+});
+
+test("one-tap decisions never carry typed acknowledgements and high-risk gates stay explicit", () => {
+  for (const item of MUTABLE_INTERACTIONS.filter((entry) => entry.humanDecision === "one-tap")) {
+    assert.ok(item.confirmation === "none" || item.confirmation === "consequence", item.id);
+    assert.equal(item.stepsAfter, 1, item.id);
+  }
+  const resume = MUTABLE_INTERACTIONS.find((item) => item.id === "dispatch.resume");
+  assert.equal(resume?.confirmation, "two-step");
+  assert.equal(resume?.humanDecision, "two-step");
+  const adjust = MUTABLE_INTERACTIONS.find((item) => item.id === "gate.adjust");
+  assert.ok(adjust?.derived.includes("version_confirmation"));
+  assert.equal(adjust?.confirmation, "consequence");
+});
+
+test("critical journeys publish the measured before/after step reduction", () => {
+  assert.deepEqual(CRITICAL_INTERACTION_JOURNEYS, [
+    { id: "daily-triage", before: 3, after: 1 },
+    { id: "exception-acknowledge", before: 3, after: 1 },
+    { id: "inbound-acknowledge", before: 4, after: 1 },
+    { id: "approve-and-queue", before: 2, after: 1 },
+    { id: "adjust-version", before: 6, after: 5 },
+  ]);
+  assert.ok(CRITICAL_INTERACTION_JOURNEYS.every((journey) => journey.after < journey.before));
+});
+
+test("renderers cannot reintroduce redundant acknowledgements or copied bookkeeping", () => {
+  const domains = source("domains.ts");
+  const lead = source("lead-detail.ts");
+  const warmbly = source("warmbly.ts");
+  const alert = source("alert-card.ts");
+  const all = `${domains}\n${lead}\n${warmbly}\n${alert}`;
+
+  assert.doesNotMatch(all, /name="ciencia"|palavra_de_confirmacao|RECONHECER/);
+  assert.doesNotMatch(warmbly, /name="confirmation"|data-approve-comment/);
+  assert.match(warmbly, /name="limit" type="number" min="1" max="10"/);
+  assert.doesNotMatch(warmbly, /data-warmbly-dispatch="acknowledge"/,
+    "the global cockpit must not ask the operator to type an unproven target");
+  assert.match(lead, /data-warmbly-dispatch="acknowledge"[\s\S]*data-one-decision="true"/);
+});
+
+test("explicit-submit protection keeps textarea newlines but blocks text-field Enter", () => {
+  let listener: ((event: Event) => void) | undefined;
+  bindExplicitSubmitKey({
+    getAttribute: () => "true",
+    addEventListener: (_type, bound) => { listener = bound; },
+  });
+  const press = (matches: (selector: string) => boolean): boolean => {
+    let prevented = false;
+    listener?.({
+      key: "Enter",
+      target: { matches },
+      preventDefault: () => { prevented = true; },
+    } as unknown as Event);
+    return prevented;
+  };
+  assert.equal(press((selector) => selector.includes("textarea")), false);
+  assert.equal(press(() => false), true);
+  assert.equal(press((selector) => selector.includes('button[type="submit"]')), false);
+});
+
+test("live draft capture preserves unsent text before another action repaints", () => {
+  resetInteractionDrafts();
+  const listeners = new Map<string, (event: Event) => void>();
+  const note = {
+    value: "plano ainda não enviado",
+    getAttribute: (name: string) => name === "name" ? "note" : null,
+  };
+  const form = {
+    getAttribute: (name: string) => name === "data-draft-key" ? "operator:live" : null,
+    addEventListener: (type: string, listener: (event: Event) => void) => { listeners.set(type, listener); },
+    querySelector: () => null,
+    querySelectorAll: () => [note],
+  };
+  bindInteractionDraftCapture({
+    innerHTML: "",
+    querySelectorAll: () => [form],
+  } as never);
+  listeners.get("input")?.({} as Event);
+  assert.equal(interactionDraft("operator:live")?.note, "plano ainda não enviado");
+});
+
+class Control {
+  value: string;
+  disabled = false;
+  textContent: string | null = null;
+  constructor(value = "") {
+    this.value = value;
+  }
+}
+
+class OperatorForm {
+  private listener: ((event: Event) => void) | undefined;
+  readonly attributes = new Map<string, string>([
+    ["data-operator-form", "START_EXCEPTION_WORK"],
+    ["data-draft-key", "operator:test"],
+  ]);
+  readonly fields: Record<string, Control> = {
+    target_canonical_id: new Control("cc:exception:1"),
+    target_source_id: new Control("source-1"),
+    note: new Control("preservar este plano"),
+  };
+  readonly button = new Control();
+
+  addEventListener(_type: string, listener: (event: Event) => void): void {
+    this.listener = listener;
+  }
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+  querySelector(selector: string): Control | null {
+    if (selector === 'button[type="submit"]') return this.button;
+    const match = selector.match(/\[name="([^"]+)"\]/);
+    return match ? this.fields[match[1]!] ?? null : null;
+  }
+  querySelectorAll(): Control[] {
+    return [...Object.values(this.fields), this.button];
+  }
+  submit(): void {
+    this.listener?.({ preventDefault(): void {} } as Event);
+  }
+}
+
+test("operator actions paint pending synchronously, block double submit and preserve failed input", async () => {
+  resetInteractionDrafts();
+  const form = new OperatorForm();
+  let calls = 0;
+  let finish!: (value: { ok: false; path: string; kind: "nota"; message: string }) => void;
+  const pending = new Promise<{ ok: false; path: string; kind: "nota"; message: string }>((resolve) => {
+    finish = resolve;
+  });
+  const adapter = {
+    operatorAction: () => {
+      calls += 1;
+      return pending;
+    },
+  };
+  let repaints = 0;
+  bindOperatorActions({ innerHTML: "", querySelectorAll: () => [form] } as never, adapter as never, () => {
+    repaints += 1;
+  });
+
+  form.submit();
+  form.submit();
+  assert.equal(form.attributes.get("aria-busy"), "true", "feedback must precede the promise");
+  assert.equal(form.button.disabled, true);
+  assert.equal(form.button.textContent, "Registrando…");
+  await Promise.resolve();
+  assert.equal(calls, 1, "a second submit while pending must be ignored");
+
+  finish({ ok: false, path: "/v1/operator-actions", kind: "nota", message: "validation failed" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(repaints, 1);
+  assert.equal(interactionDraft("operator:test")?.note, "preservar este plano");
+});

--- a/control-center/apps/web-shell/tests/lead-detail.test.ts
+++ b/control-center/apps/web-shell/tests/lead-detail.test.ts
@@ -335,7 +335,7 @@ test("local records and Warmbly writes are two separate, separately labelled gro
     );
   }
   // Every local form declares where it writes, and it is never Warmbly.
-  const localScoped = [...html.matchAll(/data-operator-form="[A-Z_]+" data-writes-to="([a-z-]+)"/g)].map(
+  const localScoped = [...html.matchAll(/data-operator-form="[A-Z_]+"[^>]* data-writes-to="([a-z-]+)"/g)].map(
     (m) => m[1],
   );
   assert.equal(localScoped.length, localForms.length);
@@ -466,7 +466,7 @@ test("an inbound exception without proven lead identity fails closed even when s
   assert.match(html, /data-warmbly-refusal="lead-id-unproven"/);
 });
 
-test("confirmation is proportional to risk and enforced by the form, not by copy", () => {
+test("confirmation is proportional to consequence without duplicating the human decision", () => {
   const html = leadDetailBlock({ snapshot: snapshotWith(representativeOperations()), resource: DEAL_ID });
   const formFor = (attr: string, value: string): string => {
     const start = html.indexOf(`${attr}="${value}"`);
@@ -483,16 +483,15 @@ test("confirmation is proportional to risk and enforced by the form, not by copy
 
   const medium = formFor("data-operator-form", "REJECT_NEXT_ACTION");
   assert.match(medium, /data-action-risk="medio"/);
-  assert.match(medium, /<input type="checkbox" name="ciencia" required \/>/);
-  assert.match(medium, /registro local/);
-  assert.equal(/pattern="RECONHECER"/.test(medium), false);
+  assert.match(medium, /Motivo operacional/);
+  assert.match(medium, /name="note" required/);
+  assert.equal(/name="ciencia"|pattern="RECONHECER"/.test(medium), false);
 
   const high = formFor("data-warmbly-dispatch", "acknowledge");
-  assert.match(high, /data-action-risk="alto"/);
-  assert.match(high, /<input type="checkbox" name="ciencia" required \/>/);
-  assert.match(high, /Entendo que esta ação grava no Warmbly/);
-  assert.match(high, /pattern="RECONHECER"/);
-  assert.match(high, /name="reason" required/);
+  assert.match(high, /data-action-risk="medio"/);
+  assert.match(high, /data-one-decision="true"/);
+  assert.match(high, /marca este alerta de inbound como visto/);
+  assert.equal(/name="ciencia"|pattern="RECONHECER"|name="reason"/.test(high), false);
 });
 
 test("an id the operator channel would reject is never offered as a Warmbly write", () => {

--- a/control-center/apps/web-shell/tests/performance-ux.test.ts
+++ b/control-center/apps/web-shell/tests/performance-ux.test.ts
@@ -93,7 +93,7 @@ test("performance budget owns exact mobile targets and critical routes", () => {
   assert.equal(budget.budgets.css_raw_bytes, 26000);
   assert.equal(budget.budgets.css_gzip_bytes, 7000);
   assert.equal(budget.budgets.bundle_gzip_bytes, 120000);
-  assert.equal(budget.budgets.javascript_gzip_bytes, 113000);
+  assert.equal(budget.budgets.javascript_gzip_bytes, 113500);
   assert.deepEqual(budget.routes.map((route: { id: string }) => route.id), ["hoje", "rascunhos", "coortes"]);
   const probe = readFileSync(join(app, "scripts/performance-probe.mjs"), "utf8");
   assert.match(probe, /performance_event_timing/);

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -708,6 +708,29 @@ test("cohorts exposes disjoint next-page progress and fresh-source recovery", ()
   assert.match(html, /class="table-wrap" role="region" tabindex="0"[^>]*aria-describedby="cohorts-table-hint"/);
 });
 
+test("creating a cohort sends the quantity chosen by the operator", async () => {
+  reset();
+  const { adapter, seen } = gateAdapter({
+    respond: () => ({
+      ok: false,
+      path: "/x",
+      kind: "nota" as const,
+      message: "fixture recusada depois de inspecionar o pedido",
+      outcome: "refused",
+      gateAction: "create" as const,
+    }),
+  });
+  const dom = paintingRoot();
+  paintShell(dom.root as never, adapter as never, "#/warmbly/cohorts");
+  const form = dom.find('[data-gate-key="create:next-unclaimed"]');
+  form.set("limit", "3");
+  form.fire();
+  await settle();
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0]!.limit, 3);
+  assert.equal(seen[0]!.selection_mode, "NEXT_UNCLAIMED");
+});
+
 /* ------------------------------------------------------------------ *
  * 3. Actions must be comprehensible and safe.
  * ------------------------------------------------------------------ */
@@ -868,10 +891,9 @@ test("HOLD e REJECT exigem motivo escrito; aprovar não exige nem motivo nem cai
 
   const approveForm = html.match(/data-gate-key="review:[^"]*:APPROVE"[\s\S]*?<\/form>/)?.[0] ?? "";
   assert.doesNotMatch(approveForm, /name="ack"/, "a caixa de ciência saiu do fluxo normal");
-  assert.doesNotMatch(approveForm, /name="reason" required/, "aprovação comum não exige texto");
-  assert.match(approveForm, /name="reason" maxlength="200"/, "o comentário continua disponível");
+  assert.doesNotMatch(approveForm, /name="reason"/, "aprovação comum não pede comentário de bookkeeping");
   assert.match(approveForm, /data-approve-meaning="true"/, "o botão precisa dizer o que ele assume");
-  assert.match(approveForm, /approved_by_human_reviewer/);
+  assert.match(approveForm, /identidade do Authelia/);
 });
 
 test("HOLD really reaches the adapter without an acknowledgement", async () => {
@@ -1012,7 +1034,8 @@ test("the adjust editor offers exactly subject, body and reason, and warns that 
   assert.match(editor, /data-adjust-warning="true"/);
   assert.match(editor, /cria uma NOVA versão/i);
   const names = [...editor.matchAll(/name="([a-z_]+)"/g)].map((match) => match[1]).sort();
-  assert.deepEqual(names, ["body_text", "confirmation", "reason", "subject"]);
+  assert.deepEqual(names, ["body_text", "reason", "subject"]);
+  assert.match(editor, /data-cohort-version="1"/, "the exact version confirmation is derived from the immutable card");
   for (const forbidden of ["mailbox", "evidence", "route_class", "policy_version", "source"]) {
     assert.doesNotMatch(editor, new RegExp(`name="${forbidden}"`), `${forbidden} must never be editable`);
   }
@@ -1043,19 +1066,29 @@ test("the first adjust submit previews the diff and writes nothing", async () =>
 test("a confirmed adjust sends the contract body and lands on the new version the server named", async () => {
   reset();
   const navigations: string[] = [];
+  let adjusted = false;
   const { adapter, seen } = gateAdapter({
-    respond: () => ({
-      ok: true,
-      path: "/x",
-      kind: "nota" as const,
-      status: 201,
-      message: "Ajuste aceito.",
-      outcome: "executed",
-      gateAction: "adjust" as const,
-      gateTarget: { cohort_id: COHORT_ID, candidate_id: CANDIDATE_ID },
-      gateResource: { cohort_id: NEXT_COHORT_ID, version: 2 },
-      diff: [{ field: "subject", before: "Assunto exato congelado", after: "Assunto revisado" }],
-    }),
+    gate: () => gatePayload(
+      ["operators", "admins"],
+      adjusted
+        ? cohort({ id: NEXT_COHORT_ID, cohort_id: NEXT_COHORT_ID, version: 2 })
+        : cohort(),
+    ),
+    respond: () => {
+      adjusted = true;
+      return {
+        ok: true,
+        path: "/x",
+        kind: "nota" as const,
+        status: 201,
+        message: "Ajuste aceito.",
+        outcome: "executed",
+        gateAction: "adjust" as const,
+        gateTarget: { cohort_id: COHORT_ID, candidate_id: CANDIDATE_ID },
+        gateResource: { cohort_id: NEXT_COHORT_ID, version: 2 },
+        diff: [{ field: "subject", before: "Assunto exato congelado", after: "Assunto revisado" }],
+      };
+    },
   });
   const dom = paintingRoot();
   paintShell(
@@ -2350,6 +2383,12 @@ test("uma releitura que não confirma o efeito devolve a mensagem para a fila", 
   await settle();
   assert.match(dom.root.innerHTML, /data-readback="not_confirmed"/);
   assert.match(dom.root.innerHTML, /data-queue-pending="1"/, "sem confirmação, continua sendo trabalho");
+  assert.equal(
+    (adapter.lastOperatorResult as AdapterWriteResult | undefined)?.ok,
+    false,
+    "uma resposta aceita sem readback não pode continuar semanticamente bem-sucedida",
+  );
+  assert.equal((adapter.lastOperatorResult as AdapterWriteResult | undefined)?.outcome, "unknown");
 });
 
 test("uma escrita aceita cuja releitura falha não some da fila nem avança a chave de idempotência", async () => {

--- a/control-center/apps/web-shell/tests/warmbly-human-gate.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-human-gate.test.ts
@@ -70,7 +70,9 @@ test("progressive review tells the new approve-and-queue truth before the button
   assert.doesNotMatch(html, /data-human-gate="validate"/);
   assert.match(html, /Aprovar e enfileirar para envio/);
   assert.match(html, /auto_send=true/);
-  assert.match(html, /pattern="v3"/, "adjust still requires immutable-version confirmation");
+  assert.match(html, /data-cohort-version="3"/, "adjust remains bound to the immutable version on screen");
+  assert.doesNotMatch(html, /name="confirmation"/, "the immutable version is derived, not copied by the operator");
+  assert.doesNotMatch(html, /data-approve-comment/, "ordinary approval is exactly its named action");
   assert.doesNotMatch(html, /data-human-gate="decide"|data-human-gate="dispatch"/);
 });
 

--- a/control-center/apps/web-shell/tests/warmbly-operation.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-operation.test.ts
@@ -290,12 +290,14 @@ test("state, reason, window, queue, limits and last action are all rendered befo
   }
 });
 
-test("the cockpit offers exactly pause, resume and acknowledge, and no send control", () => {
+test("the cockpit keeps pause/resume and routes acknowledgement through a proven alert target", () => {
   clearPendingResumeConfirmation();
   const { root, unmount } = mountWarmbly();
   try {
     const actions = [...root.innerHTML.matchAll(/data-warmbly-dispatch="([a-z_]+)"/g)].map((m) => m[1]);
-    assert.deepEqual(actions, ["pause", "resume", "acknowledge"]);
+    assert.deepEqual(actions, ["pause", "resume"]);
+    assert.match(root.innerHTML, /Abrir alertas de inbound não lidos/);
+    assert.match(root.innerHTML, /condicao=unread/);
     assert.equal(hasMutationControls(root.innerHTML), false);
     assert.doesNotMatch(root.innerHTML, /enviar campanha|SEND_CAMPAIGN|disparar agora/i);
     // The open-circuit caveat has to be standing, not only after a refusal:

--- a/control-center/docs/ONE-DECISION-ONE-ACTION.md
+++ b/control-center/docs/ONE-DECISION-ONE-ACTION.md
@@ -1,0 +1,84 @@
+# Uma decisão humana, uma ação
+
+Contrato de interação da issue #116. O inventário executável vive em
+`apps/web-shell/src/interaction-contract.ts`; esta página explica as escolhas
+operacionais sem substituir os contratos de autorização, auditoria,
+idempotência ou readback do backend.
+
+## Regra
+
+- Conteúdo e seleção humanos permanecem entrada: nota autoral, plano, edição,
+  motivo de rejeição/HOLD, seleção de versões e quantidade da cohort (1–10).
+- Bookkeeping é derivado: operador autenticado, alvos já provados, data,
+  versão/hash exibidos, modo de seleção, ciência implícita no CTA e motivos
+  padrão.
+- Uma decisão rotineira e reversível tem um botão e a consequência concreta ao
+  lado. Checkbox, frase digitada e campo “motivo” sem uso operacional não são
+  confirmação.
+- Risco adicional mantém fricção proporcional. `resume` conserva o token em
+  dois passos; `adjust` conserva edição, motivo, diff e confirmação explícita
+  no botão. A versão continua sendo validada pelo backend, mas é derivada do
+  card imutável em vez de copiada pelo operador.
+- Reconhecimento externo, aprovação/agendamento, retomada e reconciliação não
+  são tratados como reversíveis; todos mantêm confirmação de consequência ou
+  dois passos.
+- Todo write pinta `aria-busy` e desabilita controles antes do primeiro await,
+  bloqueia duplo submit, relata executado/recusado/desconhecido e só afirma o
+  efeito após readback. O orçamento para feedback local é 100 ms.
+- Enter em campo textual não aciona controles marcados como arriscados; teclado
+  e leitor de tela continuam acionando o botão focado normalmente.
+- Texto preenchido sobrevive a recusa/erro em memória volátil. Nada é salvo em
+  `localStorage` ou `sessionStorage`; sucesso confirmado ou reload o descarta.
+
+## Inventário de mutações
+
+| Rota | Ação | Risco | Decisão humana | Derivado / gate |
+|---|---|---:|---|---|
+| Hoje | Criar diretiva | baixo | título e corpo | operador, data, tipo |
+| Hoje | Reconhecer alerta | baixo | um toque | alvo, operador, nota nula |
+| Atividade | Atribuir triagem | baixo | um toque | alvo e operador |
+| Atividade | Marcar triado | baixo | um toque | alvo, operador, nota nula |
+| Exceções | Reconhecer | baixo | um toque | alvo, operador, nota nula |
+| Exceções | Iniciar tratamento | baixo | plano | alvo e operador |
+| Detalhe | Registrar nota | baixo | nota | alvo e operador |
+| Detalhe | Marcar revisto | baixo | um toque | alvo, operador, nota nula |
+| Detalhe | Revisar atividade | baixo | um toque | alvo, operador, nota nula |
+| Detalhe | Confirmar próximo passo | baixo | um toque | alvo, operador, nota nula |
+| Detalhe | Rejeitar próximo passo | médio | motivo | alvo e operador |
+| Detalhe | Reconhecer exceção | baixo | um toque | alvo, operador, nota nula |
+| Detalhe | Reabrir exceção | médio | motivo | alvo e operador |
+| Detalhe | Reconhecer inbound | médio | um toque | lead provado, operador, motivo nulo |
+| Rascunhos | Salvar ajuste | baixo | assunto e corpo | draft, operador, hash |
+| Rascunhos | Aprovar e agendar | alto | um toque | destinatário, hash e ciência no CTA |
+| Rascunhos | Rejeitar | médio | motivo | draft, operador, hash |
+| Operação | Pausar outbound | médio | um toque | operador e motivo auditável padrão |
+| Operação | Retomar outbound | alto | motivo + dois passos | observação e token de uso único |
+| Cohorts | Criar próxima | baixo | quantidade de 1 a 10 | modo de seleção |
+| Cohorts | Recuperar anteriores | médio | seleção | modo e limite de 10 |
+| Revisão | Validar destinatário | baixo | um toque | versão e candidato |
+| Revisão | Aprovar e enfileirar | alto | um toque | versão, candidato, destinatário e ciência |
+| Revisão | HOLD/REJECT | médio | decisão e motivo | versão e candidato |
+| Revisão | Ajustar | médio | conteúdo e motivo | versão, hash e diff; backend recebe confirmação |
+| Revisão | Reproduzir | baixo | um toque | versão e operador |
+| Revisão | Reconciliar | alto | um toque | vínculos aprovados; operação idempotente |
+
+O reconhecimento global de inbound foi removido de Operação: digitar um ID não
+prova o alvo. O operador abre a fila e reconhece no detalhe do alerta, onde o
+lead foi resolvido de evidência explícita.
+
+## Medição de passos
+
+| Jornada crítica | Antes | Depois |
+|---|---:|---:|
+| Triagem diária | 3 | 1 |
+| Reconhecer exceção | 3 | 1 |
+| Reconhecer inbound | 4 | 1 |
+| Aprovar e enfileirar | 2 | 1 |
+| Ajustar versão com diff | 6 | 5 |
+
+O probe de browser valida 390 × 844, ausência de campos redundantes nas ações
+de um toque, ação não encoberta pela navegação móvel, feedback realmente
+pintado dentro do orçamento e exposição do inventário compacto no runtime.
+Testes de unidade impedem a reintrodução de `ciencia`, `RECONHECER`, versão
+copiada e comentário de aprovação comum, além de preservar a escolha de 1 a 10
+fornecedores.


### PR DESCRIPTION
## Resumo
- inventaria 27 interações mutáveis e reduz cinco jornadas críticas para uma ação por decisão humana
- remove confirmações e campos contábeis redundantes, derivando metadados sem alterar os gates proporcionais de risco
- adiciona feedback síncrono, bloqueio de duplo envio, recuperação volátil de rascunho e cobertura mobile/acessível no launch probe

## Validação
- typecheck completo
- testes unitários completos
- integração com banco: 69/69
- hardening: 25/25
- E2E/axe/visual em 19 rotas, incluindo viewport 390x844 e feedback abaixo de 100 ms

Refs #116