### PR TITLE
feat: versionar autoridade delegada do primeiro toque

### DIFF
--- a/.github/workflows/commercial-authority.yml
+++ b/.github/workflows/commercial-authority.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Validate sanitized synchronous agent batch proof
         run: python scripts/validate_agent_outreach_batch.py
       - name: Adversarial tests
-        run: python -m pytest tests/test_commercial_authority.py tests/test_offer_convergence.py tests/test_commercial_mainline.py tests/test_legal_provisional.py tests/test_legal_founder_approved.py tests/test_partner_program.py tests/test_delivery_contracts.py tests/test_delivery_readiness.py tests/test_delivery_capacity.py tests/test_delivery_canary_gate.py tests/test_agent_outreach_batch.py -q
+        run: python -m pytest tests/test_commercial_authority.py tests/test_offer_convergence.py tests/test_commercial_mainline.py tests/test_legal_provisional.py tests/test_legal_founder_approved.py tests/test_partner_program.py tests/test_delivery_contracts.py tests/test_delivery_readiness.py tests/test_delivery_capacity.py tests/test_delivery_canary_gate.py tests/test_agent_outreach_batch.py tests/test_first_touch_routing_policy.py -q

--- a/commercial/outbound/cfg-first-touch-routing.v1.json
+++ b/commercial/outbound/cfg-first-touch-routing.v1.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "cfg-first-touch-routing.v1",
+  "policy_id": "CFG-FIRST-TOUCH-ROUTING",
+  "policy_version": "v1",
+  "canonical_name": "CFG-FIRST-TOUCH-ROUTING-v1",
+  "status": "ACTIVE",
+  "effective_at": "2026-08-25T00:00:00Z",
+  "authority": {
+    "decided_by_role": "FOUNDER",
+    "decision_reference": "https://github.com/tjsasakifln/Governance/issues/129",
+    "runtime_reference": "https://github.com/tjsasakifln/warmbly/issues/41",
+    "decision_source": "DELEGATED_POLICY_APPROVE",
+    "eligible_first_touch_requires_human_review": false,
+    "human_actor_impersonation_allowed": false
+  },
+  "scope": {
+    "channel": "EMAIL",
+    "message_kind": "FIRST_TOUCH",
+    "followups_authorized": false,
+    "approval_authorized": true,
+    "scheduling_authorized": true,
+    "provider_dispatch_authorized": false
+  },
+  "source_authorities": {
+    "target_identity_party_role_recipient_evidence": "extra-cli/confenge.outreach.v1",
+    "approval_scheduling_queue_transport": "warmbly/confenge",
+    "policy_governance": "Governance/CFG-FIRST-TOUCH-ROUTING-v1"
+  },
+  "evaluation": {
+    "mode": "ALL_HARD_GATES_MUST_PASS",
+    "unknown_result": "HOLD_NEEDS_REVIEW",
+    "individual_failure_stops_batch": false,
+    "replay_semantics": "IDEMPOTENT_NO_DUPLICATE_APPROVAL_OR_SCHEDULING"
+  },
+  "hard_gates": {
+    "identity_and_party_role": {
+      "target_state": "TARGET_CONFIRMED",
+      "source_run_must_be_current": true,
+      "cnpj_root_must_reconcile": true,
+      "allowed_target_party_roles": [
+        "SUPPLIER",
+        "CONTRACTOR",
+        "CONTRATADA",
+        "FORNECEDORA"
+      ],
+      "required_typed_status": "CONTRACTOR_ROLE_CONFIRMED",
+      "supplier_exact_cnpj_or_typed_branch_binding_required": true,
+      "cnpj_root_only_match_disposition": "HOLD_NEEDS_REVIEW",
+      "forbidden_target_party_roles": [
+        "BUYER",
+        "CONTRACTING_AUTHORITY",
+        "CONTRATANTE",
+        "ORGAO"
+      ],
+      "conflict_disposition": "PARTY_ROLE_CONFLICT",
+      "unknown_disposition": "HOLD_NEEDS_REVIEW",
+      "warmbly_may_reinterpret_raw_pncp": false
+    },
+    "recipient": {
+      "allowed_route_classes": [
+        "DIRECT_PERSON",
+        "ROLE_OR_DEPARTMENT",
+        "GENERIC_COMPANY",
+        "PUBLIC_COMPANY_FREEMAIL"
+      ],
+      "exact_recipient_required": true,
+      "company_association_evidence_required": true,
+      "current_source_run_required": true,
+      "forbidden_proof_only": [
+        "GUESSED_PATTERN",
+        "SYNTAX_ONLY",
+        "MX_ONLY",
+        "DOMAIN_ONLY",
+        "SEARCH_SNIPPET_ONLY",
+        "UNATTRIBUTED_FREEMAIL",
+        "UNPROVEN_SHARED_MAILBOX"
+      ]
+    },
+    "evidence": {
+      "bundle_reconciled": true,
+      "source_run_current": true,
+      "freshness_valid": true,
+      "critical_conflict_absent": true,
+      "company_cnpj_recipient_binding_required": true,
+      "every_copy_fact_supported": true,
+      "internal_hypothesis_as_fact_allowed": false
+    },
+    "compliance_and_reputation": {
+      "suppression_clear": true,
+      "opt_out_clear": true,
+      "dnc_clear": true,
+      "hard_bounce_clear": true,
+      "organization_risk_clear": true,
+      "mailbox_transport_eligible": true,
+      "kill_switch_bypass_allowed": false,
+      "dispatch_pause_bypass_allowed": false
+    },
+    "copy": {
+      "first_touch_only": true,
+      "current_composer_template_prompt_required": true,
+      "subject_and_body_nonempty": true,
+      "deterministic_editorial_qa": "PASS",
+      "deterministic_factual_qa": "PASS",
+      "raw_metadata_allowed": false,
+      "internal_reasoning_allowed": false,
+      "unsupported_economic_or_legal_claim_allowed": false,
+      "forbidden_generic_subject_allowed": false,
+      "truncation_allowed": false,
+      "near_duplicate_above_existing_limit_allowed": false,
+      "route_class_compatible_cta_required": true,
+      "non_direct_routes_request_forwarding": true,
+      "non_direct_routes_may_claim_decision_maker": false
+    }
+  },
+  "drift_invalidation": {
+    "action": "INVALIDATE_DELEGATED_APPROVAL",
+    "material_fields": [
+      "recipient",
+      "route_class",
+      "content_hash",
+      "evidence_hash",
+      "evidence_version",
+      "source_run_id",
+      "target_fit",
+      "target_party_role",
+      "template_version",
+      "composer_version",
+      "prompt_version",
+      "policy_version",
+      "suppression",
+      "opt_out",
+      "dnc",
+      "hard_bounce",
+      "organization_risk",
+      "mailbox_eligibility"
+    ]
+  },
+  "failure": {
+    "decision": "DO_NOT_APPROVE",
+    "disposition": "HOLD_NEEDS_REVIEW_EXCEPTION",
+    "concrete_reason_codes_required": true,
+    "fail_closed": true
+  },
+  "audit": {
+    "approved_by_type": "delegated_agent_or_system",
+    "human_approved_by_must_be_empty": true,
+    "required_fields": [
+      "policy_id",
+      "policy_version",
+      "authority_reference",
+      "executor",
+      "source_run_id",
+      "source_run_hash",
+      "lead_account_cnpj_root_ref",
+      "recipient",
+      "route_class",
+      "target_party_role",
+      "supplier_identity_ref",
+      "buyer_identity_ref",
+      "contract_role_match_method",
+      "contract_role_confidence",
+      "contract_role_reason_codes",
+      "contract_role_evidence_ref",
+      "evidence_bundle_version",
+      "evidence_hash",
+      "content_hash",
+      "composer_version",
+      "template_version",
+      "prompt_version",
+      "approval_timestamp",
+      "scheduling_result",
+      "due_at",
+      "reason_codes",
+      "idempotency_key",
+      "runtime_release_sha"
+    ]
+  },
+  "runtime_reuse": {
+    "existing_approval_authority": true,
+    "existing_scheduler": true,
+    "existing_queue": true,
+    "existing_crm": true,
+    "existing_suppression": true,
+    "existing_idempotency": true,
+    "existing_readback_verification": true,
+    "existing_next_eligible_slot": true,
+    "existing_min_wait_time": true,
+    "existing_business_window": true,
+    "existing_mailbox_rate_limits": true,
+    "parallel_architecture_allowed": false
+  },
+  "canary": {
+    "operational_data_allowed": true,
+    "dispatch_global_paused_required": true,
+    "kill_switch_preserved_required": true,
+    "queued_readback_required": true,
+    "smtp_send_allowed": false,
+    "sent_count_required": 0,
+    "provider_send_mutation_allowed": false
+  }
+}

--- a/control-center/apps/web-shell/src/ui/warmbly.ts
+++ b/control-center/apps/web-shell/src/ui/warmbly.ts
@@ -6,9 +6,10 @@
  * control here and there must never be one — this surface can stop outbound and
  * let it flow again, and that is the whole of its authority.
  *
- * Candidate APPROVE lives in Revisão and is the complete per-message scheduling
- * authority. It queues with auto_send=true for that message; only Warmbly's
- * worker transports later, under the controls shown here.
+ * Eligible first touches can be approved by CFG-FIRST-TOUCH-ROUTING-v1. Human
+ * APPROVE remains the per-message authority for exceptions and out-of-policy
+ * work. Both paths reuse Warmbly's scheduler; only its worker transports later,
+ * under the controls shown here.
  *
  * Everything an operator needs to decide is rendered *before* the controls:
  * dispatch state, why it is in that state, the commercial window, the approved
@@ -673,6 +674,21 @@ function stamp(value: unknown): string {
   return typeof value === "string" && value !== "" ? formatLocal(value) : "—";
 }
 
