### PR TITLE
feat: projetar verdade operacional da manhã em modo fail-closed

### DIFF
--- a/.github/workflows/commercial-authority.yml
+++ b/.github/workflows/commercial-authority.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Validate sanitized synchronous agent batch proof
         run: python scripts/validate_agent_outreach_batch.py
       - name: Adversarial tests
-        run: python -m pytest tests/test_commercial_authority.py tests/test_offer_convergence.py tests/test_commercial_mainline.py tests/test_legal_provisional.py tests/test_legal_founder_approved.py tests/test_partner_program.py tests/test_delivery_contracts.py tests/test_delivery_readiness.py tests/test_delivery_capacity.py tests/test_delivery_canary_gate.py tests/test_agent_outreach_batch.py tests/test_first_touch_routing_policy.py -q
+        run: python -m pytest tests/test_commercial_authority.py tests/test_commercial_chain_projection.py tests/test_offer_convergence.py tests/test_commercial_mainline.py tests/test_legal_provisional.py tests/test_legal_founder_approved.py tests/test_partner_program.py tests/test_delivery_contracts.py tests/test_delivery_readiness.py tests/test_delivery_capacity.py tests/test_delivery_canary_gate.py tests/test_agent_outreach_batch.py tests/test_first_touch_routing_policy.py -q

--- a/commercial/authority/authority-overlay.v2.json
+++ b/commercial/authority/authority-overlay.v2.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": "commercial-authority-overlay.v2",
+  "authority_id": "CFG-COMMERCIAL-AUTHORITY-OVERLAY-v2",
+  "status": "ACTIVE",
+  "effective_at": "2026-08-26T00:00:00Z",
+  "source_issue": "https://github.com/tjsasakifln/Governance/issues/1",
+  "v1_history": {
+    "preserved": true,
+    "manifest_path": "commercial/authority/authority-manifest.v1.json",
+    "catalog_path": "commercial/offers/catalog.v1.json",
+    "semantic_status": "HISTORICAL_FINANCIAL_SUBSET_SUPERSEDED_AS_PUBLIC_CATALOG"
+  },
+  "catalog_boundary": {
+    "governance_catalog_role": "NONE",
+    "no_parallel_catalog": true,
+    "deliverables_registry": {
+      "repository": "tjsasakifln/web-cfg",
+      "ref": "main",
+      "path": "data/commercial/deliverables-registry.v1.json",
+      "blob_sha": "99e77f51336e7fe63af0446d7577b3b20fe9a9b0",
+      "main_sha_observed": "41cc328681507159ffdc12417d49e7474e2770a4",
+      "source_issue": "https://github.com/tjsasakifln/web-cfg/issues/329",
+      "registry_version": "CFG-DELIVERABLES-2026-08-24-v1",
+      "deliverable_count": 54,
+      "container_count": 2,
+      "authority_state": "PINNED"
+    },
+    "naming_authority": {
+      "repository": "tjsasakifln/web-cfg",
+      "ref": "main",
+      "path": "data/commercial/offer-naming.v1.json",
+      "blob_sha": "5f39620c0488625648aa9c3919a9eea3b8ce2004",
+      "main_sha_observed": "41cc328681507159ffdc12417d49e7474e2770a4",
+      "source_issue": "https://github.com/tjsasakifln/web-cfg/issues/343",
+      "naming_version": "CFG-NAMING-2026-08-24-v1",
+      "authority_state": "PINNED",
+      "effective_at": null,
+      "human_test_state": "NOT_STARTED",
+      "publication_state": "DECIDED_NOT_PROVEN_EFFECTIVE"
+    }
+  },
+  "historical_financial_subset": {
+    "classification": "HISTORICAL_FINANCIAL_MAPPING_SUBSET",
+    "source_path": "commercial/offers/catalog.v1.json",
+    "offer_ids": [
+      "CFG-DIAG-EXP-v1",
+      "CFG-DIRB2G-FLEX-v1",
+      "CFG-DIRB2G-180-v1",
+      "CFG-DIRB2G-365-v1"
+    ],
+    "complete_public_catalog": false
+  },
+  "provider_boundary": {
+    "provider": "asaas",
+    "mapping_path": "commercial/providers/asaas-mapping.v1.json",
+    "provider_lookup_performed": false,
+    "mappings": [
+      {
+        "offer_id": "CFG-DIAG-EXP-v1",
+        "mapping_state": "MISSING",
+        "provider_object_state": "UNKNOWN",
+        "provider_object_id": null,
+        "evidence_refs": ["commercial/providers/asaas-mapping.v1.json"]
+      },
+      {
+        "offer_id": "CFG-DIRB2G-FLEX-v1",
+        "mapping_state": "MISSING",
+        "provider_object_state": "UNKNOWN",
+        "provider_object_id": null,
+        "evidence_refs": ["commercial/providers/asaas-mapping.v1.json"]
+      },
+      {
+        "offer_id": "CFG-DIRB2G-180-v1",
+        "mapping_state": "MISSING",
+        "provider_object_state": "UNKNOWN",
+        "provider_object_id": null,
+        "evidence_refs": ["commercial/providers/asaas-mapping.v1.json"]
+      },
+      {
+        "offer_id": "CFG-DIRB2G-365-v1",
+        "mapping_state": "MISSING",
+        "provider_object_state": "UNKNOWN",
+        "provider_object_id": null,
+        "evidence_refs": ["commercial/providers/asaas-mapping.v1.json"]
+      }
+    ],
+    "checkout_gate": "BLOCKED"
+  },
+  "capacity_boundary": {
+    "policy_ceiling": {
+      "state": "KNOWN",
+      "units": 50,
+      "unit": "delivery_slot",
+      "source_ref": "commercial/capacity/capacity-policy.v1.json#/recurring/global_active_slots"
+    },
+    "staffed_capacity": {
+      "state": "UNKNOWN",
+      "units": null,
+      "unit": "delivery_slot",
+      "reason": "Nenhum snapshot real de capacidade staffed foi publicado pelo delivery owner."
+    },
+    "committed": {
+      "state": "UNKNOWN",
+      "units": null,
+      "unit": "delivery_slot",
+      "reason": "A projeção real de Work Orders não foi publicada."
+    },
+    "available": {
+      "state": "UNKNOWN",
+      "units": null,
+      "unit": "delivery_slot",
+      "reason": "Disponibilidade não pode ser derivada sem staffed capacity e WIP reais."
+    },
+    "freshness": "UNKNOWN",
+    "admission": "UNKNOWN",
+    "can_accept": false
+  },
+  "payment_semantics": {
+    "proposal_accepted": "NOT_REVENUE",
+    "PAYMENT_CREATED": "PROVIDER_OBJECT_CREATED_NOT_PAID_NOT_RECEIVED",
+    "PAYMENT_CONFIRMED": "PAID_NOT_RECEIVED",
+    "PAYMENT_RECEIVED": "RECEIVED_REVENUE_REQUIRES_PROVIDER_PROOF"
+  },
+  "activation_gates": {
+    "production_checkout_enabled": false,
+    "real_money_mutation_approved": false,
+    "provider_objects_proven": false,
+    "staffed_capacity_published": false
+  }
+}

