### PR TITLE
feat(control-center): versionar o rollout e parar de esquecer o collector

### DIFF
--- a/control-center/deploy/overlays/production-edge/deploy-release.sh
+++ b/control-center/deploy/overlays/production-edge/deploy-release.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Roll the Control Center production edge onto an exact repository SHA.
+#
+# This replaces an unversioned host script that rebuilt only context, mcp and
+# web. The collector is built from the same repository and its image tag carries
+# the release SHA too, so leaving it out meant a merged connector change (the
+# Warmbly payload contract lives in connectors/warmbly) stayed unshipped while
+# every health check reported green — and `verify-release.sh collector` would
+# have failed if anyone had thought to run it.
+#
+# Every service whose image tag interpolates CC_RELEASE_SHA must be rebuilt, or
+# compose looks for a tag that was never produced.
+#
+# Usage: deploy-release.sh [sha]     (default: current origin/main)
+set -euo pipefail
+
+REPO_ROOT="${CC_REPO_ROOT:-/opt/confenge-control-center}"
+SECRET_ENV="${CC_SECRET_ENV:-/etc/confenge/control-center/secrets/.env}"
+
+# Services whose image tag carries the release SHA. Keep in step with
+# docker-compose.production-edge.yml; verify-release.sh checks the same set.
+RELEASE_SERVICES=(context mcp collector web)
+# Started alongside them but not release-stamped.
+EDGE_SERVICES=(caddy)
+
+cd "$REPO_ROOT"
+git fetch --quiet origin
+TARGET_SHA="${1:-$(git rev-parse origin/main)}"
+[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "DEPLOY_ERROR: full 40-character SHA required" >&2; exit 1; }
+git checkout --quiet -B main "$TARGET_SHA"
+
+# Provenance is only meaningful from a clean checkout. Untracked editor and
+# backup leftovers are enough to make the attestation unprovable, so surface
+# them here instead of at the end, after the images are already built.
+if [ -n "$(git status --porcelain=v1 --untracked-files=all)" ]; then
+  echo "DEPLOY_ERROR: checkout is not clean; image provenance would be unprovable:" >&2
+  git status --porcelain=v1 --untracked-files=all >&2
+  exit 1
+fi
+
+export CC_RELEASE_SHA="$TARGET_SHA"
+echo "== deploying Control Center $CC_RELEASE_SHA =="
+
+cd control-center/deploy/overlays/production-edge
+set -a; . "$SECRET_ENV"; set +a
+export CC_SECRET_DIR="$(dirname "$SECRET_ENV")"
+
+COMPOSE="docker compose -f docker-compose.production-edge.yml -f docker-compose.warmbly-human-gate.override.yml"
+echo "== building ${RELEASE_SERVICES[*]} =="
+$COMPOSE build "${RELEASE_SERVICES[@]}"
+echo "== up =="
+$COMPOSE up -d "${RELEASE_SERVICES[@]}" "${EDGE_SERVICES[@]}"
+
+echo "== provenance =="
+cd "$REPO_ROOT"
+./control-center/deploy/overlays/production-edge/verify-release.sh "$CC_RELEASE_SHA" "${RELEASE_SERVICES[@]}"
+
+echo "== health =="
+curl -sS -H 'Host: ops.confenge.com.br' -o /dev/null -w 'internal:%{http_code}\n' http://127.0.0.1:18080/healthz
+curl -sS -o /dev/null -w 'public:%{http_code} -> %{redirect_url}\n' https://ops.confenge.com.br/
+curl -sS -o /dev/null -w 'authelia:%{http_code}\n' https://auth.ops.confenge.com.br/