+function delegatedStatus(input: WarmblySurfaceInput): Record<string, unknown> {
+  return record(record(input.snapshot?.operations).delegated_first_touch);
+}
+
+function delegatedFirstTouchBlock(input: WarmblySurfaceInput): string {
+  const status = delegatedStatus(input);
+  const observed = status.observed === true;
+  const active = status.policy_active === true;
+  const counts = record(status.counts);
+  const items = array(status.items);
+  const state = observed ? (active ? "active" : "inactive") : "unknown";
+  const copy = !observed ? "Estado desconhecido não é aprovação" : active ? "POLICY ATIVA" : "Nenhum item deve ser tratado como aprovado por policy";
+  return `<section class="stack" data-first-touch-policy="${state}"><h2>Primeiro toque · ${escapeHtml(show(status.policy_version))}</h2><p class="banner ${active ? "ok" : "stale"}" role="status">${copy}. DELEGATED_POLICY_APPROVE/QUEUED: ${escapeHtml(show(counts.QUEUED))}; Readback QUEUED: ${escapeHtml(show(status.queued_readback))}; HOLD: ${escapeHtml(show(counts.HOLD))}; HUMAN_APPROVE: ${escapeHtml(show(status.human_approved))}.</p>${items.length ? `<details class="tech" data-first-touch-evidence="true"><summary>Abrir evidence e reason codes (${items.length})</summary><pre>${escapeHtml(JSON.stringify(items))}</pre></details>` : ""}</section>`;
+}
+
 interface DispatchReading {
   state: string;
   stateLabel: string;
@@ -1199,7 +1215,7 @@ export function pilotSteps(input: WarmblySurfaceInput): StepView[] {
       detail:
         !hasCohort || candidates.length === 0
           ? "O payload desta versão não trouxe candidatos."
-          : `${approved.length} de ${candidates.length} com APPROVE efetivo segundo o servidor. Aprovar é autoridade para enfileirar.`,
+          : `${approved.length} de ${candidates.length} com HUMAN_APPROVE efetivo.`,
     },
     {
       id: "agendamento",
@@ -1213,7 +1229,7 @@ export function pilotSteps(input: WarmblySurfaceInput): StepView[] {
             : "current",
       detail: !hasCohort
         ? "Sem cohort não há mensagens para agendar."
-        : `${scheduled.length} de ${approved.length} aprovação(ões) efetiva(s) têm auto_send por mensagem, due_at e estado QUEUED/SENT.`,
+        : `${scheduled.length} de ${approved.length} têm due_at e QUEUED/SENT.`,
     },
   ];
 }
@@ -1241,16 +1257,20 @@ function pilotSummary(input: WarmblySurfaceInput): string {
   const list = gateSection(input, "list");
   const latest = latestCohort(input);
   const authority = operatorAuthority(input);
+  const policyActive = delegatedStatus(input).observed === true && delegatedStatus(input).policy_active === true;
   const open = latest
     ? `<p><a class="button" data-open-review="true" href="#/warmbly/revisao?resource=${escapeHtml(show(latest.id))}">Abrir revisão da v${escapeHtml(show(latest.version))}</a></p>`
     : `<p><a class="button" data-open-cohorts="true" href="#/warmbly/cohorts">Abrir Cohorts para criar a primeira versão</a></p>`;
   return `
     <section class="stack" aria-labelledby="warmbly-piloto" data-pilot-summary="true">
-      <h2 id="warmbly-piloto">Onde o piloto está</h2>
-      <p class="constraint">Fonte → Cohort → Validação → Revisão → Agendamento. APPROVE já enfileira a mensagem com auto_send=true para ela; a automação global continua desligada. Cada passo abaixo repete o servidor.</p>
+      <h2 id="warmbly-piloto">${policyActive ? "Primeiro toque e exceções" : "Onde o piloto está"}</h2>
+      <p class="constraint">${policyActive
+        ? "Itens elegíveis seguem a policy ao scheduler; revisão é fila de exceção e não é pedágio."
+        : "Fonte → Cohort → Validação → HUMAN_APPROVE → Agendamento."}</p>
       ${gateUnreadableBanner(list, "a lista de cohorts")}
       ${identityBlock(input, true)}
-      ${stepperBlock(input)}
+      ${delegatedFirstTouchBlock(input)}
+      ${policyActive ? "" : stepperBlock(input)}
       ${
         latest
           ? `<article class="card" data-latest-cohort="${escapeHtml(show(latest.id))}">
@@ -1273,7 +1293,7 @@ function pilotSummary(input: WarmblySurfaceInput): string {
           ? ""
           : `<p class="constraint" data-reconcile-authority="absent">O reparo “Reprocessar aprovações” exige <code>admins</code>. Sua sessão ${
               authority.known ? "não tem esse grupo" : "não teve os grupos confirmados pelo canal"
-            }: o fluxo normal continua sendo APPROVE por <code>operators</code>, sem passo extra.</p>`
+            }: exceções continuam podendo receber HUMAN_APPROVE por <code>operators</code>; itens elegíveis seguem a policy sem esse reparo.</p>`
       }
     </section>`;
 }