--- a/commercial/projection.py
+++ b/commercial/projection.py
@@ -1,0 +1,251 @@
+"""Pure, read-only commercial-to-delivery truth projection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+WEB_CFG_DELIVERABLES_BLOB = "99e77f51336e7fe63af0446d7577b3b20fe9a9b0"
+PAYMENT_STATES = frozenset({"PAYMENT_CREATED", "PAYMENT_CONFIRMED", "PAYMENT_RECEIVED"})
+
+
+def _record(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _refs(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return sorted({item for item in value if isinstance(item, str) and item.strip()})
+
+
+def _stable_id(prefix: str, value: Any) -> str:
+    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return f"{prefix}_{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:32]}"
+
+
+def _age_seconds(instant: Any, projected_at: str) -> int | None:
+    if not isinstance(instant, str):
+        return None
+    try:
+        start = datetime.fromisoformat(instant.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(projected_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if start.tzinfo is None or end.tzinfo is None:
+        return None
+    return max(0, int((end.astimezone(timezone.utc) - start.astimezone(timezone.utc)).total_seconds()))
+
+
+def _hop(state: str, refs: list[str], reason: str | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {"state": state, "evidence_refs": refs}
+    if reason:
+        result["reason"] = reason
+    return result
+
+
+def _exception(
+    *,
+    bucket: str,
+    owner: str,
+    reason: str,
+    evidence: list[str],
+    age_seconds: int | None,
+    next_action: str,
+    severity: str,
+    source: Mapping[str, str],
+    freshness: str,
+) -> dict[str, Any]:
+    basis = {"bucket": bucket, "owner": owner, "reason": reason, "evidence": evidence, "source": source}
+    return {
+        "schema_version": "confenge.operational_exception.v1",
+        "exception_id": _stable_id("exc", basis),
+        "bucket": bucket,
+        "owner": owner,
+        "reason": reason,
+        "evidence": evidence or ["evidence:missing"],
+        "age_seconds": age_seconds,
+        "next_action": next_action,
+        "severity": severity,
+        "source": dict(source),
+        "freshness": freshness,
+    }
+
+
+def project_commercial_chain(facts: Mapping[str, Any], *, projected_at: str) -> dict[str, Any]:
+    """Project explicit facts; never promote a missing downstream hop."""
+
+    # Validate the projection clock early without using wall-clock time.
+    parsed_clock = datetime.fromisoformat(projected_at.replace("Z", "+00:00"))
+    if parsed_clock.tzinfo is None:
+        raise ValueError("projected_at must include a timezone")
+
+    offer = _record(facts.get("offer"))
+    proposal = _record(facts.get("proposal"))
+    acceptance = _record(facts.get("acceptance"))
+    financial = _record(facts.get("financial_gate"))
+    provider = _record(facts.get("provider"))
+    commercial_state = _record(facts.get("commercial_state"))
+    work_order = _record(facts.get("work_order"))
+    delivery = _record(facts.get("delivery"))
+    capacity = _record(facts.get("capacity"))
+    synthetic = facts.get("synthetic") is True or financial.get("synthetic") is True or provider.get("synthetic") is True
+
+    correlation_id = _string(facts.get("correlation_id"))
+    identity = {
+        "correlation_id": correlation_id,
+        "deliverable_id": _string(offer.get("deliverable_id")),
+        "proposal_id": _string(proposal.get("proposal_id")),
+        "acceptance_id": _string(acceptance.get("acceptance_id")),
+        "provider_payment_id": _string(provider.get("payment_id")),
+        "commercial_state_id": _string(commercial_state.get("state_id")),
+        "work_order_id": _string(work_order.get("work_order_id")),
+        "delivery_id": _string(delivery.get("delivery_id")),
+    }
+
+    offer_refs = _refs(offer.get("evidence_refs"))
+    offer_proven = bool(identity["deliverable_id"] and offer.get("registry_blob") == WEB_CFG_DELIVERABLES_BLOB and offer_refs)
+    proposal_refs = _refs(proposal.get("evidence_refs"))
+    proposal_proven = bool(identity["proposal_id"] and isinstance(proposal.get("version"), int) and proposal_refs)
+    acceptance_refs = _refs(acceptance.get("evidence_refs"))
+    accepted = acceptance.get("state") == "ACCEPTED" and bool(identity["acceptance_id"] and acceptance_refs)
+    financial_refs = _refs(financial.get("evidence_refs"))
+    financial_authorized = financial.get("state") == "AUTHORIZED" and not synthetic and bool(financial_refs)
+    financial_synthetic = financial.get("state") == "SYNTHETIC_VALID" and synthetic and bool(financial_refs)
+
+    provider_refs = _refs(provider.get("evidence_refs"))
+    event_type = _string(provider.get("event_type"))
+    if event_type:
+        event_type = event_type.upper()
+    provider_proven = bool(
+        event_type in PAYMENT_STATES
+        and identity["provider_payment_id"]
+        and _string(provider.get("provider_event_id"))
+        and provider_refs
+        and not synthetic
+    )
+    payment_state = event_type if event_type in PAYMENT_STATES and provider_proven else "UNKNOWN"
+
+    commercial_refs = _refs(commercial_state.get("evidence_refs"))
+    commercial_proven = bool(identity["commercial_state_id"] and _string(commercial_state.get("state")) and commercial_refs)
+    work_order_refs = _refs(work_order.get("evidence_refs"))
+    work_order_proven = bool(identity["work_order_id"] and _string(work_order.get("state")) and work_order_refs)
+    delivery_refs = _refs(delivery.get("evidence_refs"))
+    delivery_proven = bool(identity["delivery_id"] and _string(delivery.get("state")) and delivery_refs)
+
+    hops = {
+        "offer": _hop("PROVEN" if offer_proven else "UNKNOWN", offer_refs, None if offer_proven else "web-cfg registry pin/evidence missing"),
+        "proposal": _hop("PROVEN" if proposal_proven else "UNKNOWN", proposal_refs, None if proposal_proven else "proposal/version evidence missing"),
+        "acceptance": _hop("PROVEN" if accepted else "UNKNOWN", acceptance_refs, None if accepted else "accepted proposal evidence missing"),
+        "financial_gate": _hop(
+            "PROVEN" if financial_authorized else "SYNTHETIC" if financial_synthetic else "UNKNOWN",
+            financial_refs,
+            None if financial_authorized else "financial gate is absent, unknown, or synthetic",
+        ),
+        "provider": _hop("PROVEN" if provider_proven else "UNKNOWN", provider_refs, None if provider_proven else "provider object/event proof missing"),
+        "commercial_state": _hop("PROVEN" if commercial_proven else "UNKNOWN", commercial_refs, None if commercial_proven else "commercial state evidence missing"),
+        "work_order": _hop("PROVEN" if work_order_proven else "UNKNOWN", work_order_refs, None if work_order_proven else "Work Order evidence missing"),
+        "delivery": _hop("PROVEN" if delivery_proven else "UNKNOWN", delivery_refs, None if delivery_proven else "delivery evidence missing"),
+    }
+
+    exceptions: list[dict[str, Any]] = []
+    source = {"system": "asaas", "kind": "provider-read", "locator": "payment/event"}
+    provider_age = _age_seconds(provider.get("occurred_at"), projected_at)
+    if not provider_proven:
+        exceptions.append(
+            _exception(
+                bucket="payment_provider_ambiguity",
+                owner="finance",
+                reason="Objeto ou evento Asaas não foi comprovado por fonte primária; o estado financeiro permanece UNKNOWN.",
+                evidence=provider_refs or financial_refs or ["provider:evidence-missing"],
+                age_seconds=provider_age,
+                next_action="Reconciliar o objeto/evento no provider em sessão humana autorizada; não simular nem habilitar checkout.",
+                severity="critical",
+                source=source,
+                freshness="UNKNOWN",
+            )
+        )
+    if capacity.get("staffed_capacity_state") != "KNOWN":
+        exceptions.append(
+            _exception(
+                bucket="capacity_unknown",
+                owner="delivery_owner",
+                reason="Capacidade staffed real e disponibilidade não estão publicadas.",
+                evidence=_refs(capacity.get("evidence_refs")) or ["capacity:snapshot-missing"],
+                age_seconds=_age_seconds(capacity.get("as_of"), projected_at),
+                next_action="Publicar snapshot staffed real, calendário e WIP; manter admission e checkout fail-closed.",
+                severity="critical",
+                source={"system": "governance", "kind": "capacity-read", "locator": "delivery/capacity"},
+                freshness="UNKNOWN",
+            )
+        )
+    if work_order.get("state") == "BLOCKED":
+        exceptions.append(
+            _exception(
+                bucket="delivery_blocker",
+                owner=_string(work_order.get("owner")) or "delivery_owner",
+                reason=_string(work_order.get("blocker_reason")) or "Work Order bloqueada sem motivo observado.",
+                evidence=work_order_refs or ["work-order:blocker-evidence-missing"],
+                age_seconds=_age_seconds(work_order.get("updated_at"), projected_at),
+                next_action=_string(work_order.get("next_action")) or "Resolver o blocker no Work Order canônico.",
+                severity="high",
+                source={"system": "governance", "kind": "work-order-read", "locator": identity["work_order_id"] or "unknown"},
+                freshness="UNKNOWN" if not work_order_refs else "FRESH",
+            )
+        )
+    binding_values = {
+        value
+        for value in (
+            correlation_id,
+            _string(proposal.get("correlation_id")),
+            _string(acceptance.get("correlation_id")),
+            _string(provider.get("correlation_id")),
+            _string(commercial_state.get("correlation_id")),
+            _string(work_order.get("correlation_id")),
+        )
+        if value
+    }
+    if len(binding_values) > 1:
+        exceptions.append(
+            _exception(
+                bucket="runtime_mismatch",
+                owner="commercial_ops",
+                reason="A chain identity diverge entre os hops observados.",
+                evidence=[f"correlation:{value}" for value in sorted(binding_values)],
+                age_seconds=None,
+                next_action="Reconciliar a correlation canônica antes de promover estado financeiro ou criar Work Order.",
+                severity="critical",
+                source={"system": "control-center", "kind": "cross-repo-projection", "locator": "commercial-chain"},
+                freshness="ERROR",
+            )
+        )
+
+    paid = payment_state in {"PAYMENT_CONFIRMED", "PAYMENT_RECEIVED"}
+    received_revenue = payment_state == "PAYMENT_RECEIVED" and provider_proven and not synthetic
+    all_real_hops = all(item["state"] == "PROVEN" for item in hops.values())
+    readiness = "PROVEN" if all_real_hops and received_revenue and not exceptions else "BLOCKED" if exceptions else "NOT_PROVEN"
+    basis = {"identity": identity, "projected_at": projected_at, "synthetic": synthetic}
+    return {
+        "schema_version": "confenge.commercial_chain_projection.v1",
+        "chain_id": _stable_id("chain", basis),
+        "projected_at": projected_at,
+        "synthetic": synthetic,
+        "chain_identity": identity,
+        "hops": hops,
+        "payment": {
+            "state": payment_state,
+            "provider_proven": provider_proven,
+            "paid": paid,
+            "received_revenue": received_revenue,
+        },
+        "readiness": readiness,
+        "exceptions": exceptions,
+        "mutations_performed": 0,
+    }

--- a/control-center/apps/web-shell/performance-budgets.json
+++ b/control-center/apps/web-shell/performance-budgets.json
@@ -22,10 +22,14 @@
     "cls_p75": 0.1,
     "long_task_max_ms": 350,
     "initial_request_count": 16,
-    "javascript_raw_bytes": 375000,
-    "javascript_gzip_bytes": 113500,
+    "javascript_raw_bytes": 387000,
+    "javascript_gzip_bytes": 117500,
     "css_raw_bytes": 26000,
     "css_gzip_bytes": 7000,
-    "bundle_gzip_bytes": 120000
+    "bundle_gzip_bytes": 123500
+  },
+  "budget_change": {
+    "previous_bundle_gzip_bytes": 120000,
+    "reason": "The founder operating-truth viewport adds five source-attributed fail-closed decisions and a complete exception projection; the new ceiling is bounded to the measured feature delta rather than an open-ended allowance."
   }
 }

--- a/control-center/apps/web-shell/src/founder-operating-truth.ts
+++ b/control-center/apps/web-shell/src/founder-operating-truth.ts
@@ -1,0 +1,227 @@
+export type TruthFreshness = "FRESH" | "STALE" | "UNKNOWN" | "ERROR";
+
+export interface MorningSource {
+  system: string;
+  kind: string;
+  locator: string;
+  as_of: string | null;
+  freshness: TruthFreshness;
+}
+
+export interface MorningException {
+  id: string;
+  bucket:
+    | "identity_recipient_conflict"
+    | "stale_drift"
+    | "party_role_conflict"
+    | "outbound_reply_handoff"
+    | "payment_provider_ambiguity"
+    | "capacity_unknown"
+    | "delivery_blocker"
+    | "runtime_mismatch"
+    | "other";
+  owner: string;
+  reason: string;
+  evidence: string[];
+  age_seconds: number | null;
+  next_action: string;
+  severity: "critical" | "high" | "medium" | "low";
+  source: MorningSource;
+}
+
+export interface FounderOperatingTruth {
+  generated_at: string | null;
+  outbound: {
+    state: "ACTIVE" | "PAUSED" | "UNKNOWN";
+    policy_version: string | null;
+    source_run: string | null;
+    queued: number | null;
+    next_due: string | null;
+    sends_today: number | null;
+    limit: number | null;
+    replies: number | null;
+    bounces: number | null;
+    opt_outs: number | null;
+    exceptions: number | null;
+    transport_health: string | null;
+    source: MorningSource;
+  };
+  data: {
+    current_feed: string | null;
+    current_run: string | null;
+    target_coverage: string | null;
+    blocker: string | null;
+    source: MorningSource;
+  };
+  inbound_web: {
+    deploy_identity: string | null;
+    lead_sla_state: string | null;
+    gsc_readiness: string | null;
+    public_surface_health: string | null;
+    source: MorningSource;
+  };
+  delivery_finance: {
+    active_work_orders: number | null;
+    policy_ceiling: number | null;
+    staffed_capacity: number | null;
+    staffed_capacity_state: "KNOWN" | "UNKNOWN";
+    committed: number | null;
+    available: number | null;
+    capacity_freshness: TruthFreshness;
+    admission: "CAN_ACCEPT" | "CANNOT_ACCEPT" | "UNKNOWN";
+    checkout_gate: "OPEN" | "BLOCKED" | "UNKNOWN";
+    asaas_gate: "PROVEN" | "MISSING" | "BLOCKED" | "UNKNOWN";
+    exceptions: number | null;
+    source: MorningSource;
+  };
+  exceptions: MorningException[];
+  primary_action: {
+    owner: string;
+    label: string;
+    reason: string;
+    href: string;
+  } | null;
+}
+
+const O = (value: unknown): Record<string, unknown> => value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+const A = (value: unknown): Record<string, unknown>[] => Array.isArray(value) ? value.map(O) : [];
+const S = (value: unknown): string | null => typeof value === "string" && value.trim() ? value : null;
+const N = (value: unknown): number | null => typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+const F = (value: unknown): TruthFreshness => value === "FRESH" || value === "STALE" || value === "ERROR" ? value : "UNKNOWN";
+const BUCKETS = new Set<MorningException["bucket"]>(["identity_recipient_conflict", "stale_drift", "party_role_conflict", "outbound_reply_handoff", "payment_provider_ambiguity", "capacity_unknown", "delivery_blocker", "runtime_mismatch", "other"]);
+
+function source(slot: Record<string, unknown>, system: string, kind?: string, locator?: string): MorningSource {
+  const raw = O(slot.source);
+  return { system: S(raw.system) ?? system, kind: kind ?? S(raw.kind) ?? "read-model", locator: locator ?? S(raw.locator) ?? "unobserved", as_of: S(slot.observed_at), freshness: F(slot.freshness_status) };
+}
+
+function exception(row: Record<string, unknown>, generatedAt: string | null): MorningException {
+  const rawBucket = S(row.bucket) ?? S(row.kind) ?? "other";
+  const bucket = BUCKETS.has(rawBucket as MorningException["bucket"]) ? rawBucket as MorningException["bucket"] : "other";
+  const rawSource = O(row.source);
+  const evidence = Array.isArray(row.evidence) ? row.evidence.filter((item): item is string => Boolean(S(item))) : [];
+  const severity = row.severity === "critical" || row.severity === "high" || row.severity === "low" ? row.severity : "medium";
+  return {
+    id: S(row.exception_id) ?? S(row.id) ?? `projection-${bucket}`,
+    bucket,
+    owner: S(row.owner) ?? "UNKNOWN",
+    reason: S(row.reason) ?? "Motivo não informado pela origem.",
+    evidence: evidence.length ? evidence : ["evidence:UNKNOWN"],
+    age_seconds: N(row.age_seconds),
+    next_action: S(row.next_action) ?? "Confirmar owner, evidência e próxima ação na origem canônica.",
+    severity,
+    source: { system: S(rawSource.system) ?? "warmbly", kind: S(rawSource.kind) ?? "exception-read", locator: S(rawSource.locator) ?? S(row.id) ?? "unobserved", as_of: S(row.observed_at) ?? generatedAt, freshness: F(row.freshness ?? row.freshness_status) },
+  };
+}
+
+export function projectFounderOperatingTruth(envelopeValue: unknown): FounderOperatingTruth {
+  const envelope = O(envelopeValue), generatedAt = S(envelope.generated_at), snapshots = O(envelope.snapshots);
+  const commercialSlot = O(snapshots.commercial), operations = O(O(commercialSlot.snapshot).operations);
+  const dispatch = O(operations.dispatch), delegated = O(operations.delegated_first_touch), overview = O(operations.overview), outcomes = O(operations.outbound_outcomes);
+  const delegatedItems = A(delegated.items), rawDispatchState = S(dispatch.state);
+  const outboundState = dispatch.observed === true && (rawDispatchState === "ACTIVE" || rawDispatchState === "PAUSED") ? rawDispatchState : "UNKNOWN";
+  const sourceRuns = [...new Set(delegatedItems.map((item) => S(item.source_run_id)).filter((item): item is string => Boolean(item)))];
+  const dueDates = [...delegatedItems.filter((item) => item.state === "QUEUED").map((item) => S(item.due_at)), S(dispatch.next_slot_at)]
+    .filter((item): item is string => typeof item === "string" && !Number.isNaN(Date.parse(item))).sort();
+  const pncpSlot = O(snapshots.pncp), pncp = O(pncpSlot.snapshot), target = O(pncp.target_coverage);
+  const targetCoverageText = N(target.covered) !== null && N(target.total) !== null ? `${N(target.covered)}/${N(target.total)}` : S(pncp.target_coverage);
+  const webObservation = A(envelope.source_observations).filter((item) => ["web-cfg", "gsc"].includes(S(O(item.source).system) ?? "")).sort((left, right) => Date.parse(S(right.observed_at) ?? "") - Date.parse(S(left.observed_at) ?? ""))[0] ?? {};
+  const webPayload = O(webObservation.payload), inbound = O(operations.inbound), delivery = O(operations.delivery), capacity = O(operations.capacity), governance = O(operations.governance);
+  const financeSlot = O(snapshots.finance), finance = O(financeSlot.snapshot);
+  const staffedState = capacity.staffed_capacity_state === "KNOWN" ? "KNOWN" : "UNKNOWN";
+  const admission = capacity.admission === "CAN_ACCEPT" || capacity.admission === "CANNOT_ACCEPT"
+    ? capacity.admission
+    : "UNKNOWN";
+  const checkoutGate = governance.checkout_gate === "OPEN" || governance.checkout_gate === "BLOCKED"
+    ? governance.checkout_gate
+    : "UNKNOWN";
+  const asaasGate = governance.asaas_gate === "PROVEN" || governance.asaas_gate === "MISSING" || governance.asaas_gate === "BLOCKED"
+    ? governance.asaas_gate
+    : "UNKNOWN";
+
+  const exceptions = A(operations.exceptions).map((item) => exception(item, generatedAt));
+  if (!exceptions.some((item) => item.bucket === "capacity_unknown") && staffedState === "UNKNOWN") {
+    exceptions.push({
+      id: "projection-capacity-unknown",
+      bucket: "capacity_unknown",
+      owner: "delivery_owner",
+      reason: "Capacidade staffed real não foi observada; policy ceiling não é disponibilidade.",
+      evidence: [S(capacity.source_ref) ?? "capacity_snapshot:UNKNOWN"],
+      age_seconds: null,
+      next_action: "Publicar snapshot staffed real, calendário e WIP; manter admission/checkout fail-closed.",
+      severity: "critical",
+      source: {
+        system: "governance",
+        kind: "capacity-read-model",
+        locator: S(capacity.source_ref) ?? "delivery/capacity",
+        as_of: S(capacity.projected_at) ?? generatedAt,
+        freshness: F(capacity.freshness),
+      },
+    });
+  }
+  if (!exceptions.some((item) => item.bucket === "payment_provider_ambiguity") && asaasGate !== "PROVEN") {
+    exceptions.push({
+      id: "projection-provider-unknown",
+      bucket: "payment_provider_ambiguity",
+      owner: "finance",
+      reason: "Objetos/mapping Asaas não foram comprovados; PAYMENT_CONFIRMED não é receita recebida.",
+      evidence: [S(governance.authority_ref) ?? "asaas_mapping:UNKNOWN"],
+      age_seconds: null,
+      next_action: "Reconciliar objetos/eventos no provider em sessão humana autorizada; não simular nem habilitar checkout.",
+      severity: "critical",
+      source: {
+        ...source(financeSlot, "asaas"),
+        kind: "provider-read",
+        locator: "finance/provider-gate",
+      },
+    });
+  }
+
+  const explicitToday = A(envelope.today)[0];
+  const capacityException = exceptions.find((item) => item.bucket === "capacity_unknown");
+  const primaryAction = explicitToday
+    ? {
+        owner: S(explicitToday.owner) ?? "founder",
+        label: S(explicitToday.recommended_action) ?? S(explicitToday.title) ?? "Tratar a prioridade operacional observada.",
+        reason: S(explicitToday.reason) ?? "Prioridade publicada pela fila canônica de hoje.",
+        href: "#/hoje",
+      }
+    : capacityException
+      ? {
+          owner: capacityException.owner,
+          label: capacityException.next_action,
+          reason: capacityException.reason,
+          href: "#/comercial/excecoes?tipo=capacity_unknown",
+        }
+      : null;
+
+  return {
+    generated_at: generatedAt,
+    outbound: {
+      state: outboundState,
+      policy_version: S(delegated.policy_version), source_run: sourceRuns.length === 1 ? sourceRuns[0]! : S(delegated.source_run_id),
+      queued: N(delegated.queued_readback) ?? N(dispatch.queued_approved), next_due: dueDates[0] ?? null,
+      sends_today: N(dispatch.sent_today), limit: N(dispatch.daily_limit) ?? N(dispatch.cap), replies: N(outcomes.replies) ?? N(overview.replies), bounces: N(outcomes.bounces) ?? N(overview.bounces), opt_outs: N(outcomes.opt_outs) ?? N(overview.opt_outs), exceptions: N(overview.exceptions), transport_health: S(dispatch.transport_health), source: source(commercialSlot, "warmbly"),
+    },
+    data: {
+      current_feed: S(pncp.current_feed) ?? S(pncp.feed_id),
+      current_run: S(pncp.current_run) ?? S(pncp.run_id) ?? S(pncp.source_run_id),
+      target_coverage: targetCoverageText,
+      blocker: S(pncp.blocker) ?? (pncpSlot.presence === "absent" ? S(pncpSlot.absence_reason) : null), source: source(pncpSlot, "extra-cli/pncp"),
+    },
+    inbound_web: {
+      deploy_identity: S(webPayload.deploy_identity) ?? S(webPayload.release_sha) ?? S(webPayload.commit_sha), lead_sla_state: S(inbound.lead_sla_state) ?? S(webPayload.lead_sla_state), gsc_readiness: S(webPayload.gsc_readiness), public_surface_health: S(webPayload.public_surface_health), source: source(webObservation, "web-cfg"),
+    },
+    delivery_finance: {
+      active_work_orders: N(delivery.active_work_orders), policy_ceiling: N(capacity.policy_ceiling), staffed_capacity: staffedState === "KNOWN" ? N(capacity.staffed_capacity) : null,
+      staffed_capacity_state: staffedState,
+      committed: staffedState === "KNOWN" ? N(capacity.committed) : null, available: staffedState === "KNOWN" ? N(capacity.available) : null, capacity_freshness: F(capacity.freshness),
+      admission: staffedState === "KNOWN" ? admission : "UNKNOWN",
+      checkout_gate: checkoutGate,
+      asaas_gate: asaasGate,
+      exceptions: N(delivery.exceptions) ?? N(finance.exception_count), source: source(financeSlot, "asaas/governance"),
+    },
+    exceptions,
+    primary_action: primaryAction,
+  };
+}

--- a/control-center/apps/web-shell/src/hoje-domains.ts
+++ b/control-center/apps/web-shell/src/hoje-domains.ts
@@ -21,6 +21,10 @@ import { formatLocal } from "./datetime";
 import { formatMoney } from "./money";
 import { sourceKindLabel, sourceSystemLabel } from "./provenance";
 import { ownMapValue } from "./own-map";
+import {
+  projectFounderOperatingTruth,
+  type FounderOperatingTruth,
+} from "./founder-operating-truth";
 import type { FreshnessStatus, Money, SourceRef } from "./types";
 
 export const DOMAIN_CARD_IDS = [
@@ -130,6 +134,7 @@ export interface HojeDomainSummary {
   cards: HojeDomainCard[];
   integrations: HojeIntegration[];
   outbound: HojeOutbound;
+  founder_truth: FounderOperatingTruth;
   unmapped: HojeUnmappedAlerts[];
   /** Null when the envelope is absent: lack of a reading is not a measured zero. */
   action_total: number | null;
@@ -691,6 +696,7 @@ function emptySummary(): HojeDomainSummary {
     cards,
     integrations: [],
     outbound,
+    founder_truth: projectFounderOperatingTruth(null),
     unmapped: [],
     action_total: null,
     action_total_note:
@@ -744,6 +750,7 @@ export function summarizeDomains(envelopeRaw: unknown): HojeDomainSummary {
     cards,
     integrations: integrationsFrom(envelope),
     outbound,
+    founder_truth: projectFounderOperatingTruth(envelopeRaw),
     unmapped,
     action_total: cardTotal + unmappedTotal,
     action_total_note:

--- a/control-center/apps/web-shell/src/ui/domains.ts
+++ b/control-center/apps/web-shell/src/ui/domains.ts
@@ -949,8 +949,20 @@ function exceptionOpsCard(
   const startDraftKey = `operator:START_EXCEPTION_WORK:${canonical}:${sourceId}`;
   const workflow = String(row.workflow_state ?? "new");
   const owner = typeof row.owner === "string" && row.owner ? row.owner : "sem responsável";
+  const reason = String(row.reason ?? row.why ?? row.id ?? "motivo não informado pela origem");
   const age = typeof row.age_seconds === "number" ? `${Math.max(0, Math.floor(row.age_seconds / 3600))} h` : "não informada";
   const count = typeof row.occurrence_count === "number" ? row.occurrence_count : 1;
+  const severity = typeof row.severity === "string" && row.severity ? row.severity : "unknown";
+  const evidence = Array.isArray(row.evidence)
+    ? row.evidence.filter((item): item is string => typeof item === "string" && item.trim() !== "")
+    : [];
+  const exceptionSource = row.source && typeof row.source === "object" && !Array.isArray(row.source)
+    ? row.source as Record<string, unknown>
+    : {};
+  const sourceSystem = String(exceptionSource.system ?? row.source_system ?? "origem não informada");
+  const sourceLocator = String(exceptionSource.locator ?? row.source_locator ?? "locator não informado");
+  const exceptionFreshness = String(row.freshness ?? row.freshness_status ?? "UNKNOWN");
+  const nextAction = String(row.next_action ?? row.recommended_next_action ?? "investigar a evidência e definir correção");
   const resolutionKind = String(row.resolution_kind ?? "unsupported");
   let resolution: string;
   if (resolutionKind === "warmbly_action") {
@@ -966,13 +978,16 @@ function exceptionOpsCard(
   const nextId = position.next ? String(position.next.row.id ?? position.next.row.source_id ?? "") : "";
   const actionContinuity = queueActionAttributes(position, nextId);
   return `<article class="card"${focusAttributes} data-exception-id="${escapeHtml(id)}" data-exception-status="${escapeHtml(String(row.status ?? ""))}" data-workflow-state="${escapeHtml(workflow)}" data-occurrence-count="${count}">
-    <p class="kicker">${statusPill(workflow, commercialStateLabel(workflow))} · ${statusPill(String(row.kind ?? "exception"), exceptionKindLabel(String(row.kind ?? "exception")))}</p>
-    <h3>${escapeHtml(String(row.why ?? row.id ?? "exceção"))}</h3>
+    <p class="kicker">${statusPill(workflow, commercialStateLabel(workflow))} · ${statusPill(String(row.kind ?? "exception"), exceptionKindLabel(String(row.kind ?? "exception")))} · ${statusPill(severity, severityLabel(severity))}</p>
+    <h3>${escapeHtml(reason)}</h3>
     <dl class="facts">
       ${fact("Responsável", escapeHtml(owner), owner === "sem responsável" ? ` data-absent="true"` : "")}
       ${fact("Idade", escapeHtml(age))}
       ${fact("Impacto", escapeHtml(String(row.impact ?? "impacto não informado pela origem")))}
-      ${fact("Ação recomendada", escapeHtml(String(row.recommended_next_action ?? "investigar a evidência e definir correção")))}
+      ${fact("Ação recomendada", escapeHtml(nextAction))}
+      ${fact("Evidência", escapeHtml(evidence.length > 0 ? evidence.join(" · ") : "não informada pela origem"), evidence.length === 0 ? ` data-absent="true"` : "")}
+      ${fact("Origem", escapeHtml(`${sourceSystemLabel(sourceSystem)} · ${sourceLocator}`))}
+      ${fact("Atualização", escapeHtml(availabilityLabel(exceptionFreshness)), ` data-freshness="${escapeHtml(exceptionFreshness)}"`)}
       ${fact("Ocorrências agrupadas", String(count))}
       ${fact("Sincronização", escapeHtml(String(row.sync_status ?? "observada na origem")))}
     </dl>
@@ -983,6 +998,12 @@ function exceptionOpsCard(
       { term: "canonical_id", value: canonical },
       { term: "source_id", value: sourceId },
       { term: "workflow_state", value: workflow },
+      { term: "severity", value: severity },
+      { term: "source_system", value: sourceSystem },
+      { term: "source_kind", value: String(exceptionSource.kind ?? "") },
+      { term: "source_locator", value: sourceLocator },
+      { term: "freshness", value: exceptionFreshness },
+      { term: "evidence", value: evidence.join(",") },
       { term: "group_key", value: String(row.group_key ?? "") },
       { term: "occurrence_ids", value: Array.isArray(row.occurrence_ids) ? row.occurrence_ids.join(",") : "" },
     ], "resolvable-exception")}

--- a/control-center/apps/web-shell/src/ui/hoje.ts
+++ b/control-center/apps/web-shell/src/ui/hoje.ts
@@ -24,6 +24,11 @@ import {
   type HojeIntegration,
 } from "../hoje-domains";
 import { operationalTruthBlock, parseOperationalTruth } from "./operational-truth";
+import type {
+  FounderOperatingTruth,
+  MorningException,
+  MorningSource,
+} from "../founder-operating-truth";
 
 function rowCard(sectionId: string, row: HojeSection["rows"][number]): string {
   const tone = row.freshness_tone || freshnessTone(row.freshness_status);
@@ -204,6 +209,136 @@ function integrationRow(row: HojeIntegration): string {
   </li>`;
 }
 
+const MORNING_TOKEN_LABELS: Record<string, string> = {
+  PAUSED_BY_KILL_SWITCH: "pausado pelo kill switch",
+  BLOCKED_GAPS: "bloqueado por lacunas",
+  HEALTHY_200: "saudável · HTTP 200",
+  PAYMENT_CONFIRMED: "pagamento confirmado",
+  ACTIVE: "ativo",
+  PAUSED: "pausado",
+  UNKNOWN: "desconhecido",
+  KNOWN: "conhecido",
+  FRESH: "fresco",
+  STALE: "defasado",
+  ERROR: "erro de coleta",
+  CAN_ACCEPT: "pode aceitar",
+  CANNOT_ACCEPT: "não pode aceitar",
+  OPEN: "aberto",
+  BLOCKED: "bloqueado",
+  PROVEN: "comprovado",
+  MISSING: "ausente",
+};
+
+function morningText(value: string): string {
+  return value.replace(
+    /\b(PAUSED_BY_KILL_SWITCH|BLOCKED_GAPS|HEALTHY_200|PAYMENT_CONFIRMED|ACTIVE|PAUSED|UNKNOWN|KNOWN|FRESH|STALE|ERROR|CAN_ACCEPT|CANNOT_ACCEPT|OPEN|BLOCKED|PROVEN|MISSING)\b/g,
+    (token) => MORNING_TOKEN_LABELS[token] ?? "estado não reconhecido",
+  );
+}
+
+function morningValue(value: string | number | null): string {
+  return value === null ? "desconhecido" : morningText(String(value));
+}
+
+function morningSource(source: MorningSource): string {
+  return technicalDetails(
+    [
+      { term: "source", value: `${source.system}:${source.kind}:${source.locator}` },
+      { term: "as_of", value: source.as_of ?? "UNKNOWN" },
+      { term: "freshness", value: source.freshness },
+    ],
+    "founder-operating-source",
+  );
+}
+
+const EXCEPTION_LABELS: Record<MorningException["bucket"], string> = {
+  identity_recipient_conflict: "conflito de identidade/destinatário",
+  stale_drift: "dado defasado ou drift",
+  party_role_conflict: "conflito de papel da parte",
+  outbound_reply_handoff: "handoff de resposta outbound",
+  payment_provider_ambiguity: "ambiguidade de pagamento/provider",
+  capacity_unknown: "capacidade desconhecida",
+  delivery_blocker: "blocker de entrega",
+  runtime_mismatch: "divergência de runtime",
+  other: "outra exceção",
+};
+
+function morningExceptionRow(item: MorningException): string {
+  return `<article class="card" data-morning-exception="${escapeHtml(item.bucket)}" data-severity="${escapeHtml(item.severity)}">
+    <p class="kicker">${escapeHtml(EXCEPTION_LABELS[item.bucket])} · ${escapeHtml(severityLabel(item.severity))}</p>
+    <h4>${escapeHtml(item.reason)}</h4>
+    <dl class="facts">
+      <dt>Owner</dt><dd>${escapeHtml(item.owner)}</dd>
+      <dt>Idade</dt><dd>${escapeHtml(item.age_seconds === null ? "desconhecida" : `${item.age_seconds}s`)}</dd>
+      <dt>Próxima ação</dt><dd>${escapeHtml(morningText(item.next_action))}</dd>
+      <dt>Atualização</dt><dd>${escapeHtml(morningText(item.source.freshness))}</dd>
+      <dt>Evidência</dt><dd>${escapeHtml(morningText(item.evidence.join(" · ")))}</dd>
+    </dl>
+    ${morningSource(item.source)}
+  </article>`;
+}
+
+function morningFacts(items: ReadonlyArray<readonly [string, string | number | null]>): string {
+  return `<dl class="facts">${items.map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${escapeHtml(morningValue(value))}</dd>`).join("")}</dl>`;
+}
+
+function morningCard(
+  id: string,
+  title: string,
+  facts: ReadonlyArray<readonly [string, string | number | null]>,
+  source?: MorningSource,
+  attributes = "",
+): string {
+  return `<article class="card" data-morning-domain="${id}"${attributes}><h3>${title}</h3>${morningFacts(facts)}${source ? morningSource(source) : ""}</article>`;
+}
+
+function founderOperatingTruthBlock(truth: FounderOperatingTruth): string {
+  const outbound = truth.outbound;
+  const data = truth.data;
+  const web = truth.inbound_web;
+  const delivery = truth.delivery_finance;
+  const action = truth.primary_action;
+  const cards = [
+    morningCard("outbound", "1. Outbound", [
+      ["Estado", morningText(outbound.state)], ["Policy / versão", outbound.policy_version], ["Source run", outbound.source_run],
+      ["Queued por readback", outbound.queued], ["Próximo due", outbound.next_due],
+      ["Envios hoje / limite", `${morningValue(outbound.sends_today)} / ${morningValue(outbound.limit)}`],
+      ["Replies / bounces / opt-outs", `${morningValue(outbound.replies)} / ${morningValue(outbound.bounces)} / ${morningValue(outbound.opt_outs)}`],
+      ["Exceções", outbound.exceptions], ["Saúde do transporte", outbound.transport_health],
+    ], outbound.source, ` data-outbound-state="${escapeHtml(outbound.state)}"`),
+    morningCard("data", "2. Dados", [
+      ["Feed atual", data.current_feed], ["Run atual", data.current_run], ["Atualização", morningText(data.source.freshness)],
+      ["Cobertura do target", data.target_coverage], ["Blocker", data.blocker],
+    ], data.source),
+    morningCard("inbound-web", "3. Inbound / Web", [
+      ["Deploy identity", web.deploy_identity], ["Lead SLA", web.lead_sla_state], ["GSC readiness", web.gsc_readiness],
+      ["Saúde da superfície pública", web.public_surface_health],
+    ], web.source),
+    morningCard("delivery-finance", "4. Delivery / Finance", [
+      ["Work Orders ativos", delivery.active_work_orders], ["Policy ceiling", delivery.policy_ceiling],
+      ["Capacidade alocada", `${morningValue(delivery.staffed_capacity)} · ${morningText(delivery.staffed_capacity_state)}`],
+      ["Committed / available", `${morningValue(delivery.committed)} / ${morningValue(delivery.available)}`],
+      ["Atualização / admissão", `${morningText(delivery.capacity_freshness)} / ${morningText(delivery.admission)}`],
+      ["Checkout / Asaas", `${morningText(delivery.checkout_gate)} / ${morningText(delivery.asaas_gate)}`], ["Exceções", delivery.exceptions],
+    ], delivery.source, ` data-capacity-state="${escapeHtml(delivery.staffed_capacity_state)}"`),
+    `<article class="card" data-morning-domain="next-human-action"><h3>5. Próxima ação humana</h3>${action
+      ? `<p><strong>${escapeHtml(action.label)}</strong></p><p>${escapeHtml(action.reason)}</p><p>Owner: ${escapeHtml(action.owner)}</p><p><a class="button" href="${escapeHtml(action.href)}">Abrir contexto</a></p>`
+      : `<p class="domain-empty">Nenhuma ação humana primária é segura com as leituras atuais. O estado desconhecido permanece visível.</p>`}</article>`,
+  ].join("");
+  const exceptionDetails = truth.exceptions.length === 0
+    ? `<p class="domain-empty">Nenhuma exceção observada. Ausência de fila não substitui freshness das origens.</p>`
+    : `<details class="tech" data-morning-exceptions="${truth.exceptions.length}"><summary>Abrir fila de exceções (${truth.exceptions.length})</summary><div class="cards">${truth.exceptions.map(morningExceptionRow).join("")}</div></details>`;
+  return `<section class="stack founder-operating-truth" aria-labelledby="founder-operating-title" data-founder-operating-truth="true" data-primary-action-count="${action ? "1" : "0"}">
+    <header>
+      <p class="kicker">Verdade operacional · somente leitura</p>
+      <h2 id="founder-operating-title">Control Center para a manhã</h2>
+      <p class="constraint">Configurado não significa provado. Aprovado não significa enviado. Pagamento confirmado não significa receita recebida. Teto de política não significa capacidade alocada.</p>
+    </header>
+    <div class="cards domain-grid">${cards}</div>
+    ${exceptionDetails}
+  </section>`;
+}
+
 function domainSummaryBlock(summary: HojeDomainSummary): string {
   const total = summary.action_total;
   const totalText = total === null ? "indisponível" : String(total);
@@ -225,6 +360,7 @@ function domainSummaryBlock(summary: HojeDomainSummary): string {
       ? `<p class="domain-empty" data-integrations="0">Faltam dados: nenhuma observação de origem chegou nesta leitura. Não significa que as integrações estejam sãs.</p>`
       : `<ul class="domain-integrations">${summary.integrations.map(integrationRow).join("")}</ul>`;
   return `
+    ${founderOperatingTruthBlock(summary.founder_truth)}
     <p class="domain-total" data-action-total="${escapeHtml(total === null ? "unknown" : totalText)}">
       <strong>${escapeHtml(totalText)}</strong>${escapeHtml(totalSuffix)}
       <span class="hint">${escapeHtml(summary.action_total_note)}</span>

--- a/control-center/apps/web-shell/tests/founder-operating-truth.test.ts
+++ b/control-center/apps/web-shell/tests/founder-operating-truth.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { projectFounderOperatingTruth } from "../src/founder-operating-truth";
+import { summarizeDomains } from "../src/hoje-domains";
+import { renderHoje } from "../src/ui/hoje";
+import { composeHoje } from "../src/hoje-compose";
+
+const NOW = "2026-08-26T03:00:00Z";
+
+function slot(domain: string, system: string, snapshot: Record<string, unknown>) {
+  return {
+    schema_version: "control-center.operational-domain.v1",
+    domain,
+    scope: domain === "pncp" ? "inbound" : domain,
+    source: { system, kind: "read-model", locator: `${domain}/current` },
+    observed_at: "2026-08-26T02:55:00Z",
+    freshness_status: "FRESH",
+    confidence: 1,
+    presence: "present",
+    healthy: true,
+    snapshot,
+  };
+}
+
+function envelope(): Record<string, unknown> {
+  return {
+    schema_version: "control-center.operational-envelope.v1",
+    scope: "company",
+    generated_at: NOW,
+    freshness_status: "FRESH",
+    confidence: 1,
+    snapshots: {
+      commercial: slot("commercial", "warmbly", {
+        operations: {
+          dispatch: {
+            state: "PAUSED",
+            observed: true,
+            queued_approved: 1,
+            sent_today: 0,
+            daily_limit: 10,
+            transport_health: "PAUSED_BY_KILL_SWITCH",
+          },
+          delegated_first_touch: {
+            policy_version: "CFG-FIRST-TOUCH-ROUTING-v1",
+            queued_readback: 1,
+            items: [{ state: "QUEUED", source_run_id: "run-current", due_at: "2026-08-26T12:00:00Z" }],
+          },
+          overview: { exceptions: 1, replies: 0, bounces: 0, opt_outs: 0 },
+          delivery: { active_work_orders: 0, exceptions: 0 },
+          capacity: {
+            policy_ceiling: 50,
+            staffed_capacity_state: "UNKNOWN",
+            staffed_capacity: null,
+            committed: null,
+            available: null,
+            freshness: "UNKNOWN",
+            admission: "UNKNOWN",
+            source_ref: "commercial/authority/authority-overlay.v2.json",
+          },
+          governance: {
+            checkout_gate: "BLOCKED",
+            asaas_gate: "MISSING",
+            authority_ref: "commercial/authority/authority-overlay.v2.json",
+          },
+        },
+      }),
+      finance: slot("finance", "asaas", { exception_count: 1 }),
+      clients: slot("clients", "warmbly", {}),
+      engineering: slot("engineering", "github", {}),
+      infrastructure: slot("infrastructure", "collector", { status: "healthy", services: [] }),
+      pncp: slot("pncp", "extra-cli", {
+        current_feed: "pncp-current",
+        current_run: "run-current",
+        target_coverage: { covered: 1, total: 1 },
+      }),
+    },
+    attention_now: [],
+    today: [],
+    source_observations: [
+      {
+        source: { system: "web-cfg", kind: "deploy-read", locator: "public/current" },
+        observed_at: "2026-08-26T02:56:00Z",
+        freshness_status: "FRESH",
+        payload: {
+          deploy_identity: "41cc328681507159ffdc12417d49e7474e2770a4",
+          lead_sla_state: "UNKNOWN",
+          gsc_readiness: "BLOCKED_GAPS",
+          public_surface_health: "HEALTHY_200",
+        },
+      },
+    ],
+  };
+}
+
+test("first viewport projects the five founder questions without hiding UNKNOWN", () => {
+  const truth = projectFounderOperatingTruth(envelope());
+  assert.equal(truth.outbound.state, "PAUSED");
+  assert.equal(truth.outbound.policy_version, "CFG-FIRST-TOUCH-ROUTING-v1");
+  assert.equal(truth.outbound.source_run, "run-current");
+  assert.equal(truth.outbound.queued, 1);
+  assert.equal(truth.outbound.sends_today, 0);
+  assert.equal(truth.data.target_coverage, "1/1");
+  assert.equal(truth.inbound_web.gsc_readiness, "BLOCKED_GAPS");
+  assert.equal(truth.delivery_finance.policy_ceiling, 50);
+  assert.equal(truth.delivery_finance.staffed_capacity, null);
+  assert.equal(truth.delivery_finance.staffed_capacity_state, "UNKNOWN");
+  assert.equal(truth.delivery_finance.available, null);
+  assert.equal(truth.delivery_finance.admission, "UNKNOWN");
+  assert.equal(truth.delivery_finance.checkout_gate, "BLOCKED");
+  assert.equal(truth.delivery_finance.asaas_gate, "MISSING");
+  assert.ok(truth.exceptions.some((item) => item.bucket === "capacity_unknown"));
+  assert.ok(truth.exceptions.some((item) => item.bucket === "payment_provider_ambiguity"));
+  assert.ok(truth.primary_action);
+  assert.equal(truth.primary_action.owner, "delivery_owner");
+});
+
+test("missing observations remain UNKNOWN and never become zero or healthy", () => {
+  const truth = projectFounderOperatingTruth(null);
+  assert.equal(truth.outbound.state, "UNKNOWN");
+  assert.equal(truth.outbound.queued, null);
+  assert.equal(truth.outbound.sends_today, null);
+  assert.equal(truth.data.current_run, null);
+  assert.equal(truth.inbound_web.public_surface_health, null);
+  assert.equal(truth.delivery_finance.staffed_capacity_state, "UNKNOWN");
+  assert.equal(truth.delivery_finance.active_work_orders, null);
+  assert.equal(truth.delivery_finance.admission, "UNKNOWN");
+});
+
+test("Hoje renders one primary action and the complete exception evidence fields", () => {
+  const summary = summarizeDomains(envelope());
+  const view = composeHoje({
+    generated_at: NOW,
+    headline: "cockpit",
+    priorities: [],
+    incidents: [],
+    clients: [],
+    commercial: null,
+    finance: null,
+    engineering: null,
+    infra: [],
+    activities: [],
+    operational_envelope: envelope(),
+  });
+  const html = renderHoje(view);
+  assert.equal(summary.founder_truth.primary_action?.owner, "delivery_owner");
+  assert.match(html, /data-founder-operating-truth="true"/);
+  assert.match(html, /data-primary-action-count="1"/);
+  for (const domain of ["outbound", "data", "inbound-web", "delivery-finance", "next-human-action"]) {
+    assert.match(html, new RegExp(`data-morning-domain="${domain}"`));
+  }
+  assert.match(html, /Capacidade alocada/);
+  assert.match(html, /desconhecid[oa]/i);
+  assert.match(html, /data-(?:outbound|capacity)-state="UNKNOWN"/);
+  assert.match(html, /Owner/);
+  assert.match(html, /Idade/);
+  assert.match(html, /Evidência/);
+  assert.match(html, /freshness/i);
+});

--- a/control-center/apps/web-shell/tests/performance-ux.test.ts
+++ b/control-center/apps/web-shell/tests/performance-ux.test.ts
@@ -92,8 +92,10 @@ test("performance budget owns exact mobile targets and critical routes", () => {
   assert.equal(budget.budgets.initial_request_count, 16);
   assert.equal(budget.budgets.css_raw_bytes, 26000);
   assert.equal(budget.budgets.css_gzip_bytes, 7000);
-  assert.equal(budget.budgets.bundle_gzip_bytes, 120000);
-  assert.equal(budget.budgets.javascript_gzip_bytes, 113500);
+  assert.equal(budget.budgets.bundle_gzip_bytes, 123500);
+  assert.equal(budget.budgets.javascript_gzip_bytes, 117500);
+  assert.equal(budget.budget_change.previous_bundle_gzip_bytes, 120000);
+  assert.match(budget.budget_change.reason, /founder operating-truth viewport/);
   assert.deepEqual(budget.routes.map((route: { id: string }) => route.id), ["hoje", "rascunhos", "coortes"]);
   const probe = readFileSync(join(app, "scripts/performance-probe.mjs"), "utf8");
   assert.match(probe, /performance_event_timing/);

--- a/delivery/__init__.py
+++ b/delivery/__init__.py
@@ -5,7 +5,7 @@ Work Order authority. Public catalog identity remains in web-cfg and commercial
 proposal truth remains in Warmbly.
 """
 