--- a/control-center/tests/convergence/deploy-release.test.ts
+++ b/control-center/tests/convergence/deploy-release.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const OVERLAY = join(import.meta.dirname, "..", "..", "deploy", "overlays", "production-edge");
+const COMPOSE = readFileSync(join(OVERLAY, "docker-compose.production-edge.yml"), "utf8");
+const DEPLOY = readFileSync(join(OVERLAY, "deploy-release.sh"), "utf8");
+
+/** Services whose image tag interpolates the release SHA, read from compose itself. */
+function releaseStampedServices(): string[] {
+  const names = new Set<string>();
+  for (const line of COMPOSE.split("\n")) {
+    const match = /^\s*image:\s*confenge-control-center-([a-z0-9-]+):\$\{CC_RELEASE_SHA/.exec(line);
+    if (match) names.add(match[1]);
+  }
+  return [...names].sort();
+}
+
+function declaredReleaseServices(): string[] {
+  const match = /RELEASE_SERVICES=\(([^)]*)\)/.exec(DEPLOY);
+  assert.ok(match, "deploy-release.sh must declare RELEASE_SERVICES");
+  return match[1].trim().split(/\s+/).filter(Boolean).sort();
+}
+
+test("every release-stamped service is rebuilt by the rollout", () => {
+  // The previous, unversioned host script rebuilt context, mcp and web only.
+  // The collector is built from this same repository and carries the release SHA
+  // in its tag, so a merged connectors/warmbly change stayed unshipped while
+  // every health check reported green.
+  assert.deepEqual(declaredReleaseServices(), releaseStampedServices());
+});
+
+test("the collector is not forgotten", () => {
+  assert.ok(releaseStampedServices().includes("collector"));
+  assert.ok(declaredReleaseServices().includes("collector"));
+});
+
+test("provenance is checked for every rebuilt service, not a subset", () => {
+  assert.match(DEPLOY, /verify-release\.sh "\$CC_RELEASE_SHA" "\$\{RELEASE_SERVICES\[@\]\}"/);
+});
+
+test("a dirty checkout is refused before anything is built", () => {
+  const dirtyGuard = DEPLOY.indexOf("git status --porcelain");
+  const firstBuild = DEPLOY.indexOf("$COMPOSE build");
+  assert.ok(dirtyGuard > 0, "the rollout must inspect the checkout");
+  assert.ok(dirtyGuard < firstBuild, "the dirty-checkout guard must run before the build");
+});
+
+test("the rollout pins an exact commit and never a floating branch", () => {
+  assert.match(DEPLOY, /\[\[ "\$TARGET_SHA" =~ \^\[0-9a-f\]\{40\}\$ \]\]/);
+  assert.match(DEPLOY, /git checkout --quiet -B main "\$TARGET_SHA"/);
+});


### PR DESCRIPTION
O deploy do edge de produção era um script **não versionado no host** (`/root/deploy-cc.sh`) que reconstruía `context`, `mcp` e `web`.

O `collector` é construído deste mesmo repositório (`connectors/runner/Dockerfile`) e sua tag também interpola `CC_RELEASE_SHA`. Ficava de fora.

Estado real em produção depois do merge de #155:

```
confenge-control-center-web:984e3af2…        Up (healthy)
confenge-control-center-mcp:984e3af2…        Up (healthy)
confenge-control-center-context:984e3af2…    Up (healthy)
confenge-control-center-collector:914270e4…  Up (healthy)   ← três releases atrás
```

`control-center/connectors/warmbly/src/contracts/warmbly-payload.ts` — alterado em #155 — roda no collector. A mudança estava mergeada, deployada segundo todo health check, e não embarcada.

`deploy-release.sh`:
- cobre **todos** os serviços cujo tag interpola `CC_RELEASE_SHA`, lidos do compose;
- recusa checkout sujo **antes** de construir (a atestação não vale nada depois — foi o que aconteceu: quatro `.bak`/`.orig` esquecidos derrubaram o `verify-release.sh` no fim de um deploy já concluído);
- fixa commit exato, nunca branch flutuante;
- verifica procedência do conjunto inteiro.

`tests/convergence/deploy-release.test.ts` lê o compose e falha se os dois conjuntos divergirem, para o collector não sumir de novo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)