@@ -1527,7 +1547,7 @@ function cohortSurface(input: WarmblySurfaceInput): string {
   const createLimit = interactionDraftValue(`gate:${createKey}`, "limit", "10");
   const createPending = gateInFlight(createKey);
   const recoverPending = gateInFlight(recoverKey);
-  return `<section class="stack" aria-labelledby="cohorts-title"><h2 id="cohorts-title">Cohorts versionadas</h2><p class="constraint">Denominadores vêm do preview Warmbly: considerados = elegíveis + excluídos e destinatários finais nunca são recalculados nesta tela. A automação global permanece desligada; cada APPROVE agenda somente sua mensagem com <code>auto_send=true</code>.</p>
+  return `<section class="stack" aria-labelledby="cohorts-title"><h2 id="cohorts-title">Cohorts versionadas</h2><p class="constraint">O preview Warmbly é a autoridade dos denominadores e destinatários.</p>
   ${gateUnreadableBanner(list, "a lista de cohorts")}
   ${feedback.remainder()}
   ${identityBlock(input, true)}
@@ -1805,7 +1825,7 @@ function candidateCard(
     ${gateInFlight(approveKey) ? pendingBlock("Registrando a aprovação") : ""}
     <form class="operator-form approve-form" data-human-gate="review" data-interaction="gate.approve" data-one-decision="true" data-explicit-submit="true" data-gate-key="${escapeHtml(approveKey)}" data-decision="APPROVE" data-version="${escapeHtml(cohortId)}" data-candidate="${escapeHtml(candidateId)}"${gate.needsValidation ? ` data-auto-validate="true"` : ""}>
       <h4>Aprovar e enfileirar este candidato</h4>
-      <p class="constraint" data-approve-meaning="true">Clicar em Aprovar e enfileirar é a ciência e a autoridade de agendamento: a trilha grava sua identidade do Authelia, o instante, esta versão v${escapeHtml(version)}, o hash congelado, o destinatário exato e a decisão; a mesma operação cria a mensagem com <code>auto_send=true</code> e <code>due_at</code> na próxima janela comercial. Não há GO, segunda caixa ou passo de entrega.</p>
+      <p class="constraint" data-approve-meaning="true">HUMAN_APPROVE vincula a identidade do Authelia, v${escapeHtml(version)}, hash e destinatário; a mesma operação agenda com <code>due_at</code>.</p>
       ${
         gate.needsValidation
           ? `<p class="constraint" data-approve-autovalidate="true">Este destinatário ainda não tem verificação vigente. Aprovar pede a verificação ao Warmbly primeiro e só registra o APPROVE se ela voltar VALID — você não precisa acionar nada antes.</p>`
@@ -1829,12 +1849,12 @@ function candidateCard(
     ? schedulingConfirmed
       ? `<article class="banner ok" role="status" data-approval-scheduling="true" data-scheduling-confirmed="true" data-scheduling-state="${escapeHtml(schedulingState ?? "")}">
           <h4>Agendamento confirmado pelo servidor</h4>
-          <p>APPROVE agenda a mensagem: ela está ${schedulingState === "SENT" ? "marcada como enviada" : "na fila do worker"}, com <code>auto_send=true</code>${schedulingState === "QUEUED" ? " e saída prevista para a próxima janela permitida" : ""}. Pausa, kill switch, janela comercial, teto por hora e validação de última milha ainda governam o transporte.</p>
+          <p>HUMAN_APPROVE agenda a mensagem ${schedulingState === "SENT" ? "como enviada" : "na fila do worker"}; os gates de transporte continuam valendo.</p>
           <dl class="facts">${fact("Estado", schedulingState ?? NOT_IN_PAYLOAD)}${fact("due_at", schedulingDueAt === null ? NOT_IN_PAYLOAD : stamp(schedulingDueAt))}${fact("auto_send da mensagem", "true")}</dl>
         </article>`
       : `<article class="banner error" role="alert" data-approval-scheduling="true" data-scheduling-confirmed="false">
           <h4>Defeito: APPROVE efetivo sem agendamento confirmado</h4>
-          <p>Uma aprovação válida deve sair da mesma operação em <code>QUEUED</code>, com <code>due_at</code> e <code>auto_send=true</code>. Não reaprove. Um admin deve executar “Reprocessar aprovações já registradas” e reler este candidato.</p>
+          <p>A aprovação deveria estar em <code>QUEUED</code> com <code>due_at</code>. Não reaprove; peça o reparo admin.</p>
           <dl class="facts">${fact("Estado", schedulingState ?? NOT_IN_PAYLOAD)}${fact("due_at", schedulingDueAt === null ? NOT_IN_PAYLOAD : stamp(schedulingDueAt))}${fact("auto_send da mensagem", scheduling.auto_send === undefined ? NOT_IN_PAYLOAD : String(scheduling.auto_send))}</dl>
         </article>`
     : "";
@@ -1977,7 +1997,7 @@ function adjustBlock(args: {
           <div data-diff-field="body_text"><dt>Corpo</dt><dd><del><pre class="message-preview">${escapeHtml(draft.before_body_text)}</pre></del><ins><pre class="message-preview">${escapeHtml(draft.body_text)}</pre></ins></dd></div>
           <div data-diff-field="reason"><dt>Motivo</dt><dd>${escapeHtml(draft.reason)}</dd></div>
         </dl>
-        <p class="constraint">Confirmar cria a versão seguinte. A versão v${escapeHtml(version)} continua existindo e legível; validação e revisão da nova versão começam pendentes. Cada APPROVE nela fará o próprio agendamento.</p>
+        <p class="constraint">Confirmar cria outra versão; v${escapeHtml(version)} permanece legível e cada HUMAN_APPROVE agenda só seu item.</p>
       </div>`
     : "";
   return `
@@ -2084,7 +2104,7 @@ function queueBlock(
     <p class="kicker"><span class="pill">FILA</span></p>
     <h3 data-queue-progress-text="true">${counts.pendentes} pendente(s) · ${counts.aprovadas} aprovada(s) · ${counts.ajuste} em ajuste · ${counts.total} no total</h3>
     <nav class="subnav queue-filters" data-review-filters="true" aria-label="Estado da revisão">${tabs}</nav>
-    <p class="constraint">A fila abre em Pendentes. Uma mensagem aprovada sai deste recorte e, na mesma operação, entra na fila do worker com <code>auto_send=true</code>; as concluídas continuam legíveis nos outros recortes.</p>
+    <p class="constraint">Pendentes abre primeiro; decisões continuam legíveis nos demais recortes.</p>
   </article>`;
 }
 
@@ -2128,8 +2148,8 @@ function reconcileBlock(authority: OperatorAuthority): string {
   <article class="card" data-approval-reconcile="true">
     <p class="kicker"><span class="pill">REPARO · ADMINS</span></p>
     <h3>Reprocessar aprovações já registradas</h3>
-    <p data-reconcile-meaning="true">Este não é um passo normal depois da revisão. APPROVE já agenda sozinho. Use o reparo somente para aprovações antigas ou para um APPROVE cujo card mostre “sem agendamento confirmado”.</p>
-    <p class="constraint" data-reconcile-repeat="true">A operação percorre o histórico pelo mesmo caminho de código do APPROVE, deduplica candidatos repetidos entre cohorts e é idempotente: executar de novo não cria outra mensagem nem reenvia o que já saiu.</p>
+    <p data-reconcile-meaning="true">Este não é um passo normal depois da revisão; use só quando faltar agendamento confirmado.</p>
+    <p class="constraint" data-reconcile-repeat="true">É idempotente, deduplica candidatos repetidos entre cohorts e não reenvia.</p>
     <p class="constraint">O resultado mostra quantos registros, vínculos e candidatos únicos foram encontrados e quantos ficaram agendados. Isto não transporta e-mail; o worker continua sob janela comercial, teto por hora, pausa e kill switch.</p>
     <form class="operator-form" data-human-gate="reconcile" data-interaction="gate.reconcile" data-one-decision="true" data-explicit-submit="true" data-gate-key="${escapeHtml(reconcileKey)}">
       <button type="submit" data-reconcile-submit="true"${authority.canReconcile && !pending ? "" : " disabled"}>${pending ? "Enviando…" : "Reprocessar aprovações já registradas"}</button>
@@ -2214,7 +2234,8 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   <form class="operator-form" data-human-gate="reproduce" data-interaction="gate.reproduce" data-one-decision="true" data-gate-key="${escapeHtml(reproduceKey)}" data-version="${escapeHtml(cohortId)}"><button type="submit"${gateInFlight(reproduceKey) || !authority.canReview ? " disabled" : ""}>${gateInFlight(reproduceKey) ? "Enviando…" : "Reproduzir versão imutável"}</button></form>
 `
     : "";
-  return `<section class="stack" aria-labelledby="review-title" data-review-cohort="${escapeHtml(cohortId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}"><h2 id="review-title">Revisão v${escapeHtml(version)}</h2>
+  return `<section class="stack" aria-labelledby="review-title" data-review-cohort="${escapeHtml(cohortId)}" data-editorial-state="${escapeHtml(editorial.state)}" data-actionable="${editorial.actionable ? "true" : "false"}"><h2 id="review-title">Revisão v${escapeHtml(version)} · fila de exceções</h2>
+  ${delegatedFirstTouchBlock(input)}
   ${outboundStatusBlock(input)}
   ${legacyBanner(editorial, cohortId)}
   ${leftover}${cohortFeedback}
@@ -2242,7 +2263,7 @@ function reviewSurface(input: WarmblySurfaceInput): string {
   }
   <details class="card" data-historical-go-audit="true"><summary>Auditoria histórica de GO/NO-GO (sem efeito operacional)</summary><dl class="facts"><div><dt>Último valor histórico</dt><dd>${escapeHtml(historicalDecision)}</dd></div></dl><p class="constraint">O controle foi removido da Revisão. Este dado antigo permanece apenas para auditoria: não autoriza, bloqueia, enfileira nem desenfileira mensagens.</p></details>
   ${reconcileBlock(authority)}
-  <p class="constraint">APPROVE é o único ato humano necessário para agendar a mensagem. O envio em si continua sendo do worker do Warmbly, na janela comercial e sob o teto por hora; esta tela não expõe send, queue ou resume.</p></section>`;
+  <p class="constraint">HUMAN_APPROVE agenda exceções; a policy agenda first touches elegíveis no mesmo scheduler. Pausa, kill switch, janela e teto continuam dominantes.</p></section>`;
 }
 
 function warmblySubnav(current: WarmblySurface, input: WarmblySurfaceInput): string {

--- a/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
+++ b/control-center/apps/web-shell/tests/warmbly-cohort-ui.test.ts
@@ -135,6 +135,88 @@ function surfaceInput(overrides: Record<string, unknown> = {}): Parameters<typeo
   } as Parameters<typeof warmblyBlock>[0];
 }
 
+function delegatedSnapshot(policyActive = true): Record<string, unknown> {
+  return {
+    operations: {
+      delegated_first_touch: {
+        observed: true,
+        policy_id: "CFG-FIRST-TOUCH-ROUTING-v1",
+        policy_version: "CFG-FIRST-TOUCH-ROUTING-v1",
+        policy_hash: "3ea77bb047d9db19c061d96c62ae302768f25dbd075db7cccac5fe56d3fe3b99",
+        policy_active: policyActive,
+        counts: { QUEUED: 1, HOLD: 1 },
+        human_approved: 2,
+        queued_readback: 1,
+        duplicate_live_account: 0,
+        duplicate_live_root: 0,
+        items: [
+          {
+            batch_id: "batch-fixture-001",
+            cnpj14: "12345678000190",
+            supplier_cnpj14: "12345678000190",
+            buyer_cnpj14: "98765432000110",
+            recipient: "compras@fornecedora.invalid",
+            route_class: "ROLE_OR_DEPARTMENT",
+            approval_source: "DELEGATED_POLICY_APPROVE",
+            state: "QUEUED",
+            evidence_reference: "extra-cli:v_contracts_canonical_v2:contract-fixture",
+            evidence_hash: "evidence-fixture-hash",
+            source_run_id: "run-current",
+            source_snapshot_hash: "snapshot-current",
+            content_hash: "content-fixture-hash",
+            reason_codes: ["ALL_HARD_GATES_PASS"],
+            due_at: "2026-08-25T15:00:00Z",
+            readback_at: "2026-08-25T14:59:01Z",
+            decided_at: "2026-08-25T14:59:00Z",
+          },
+          {
+            cnpj14: "22345678000190",
+            route_class: "GENERIC_COMPANY",
+            approval_source: "POLICY_EVALUATION_HOLD",
+            state: "HOLD",
+            reason_codes: ["PARTY_ROLE_UNKNOWN"],
+            blocker_codes: ["PARTY_ROLE_UNKNOWN"],
+            source_run_id: "run-current",
+          },
+        ],
+      },
+    },
+  };
+}
+
+test("Control Center distinguishes delegated approval, human approval and fail-closed exceptions", () => {
+  const input = surfaceInput({ snapshot: delegatedSnapshot() });
+  const operation = warmblyBlock(input, "operacao");
+  const review = warmblyBlock(input, "revisao");
+
+  for (const html of [operation, review]) {
+    assert.match(html, /data-first-touch-policy="active"/);
+    assert.match(html, /CFG-FIRST-TOUCH-ROUTING-v1/);
+    assert.match(html, /DELEGATED_POLICY_APPROVE/);
+    assert.match(html, /HUMAN_APPROVE/);
+    assert.match(html, /POLICY_EVALUATION_HOLD/);
+    assert.match(html, /PARTY_ROLE_UNKNOWN/);
+    assert.match(html, /data-first-touch-evidence="true"/);
+    assert.match(html, /Readback QUEUED/);
+  }
+  assert.match(operation, /não é pedágio/);
+  assert.match(review, /fila de exceções/);
+  assert.doesNotMatch(review, /APPROVE é o único ato humano necessário/);
+});
+
+test("unobserved or inactive delegated authority never looks approved", () => {
+  const inactive = warmblyBlock(
+    surfaceInput({ snapshot: delegatedSnapshot(false) }),
+    "operacao",
+  );
+  assert.match(inactive, /data-first-touch-policy="inactive"/);
+  assert.match(inactive, /Nenhum item deve ser tratado como aprovado por policy/);
+
+  const unknown = warmblyBlock(surfaceInput(), "operacao");
+  assert.match(unknown, /data-first-touch-policy="unknown"/);
+  assert.match(unknown, /Estado desconhecido não é aprovação/);
+});
+
 /* ------------------------------------------------------------------ *
  * A root that really parses the markup it was handed.
  *
@@ -1152,7 +1234,7 @@ test("the new version opens with validation, review and scheduling pending", () 
   assert.ok(!html.includes("Revisão registrada"));
   assert.match(html, /<dt>Validação<\/dt><dd>UNKNOWN<\/dd>/);
   assert.doesNotMatch(html, /data-human-gate="decide"|data-human-gate="dispatch"/);
-  assert.match(html, /data-step="agendamento"|APPROVE é o único ato humano necessário/);
+  assert.match(html, /data-step="agendamento"|HUMAN_APPROVE agenda exceções/);
 });
 
 test("every adjust refusal code renders its own actionable sentence", () => {

--- a/control-center/connectors/warmbly/README.md
+++ b/control-center/connectors/warmbly/README.md
@@ -31,7 +31,7 @@ Canonical CRM remains Warmbly. This workstream does not persist leads/deals/stag
   - Operator writes are **never retried** (a retried acknowledge would double-acknowledge). 4xx from Warmbly does not trip the circuit breaker; 5xx/429/timeout does.
   - The channel may share the read client's `CircuitBreaker`, so a degraded Warmbly blocks operator writes too. When the breaker is open, the refusal names the out-of-band fallback: `deploy/confenge-vps/pause.sh` on the VPS.
 - **Amended boundary (human-review bridge).** `control-center/services/context` may call only the exact review routes listed in `required_upstream_contract.json → human_review_bridge`. The authenticated founder may save copy adjustments, approve an exact content hash for the next eligible business window, reject a draft back into editorial recovery, or apply those decisions in a bounded batch. Approval never transports a message immediately.
-- **Amended boundary (cohort human gate).** The authenticated edge may list/read immutable cohorts and candidates; create the next disjoint supplier cohort; recover stale supplier versions; validate, review, or adjust one candidate; and let `admins` invoke the targetless, idempotent reconciliation of old durable approvals. Leads are supplier/contracted-company CNPJ roots, never contracting authorities. Effective APPROVE is the sole operation that asks Warmbly to schedule the exact reviewed message for its next eligible business window. There is no GO or cohort-dispatch route in the current allowlist.
+- **Amended boundary (cohort human exception gate).** The authenticated edge may list/read immutable cohorts and candidates; create the next disjoint supplier cohort; recover stale supplier versions; validate, review, or adjust one candidate; and let `admins` invoke the targetless, idempotent reconciliation of old durable human approvals. Leads are supplier/contracted-company CNPJ roots, never contracting authorities. `HUMAN_APPROVE` schedules an exception through the existing Warmbly scheduler. Eligible first touches may instead arrive as `DELEGATED_POLICY_APPROVE` under `CFG-FIRST-TOUCH-ROUTING-v1`; the read-only collector displays that authoritative Warmbly decision and never evaluates it locally. There is no GO or cohort-dispatch route in the current allowlist.
 - **Still forbidden:** `PATCH`/`PUT`/`DELETE` on any path, creating contacts/deals/tasks, campaign start/stop/send, `dispatch-now` / cohort dispatch / cohort decision, enroll, draft send, review writes outside the typed bridges, `POST /v1/confenge/inbound/:id/outcome` and `/resolve`, Confenge import/sync/bootstrap, unibox reply/compose/snooze, and **any Asaas / checkout / refund / financial mutation** (`commercial/authority/authority-manifest.v1.json` still carries `real_money_mutation_approved: false`).
 - Every aggregated item carries `source`, `observed_at` (UTC), `freshness_status`, and `confidence` when the upstream payload supplies it.
 - Deal money is integer **cents** + `currency`. Warmbly `value` is treated as major units (1500.50 BRL → 150050 cents).
@@ -60,6 +60,8 @@ See `required_upstream_contract.json` for the full table. Collect calls:
 | GET | `/v1/confenge/attention` | Warmbly-native needs-attention |
 | GET | `/v1/confenge/today` | executable human work |
 | GET | `/v1/confenge/inbound` | inbound leads needing a human |
+| GET | `/v1/confenge/dispatch/status` | pause/window/queue transport controls |
+| GET | `/v1/confenge/first-touch/status` | delegated policy/version, approval source, HOLD exceptions, evidence/reasons and QUEUED readback |
 
 Auth: `Authorization: Bearer <token>` and `API-Version: v1`. Tokens are prefixed `wmbly_`.
 
@@ -74,7 +76,7 @@ The Control Center's `Comercial → Rascunhos` surface uses a dedicated, server-
 | `POST /v1/commercial/review-drafts/:id` | `POST /v1/confenge/review/drafts/:id/decision` | save adjustment, approve, or reject |
 | `POST /v1/commercial/review-batches` | `POST /v1/confenge/review/batches` | apply up to 500 independently reported decisions |
 
-Every request requires the trusted founder identity. `APPROVE` carries `expected_content_hash` and only creates a durable queue entry for the next eligible business window. `REJECT` preserves the lead and routes the draft to AI-assisted editorial recovery. This bridge does not expose an immediate-send operation.
+Every request requires the trusted founder identity. `HUMAN_APPROVE` carries `expected_content_hash` and only creates a durable queue entry for the next eligible business window. It is the exception path, not a requirement for first touches already covered by `CFG-FIRST-TOUCH-ROUTING-v1`. `REJECT` preserves the lead and routes the draft to AI-assisted editorial recovery. This bridge does not expose an immediate-send operation.
 
 The list boundary emits `control-center.review-draft-page.v1`. Requested
 `limit`/`offset` and the observed row count always describe the local page;

--- a/control-center/connectors/warmbly/config/production.json
+++ b/control-center/connectors/warmbly/config/production.json
@@ -13,6 +13,10 @@
   },
   "http": {
     "allowed_methods": ["GET", "HEAD", "POST"],
+    "get_read_paths": [
+      "/v1/confenge/dispatch/status",
+      "/v1/confenge/first-touch/status"
+    ],
     "post_read_paths": [
       "/v1/contacts/search",
       "/v1/crm/deals/search",

--- a/control-center/connectors/warmbly/fixtures/commercial-runtime.json
+++ b/control-center/connectors/warmbly/fixtures/commercial-runtime.json
@@ -215,6 +215,40 @@
     "sending_allowed": true,
     "feed_configured": true
   },
+  "confenge_first_touch_status": {
+    "policy_id": "CFG-FIRST-TOUCH-ROUTING-v1",
+    "policy_version": "CFG-FIRST-TOUCH-ROUTING-v1",
+    "policy_hash": "3ea77bb047d9db19c061d96c62ae302768f25dbd075db7cccac5fe56d3fe3b99",
+    "policy_active": true,
+    "counts": { "QUEUED": 1, "HOLD": 1 },
+    "human_approved": 2,
+    "queued_readback": 1,
+    "items": [
+      {
+        "cnpj14": "12345678000190",
+        "supplier_cnpj14": "12345678000190",
+        "recipient": "compras@fornecedora.invalid",
+        "route_class": "ROLE_OR_DEPARTMENT",
+        "approval_source": "DELEGATED_POLICY_APPROVE",
+        "state": "QUEUED",
+        "evidence_reference": "extra-cli:v_contracts_canonical_v2:contract-fixture",
+        "evidence_hash": "evidence-fixture-hash",
+        "source_run_id": "run-current",
+        "reason_codes": ["ALL_HARD_GATES_PASS"],
+        "content_hash": "content-fixture-hash",
+        "due_at": "2026-08-25T15:00:00Z",
+        "readback_at": "2026-08-25T14:59:01Z"
+      },
+      {
+        "cnpj14": "22345678000190",
+        "route_class": "GENERIC_COMPANY",
+        "approval_source": "POLICY_EVALUATION_HOLD",
+        "state": "HOLD",
+        "source_run_id": "run-current",
+        "reason_codes": ["PARTY_ROLE_UNKNOWN"]
+      }
+    ]
+  },
   "confenge_ops_health": {
     "data": {
       "computed_at": "2026-08-20T14:50:00.000Z",

--- a/control-center/connectors/warmbly/required_upstream_contract.json
+++ b/control-center/connectors/warmbly/required_upstream_contract.json
@@ -22,7 +22,9 @@
     { "method": "GET", "path": "/v1/confenge/ops/health", "notes": "feature-flagged; 404 when Confenge org is off" },
     { "method": "GET", "path": "/v1/confenge/attention", "notes": "feature-flagged needs-attention accounts" },
     { "method": "GET", "path": "/v1/confenge/today", "notes": "feature-flagged executable human work" },
-    { "method": "GET", "path": "/v1/confenge/inbound", "notes": "feature-flagged inbound-now queue (lead surface)" }
+    { "method": "GET", "path": "/v1/confenge/inbound", "notes": "feature-flagged inbound-now queue (lead surface)" },
+    { "method": "GET", "path": "/v1/confenge/dispatch/status", "notes": "authoritative pause, kill-switch-adjacent scheduling and queue readback surface" },
+    { "method": "GET", "path": "/v1/confenge/first-touch/status", "notes": "authoritative CFG-FIRST-TOUCH-ROUTING-v1 delegated decisions, HOLD exceptions, approval source, evidence/reason codes and QUEUED readback; Control Center displays but never re-evaluates it" }
   ],
   "operator_actions": {
     "note": "Amended boundary. Three named, individually typed operational controls are the ONLY writes this connector may issue. Verified against the live Warmbly backend on the VPS (warmbly-confenge-backend-1, 127.0.0.1:8080) on 2026-08-22: each route answers 401 unauthenticated (registered) and 404 on the wrong method (not registered for it). Discovered in Warmbly internal/api/routes.go lines 594-604 under the feature-flagged `confengeWrite` group.",

--- a/control-center/connectors/warmbly/src/collector/fetch.ts
+++ b/control-center/connectors/warmbly/src/collector/fetch.ts
@@ -143,6 +143,9 @@ function assignRoute(payload: WarmblyPayload, key: CollectRouteKey, json: unknow
     case "confenge_dispatch_status":
       payload.confenge_dispatch_status = json as WarmblyPayload["confenge_dispatch_status"];
       break;
+    case "confenge_first_touch_status":
+      payload.confenge_first_touch_status = json as WarmblyPayload["confenge_first_touch_status"];
+      break;
     case "confenge_intel_scoreboard": {
       const rec = asRecordOrUndefined(json);
       if (rec) payload.confenge_intel_scoreboard = rec;

--- a/control-center/connectors/warmbly/src/collector/routes.ts
+++ b/control-center/connectors/warmbly/src/collector/routes.ts
@@ -56,6 +56,12 @@ export const COLLECT_ROUTES: CollectRoute[] = [
     required: false,
   },
   {
+    key: "confenge_first_touch_status",
+    method: "GET",
+    path: "/v1/confenge/first-touch/status",
+    required: false,
+  },
+  {
     key: "confenge_intel_scoreboard",
     method: "GET",
     path: "/v1/confenge/intel/scoreboard?include_synthetic=0",

--- a/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
+++ b/control-center/connectors/warmbly/src/contracts/warmbly-payload.ts
@@ -262,6 +262,48 @@ export type WarmblyDispatchStatus = {
   active_leases?: number;
 };
 
+/**
+ * GET /v1/confenge/first-touch/status. This is an audit/read model only: the
+ * connector never evaluates the policy and never infers an approval locally.
+ */
+export type WarmblyDelegatedFirstTouchItem = {
+  batch_id?: string;
+  account_id?: string;
+  cnpj14?: string;
+  supplier_cnpj14?: string;
+  buyer_cnpj14?: string;
+  recipient?: string;
+  route_class?: string;
+  decision?: string;
+  approval_source?: string;
+  state?: string;
+  evidence_reference?: string;
+  evidence_hash?: string;
+  source_run_id?: string;
+  source_snapshot_hash?: string;
+  reason_codes?: string[];
+  blocker_codes?: string[];
+  content_hash?: string;
+  runtime_release_sha?: string;
+  due_at?: string | null;
+  readback_at?: string | null;
+  decided_at?: string;
+};
+
+export type WarmblyDelegatedFirstTouchStatus = {
+  batch_id?: string;
+  policy_id?: string;
+  policy_version?: string;
+  policy_hash?: string;
+  policy_active?: boolean;
+  counts?: Record<string, number>;
+  human_approved?: number;
+  queued_readback?: number;
+  duplicate_live_account?: number;
+  duplicate_live_root?: number;
+  items?: WarmblyDelegatedFirstTouchItem[];
+};
+
 export type WarmblyObservedText = {
   availability?: "OBSERVED" | "UNKNOWN";
   value?: string;
@@ -327,6 +369,7 @@ export type WarmblyPayload = {
   confenge_today?: WarmblyTodayView | { data: WarmblyTodayView };
   confenge_inbound?: WarmblyInboundItem[] | WarmblyList<WarmblyInboundItem>;
   confenge_dispatch_status?: WarmblyDispatchStatus | { data: WarmblyDispatchStatus };
+  confenge_first_touch_status?: WarmblyDelegatedFirstTouchStatus | { data: WarmblyDelegatedFirstTouchStatus };
   confenge_intel_scoreboard?: Record<string, unknown>;
   confenge_intel_executive?: WarmblyIntelExecutive;
   confenge_intel_report?: Record<string, unknown>;

--- a/control-center/connectors/warmbly/src/http/allowlist.ts
+++ b/control-center/connectors/warmbly/src/http/allowlist.ts
@@ -29,6 +29,7 @@ export const GET_EXACT = new Set<string>([
   "/v1/confenge/accounts",
   "/v1/confenge/working-overview",
   "/v1/confenge/dispatch/status",
+  "/v1/confenge/first-touch/status",
   "/v1/confenge/intel/scoreboard",
   "/v1/confenge/intel/executive",
   "/v1/confenge/intel/report",

--- a/control-center/connectors/warmbly/src/mapper/normalize.ts
+++ b/control-center/connectors/warmbly/src/mapper/normalize.ts
@@ -513,6 +513,7 @@ export function collectFromWarmblyPayload(
     authority: "warmbly",
     this_document: "read_model",
     dispatch: dispatchOf(payload),
+    delegated_first_touch: delegatedFirstTouchOf(payload),
     cap: OPERATIONS_CAP,
     deals: fullOperations.deals.slice(0, OPERATIONS_CAP),
     tasks: fullOperations.tasks.slice(0, OPERATIONS_CAP),
@@ -580,6 +581,22 @@ function dispatchOf(payload: WarmblyPayload): Record<string, unknown> {
   if (typeof st.queued_approved === "number") out.queued_approved = st.queued_approved;
   if (typeof st.active_leases === "number") out.active_leases = st.active_leases;
   return out;
+}
+
+/**
+ * Preserve Warmbly's typed delegated-decision read model without re-deciding
+ * any gate in Governance. Missing/malformed data is explicitly unobserved.
+ */
+function delegatedFirstTouchOf(payload: WarmblyPayload): Record<string, unknown> {
+  const raw = unwrapData(payload.confenge_first_touch_status);
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      observed: false,
+      state: "UNKNOWN",
+      why: "GET /v1/confenge/first-touch/status não respondeu; a autoridade delegada e as exceções não foram observadas",
+    };
+  }
+  return { ...(raw as Record<string, unknown>), observed: true };
 }
 
 /** Stable attention slice for idempotency comparisons (ignores observed_at). */

--- a/control-center/connectors/warmbly/src/stub-server.ts
+++ b/control-center/connectors/warmbly/src/stub-server.ts
@@ -88,6 +88,10 @@ function routeBody(payload: WarmblyPayload, pathname: string): unknown | undefin
       return payload.unibox_overview ?? { unread: 0, awaiting_reply: 0 };
     case "/v1/confenge/status":
       return payload.confenge_status ?? { enabled: false };
+    case "/v1/confenge/dispatch/status":
+      return payload.confenge_dispatch_status;
+    case "/v1/confenge/first-touch/status":
+      return payload.confenge_first_touch_status;
     case "/v1/confenge/ops/health":
       return payload.confenge_ops_health ?? { data: { computed_at: new Date().toISOString() } };
     case "/v1/confenge/attention":

--- a/control-center/connectors/warmbly/tests/collect.test.ts
+++ b/control-center/connectors/warmbly/tests/collect.test.ts
@@ -22,6 +22,16 @@ describe("collectFromWarmblyPayload (shipped normalize)", () => {
     assert.equal(snapshot.health.status, "ok");
     assert.equal(snapshot.health.api_version, "v1");
 
+    const delegated = snapshot.operations?.delegated_first_touch as Record<string, unknown>;
+    assert.equal(delegated.observed, true);
+    assert.equal(delegated.policy_id, "CFG-FIRST-TOUCH-ROUTING-v1");
+    assert.equal(delegated.policy_active, true);
+    assert.equal(delegated.queued_readback, 1);
+    assert.deepEqual(delegated.counts, { QUEUED: 1, HOLD: 1 });
+    const decisions = delegated.items as Array<Record<string, unknown>>;
+    assert.equal(decisions[0]?.approval_source, "DELEGATED_POLICY_APPROVE");
+    assert.equal(decisions[1]?.approval_source, "POLICY_EVALUATION_HOLD");
+
     for (const row of snapshot.attention) {
       assert.equal(row.provenance.source, "warmbly");
       assert.equal(row.provenance.observed_at, NOW.toISOString());
@@ -161,6 +171,14 @@ describe("collect() against a local Warmbly-shaped stub", () => {
       assert.equal(run1.schema, COMMERCIAL_SNAPSHOT_SCHEMA);
       assert.ok(run1.attention.length > 0);
       assert.deepEqual(attentionSlice(run1), attentionSlice(run2));
+      assert.equal(
+        (run1.operations?.delegated_first_touch as Record<string, unknown>).observed,
+        true,
+      );
+      assert.equal(
+        stub.calls.some((c) => c.method === "GET" && c.path === "/v1/confenge/first-touch/status"),
+        true,
+      );
       assert.equal(
         stub.calls.some((c) => c.method === "PATCH" || c.method === "PUT" || c.method === "DELETE"),
         false,

--- a/control-center/connectors/warmbly/tests/http-safety.test.ts
+++ b/control-center/connectors/warmbly/tests/http-safety.test.ts
@@ -17,6 +17,7 @@ describe("HTTP allowlist", () => {
   it("allows GET commercial reads and documented search/summary POST", () => {
     assert.equal(classifyRequest("GET", "/health").allowed, true);
     assert.equal(classifyRequest("GET", "/v1/crm/deals?limit=100").allowed, true);
+    assert.equal(classifyRequest("GET", "/v1/confenge/first-touch/status").allowed, true);
     assert.equal(classifyRequest("POST", "/v1/contacts/search").allowed, true);
     assert.equal(classifyRequest("POST", "/v1/crm/deals/search").allowed, true);
     assert.equal(classifyRequest("POST", "/v1/crm/deals/summary").allowed, true);
@@ -30,6 +31,7 @@ describe("HTTP allowlist", () => {
     assert.equal(classifyRequest("POST", "/v1/contacts").allowed, false);
     assert.equal(classifyRequest("POST", "/v1/campaigns/abc/start").allowed, false);
     assert.equal(classifyRequest("POST", "/v1/confenge/import").allowed, false);
+    assert.equal(classifyRequest("POST", "/v1/confenge/first-touch/status").allowed, false);
     assert.equal(classifyRequest("POST", "/v1/confenge/crm/bootstrap").allowed, false);
     assert.equal(classifyRequest("POST", "/v1/unibox/reply").allowed, false);
     assert.equal(classifyRequest("PATCH", "/v1/crm/deals/x").allowed, false);

--- a/control-center/docs/WARMBLY-HUMAN-GATE-FLOW.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-FLOW.md
@@ -1,22 +1,33 @@
-# Gate humano Warmbly — APPROVE agenda a mensagem
+# Gate humano Warmbly — exceções e aprovação explícita
 
 Status: contrato implantável de `ops.confenge.com.br`.
+
+> Escopo supersedido em 2026-08-25 por
+> `ADR-CFG-FIRST-TOUCH-ROUTING-001`: revisão humana não é obrigatória para um
+> first touch que passe integralmente `CFG-FIRST-TOUCH-ROUTING-v1`. Este fluxo
+> continua canônico para exceções, `UNKNOWN`, conflito, drift, reprovação de
+> gate e qualquer mensagem fora da policy. O histórico abaixo é preservado;
+> ele não deve ser lido como pedágio universal.
 
 ## Fluxo canônico
 
 ```text
-cohort/version imutável
+exceção/cohort versionada
   → leitura autenticada do candidate + preview congelado
   → validation vigente e VALID no Warmbly
-  → APPROVE por operators, com acknowledged=true
+  → HUMAN_APPROVE por operators, com acknowledged=true
   → na mesma transação lógica: touchpoint + auto_send=true + QUEUED + due_at
   → worker Warmbly, quando todos os gates permitirem
   → envio em dia útil, 09:00–18:00 America/Sao_Paulo, ≤10/hora
 ```
 
-APPROVE é a autoridade humana completa para uma mensagem. Não há GO, handoff,
+HUMAN_APPROVE é a autoridade humana completa para a mensagem em exceção. Não há GO, handoff,
 “Entregar à fila” nem segunda tela. O clique não transporta e-mail: ele deixa a
 mensagem agendada, e somente o worker pode transportá-la depois.
+
+No caminho feliz delegado, Warmbly registra `DELEGATED_POLICY_APPROVE` com o
+executor real `agent/system`, policy/version, hashes, evidência e readback. Esse
+evento jamais usa a identidade do founder e reutiliza o mesmo scheduler e fila.
 
 `NEXT_UNCLAIMED` usa claims transacionais por conta, fonte, fornecedor e
 destinatário. Não existe offset controlável pelo navegador: cohorts sucessivas
@@ -29,7 +40,8 @@ herdados.
 |---|---|---|
 | Cohort/version | Warmbly | congela seleção, denominadores, copy, hashes e policy |
 | Validation | Warmbly | precisa estar vigente e `VALID`; a ação de aprovar pode obtê-la antes da escrita |
-| APPROVE | `operators` | grava a revisão e converge a mensagem para `QUEUED`, `due_at`, `auto_send=true` |
+| HUMAN_APPROVE | `operators` | grava a revisão de exceção e converge a mensagem para `QUEUED`, `due_at`, `auto_send=true` |
+| DELEGATED_POLICY_APPROVE | Warmbly sob policy founder-versionada | para first touch integralmente elegível, grava a decisão não humana e usa o mesmo agendador |
 | HOLD/REJECT | `operators` | exige motivo e cancela/desenfileira a mensagem ainda não enviada |
 | Reconciliação | `admins` | reprocessa APPROVEs já gravados pelo mesmo agendador; é reparo global e idempotente |
 | Transporte | worker Warmbly | revalida drift e gates operacionais; envia somente na janela e sob o teto |
@@ -37,13 +49,13 @@ herdados.
 ## Auto-send: dois conceitos diferentes
 
 - `scheduling.auto_send=true` é por mensagem aprovada. É o efeito esperado de
-  APPROVE e permite que o worker a recolha na janela comercial.
+  HUMAN_APPROVE ou DELEGATED_POLICY_APPROVE e permite que o worker a recolha na janela comercial.
 - `CONFENGE_AUTO_SEND_ENABLED=true` e `GREEN_AUTORUN=true` continuam proibidos e
   derrubam o boot. As flags globais permanecem `false`.
 
 Não existe job de dispatch de cohort. A única criação de trabalho outbound
-controlado nasce de uma aprovação individual ou da reconciliação dessa mesma
-aprovação preexistente.
+controlado nasce de uma aprovação humana individual, de uma aprovação delegada
+válida ou da reconciliação idempotente de aprovação preexistente.
 
 ## GO/NO-GO histórico
 
@@ -86,7 +98,10 @@ deste fluxo.
 ## Invariantes de segurança
 
 - O frontend não calcula elegibilidade nem destinatários.
-- APPROVE continua exigindo validation vigente e `VALID` no servidor.
+- HUMAN_APPROVE continua exigindo validation vigente e `VALID` no servidor.
+- DELEGATED_POLICY_APPROVE exige simultaneamente todos os hard gates e falha
+  fechado para `UNKNOWN`, conflito ou drift; a UI apenas lê essa decisão do
+  Warmbly e nunca recalcula elegibilidade.
 - O clique continua produzindo `acknowledged=true`; o adaptador recusa antes do
   fio quando ele falta.
 - HOLD/REJECT continuam exigindo motivo escrito.
@@ -106,7 +121,7 @@ deste fluxo.
 ## RBAC deliberado
 
 - `operators`: listar, criar/reproduzir, validar, ajustar e registrar
-  APPROVE/HOLD/REJECT. Portanto `operators` podem provocar saída futura de
+  HUMAN_APPROVE/HOLD/REJECT nas exceções. Portanto `operators` podem provocar saída futura de
   e-mail; o botão diz “Aprovar e enfileirar para envio”.
 - `admins`: reparo global de aprovações já registradas. Na instalação atual a
   identidade administrativa também pertence a `operators`.

--- a/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
+++ b/control-center/docs/WARMBLY-HUMAN-GATE-RUNBOOK.md
@@ -1,6 +1,11 @@
-# Runbook — gate humano Warmbly
+# Runbook — gate humano de exceções Warmbly
 
-## Revisão normal
+Este runbook preserva o caminho humano para `UNKNOWN`, conflito, drift,
+reprovação ou mensagem fora da policy. Desde 2026-08-25, um first touch que
+passa integralmente `CFG-FIRST-TOUCH-ROUTING-v1` usa
+`DELEGATED_POLICY_APPROVE` e não entra nesta fila como trabalho humano pendente.
+
+## Revisão de exceções
 
 1. Autentique em `ops.confenge.com.br` pelo Authelia. `operators` revisam e
    aprovam; `admins` somente reprocessam aprovações já registradas.
@@ -17,8 +22,10 @@
 3. Antes de qualquer trabalho, leia o banner de outbound no topo. Se o kill
    switch ou a pausa estiver ativo, APPROVE ainda agenda, mas nenhuma mensagem
    sairá enquanto o bloqueio durar. Estado ausente/desconhecido não é liberado.
-4. Leia destinatário, fato/proveniência, assunto e corpo exatos. O botão
-   **Aprovar e enfileirar para envio** é o único ato humano do caminho feliz.
+4. Para uma exceção que recebeu correção/evidência humana suficiente, leia
+   destinatário, fato/proveniência, assunto e corpo exatos. O botão
+   **Aprovar e enfileirar para envio** registra `HUMAN_APPROVE`; ele não deve ser
+   aplicado em massa aos first touches que a policy já aprovou.
    Ele:
    - obtém uma validation quando necessário e só continua se voltar `VALID`;
    - envia `acknowledged=true` e um comentário opcional (ou
@@ -99,8 +106,11 @@ continuam obrigatoriamente desligadas:
 CONFENGE_AUTO_SEND_ENABLED=false
 GREEN_AUTORUN=false
 CONFENGE_REQUIRE_HUMAN_APPROVAL=true
+CONFENGE_DELEGATED_FIRST_TOUCH_ENABLED=true  # somente após grant founder ativo e policy/hash exatos
 ```
 
+`CONFENGE_REQUIRE_HUMAN_APPROVAL=true` mantém a automação global irrestrita
+proibida; ele não anula a exceção estreita, versionada e auditável da policy.
 Ligar auto-send/autorun global derruba o boot e não é procedimento operacional.
 Não remova o kill switch durante deploy ou backfill. Não rode POST de smoke em
 produção além da reconciliação planejada.
@@ -156,7 +166,7 @@ agendamento, touchpoints por estado, `due_at`, falhas de reconciliação, pausa,
 kill switch e envios por hora. GO/NO_GO pode aparecer somente como auditoria
 histórica, nunca como gate atual.
 
-Alerta imediato para: APPROVE efetivo sem scheduling, `effective` ausente
+Alerta imediato para: HUMAN_APPROVE ou DELEGATED_POLICY_APPROVE efetivo sem scheduling, `effective` ausente
 tratado como aprovado, `auto_send` da mensagem diferente de true, drift depois
 do agendamento, write `UNKNOWN`, reconciliação com falha, flags globais ligadas,
 ou outbound mostrado como liberado sem leitura completa do servidor.

--- a/control-center/services/context/README.md
+++ b/control-center/services/context/README.md
@@ -60,7 +60,7 @@ POST /v1/commercial/review-drafts/:id
 POST /v1/commercial/review-batches
 ```
 
-As quatro rotas comerciais são uma ponte server-side protegida pela identidade operacional autenticada no edge para o human gate do Warmbly. `APPROVE` vincula `expected_content_hash` e agenda a próxima janela útil; não existe envio imediato nessa ponte.
+As quatro rotas comerciais são uma ponte server-side protegida pela identidade operacional autenticada no edge para o gate humano de exceções do Warmbly. `HUMAN_APPROVE` vincula `expected_content_hash` e agenda a próxima janela útil; não existe envio imediato nessa ponte. First touches que já receberam `DELEGATED_POLICY_APPROVE` sob `CFG-FIRST-TOUCH-ROUTING-v1` não dependem desta ponte e não são apresentados como cliques do founder.
 
 A listagem devolve `control-center.review-draft-page.v1`: `limit`, `offset` e
 `loaded_count` descrevem o recorte solicitado. `total_count`,

--- a/decisions/ADR-CFG-FIRST-TOUCH-ROUTING-001.md
+++ b/decisions/ADR-CFG-FIRST-TOUCH-ROUTING-001.md
@@ -1,0 +1,45 @@
+# ADR-CFG-FIRST-TOUCH-ROUTING-001
+
+Status: accepted
+Effective: 2026-08-25
+Authority: founder decision recorded in [Governance #129](https://github.com/tjsasakifln/Governance/issues/129)
+Runtime tracking: [Warmbly #41](https://github.com/tjsasakifln/warmbly/issues/41)
+
+## Decision
+
+The founder delegates per-message approval for an eligible outbound first touch
+to the executing agent or system under `CFG-FIRST-TOUCH-ROUTING-v1`. A delegated
+decision is recorded as `DELEGATED_POLICY_APPROVE`; it is never represented as a
+human click or as `HUMAN_APPROVE`.
+
+Every hard gate in
+`commercial/outbound/cfg-first-touch-routing.v1.json` must pass at the same
+version and source run. Any `UNKNOWN`, conflict, failure or material drift
+invalidates the delegated decision and routes the item to the existing human
+exception path.
+
+The policy covers first-touch approval and scheduling only. It does not
+authorize follow-ups or provider dispatch. The operational canary must preserve
+the kill switch and global dispatch pause and must record zero SMTP/provider
+send mutations.
+
+The global dispatch pause and kill switch are revocable transport controls, not
+material message inputs. Their activation defers or blocks provider handoff but
+does not erase an otherwise valid approval. This distinction permits a
+zero-SMTP canary to reach the existing `QUEUED` state while dispatch remains
+paused; neither control may ever be bypassed.
+
+## Superseded decision
+
+Before this ADR, Governance #129 and Warmbly #41 required human review or a
+human cohort/policy authorization before every first touch could advance. That
+decision remains historical and still governs messages outside this policy,
+but it no longer applies to first touches that satisfy every v1 hard gate.
+
+## Architecture consequence
+
+extra-cli remains the authority for target identity, typed buyer/supplier role,
+recipient and evidence. Warmbly remains the authority for drafts, approvals,
+scheduling, queue, suppression, idempotency, readback and transport controls.
+Governance owns only the versioned policy. No parallel CRM, lead base, queue,
+scheduler or raw PNCP reinterpretation is introduced.

--- a/schemas/cfg-first-touch-routing.v1.schema.json
+++ b/schemas/cfg-first-touch-routing.v1.schema.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/schemas/cfg-first-touch-routing.v1.schema.json",
+  "title": "CONFENGE delegated first-touch routing policy v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "policy_id",
+    "policy_version",
+    "canonical_name",
+    "status",
+    "effective_at",
+    "authority",
+    "scope",
+    "source_authorities",
+    "evaluation",
+    "hard_gates",
+    "drift_invalidation",
+    "failure",
+    "audit",
+    "runtime_reuse",
+    "canary"
+  ],
+  "properties": {
+    "schema_version": { "const": "cfg-first-touch-routing.v1" },
+    "policy_id": { "const": "CFG-FIRST-TOUCH-ROUTING" },
+    "policy_version": { "const": "v1" },
+    "canonical_name": { "const": "CFG-FIRST-TOUCH-ROUTING-v1" },
+    "status": { "const": "ACTIVE" },
+    "effective_at": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$" },
+    "authority": { "$ref": "#/$defs/authority" },
+    "scope": { "$ref": "#/$defs/scope" },
+    "source_authorities": { "$ref": "#/$defs/source_authorities" },
+    "evaluation": { "$ref": "#/$defs/evaluation" },
+    "hard_gates": { "$ref": "#/$defs/hard_gates" },
+    "drift_invalidation": { "$ref": "#/$defs/drift_invalidation" },
+    "failure": { "$ref": "#/$defs/failure" },
+    "audit": { "$ref": "#/$defs/audit" },
+    "runtime_reuse": { "$ref": "#/$defs/runtime_reuse" },
+    "canary": { "$ref": "#/$defs/canary" }
+  },
+  "$defs": {
+    "string_array": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decided_by_role", "decision_reference", "runtime_reference", "decision_source", "eligible_first_touch_requires_human_review", "human_actor_impersonation_allowed"],
+      "properties": {
+        "decided_by_role": { "const": "FOUNDER" },
+        "decision_reference": { "const": "https://github.com/tjsasakifln/Governance/issues/129" },
+        "runtime_reference": { "const": "https://github.com/tjsasakifln/warmbly/issues/41" },
+        "decision_source": { "const": "DELEGATED_POLICY_APPROVE" },
+        "eligible_first_touch_requires_human_review": { "const": false },
+        "human_actor_impersonation_allowed": { "const": false }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["channel", "message_kind", "followups_authorized", "approval_authorized", "scheduling_authorized", "provider_dispatch_authorized"],
+      "properties": {
+        "channel": { "const": "EMAIL" },
+        "message_kind": { "const": "FIRST_TOUCH" },
+        "followups_authorized": { "const": false },
+        "approval_authorized": { "const": true },
+        "scheduling_authorized": { "const": true },
+        "provider_dispatch_authorized": { "const": false }
+      }
+    },
+    "source_authorities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target_identity_party_role_recipient_evidence", "approval_scheduling_queue_transport", "policy_governance"],
+      "properties": {
+        "target_identity_party_role_recipient_evidence": { "const": "extra-cli/confenge.outreach.v1" },
+        "approval_scheduling_queue_transport": { "const": "warmbly/confenge" },
+        "policy_governance": { "const": "Governance/CFG-FIRST-TOUCH-ROUTING-v1" }
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "unknown_result", "individual_failure_stops_batch", "replay_semantics"],
+      "properties": {
+        "mode": { "const": "ALL_HARD_GATES_MUST_PASS" },
+        "unknown_result": { "const": "HOLD_NEEDS_REVIEW" },
+        "individual_failure_stops_batch": { "const": false },
+        "replay_semantics": { "const": "IDEMPOTENT_NO_DUPLICATE_APPROVAL_OR_SCHEDULING" }
+      }
+    },
+    "hard_gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identity_and_party_role", "recipient", "evidence", "compliance_and_reputation", "copy"],
+      "properties": {
+        "identity_and_party_role": {
+          "const": {
+            "target_state": "TARGET_CONFIRMED",
+            "source_run_must_be_current": true,
+            "cnpj_root_must_reconcile": true,
+            "allowed_target_party_roles": ["SUPPLIER", "CONTRACTOR", "CONTRATADA", "FORNECEDORA"],
+            "required_typed_status": "CONTRACTOR_ROLE_CONFIRMED",
+            "supplier_exact_cnpj_or_typed_branch_binding_required": true,
+            "cnpj_root_only_match_disposition": "HOLD_NEEDS_REVIEW",
+            "forbidden_target_party_roles": ["BUYER", "CONTRACTING_AUTHORITY", "CONTRATANTE", "ORGAO"],
+            "conflict_disposition": "PARTY_ROLE_CONFLICT",
+            "unknown_disposition": "HOLD_NEEDS_REVIEW",
+            "warmbly_may_reinterpret_raw_pncp": false
+          }
+        },
+        "recipient": {
+          "const": {
+            "allowed_route_classes": ["DIRECT_PERSON", "ROLE_OR_DEPARTMENT", "GENERIC_COMPANY", "PUBLIC_COMPANY_FREEMAIL"],
+            "exact_recipient_required": true,
+            "company_association_evidence_required": true,
+            "current_source_run_required": true,
+            "forbidden_proof_only": ["GUESSED_PATTERN", "SYNTAX_ONLY", "MX_ONLY", "DOMAIN_ONLY", "SEARCH_SNIPPET_ONLY", "UNATTRIBUTED_FREEMAIL", "UNPROVEN_SHARED_MAILBOX"]
+          }
+        },
+        "evidence": {
+          "const": {
+            "bundle_reconciled": true,
+            "source_run_current": true,
+            "freshness_valid": true,
+            "critical_conflict_absent": true,
+            "company_cnpj_recipient_binding_required": true,
+            "every_copy_fact_supported": true,
+            "internal_hypothesis_as_fact_allowed": false
+          }
+        },
+        "compliance_and_reputation": {
+          "const": {
+            "suppression_clear": true,
+            "opt_out_clear": true,
+            "dnc_clear": true,
+            "hard_bounce_clear": true,
+            "organization_risk_clear": true,
+            "mailbox_transport_eligible": true,
+            "kill_switch_bypass_allowed": false,
+            "dispatch_pause_bypass_allowed": false
+          }
+        },
+        "copy": {
+          "const": {
+            "first_touch_only": true,
+            "current_composer_template_prompt_required": true,
+            "subject_and_body_nonempty": true,
+            "deterministic_editorial_qa": "PASS",
+            "deterministic_factual_qa": "PASS",
+            "raw_metadata_allowed": false,
+            "internal_reasoning_allowed": false,
+            "unsupported_economic_or_legal_claim_allowed": false,
+            "forbidden_generic_subject_allowed": false,
+            "truncation_allowed": false,
+            "near_duplicate_above_existing_limit_allowed": false,
+            "route_class_compatible_cta_required": true,
+            "non_direct_routes_request_forwarding": true,
+            "non_direct_routes_may_claim_decision_maker": false
+          }
+        }
+      }
+    },
+    "drift_invalidation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "material_fields"],
+      "properties": {
+        "action": { "const": "INVALIDATE_DELEGATED_APPROVAL" },
+        "material_fields": { "$ref": "#/$defs/string_array" }
+      }
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "disposition", "concrete_reason_codes_required", "fail_closed"],
+      "properties": {
+        "decision": { "const": "DO_NOT_APPROVE" },
+        "disposition": { "const": "HOLD_NEEDS_REVIEW_EXCEPTION" },
+        "concrete_reason_codes_required": { "const": true },
+        "fail_closed": { "const": true }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approved_by_type", "human_approved_by_must_be_empty", "required_fields"],
+      "properties": {
+        "approved_by_type": { "const": "delegated_agent_or_system" },
+        "human_approved_by_must_be_empty": { "const": true },
+        "required_fields": { "$ref": "#/$defs/string_array" }
+      }
+    },
+    "runtime_reuse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["existing_approval_authority", "existing_scheduler", "existing_queue", "existing_crm", "existing_suppression", "existing_idempotency", "existing_readback_verification", "existing_next_eligible_slot", "existing_min_wait_time", "existing_business_window", "existing_mailbox_rate_limits", "parallel_architecture_allowed"],
+      "properties": {
+        "existing_approval_authority": { "const": true },
+        "existing_scheduler": { "const": true },
+        "existing_queue": { "const": true },
+        "existing_crm": { "const": true },
+        "existing_suppression": { "const": true },
+        "existing_idempotency": { "const": true },
+        "existing_readback_verification": { "const": true },
+        "existing_next_eligible_slot": { "const": true },
+        "existing_min_wait_time": { "const": true },
+        "existing_business_window": { "const": true },
+        "existing_mailbox_rate_limits": { "const": true },
+        "parallel_architecture_allowed": { "const": false }
+      }
+    },
+    "canary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operational_data_allowed", "dispatch_global_paused_required", "kill_switch_preserved_required", "queued_readback_required", "smtp_send_allowed", "sent_count_required", "provider_send_mutation_allowed"],
+      "properties": {
+        "operational_data_allowed": { "const": true },
+        "dispatch_global_paused_required": { "const": true },
+        "kill_switch_preserved_required": { "const": true },
+        "queued_readback_required": { "const": true },
+        "smtp_send_allowed": { "const": false },
+        "sent_count_required": { "const": 0 },
+        "provider_send_mutation_allowed": { "const": false }
+      }
+    }
+  }
+}

--- a/tests/test_first_touch_routing_policy.py
+++ b/tests/test_first_touch_routing_policy.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import importlib.util
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT / "scripts" / "validate_commercial_authority.py"
+POLICY_PATH = ROOT / "commercial" / "outbound" / "cfg-first-touch-routing.v1.json"
+SCHEMA_PATH = ROOT / "schemas" / "cfg-first-touch-routing.v1.schema.json"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_commercial_authority", VALIDATOR_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+v = load_validator()
+
+
+def policy():
+    return v.load_json(POLICY_PATH)
+
+
+def validate(value):
+    schema = v.load_json(SCHEMA_PATH)
+    v.schema_validate(value, schema)
+
+
+def test_policy_is_closed_versioned_and_machine_readable():
+    value = policy()
+    validate(value)
+    assert value["canonical_name"] == "CFG-FIRST-TOUCH-ROUTING-v1"
+    assert value["authority"]["decision_source"] == "DELEGATED_POLICY_APPROVE"
+    assert value["authority"]["eligible_first_touch_requires_human_review"] is False
+    assert value["authority"]["human_actor_impersonation_allowed"] is False
+
+    unknown = deepcopy(value)
+    unknown["silent_auto_send"] = True
+    with pytest.raises(v.ValidationError, match="unknown critical field"):
+        validate(unknown)
+
+
+def test_scope_queues_but_never_authorizes_provider_dispatch_or_followups():
+    scope = policy()["scope"]
+    assert scope == {
+        "channel": "EMAIL",
+        "message_kind": "FIRST_TOUCH",
+        "followups_authorized": False,
+        "approval_authorized": True,
+        "scheduling_authorized": True,
+        "provider_dispatch_authorized": False,
+    }
+
+    for field in ("followups_authorized", "provider_dispatch_authorized"):
+        bad = policy()
+        bad["scope"][field] = True
+        with pytest.raises(v.ValidationError):
+            validate(bad)
+
+
+def test_supplier_is_required_and_buyer_unknown_conflict_fail_closed():
+    gate = policy()["hard_gates"]["identity_and_party_role"]
+    assert gate["target_state"] == "TARGET_CONFIRMED"
+    assert set(gate["allowed_target_party_roles"]) == {
+        "SUPPLIER",
+        "CONTRACTOR",
+        "CONTRATADA",
+        "FORNECEDORA",
+    }
+    assert {"BUYER", "CONTRACTING_AUTHORITY", "CONTRATANTE", "ORGAO"}.issubset(
+        gate["forbidden_target_party_roles"]
+    )
+    assert gate["required_typed_status"] == "CONTRACTOR_ROLE_CONFIRMED"
+    assert gate["supplier_exact_cnpj_or_typed_branch_binding_required"] is True
+    assert gate["cnpj_root_only_match_disposition"] == "HOLD_NEEDS_REVIEW"
+    assert gate["conflict_disposition"] == "PARTY_ROLE_CONFLICT"
+    assert gate["unknown_disposition"] == "HOLD_NEEDS_REVIEW"
+    assert gate["warmbly_may_reinterpret_raw_pncp"] is False
+
+    weakened = policy()
+    weakened["hard_gates"]["identity_and_party_role"]["required_typed_status"] = "PRESENT_IN_PNCP"
+    with pytest.raises(v.ValidationError, match="expected const"):
+        validate(weakened)
+
+
+def test_all_recipient_classes_are_allowed_but_guesses_are_not_proof():
+    gate = policy()["hard_gates"]["recipient"]
+    assert set(gate["allowed_route_classes"]) == {
+        "DIRECT_PERSON",
+        "ROLE_OR_DEPARTMENT",
+        "GENERIC_COMPANY",
+        "PUBLIC_COMPANY_FREEMAIL",
+    }
+    assert gate["exact_recipient_required"] is True
+    assert gate["company_association_evidence_required"] is True
+    assert {"GUESSED_PATTERN", "MX_ONLY", "SYNTAX_ONLY", "UNATTRIBUTED_FREEMAIL"}.issubset(
+        gate["forbidden_proof_only"]
+    )
+
+    weakened = policy()
+    weakened["hard_gates"]["recipient"]["company_association_evidence_required"] = False
+    with pytest.raises(v.ValidationError, match="expected const"):
+        validate(weakened)
+
+
+def test_policy_invalidates_every_material_binding_and_compliance_change():
+    required = {
+        "recipient",
+        "route_class",
+        "content_hash",
+        "evidence_hash",
+        "evidence_version",
+        "source_run_id",
+        "target_fit",
+        "target_party_role",
+        "template_version",
+        "composer_version",
+        "prompt_version",
+        "policy_version",
+        "suppression",
+        "opt_out",
+        "dnc",
+        "hard_bounce",
+        "organization_risk",
+        "mailbox_eligibility",
+    }
+    assert required == set(policy()["drift_invalidation"]["material_fields"])
+
+
+def test_audit_contract_has_no_fake_human_and_covers_decision_schedule_runtime():
+    audit = policy()["audit"]
+    assert audit["approved_by_type"] == "delegated_agent_or_system"
+    assert audit["human_approved_by_must_be_empty"] is True
+    required = set(audit["required_fields"])
+    assert {
+        "policy_id",
+        "policy_version",
+        "authority_reference",
+        "executor",
+        "source_run_id",
+        "source_run_hash",
+        "recipient",
+        "route_class",
+        "target_party_role",
+        "supplier_identity_ref",
+        "buyer_identity_ref",
+        "evidence_hash",
+        "content_hash",
+        "approval_timestamp",
+        "scheduling_result",
+        "due_at",
+        "reason_codes",
+        "idempotency_key",
+        "runtime_release_sha",
+    }.issubset(required)
+
+
+def test_reuses_existing_runtime_and_canary_stays_zero_smtp():
+    reuse = policy()["runtime_reuse"]
+    assert reuse["parallel_architecture_allowed"] is False
+    assert all(value is True for key, value in reuse.items() if key != "parallel_architecture_allowed")
+
+    canary = policy()["canary"]
+    assert canary["dispatch_global_paused_required"] is True
+    assert canary["kill_switch_preserved_required"] is True
+    assert canary["queued_readback_required"] is True
+    assert canary["smtp_send_allowed"] is False
+    assert canary["sent_count_required"] == 0
+    assert canary["provider_send_mutation_allowed"] is False
+
+
+def test_failure_and_replay_are_fail_closed_per_item():
+    value = policy()
+    assert value["evaluation"]["mode"] == "ALL_HARD_GATES_MUST_PASS"
+    assert value["evaluation"]["individual_failure_stops_batch"] is False
+    assert value["evaluation"]["replay_semantics"] == "IDEMPOTENT_NO_DUPLICATE_APPROVAL_OR_SCHEDULING"
+    assert value["failure"] == {
+        "decision": "DO_NOT_APPROVE",
+        "disposition": "HOLD_NEEDS_REVIEW_EXCEPTION",
+        "concrete_reason_codes_required": True,
+        "fail_closed": True,
+    }


### PR DESCRIPTION
## Resultado

Materializa `CFG-FIRST-TOUCH-ROUTING-v1` como autoridade founder versionada, machine-readable e fail-closed. A policy distingue `DELEGATED_POLICY_APPROVE` de `HUMAN_APPROVE`, exige papel tipado de fornecedor/contratada, destinatário atribuível, evidência corrente, QA e invalidação por drift.

O Control Center passa a projetar policy ativa, aprovação delegada/humana, QUEUED/readback e HOLD/reason codes; a revisão humana deixa de aparecer como pedágio universal para o escopo elegível, preservando revisão, revogação, rejeição e pausa.

## Segurança e escopo

- somente `FIRST_TOUCH`; follow-up e provider dispatch não são autorizados
- nenhuma identidade humana é forjada
- nenhuma fila, scheduler, CRM ou datalake paralelo
- suppression, opt-out, bounce, risk, kill switch e dispatch pause permanecem dominantes
- canário exige dispatch pausado, kill switch preservado e zero SMTP/SENT

## Validação

- `python3 -m pytest ... tests/test_first_touch_routing_policy.py -q`: 196 passed
- `npm test` em `control-center`: passou integralmente
- `npm run typecheck` em `control-center`: passou integralmente
- `git diff --check origin/main...HEAD`: passou

## Dependências e prova live

Autoridade base para os PRs tipados de extra-cli e runtime Warmbly que serão ligados a este PR. Merge/CI não constitui por si só prova de publicação PNCP nem do canário operacional; essas provas permanecem explícitas e fail-closed.

Refs #126, #127, #128, #129.