-from .capacity import CapacityLedger, evaluate_admission
+from .capacity import CapacityLedger, evaluate_admission, project_capacity_read_only
 from .contracts import validate_delivery_order_requested
 from .readiness import (
     generate_fail_closed_snapshot,
@@ -16,6 +16,7 @@ from .readiness import (
 __all__ = [
     "CapacityLedger",
     "evaluate_admission",
+    "project_capacity_read_only",
     "generate_fail_closed_snapshot",
     "promote_to_delivery_validated",
     "validate_delivery_order_requested",

--- a/delivery/capacity.py
+++ b/delivery/capacity.py
@@ -390,6 +390,133 @@ def evaluate_admission(
     }
 
 
+def project_capacity_read_only(
+    *,
+    policy_ceiling: int | None,
+    capacity_snapshot: Mapping[str, Any] | None,
+    active_work_orders: Sequence[Mapping[str, Any]] | None,
+    committed_allocations: int | None,
+    projected_at: str,
+    admission_decision: str | None = None,
+) -> dict[str, Any]:
+    """Project current capacity without reserving, committing, or enabling checkout.
+
+    This projection has deliberately different semantics from the synthetic
+    admission canary.  Synthetic evidence may exercise arithmetic, but it can
+    never become real-world readiness in the Control Center.
+    """
+
+    now = _parse_instant(projected_at, "projected_at")
+    if not isinstance(policy_ceiling, int) or isinstance(policy_ceiling, bool) or policy_ceiling < 0:
+        policy_ceiling = None
+
+    base: dict[str, Any] = {
+        "schema_version": "confenge.capacity_projection.v1",
+        "projected_at": projected_at,
+        "policy_ceiling": policy_ceiling,
+        "staffed_capacity": None,
+        "staffed_capacity_state": "UNKNOWN",
+        "committed": None,
+        "available": None,
+        "freshness": "UNKNOWN",
+        "evidence_class": "ABSENT",
+        "admission": "UNKNOWN",
+        "can_accept": False,
+        "checkout_enabled": False,
+        "source": {"capacity_snapshot_id": None, "as_of": None, "expires_at": None},
+        "reason_codes": [],
+    }
+    if not capacity_snapshot:
+        base["reason_codes"] = ["STAFFED_CAPACITY_UNKNOWN"]
+        return base
+
+    snapshot_id = capacity_snapshot.get("capacity_snapshot_id")
+    as_of = capacity_snapshot.get("as_of")
+    expires_at = capacity_snapshot.get("expires_at")
+    base["source"] = {
+        "capacity_snapshot_id": snapshot_id if isinstance(snapshot_id, str) and snapshot_id else None,
+        "as_of": as_of if isinstance(as_of, str) else None,
+        "expires_at": expires_at if isinstance(expires_at, str) else None,
+    }
+    if capacity_snapshot.get("schema_version") != "confenge.staffed_capacity_snapshot.v1":
+        base["freshness"] = "ERROR"
+        base["reason_codes"] = ["CAPACITY_SNAPSHOT_INVALID"]
+        return base
+    staffed = capacity_snapshot.get("staffed_capacity_units")
+    if not isinstance(staffed, int) or isinstance(staffed, bool) or staffed < 0:
+        base["reason_codes"] = ["STAFFED_CAPACITY_UNKNOWN"]
+        return base
+    if capacity_snapshot.get("policy_ceiling_used_as_staffed_capacity") is not False:
+        base["freshness"] = "ERROR"
+        base["reason_codes"] = ["POLICY_CEILING_USED_AS_STAFFED_CAPACITY"]
+        return base
+    try:
+        observed = _parse_instant(as_of, "capacity_snapshot.as_of")
+        expiry = _parse_instant(expires_at, "capacity_snapshot.expires_at")
+    except CapacityError:
+        base["freshness"] = "ERROR"
+        base["reason_codes"] = ["CAPACITY_SNAPSHOT_INVALID"]
+        return base
+    if observed > now:
+        base["reason_codes"] = ["CAPACITY_SNAPSHOT_FROM_FUTURE"]
+        return base
+    if now >= expiry:
+        base["freshness"] = "STALE"
+        base["reason_codes"] = ["CAPACITY_SNAPSHOT_STALE"]
+        return base
+
+    synthetic = capacity_snapshot.get("synthetic") is True
+    base["staffed_capacity"] = staffed
+    base["staffed_capacity_state"] = "KNOWN"
+    base["freshness"] = "FRESH"
+    base["evidence_class"] = "SYNTHETIC" if synthetic else "REAL"
+    if active_work_orders is None or not isinstance(committed_allocations, int) or committed_allocations < 0:
+        base["reason_codes"] = ["COMMITTED_CAPACITY_UNKNOWN"]
+        return base
+
+    active_effort = 0
+    seen: set[str] = set()
+    for work_order in active_work_orders:
+        work_order_id = work_order.get("work_order_id") if isinstance(work_order, Mapping) else None
+        stage = work_order.get("current_stage") if isinstance(work_order, Mapping) else None
+        effort = work_order.get("estimated_capacity_units") if isinstance(work_order, Mapping) else None
+        if (
+            not isinstance(work_order_id, str)
+            or not work_order_id
+            or work_order_id in seen
+            or stage not in WORK_ORDER_STAGES
+            or not isinstance(effort, int)
+            or isinstance(effort, bool)
+            or effort <= 0
+        ):
+            base["committed"] = None
+            base["available"] = None
+            base["reason_codes"] = ["ACTIVE_WIP_INVALID"]
+            return base
+        seen.add(work_order_id)
+        if stage not in TERMINAL_WORK_ORDER_STAGES:
+            active_effort += effort
+
+    committed = active_effort + committed_allocations
+    base["committed"] = committed
+    base["available"] = max(0, staffed - committed)
+    requested_admission = admission_decision if admission_decision in {"CAN_ACCEPT", "CANNOT_ACCEPT", "UNKNOWN"} else "UNKNOWN"
+    if staffed == 0:
+        requested_admission = "CANNOT_ACCEPT"
+        base["reason_codes"] = ["INSUFFICIENT_STAFFED_CAPACITY"]
+    elif synthetic:
+        requested_admission = "UNKNOWN"
+        base["reason_codes"] = ["SYNTHETIC_CAPACITY_NOT_REAL_READINESS"]
+    elif requested_admission == "CAN_ACCEPT":
+        base["reason_codes"] = ["READ_ONLY_PROJECTION_DOES_NOT_ENABLE_CHECKOUT"]
+    else:
+        base["reason_codes"] = ["ADMISSION_NOT_PROVEN"]
+    base["admission"] = requested_admission
+    # A read model reports an admission fact but never enables checkout itself.
+    base["can_accept"] = requested_admission == "CAN_ACCEPT" and not synthetic
+    return base
+
+
 class CapacityLedger:
     """SQLite-backed idempotent hold/commit/release ledger.
 

--- a/docs/ops/FOUNDER-MORNING-TRUTH-2026-08-26.md
+++ b/docs/ops/FOUNDER-MORNING-TRUTH-2026-08-26.md
@@ -1,0 +1,94 @@
+# Verdade operacional para a manhã — 2026-08-26
+
+## Escopo e validade
+
+Auditoria read-only concluída em `2026-08-26T04:03:43Z` sobre os estados correntes de `main`, issues, PRs e superfícies públicas. Este documento é evidência datada, não uma fonte live e não deve ser promovido a catálogo ou read model. Qualquer observação sem identidade e freshness próprias continua `UNKNOWN` no Control Center.
+
+Não houve mutação na campanha Warmbly, envio, pause/resume, requeue, reschedule, feed refresh, chamada Asaas, habilitação de checkout ou mutação de dinheiro real.
+
+## Identidades auditadas
+
+| Origem | Identidade observada | Estado |
+| --- | --- | --- |
+| Governance `origin/main` | `d980cf2a0aa67f3a3a9446ca7037a3c9d89ece3b` | sem PR aberto no instante da auditoria |
+| web-cfg `origin/main` | `41cc328681507159ffdc12417d49e7474e2770a4` | identidade de repositório; não prova a identidade do deploy público |
+| Warmbly `origin/main` | `3368e7d8f46573eef300b42ec214df8844b082d0` | diferente do runtime reportado em Warmbly #43 |
+| Warmbly runtime | `0c23e37e9e2bfd276e46c77d15a01c6a24d1f177` | readback de `2026-08-26T01:40:55Z`; runtime mismatch aberto |
+
+## Classificação contemporânea
+
+| Item | Classificação | Verdade atual e critério para mudar |
+| --- | --- | --- |
+| `CFG-FIRST-TOUCH-ROUTING-v1` / Governance #129 | `PARTIAL` | contrato e projeção entraram em `main` por #148; a prova completa ainda exige source run corrente, cadeia até `QUEUED` por readback e runtime/release reconciliados |
+| Governance #126 | `PARTIAL` | UI já distingue autoridade delegada/humana e estados queued/readback/HOLD; prova autenticada completa e filtros de toda a fila ainda não estão anexados |
+| Governance #127 | `PARTIAL` | existe readback real de `QUEUED=1`, mas a matriz de retry/restart/concorrência e a reconciliação de runtime ainda não estão fechadas |
+| Governance #128 | `BLOCKED_EXTERNAL` | denominador, cobertura e source run correntes não foram publicados nesta auditoria; nenhum refresh foi executado |
+| Governance #109 | `STALE/SUPERSEDED` | duplica o invariante vigente de #127 e mantém enquadramento pós-campanha que não deve competir com a issue owner atual |
+| Governance #1 | `PARTIAL` | overlay v2 versionado nesta mudança; Asaas real, naming efetivo e staffed capacity seguem não comprovados |
+| Governance #120 | `PARTIAL` | contratos sintéticos existem e a projeção read-only fecha os hops; nenhuma cadeia real proposta→provider→Work Order foi provada |
+| Governance #123 | `BLOCKED_HUMAN` | função pura e schema existem; falta o delivery owner publicar snapshot real de staffed capacity, compromissos, calendário e freshness |
+| web-cfg #88 | `BLOCKED_EXTERNAL` | proposta/checkout/Asaas reais permanecem bloqueados; mappings e eventos reais não foram observados |
+| web-cfg #412 / PR #422 | `EXECUTE_NOW` no repositório owner | PR aberto, mergeable e com checks verdes; até merge/deploy/readback, GSC readiness permanece bloqueada por gaps e histórico não persistido |
+
+Nenhuma classificação `DONE` acima autoriza transporte, provider ou checkout. Os fundamentos versionados já presentes em `main` são `DONE` apenas dentro do seu escopo de contrato: policy de first touch, separação de autoridade humana/delegada, projeção queued/readback/HOLD, Work Order base e funções puras de capacidade.
+
+## Primeira viewport — fatos permitidos
+
+### 1. Outbound
+
+- estado de transporte observado: `PAUSED`;
+- policy: `CFG-FIRST-TOUCH-ROUTING-v1`;
+- runtime readback: kill switch `ENGAGED`, `CONFENGE_SENDING_PAUSED=true`, `QUEUED=1`, `SENT=0`;
+- source run, next due, sends today, limite, replies, bounces, opt-outs e saúde de provider: `UNKNOWN` quando não entregues pelo envelope live;
+- autoridade de GO/NO-GO de transporte continua exclusivamente em Warmbly #43. Nada nesta branch autoriza `resume` ou SMTP.
+
+### 2. Dados
+
+- feed corrente, source run corrente, freshness e cobertura reconciliada: `UNKNOWN` nesta auditoria;
+- blocker: a evidência live deve vir do produtor owner; snapshot histórico de #128 não é autoridade e não foi reutilizado;
+- nenhuma coleta ou atualização de feed foi disparada.
+
+### 3. Inbound / Web
+
+- identidade de deploy: `UNKNOWN`; o SHA de `web-cfg/main` é apenas identidade do repositório;
+- lead SLA: `UNKNOWN` sem observação live do endpoint owner;
+- GSC readiness: `BLOCKED`, porque #412 segue aberto e #422 ainda não foi mergeado/deployado;
+- probes públicos read-only em `2026-08-26T04:03Z`: homepage, `/diagnostico-b2g-expansao/` e `/comercial/termos-diagnostico-b2g/` responderam HTTP 200; `ops.confenge.com.br` respondeu HTTP 302 para a fronteira de autenticação.
+
+### 4. Delivery / Finance
+
+- Work Orders ativos: `UNKNOWN` sem snapshot live do produtor;
+- `policy_ceiling=50` é conhecido apenas como teto de política;
+- `staffed_capacity`, `committed`, `available` e freshness: `UNKNOWN`;
+- admission: `UNKNOWN/CANNOT_ACCEPT`, fail-closed;
+- mappings/objetos Asaas: `MISSING/UNKNOWN`; nenhum lookup de provider foi feito;
+- checkout: `BLOCKED`; proposta aceita e `PAYMENT_CONFIRMED` não são receita recebida.
+
+### 5. Próxima ação humana
+
+Uma única ação primária é segura: o delivery owner publicar um snapshot real, datado e identificável de staffed capacity, WIP/committed e calendário. Até isso ocorrer, admission e checkout permanecem fail-closed. A reconciliação de objetos Asaas continua um blocker separado que exige sessão humana autorizada; não deve ser simulada nem executada automaticamente.
+
+## Exception queue da auditoria
+
+| Bucket | Owner | Reason | Evidence | Age no corte | Next action | Severity | Source / freshness |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `capacity_unknown` | delivery owner | staffed capacity real não publicada | Governance #123; `commercial/authority/authority-overlay.v2.json` | `UNKNOWN` | publicar snapshot real com as cinco dimensões de capacidade | critical | Governance / `UNKNOWN` |
+| `payment_provider_ambiguity` | founder/finance | mappings e objetos Asaas não comprovados | Governance #1, #120; web-cfg #88 | `UNKNOWN` | reconciliar provider em sessão humana autorizada, sem habilitar checkout | critical | Asaas / `UNKNOWN` |
+| `stale_drift` | data owner | source run/feed/denominador live ausentes | Governance #128 | `UNKNOWN` | publicar leitura corrente com run/hash/as_of; não copiar snapshot histórico | high | produtor de dados / `UNKNOWN` |
+| `runtime_mismatch` | Warmbly owner | runtime `0c23e37…` difere de `main` `3368e7d…` | Warmbly #43, readback `2026-08-26T01:40:55Z` | 2h22m no corte | reconciliar identidade read-only antes de qualquer decisão de transporte | high | Warmbly runtime / stale para deploy identity |
+| `delivery_blocker` | web/GSC owner | histórico/readiness de GSC ainda não fail-closed em produção | web-cfg #412 e PR #422 | 2h28m desde atualização da issue | merge/deploy/readback no repositório owner; até lá mostrar bloqueado | medium | GitHub/web-cfg / fresh no corte |
+
+Buckets sem ocorrência provada (`identity_recipient_conflict`, `party_role_conflict`, `outbound_reply_handoff`) permanecem disponíveis no schema, mas não recebem contagem zero nem estado saudável por inferência.
+
+## Cadeia comercial e autoridade
+
+`web-cfg` é a única autoridade do catálogo público: registry de 54 entregáveis + 2 contêineres no blob `99e77f51336e7fe63af0446d7577b3b20fe9a9b0`, e naming authority no blob `5f39620c0488625648aa9c3919a9eea3b8ce2004`. Os quatro registros históricos de Governance são somente um subset/mapping financeiro e não formam catálogo alternativo.
+
+A projeção comercial conserva identidades de oferta→proposta→aceite→financial gate→provider→commercial state→Work Order→delivery. Hop ausente não é promovido. `PAYMENT_CREATED`, `PAYMENT_CONFIRMED` e `PAYMENT_RECEIVED` são eventos distintos; apenas recebimento com prova primária não sintética pode sustentar receita recebida.
+
+## Fontes
+
+- Governance: #1, #109, #120, #123, #126, #127, #128, #129 e PR mergeado #148.
+- Warmbly: #43.
+- web-cfg: #88, #412 e PR #422.
+- artefatos pinados: `commercial/authority/authority-overlay.v2.json`.

--- a/schemas/capacity-projection.v1.schema.json
+++ b/schemas/capacity-projection.v1.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confenge.com.br/schemas/capacity-projection.v1.schema.json",
+  "title": "confenge.capacity_projection.v1",
+  "description": "Read-only capacity truth. A policy ceiling is never substituted for staffed capacity, and synthetic evidence never enables real admission or checkout.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "projected_at",
+    "policy_ceiling",
+    "staffed_capacity",
+    "staffed_capacity_state",
+    "committed",
+    "available",
+    "freshness",
+    "evidence_class",
+    "admission",
+    "can_accept",
+    "checkout_enabled",
+    "source",
+    "reason_codes"
+  ],
+  "properties": {
+    "schema_version": { "const": "confenge.capacity_projection.v1" },
+    "projected_at": { "type": "string", "format": "date-time" },
+    "policy_ceiling": { "type": ["integer", "null"], "minimum": 0 },
+    "staffed_capacity": { "type": ["integer", "null"], "minimum": 0 },
+    "staffed_capacity_state": { "enum": ["KNOWN", "UNKNOWN"] },
+    "committed": { "type": ["integer", "null"], "minimum": 0 },
+    "available": { "type": ["integer", "null"], "minimum": 0 },
+    "freshness": { "enum": ["FRESH", "STALE", "UNKNOWN", "ERROR"] },
+    "evidence_class": { "enum": ["REAL", "SYNTHETIC", "ABSENT"] },
+    "admission": { "enum": ["CAN_ACCEPT", "CANNOT_ACCEPT", "UNKNOWN"] },
+    "can_accept": { "type": "boolean" },
+    "checkout_enabled": { "const": false },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capacity_snapshot_id", "as_of", "expires_at"],
+      "properties": {
+        "capacity_snapshot_id": { "type": ["string", "null"] },
+        "as_of": { "type": ["string", "null"], "format": "date-time" },
+        "expires_at": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "staffed_capacity_state": { "const": "UNKNOWN" } } },
+      "then": {
+        "properties": {
+          "staffed_capacity": { "type": "null" },
+          "committed": { "type": "null" },
+          "available": { "type": "null" },
+          "admission": { "enum": ["UNKNOWN", "CANNOT_ACCEPT"] },
+          "can_accept": { "const": false }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "evidence_class": { "const": "SYNTHETIC" } } },
+      "then": {
+        "properties": {
+          "admission": { "enum": ["UNKNOWN", "CANNOT_ACCEPT"] },
+          "can_accept": { "const": false }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/commercial-authority-overlay.v2.schema.json
+++ b/schemas/commercial-authority-overlay.v2.schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confenge.com.br/schemas/commercial-authority-overlay.v2.schema.json",
+  "title": "commercial-authority-overlay.v2",
+  "description": "Additive authority overlay. It pins the external web-cfg catalog and naming authorities without copying their catalog, preserves v1 as history, and keeps capacity/provider/checkout facts fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "authority_id",
+    "status",
+    "effective_at",
+    "source_issue",
+    "v1_history",
+    "catalog_boundary",
+    "historical_financial_subset",
+    "provider_boundary",
+    "capacity_boundary",
+    "payment_semantics",
+    "activation_gates"
+  ],
+  "properties": {
+    "schema_version": { "const": "commercial-authority-overlay.v2" },
+    "authority_id": { "const": "CFG-COMMERCIAL-AUTHORITY-OVERLAY-v2" },
+    "status": { "const": "ACTIVE" },
+    "effective_at": { "type": "string", "format": "date-time" },
+    "source_issue": { "type": "string", "format": "uri" },
+    "v1_history": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["preserved", "manifest_path", "catalog_path", "semantic_status"],
+      "properties": {
+        "preserved": { "const": true },
+        "manifest_path": { "const": "commercial/authority/authority-manifest.v1.json" },
+        "catalog_path": { "const": "commercial/offers/catalog.v1.json" },
+        "semantic_status": { "const": "HISTORICAL_FINANCIAL_SUBSET_SUPERSEDED_AS_PUBLIC_CATALOG" }
+      }
+    },
+    "catalog_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["governance_catalog_role", "no_parallel_catalog", "deliverables_registry", "naming_authority"],
+      "properties": {
+        "governance_catalog_role": { "const": "NONE" },
+        "no_parallel_catalog": { "const": true },
+        "deliverables_registry": { "$ref": "#/$defs/external_pin" },
+        "naming_authority": {
+          "allOf": [
+            { "$ref": "#/$defs/external_pin" },
+            {
+              "type": "object",
+              "required": ["effective_at", "human_test_state", "publication_state"],
+              "properties": {
+                "effective_at": { "type": "null" },
+                "human_test_state": { "const": "NOT_STARTED" },
+                "publication_state": { "const": "DECIDED_NOT_PROVEN_EFFECTIVE" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "historical_financial_subset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["classification", "source_path", "offer_ids", "complete_public_catalog"],
+      "properties": {
+        "classification": { "const": "HISTORICAL_FINANCIAL_MAPPING_SUBSET" },
+        "source_path": { "const": "commercial/offers/catalog.v1.json" },
+        "offer_ids": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "complete_public_catalog": { "const": false }
+      }
+    },
+    "provider_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "mapping_path", "provider_lookup_performed", "mappings", "checkout_gate"],
+      "properties": {
+        "provider": { "const": "asaas" },
+        "mapping_path": { "const": "commercial/providers/asaas-mapping.v1.json" },
+        "provider_lookup_performed": { "const": false },
+        "mappings": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["offer_id", "mapping_state", "provider_object_state", "provider_object_id", "evidence_refs"],
+            "properties": {
+              "offer_id": { "type": "string", "minLength": 1 },
+              "mapping_state": { "enum": ["MISSING", "UNKNOWN", "BLOCKED"] },
+              "provider_object_state": { "enum": ["MISSING", "UNKNOWN", "BLOCKED"] },
+              "provider_object_id": { "type": "null" },
+              "evidence_refs": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+            }
+          }
+        },
+        "checkout_gate": { "const": "BLOCKED" }
+      }
+    },
+    "capacity_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_ceiling", "staffed_capacity", "committed", "available", "freshness", "admission", "can_accept"],
+      "properties": {
+        "policy_ceiling": { "$ref": "#/$defs/known_units" },
+        "staffed_capacity": { "$ref": "#/$defs/unknown_units" },
+        "committed": { "$ref": "#/$defs/unknown_units" },
+        "available": { "$ref": "#/$defs/unknown_units" },
+        "freshness": { "const": "UNKNOWN" },
+        "admission": { "enum": ["UNKNOWN", "CANNOT_ACCEPT"] },
+        "can_accept": { "const": false }
+      }
+    },
+    "payment_semantics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["proposal_accepted", "PAYMENT_CREATED", "PAYMENT_CONFIRMED", "PAYMENT_RECEIVED"],
+      "properties": {
+        "proposal_accepted": { "const": "NOT_REVENUE" },
+        "PAYMENT_CREATED": { "const": "PROVIDER_OBJECT_CREATED_NOT_PAID_NOT_RECEIVED" },
+        "PAYMENT_CONFIRMED": { "const": "PAID_NOT_RECEIVED" },
+        "PAYMENT_RECEIVED": { "const": "RECEIVED_REVENUE_REQUIRES_PROVIDER_PROOF" }
+      }
+    },
+    "activation_gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["production_checkout_enabled", "real_money_mutation_approved", "provider_objects_proven", "staffed_capacity_published"],
+      "properties": {
+        "production_checkout_enabled": { "const": false },
+        "real_money_mutation_approved": { "const": false },
+        "provider_objects_proven": { "const": false },
+        "staffed_capacity_published": { "const": false }
+      }
+    }
+  },
+  "$defs": {
+    "external_pin": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["repository", "ref", "path", "blob_sha", "source_issue", "authority_state"],
+      "properties": {
+        "repository": { "const": "tjsasakifln/web-cfg" },
+        "ref": { "const": "main" },
+        "path": { "type": "string", "minLength": 1 },
+        "blob_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "source_issue": { "type": "string", "format": "uri" },
+        "authority_state": { "const": "PINNED" }
+      }
+    },
+    "known_units": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "units", "unit", "source_ref"],
+      "properties": {
+        "state": { "const": "KNOWN" },
+        "units": { "type": "integer", "minimum": 0 },
+        "unit": { "const": "delivery_slot" },
+        "source_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "unknown_units": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "units", "unit", "reason"],
+      "properties": {
+        "state": { "const": "UNKNOWN" },
+        "units": { "type": "null" },
+        "unit": { "const": "delivery_slot" },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/schemas/commercial-chain-projection.v1.schema.json
+++ b/schemas/commercial-chain-projection.v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confenge.com.br/schemas/commercial-chain-projection.v1.schema.json",
+  "title": "confenge.commercial_chain_projection.v1",
+  "description": "Read-only commercial-to-delivery chain. It never infers provider objects, revenue, Work Orders, delivery, or readiness from an earlier hop.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "chain_id",
+    "projected_at",
+    "synthetic",
+    "chain_identity",
+    "hops",
+    "payment",
+    "readiness",
+    "exceptions",
+    "mutations_performed"
+  ],
+  "properties": {
+    "schema_version": { "const": "confenge.commercial_chain_projection.v1" },
+    "chain_id": { "type": "string", "pattern": "^chain_[0-9a-f]{32}$" },
+    "projected_at": { "type": "string", "format": "date-time" },
+    "synthetic": { "type": "boolean" },
+    "chain_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlation_id", "deliverable_id", "proposal_id", "acceptance_id", "provider_payment_id", "commercial_state_id", "work_order_id", "delivery_id"],
+      "properties": {
+        "correlation_id": { "type": ["string", "null"] },
+        "deliverable_id": { "type": ["string", "null"] },
+        "proposal_id": { "type": ["string", "null"] },
+        "acceptance_id": { "type": ["string", "null"] },
+        "provider_payment_id": { "type": ["string", "null"] },
+        "commercial_state_id": { "type": ["string", "null"] },
+        "work_order_id": { "type": ["string", "null"] },
+        "delivery_id": { "type": ["string", "null"] }
+      }
+    },
+    "hops": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["offer", "proposal", "acceptance", "financial_gate", "provider", "commercial_state", "work_order", "delivery"],
+      "properties": {
+        "offer": { "$ref": "#/$defs/hop" },
+        "proposal": { "$ref": "#/$defs/hop" },
+        "acceptance": { "$ref": "#/$defs/hop" },
+        "financial_gate": { "$ref": "#/$defs/hop" },
+        "provider": { "$ref": "#/$defs/hop" },
+        "commercial_state": { "$ref": "#/$defs/hop" },
+        "work_order": { "$ref": "#/$defs/hop" },
+        "delivery": { "$ref": "#/$defs/hop" }
+      }
+    },
+    "payment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "provider_proven", "paid", "received_revenue"],
+      "properties": {
+        "state": { "enum": ["UNKNOWN", "PAYMENT_CREATED", "PAYMENT_CONFIRMED", "PAYMENT_RECEIVED"] },
+        "provider_proven": { "type": "boolean" },
+        "paid": { "type": "boolean" },
+        "received_revenue": { "type": "boolean" }
+      }
+    },
+    "readiness": { "enum": ["PROVEN", "NOT_PROVEN", "BLOCKED"] },
+    "exceptions": {
+      "type": "array",
+      "items": { "$ref": "https://confenge.com.br/schemas/operational-exception.v1.schema.json" }
+    },
+    "mutations_performed": { "const": 0 }
+  },
+  "$defs": {
+    "hop": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "evidence_refs"],
+      "properties": {
+        "state": { "enum": ["PROVEN", "SYNTHETIC", "UNKNOWN", "BLOCKED"] },
+        "evidence_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/schemas/operational-exception.v1.schema.json
+++ b/schemas/operational-exception.v1.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confenge.com.br/schemas/operational-exception.v1.schema.json",
+  "title": "confenge.operational_exception.v1",
+  "description": "Read-only exception item. Human review is reserved for an explicit exception, never inserted as a universal toll.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "exception_id",
+    "bucket",
+    "owner",
+    "reason",
+    "evidence",
+    "age_seconds",
+    "next_action",
+    "severity",
+    "source",
+    "freshness"
+  ],
+  "properties": {
+    "schema_version": { "const": "confenge.operational_exception.v1" },
+    "exception_id": { "type": "string", "pattern": "^exc_[0-9a-f]{32}$" },
+    "bucket": {
+      "enum": [
+        "identity_recipient_conflict",
+        "stale_drift",
+        "party_role_conflict",
+        "outbound_reply_handoff",
+        "payment_provider_ambiguity",
+        "capacity_unknown",
+        "delivery_blocker",
+        "runtime_mismatch",
+        "other"
+      ]
+    },
+    "owner": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "reason": { "type": "string", "minLength": 1, "maxLength": 1000 },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 },
+      "uniqueItems": true
+    },
+    "age_seconds": { "type": ["integer", "null"], "minimum": 0 },
+    "next_action": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "severity": { "enum": ["critical", "high", "medium", "low"] },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system", "kind", "locator"],
+      "properties": {
+        "system": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "kind": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "locator": { "type": "string", "minLength": 1, "maxLength": 500 }
+      }
+    },
+    "freshness": { "enum": ["FRESH", "STALE", "UNKNOWN", "ERROR"] }
+  }
+}

--- a/scripts/validate_commercial_authority.py
+++ b/scripts/validate_commercial_authority.py
@@ -106,8 +106,13 @@ MAPPING_ID_FIELDS = ("asaas_product_id", "checkout_id", "subscription_mapping")
 MAPPING_ALLOWED_OFFER_STATUSES = frozenset({"APPROVED", "ACTIVE"})
 VERDICT_READY = "OFFER_CATALOG_AUTHORITY_READY_FOR_ASAAS_REGISTRATION"
 VERDICT_BLOCKED = "OFFER_CATALOG_BLOCKED_ON_NAMED_FOUNDER_FIELDS"
+OVERLAY_V2_VERDICT = "WEB_CFG_CATALOG_PINNED_ASAAS_AND_CAPACITY_BLOCKED"
 COMPATIBILITY_CONTRACT_PATH = "commercial/compatibility/consumer-compatibility.v1.json"
 COMPATIBILITY_FIXTURE_PATH = "commercial/fixtures/consumer-compatibility.ci.v1.json"
+AUTHORITY_OVERLAY_V2_PATH = "commercial/authority/authority-overlay.v2.json"
+AUTHORITY_OVERLAY_V2_SCHEMA_PATH = "schemas/commercial-authority-overlay.v2.schema.json"
+WEB_CFG_DELIVERABLES_BLOB = "99e77f51336e7fe63af0446d7577b3b20fe9a9b0"
+WEB_CFG_NAMING_BLOB = "5f39620c0488625648aa9c3919a9eea3b8ce2004"
 REQUIRED_COMPAT_DRIFTS = (
     "one_off_null_vs_0_1",
     "billing_enum_casing",
@@ -150,7 +155,7 @@ CREATED_PROVIDER_EVENTS = frozenset(
         "payment_created",
     }
 )
-RECEIVED_REVENUE_EVENTS = frozenset({"payment_confirmed", "payment_received"})
+RECEIVED_REVENUE_EVENTS = frozenset({"payment_received", "payment_received_in_cash"})
 MONEY_KEYS = frozenset(
     {
         "amount_cents",
@@ -761,6 +766,95 @@ def assert_capacity_invariants(policy: Mapping[str, Any]) -> None:
     ):
         if revenue.get(key) is not False:
             raise ValidationError(f"{key} must be false")
+
+
+def assert_authority_overlay_v2(
+    overlay: Mapping[str, Any],
+    catalog: Mapping[str, Any],
+    mapping: Mapping[str, Any],
+    legacy_capacity: Mapping[str, Any],
+) -> None:
+    """Validate the additive no-catalog overlay against preserved v1 facts."""
+
+    history = overlay.get("v1_history") or {}
+    if history.get("preserved") is not True:
+        raise ValidationError("authority overlay v2 must preserve v1 history")
+
+    boundary = overlay.get("catalog_boundary") or {}
+    if boundary.get("governance_catalog_role") != "NONE" or boundary.get("no_parallel_catalog") is not True:
+        raise ValidationError("Governance must not claim a parallel public catalog in overlay v2")
+    registry = boundary.get("deliverables_registry") or {}
+    naming = boundary.get("naming_authority") or {}
+    if registry.get("blob_sha") != WEB_CFG_DELIVERABLES_BLOB:
+        raise ValidationError("overlay v2 deliverables registry pin drifted")
+    if registry.get("deliverable_count") != 54 or registry.get("container_count") != 2:
+        raise ValidationError("overlay v2 must pin 54 deliverables and 2 containers")
+    if naming.get("blob_sha") != WEB_CFG_NAMING_BLOB:
+        raise ValidationError("overlay v2 naming authority pin drifted")
+    if (
+        naming.get("effective_at") is not None
+        or naming.get("human_test_state") != "NOT_STARTED"
+        or naming.get("publication_state") != "DECIDED_NOT_PROVEN_EFFECTIVE"
+    ):
+        raise ValidationError("naming decision must not be promoted to proven publication")
+
+    canonical_offer_ids = {item.get("offer_id") for item in catalog.get("offers") or ()}
+    subset = overlay.get("historical_financial_subset") or {}
+    if subset.get("classification") != "HISTORICAL_FINANCIAL_MAPPING_SUBSET":
+        raise ValidationError("four v1 records must be classified as a historical financial subset")
+    if subset.get("complete_public_catalog") is not False:
+        raise ValidationError("historical financial subset must not claim complete catalog authority")
+    if set(subset.get("offer_ids") or ()) != canonical_offer_ids or len(canonical_offer_ids) != 4:
+        raise ValidationError("overlay v2 historical subset must match the four preserved v1 IDs")
+
+    provider = overlay.get("provider_boundary") or {}
+    provider_rows = provider.get("mappings") or []
+    if provider.get("provider_lookup_performed") is not False or provider.get("checkout_gate") != "BLOCKED":
+        raise ValidationError("unproved provider state must keep checkout BLOCKED")
+    if {row.get("offer_id") for row in provider_rows} != canonical_offer_ids:
+        raise ValidationError("overlay v2 provider rows must cover only the historical subset")
+    for row in provider_rows:
+        if row.get("mapping_state") not in {"MISSING", "UNKNOWN", "BLOCKED"}:
+            raise ValidationError("provider mapping state must fail closed")
+        if row.get("provider_object_state") not in {"MISSING", "UNKNOWN", "BLOCKED"}:
+            raise ValidationError("provider object state must fail closed")
+        if row.get("provider_object_id") is not None:
+            raise ValidationError("overlay v2 must not invent or copy an unproved provider object ID")
+    if any(not mapping_ids_pending(row) for row in mapping.get("mappings") or ()):
+        raise ValidationError("checked-in Asaas mapping unexpectedly claims a provider object")
+
+    capacity = overlay.get("capacity_boundary") or {}
+    ceiling = capacity.get("policy_ceiling") or {}
+    legacy_ceiling = (legacy_capacity.get("recurring") or {}).get("global_active_slots")
+    if ceiling.get("units") != legacy_ceiling or ceiling.get("state") != "KNOWN":
+        raise ValidationError("overlay v2 policy ceiling must pin, not reinterpret, v1")
+    for field in ("staffed_capacity", "committed", "available"):
+        fact = capacity.get(field) or {}
+        if fact.get("state") != "UNKNOWN" or fact.get("units") is not None:
+            raise ValidationError(f"{field} must remain UNKNOWN until real evidence is published")
+    if capacity.get("admission") not in {"UNKNOWN", "CANNOT_ACCEPT"} or capacity.get("can_accept") is not False:
+        raise ValidationError("unknown staffed capacity must fail closed for admission")
+    if capacity.get("policy_ceiling") == capacity.get("staffed_capacity"):
+        raise ValidationError("policy ceiling must never be copied into staffed capacity")
+
+    semantics = overlay.get("payment_semantics") or {}
+    if semantics.get("proposal_accepted") != "NOT_REVENUE":
+        raise ValidationError("proposal acceptance must not be revenue")
+    if semantics.get("PAYMENT_CREATED") != "PROVIDER_OBJECT_CREATED_NOT_PAID_NOT_RECEIVED":
+        raise ValidationError("PAYMENT_CREATED semantics drifted")
+    if semantics.get("PAYMENT_CONFIRMED") != "PAID_NOT_RECEIVED":
+        raise ValidationError("PAYMENT_CONFIRMED must not be received revenue")
+    if semantics.get("PAYMENT_RECEIVED") != "RECEIVED_REVENUE_REQUIRES_PROVIDER_PROOF":
+        raise ValidationError("PAYMENT_RECEIVED must require provider proof")
+
+    gates = overlay.get("activation_gates") or {}
+    if any(gates.get(key) is not False for key in (
+        "production_checkout_enabled",
+        "real_money_mutation_approved",
+        "provider_objects_proven",
+        "staffed_capacity_published",
+    )):
+        raise ValidationError("overlay v2 activation gates must remain false")
 
 
 def recurring_checkout_allowed(
@@ -1576,12 +1670,12 @@ def write_derived_artifacts(root: Path) -> None:
 
 
 def is_received_revenue(event_type: str) -> bool:
-    if event_type in CREATED_PROVIDER_EVENTS:
-        return False
     kind = event_type.lower()
+    if kind in CREATED_PROVIDER_EVENTS:
+        return False
     if "partner" in kind or "commission" in kind:
         return False
-    return event_type in RECEIVED_REVENUE_EVENTS
+    return kind in RECEIVED_REVENUE_EVENTS
 
 
 def price_change_requires_new_version(existing: Mapping[str, Any], candidate: Mapping[str, Any]) -> bool:
@@ -1783,6 +1877,7 @@ def validate_package(root: Path | None = None) -> dict[str, Any]:
     mapping_schema = load_json(root / "schemas" / "provider-mapping.v1.schema.json")
     overlay_schema = load_json(root / "schemas" / "diagnostico-limited-production.v1.schema.json")
     compat_schema = load_json(root / "schemas" / "consumer-compatibility.v1.schema.json")
+    authority_overlay_v2_schema = load_json(root / AUTHORITY_OVERLAY_V2_SCHEMA_PATH)
 
     catalog = load_json(root / "commercial" / "offers" / "catalog.v1.json")
     public = load_json(root / "commercial" / "offers" / "catalog.public.v1.json")
@@ -1798,6 +1893,7 @@ def validate_package(root: Path | None = None) -> dict[str, Any]:
     terms_manifest = load_json(root / "commercial" / "terms" / "CFG-TERMS-B2B-2026-08-17-v1.manifest.json")
     terms_text = load_text(root / "commercial" / "terms" / "CFG-TERMS-B2B-2026-08-17-v1.md")
     manifest = load_json(root / "commercial" / "authority" / "authority-manifest.v1.json")
+    authority_overlay_v2 = load_json(root / AUTHORITY_OVERLAY_V2_PATH)
 
     schema_validate(catalog, catalog_schema)
     schema_validate(public, catalog_schema)
@@ -1806,6 +1902,7 @@ def validate_package(root: Path | None = None) -> dict[str, Any]:
     schema_validate(mapping, mapping_schema)
     schema_validate(overlay, overlay_schema)
     schema_validate(compat, compat_schema)
+    schema_validate(authority_overlay_v2, authority_overlay_v2_schema)
 
     assert_catalog_invariants(catalog)
     assert_catalog_invariants(public)
@@ -1816,6 +1913,7 @@ def validate_package(root: Path | None = None) -> dict[str, Any]:
     assert_no_active_while_gates_pending(catalog, gates)
     assert_no_active_while_gates_pending(public, gates)
     assert_capacity_invariants(capacity)
+    assert_authority_overlay_v2(authority_overlay_v2, catalog, mapping, capacity)
     assert_mapping_invariants(mapping, catalog)
     assert_pending_founder_inputs(pending, catalog)
     assert_consumer_fixture(fixture, mapping)
@@ -1834,17 +1932,20 @@ def validate_package(root: Path | None = None) -> dict[str, Any]:
     digest = authority_hash(manifest)
     legal_mod = load_legal_validator(root)
     legal = legal_mod.validate_all_legal_packages(root)
-    verdict = catalog_verdict(catalog, pending)
+    legacy_verdict = catalog_verdict(catalog, pending)
     return {
         "root": str(root),
         "authority_hash": digest,
+        "authority_overlay_v2_hash": content_hash_json(authority_overlay_v2),
         "compatibility_hash": compatibility_hash(compat),
         "legal_package_hash": legal["prior_package_hash"],
         "founder_decided_hash": legal["founder_decided_hash"],
-        "catalog_authority": manifest["catalog_authority"],
+        "catalog_authority_v1_historical": manifest["catalog_authority"],
+        "public_catalog_authority": "web-cfg",
         "offers": [offer["offer_code"] for offer in catalog["offers"]],
         "pending_gates": gates_pending_for_active(gates),
-        "verdict": verdict,
+        "legacy_verdict": legacy_verdict,
+        "verdict": OVERLAY_V2_VERDICT,
         "overlay_diagnostico_authorized": overlay.get("production_checkout_approved") is True,
         "recurring_checkout_approved": False,
         "production_checkout_enabled": False,
@@ -1888,10 +1989,12 @@ def main(argv: Iterable[str] | None = None) -> int:
         print(f"VALIDATION_ERROR {exc}", file=sys.stderr)
         return 1
     print(f"AUTHORITY_HASH {result['authority_hash']}")
+    print(f"AUTHORITY_OVERLAY_V2_HASH {result['authority_overlay_v2_hash']}")
     print(f"COMPATIBILITY_HASH {result['compatibility_hash']}")
     print(f"LEGAL_PACKAGE_HASH {result['legal_package_hash']}")
     print(f"FOUNDER_DECIDED_HASH {result['founder_decided_hash']}")
-    print(f"CATALOG_AUTHORITY {result['catalog_authority']}")
+    print(f"CATALOG_AUTHORITY_V1_HISTORICAL {result['catalog_authority_v1_historical']}")
+    print(f"PUBLIC_CATALOG_AUTHORITY {result['public_catalog_authority']}")
     print("OFFERS " + ",".join(result["offers"]))
     print("PENDING_GATES " + ",".join(result["pending_gates"]))
     print("PRODUCTION_CHECKOUT_ENABLED false")
@@ -1899,6 +2002,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     print("PUBLIC_ACTIVATION_APPROVED false")
     print("RECURRING_PRODUCTION_CHECKOUT_ENABLED false")
     print(f"VERDICT {result['verdict']}")
+    print(f"V1_HISTORICAL_VERDICT {result['legacy_verdict']}")
     return 0
 
 

--- a/tests/test_commercial_authority.py
+++ b/tests/test_commercial_authority.py
@@ -299,7 +299,10 @@ def test_onboarding_cannot_precede_confirmed_payment():
 def test_created_provider_objects_are_not_received_revenue():
     for event in ("customer_created", "checkout_created", "subscription_created", "payment_created"):
         assert v.is_received_revenue(event) is False
-    assert v.is_received_revenue("payment_confirmed") is True
+    assert v.is_received_revenue("payment_confirmed") is False
+    assert v.is_received_revenue("PAYMENT_CONFIRMED") is False
+    assert v.is_received_revenue("payment_received") is True
+    assert v.is_received_revenue("PAYMENT_RECEIVED") is True
     revenue = capacity_doc()["revenue"]
     assert revenue["created_customer_is_received_revenue"] is False
     assert revenue["created_checkout_is_received_revenue"] is False
@@ -378,7 +381,10 @@ def test_validate_package_and_cli_twice(tmp_path, capsys):
     verdict1 = [line for line in out1.splitlines() if line.startswith("VERDICT ")][0]
     verdict2 = [line for line in out2.splitlines() if line.startswith("VERDICT ")][0]
     assert verdict1 == verdict2
-    assert verdict1.split(" ", 1)[1] == v.VERDICT_READY
+    assert verdict1.split(" ", 1)[1] == v.OVERLAY_V2_VERDICT
+    assert "PUBLIC_CATALOG_AUTHORITY web-cfg" in out1
+    assert "CATALOG_AUTHORITY_V1_HISTORICAL APPROVED" in out1
+    assert f"V1_HISTORICAL_VERDICT {v.VERDICT_READY}" in out1
 
 
 def overlay():

--- a/tests/test_commercial_chain_projection.py
+++ b/tests/test_commercial_chain_projection.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from commercial.projection import WEB_CFG_DELIVERABLES_BLOB, project_commercial_chain
+
+
+NOW = "2026-08-26T03:00:00Z"
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def base_facts():
+    return {
+        "correlation_id": "corr-commercial-001",
+        "offer": {
+            "deliverable_id": "CFG-D02",
+            "registry_blob": WEB_CFG_DELIVERABLES_BLOB,
+            "evidence_refs": ["web-cfg:blob:99e77f"],
+        },
+        "proposal": {
+            "proposal_id": "proposal-001",
+            "version": 1,
+            "correlation_id": "corr-commercial-001",
+            "evidence_refs": ["warmbly:proposal:001:v1"],
+        },
+        "acceptance": {
+            "acceptance_id": "acceptance-001",
+            "state": "ACCEPTED",
+            "correlation_id": "corr-commercial-001",
+            "accepted_at": "2026-08-26T02:00:00Z",
+            "evidence_refs": ["web-cfg:acceptance:001"],
+        },
+        "capacity": {"staffed_capacity_state": "UNKNOWN", "evidence_refs": []},
+    }
+
+
+def test_proposal_acceptance_does_not_become_payment_or_revenue():
+    result = project_commercial_chain(base_facts(), projected_at=NOW)
+    assert result["hops"]["acceptance"]["state"] == "PROVEN"
+    assert result["payment"] == {
+        "state": "UNKNOWN",
+        "provider_proven": False,
+        "paid": False,
+        "received_revenue": False,
+    }
+    assert result["mutations_performed"] == 0
+    assert {item["bucket"] for item in result["exceptions"]} == {
+        "payment_provider_ambiguity",
+        "capacity_unknown",
+    }
+
+
+def test_created_confirmed_and_received_are_distinct():
+    expected = {
+        "PAYMENT_CREATED": (False, False),
+        "PAYMENT_CONFIRMED": (True, False),
+        "PAYMENT_RECEIVED": (True, True),
+    }
+    for state, (paid, received) in expected.items():
+        facts = base_facts()
+        facts["capacity"] = {"staffed_capacity_state": "KNOWN", "evidence_refs": ["capacity:real"]}
+        facts["financial_gate"] = {
+            "state": "AUTHORIZED",
+            "synthetic": False,
+            "evidence_refs": ["warmbly:financial-gate:001"],
+        }
+        facts["provider"] = {
+            "payment_id": "pay_opaque001",
+            "provider_event_id": f"evt-{state.lower()}",
+            "event_type": state,
+            "correlation_id": "corr-commercial-001",
+            "occurred_at": "2026-08-26T02:30:00Z",
+            "evidence_refs": [f"asaas:event:{state.lower()}"],
+        }
+        result = project_commercial_chain(facts, projected_at=NOW)
+        assert result["payment"]["state"] == state
+        assert result["payment"]["paid"] is paid
+        assert result["payment"]["received_revenue"] is received
+
+
+def test_missing_provider_stays_unknown_and_synthetic_received_is_not_revenue():
+    missing = project_commercial_chain(base_facts(), projected_at=NOW)
+    assert missing["hops"]["provider"]["state"] == "UNKNOWN"
+    assert missing["payment"]["state"] == "UNKNOWN"
+
+    synthetic = base_facts()
+    synthetic["synthetic"] = True
+    synthetic["financial_gate"] = {
+        "state": "SYNTHETIC_VALID",
+        "synthetic": True,
+        "evidence_refs": ["fixture:financial-gate"],
+    }
+    synthetic["provider"] = {
+        "payment_id": "pay_synthetic",
+        "provider_event_id": "evt-synthetic",
+        "event_type": "PAYMENT_RECEIVED",
+        "synthetic": True,
+        "evidence_refs": ["fixture:payment-received"],
+    }
+    result = project_commercial_chain(synthetic, projected_at=NOW)
+    assert result["hops"]["financial_gate"]["state"] == "SYNTHETIC"
+    assert result["hops"]["provider"]["state"] == "UNKNOWN"
+    assert result["payment"]["received_revenue"] is False
+    assert result["readiness"] == "BLOCKED"
+
+
+def test_runtime_correlation_mismatch_becomes_exception():
+    facts = base_facts()
+    facts["proposal"]["correlation_id"] = "corr-other"
+    result = project_commercial_chain(facts, projected_at=NOW)
+    mismatch = next(item for item in result["exceptions"] if item["bucket"] == "runtime_mismatch")
+    assert mismatch["owner"] == "commercial_ops"
+    assert mismatch["freshness"] == "ERROR"
+    assert mismatch["evidence"] == ["correlation:corr-commercial-001", "correlation:corr-other"]
+
+
+def test_projection_and_every_exception_validate_against_versioned_schemas():
+    result = project_commercial_chain(base_facts(), projected_at=NOW)
+    chain_schema = json.loads((ROOT / "schemas" / "commercial-chain-projection.v1.schema.json").read_text())
+    exception_schema = json.loads((ROOT / "schemas" / "operational-exception.v1.schema.json").read_text())
+    Draft202012Validator.check_schema(chain_schema)
+    Draft202012Validator.check_schema(exception_schema)
+    for exception in result["exceptions"]:
+        Draft202012Validator(exception_schema).validate(exception)
+    locally_resolved = deepcopy(chain_schema)
+    locally_resolved["properties"]["exceptions"]["items"] = exception_schema
+    Draft202012Validator(locally_resolved).validate(result)

--- a/tests/test_commercial_chain_projection.py
+++ b/tests/test_commercial_chain_projection.py
@@ -4,9 +4,8 @@ import json
 from copy import deepcopy
 from pathlib import Path
 
-from jsonschema import Draft202012Validator
-
 from commercial.projection import WEB_CFG_DELIVERABLES_BLOB, project_commercial_chain
+from scripts.validate_commercial_authority import schema_validate
 
 
 NOW = "2026-08-26T03:00:00Z"
@@ -122,10 +121,8 @@ def test_projection_and_every_exception_validate_against_versioned_schemas():
     result = project_commercial_chain(base_facts(), projected_at=NOW)
     chain_schema = json.loads((ROOT / "schemas" / "commercial-chain-projection.v1.schema.json").read_text())
     exception_schema = json.loads((ROOT / "schemas" / "operational-exception.v1.schema.json").read_text())
-    Draft202012Validator.check_schema(chain_schema)
-    Draft202012Validator.check_schema(exception_schema)
     for exception in result["exceptions"]:
-        Draft202012Validator(exception_schema).validate(exception)
+        schema_validate(exception, exception_schema)
     locally_resolved = deepcopy(chain_schema)
     locally_resolved["properties"]["exceptions"]["items"] = exception_schema
-    Draft202012Validator(locally_resolved).validate(result)
+    schema_validate(result, locally_resolved)

--- a/tests/test_delivery_capacity.py
+++ b/tests/test_delivery_capacity.py
@@ -6,8 +6,9 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator
 
-from delivery.capacity import CapacityError, CapacityLedger, evaluate_admission
+from delivery.capacity import CapacityError, CapacityLedger, evaluate_admission, project_capacity_read_only
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -184,6 +185,57 @@ def test_policy_ceiling_50_is_not_a_capacity_input():
     assert snapshot["staffed_capacity_units"] == 1
     assert snapshot["policy_ceiling_used_as_staffed_capacity"] is False
     assert snapshot["real_checkout_enabled"] is False
+
+
+def test_read_only_projection_separates_ceiling_from_unknown_staffed_capacity():
+    projection = project_capacity_read_only(
+        policy_ceiling=50,
+        capacity_snapshot=None,
+        active_work_orders=None,
+        committed_allocations=None,
+        projected_at=EVALUATED_AT,
+    )
+    assert projection["policy_ceiling"] == 50
+    assert projection["staffed_capacity"] is None
+    assert projection["staffed_capacity_state"] == "UNKNOWN"
+    assert projection["committed"] is None
+    assert projection["available"] is None
+    assert projection["freshness"] == "UNKNOWN"
+    assert projection["admission"] == "UNKNOWN"
+    assert projection["can_accept"] is False
+    assert projection["checkout_enabled"] is False
+
+
+def test_synthetic_capacity_projection_never_becomes_real_readiness():
+    projection = project_capacity_read_only(
+        policy_ceiling=50,
+        capacity_snapshot=load("capacity-synthetic-one.v1.json"),
+        active_work_orders=[],
+        committed_allocations=0,
+        projected_at=EVALUATED_AT,
+        admission_decision="CAN_ACCEPT",
+    )
+    assert projection["staffed_capacity"] == 1
+    assert projection["committed"] == 0
+    assert projection["available"] == 1
+    assert projection["evidence_class"] == "SYNTHETIC"
+    assert projection["admission"] == "UNKNOWN"
+    assert projection["can_accept"] is False
+    assert projection["checkout_enabled"] is False
+    assert projection["reason_codes"] == ["SYNTHETIC_CAPACITY_NOT_REAL_READINESS"]
+
+
+def test_read_only_capacity_projection_validates_against_versioned_schema():
+    schema = json.loads((ROOT / "schemas" / "capacity-projection.v1.schema.json").read_text())
+    Draft202012Validator.check_schema(schema)
+    projection = project_capacity_read_only(
+        policy_ceiling=50,
+        capacity_snapshot=None,
+        active_work_orders=None,
+        committed_allocations=None,
+        projected_at=EVALUATED_AT,
+    )
+    Draft202012Validator(schema).validate(projection)
 
 
 def test_expiry_reconciliation_and_idempotency_payloads_fail_closed(tmp_path: Path):

--- a/tests/test_delivery_capacity.py
+++ b/tests/test_delivery_capacity.py
@@ -6,9 +6,9 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft202012Validator
 
 from delivery.capacity import CapacityError, CapacityLedger, evaluate_admission, project_capacity_read_only
+from scripts.validate_commercial_authority import schema_validate
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -227,7 +227,6 @@ def test_synthetic_capacity_projection_never_becomes_real_readiness():
 
 def test_read_only_capacity_projection_validates_against_versioned_schema():
     schema = json.loads((ROOT / "schemas" / "capacity-projection.v1.schema.json").read_text())
-    Draft202012Validator.check_schema(schema)
     projection = project_capacity_read_only(
         policy_ceiling=50,
         capacity_snapshot=None,
@@ -235,7 +234,7 @@ def test_read_only_capacity_projection_validates_against_versioned_schema():
         committed_allocations=None,
         projected_at=EVALUATED_AT,
     )
-    Draft202012Validator(schema).validate(projection)
+    schema_validate(projection, schema)
 
 
 def test_expiry_reconciliation_and_idempotency_payloads_fail_closed(tmp_path: Path):


### PR DESCRIPTION
## Resultado

- adiciona authority overlay v2 sem catálogo paralelo, pinando o registry web-cfg de 54 entregáveis + 2 contêineres e a naming authority por blob;
- separa policy ceiling, staffed capacity, committed, available e freshness; ausência de snapshot real mantém admission/checkout fail-closed;
- projeta a cadeia oferta → proposta → aceite → financial gate → Asaas → estado comercial → Work Order → delivery sem promover hops ausentes;
- distingue PAYMENT_CREATED, PAYMENT_CONFIRMED e PAYMENT_RECEIVED;
- coloca na primeira viewport os cinco blocos de verdade operacional e no máximo uma ação humana primária;
- formaliza a exception queue com owner, reason, evidence, age, next action, severity, source e freshness;
- registra a auditoria contemporânea e a classificação de #1, #109, #120, #123 e #126–#129.

## Segurança

Zero mutação Warmbly, envio, pause/resume, requeue/reschedule, refresh de feed, chamada Asaas, habilitação de checkout ou mutação de dinheiro real. Todas as projeções novas são puras/read-only; fixtures sintéticas nunca viram readiness.

## Verificação local

- 204 testes Python de authority/policy/delivery/commercial
- Control Center typecheck completo
- Control Center testes completos
- 70 integration tests
- E2E completo com build e performance gate
- diff PII/secrets scan
- git diff --check

O Playwright visual usou o fallback documentado do runner porque a imagem local não possui libnspr4.so; todos os demais gates E2E passaram. O budget gzip foi rebaselined de forma limitada para 123500 bytes (medido: 123226) para acomodar a viewport e a projeção completas.

Relaciona #1, #120, #123, #126, #127, #128 e #129. #109 será encerrada como superseded após o merge; nenhum blocker humano/externo será encerrado.