### PR TITLE
fix(control-center): converge complete production releases

### DIFF
--- a/control-center/deploy/PRODUCTION-RUNBOOK.md
+++ b/control-center/deploy/PRODUCTION-RUNBOOK.md
@@ -29,7 +29,9 @@ Caddy never binds host `:80`/`:443` and never issues public ACME.
 - Compose project: `confenge-control-center`
 - Canonical overlay: `control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml`
 - Caddyfile: `overlays/production-edge/Caddyfile` (must contain `forward_auth`; the open `deploy/Caddyfile` is not this pack)
-- Optional read-only collector join: `docker-compose.warmbly-collector.override.yml`
+- Required read-only collector join for release apply: `docker-compose.warmbly-collector.override.yml`
+- Required host collector environment overlay: `/etc/confenge/control-center/docker-compose.collector-env.yml`
+- Canonical release compose wrapper: `overlays/production-edge/release-compose.sh`
 - Warmbly human-gate and draft-review join: `docker-compose.warmbly-human-gate.override.yml`
 - Nginx vhost templates: `control-center/deploy/nginx/`
 - Secrets contract: `control-center/security/production/secrets/manifest.json` + `generate-local.sh`
@@ -136,39 +138,33 @@ Do not create a browser token or expose the credential to `web`.
 
 ## Deploy (production-edge)
 
-Before every release, record the current Git SHA and image IDs for `context`,
-`web` and `mcp`; those are the rollback point. Then fast-forward the certified
-release at `/opt/confenge-control-center`. The Warmbly connector is compiled
-inside the Context image, so every connector change must rebuild `context`.
+Run the repository-wide mandatory checks on a clean branch rebased onto the
+contemporary `origin/main`. Merge only after they pass. Fetch `origin/main`
+again and pass that exact full SHA to the versioned release script; never pass a
+branch, tag, abbreviation, or historical SHA.
 
 ```bash
-git -C /opt/confenge-control-center pull --ff-only
-cd /opt/confenge-control-center/control-center/deploy/overlays/production-edge
-set -a
-source /etc/confenge/control-center/secrets/.env
-set +a
-export CC_SECRET_DIR=/etc/confenge/control-center/secrets
-export CC_RELEASE_SHA=<certified-git-sha>
+git -C /opt/confenge-control-center fetch --all --prune
+CERTIFIED_SHA="$(git -C /opt/confenge-control-center rev-parse --verify origin/main)"
+/opt/confenge-control-center/control-center/deploy/overlays/production-edge/deploy-release.sh \
+  "$CERTIFIED_SHA"
+```
 
-# Build and replace both artifacts touched by the release. The connector travels
-# in Context; updating only web leaves the old server contract in production.
-docker compose -p confenge-control-center \
-  -f docker-compose.production-edge.yml \
-  -f docker-compose.warmbly-human-gate.override.yml \
-  build context web
-docker compose -p confenge-control-center \
-  -f docker-compose.production-edge.yml \
-  -f docker-compose.warmbly-human-gate.override.yml \
-  up -d context web
+`deploy-release.sh` refuses a dirty checkout before any build, refuses a SHA
+different from the just-fetched `origin/main`, derives the release set from the
+complete rendered compose, includes both collector overlays, builds the whole
+set, waits for compose health, and then verifies repository/image/runtime SHA.
+It writes a rollback-point receipt before mutation and a sanitized final or
+partial-failure receipt under
+`/opt/confenge-control-center-release-evidence/` (mode `0600`). A green HTTP
+probe with any SHA, runtime, topology, or health divergence is a failed release.
 
-# Mandatory identity gate: proves baseline ancestry and reconciles repository
-# SHA -> image label/ID -> container env -> each live HTTP response. Save this
-# output beside the release record; health alone is not release evidence.
-export CC_RELEASE_EVIDENCE_DIR=/opt/confenge-control-center-release-evidence
-mkdir -p "$CC_RELEASE_EVIDENCE_DIR"
-set -o pipefail
-./verify-release.sh "$CC_RELEASE_SHA" context web | tee \
-  "$CC_RELEASE_EVIDENCE_DIR/release-attestation-${CC_RELEASE_SHA}.log"
+Direct readback uses the same full compose topology and never accepts a service
+subset:
+
+```bash
+cd /opt/confenge-control-center
+./control-center/deploy/overlays/production-edge/verify-release.sh "$CERTIFIED_SHA"
 ```
 
 For a first installation only, use the full bootstrap sequence instead of the
@@ -181,13 +177,9 @@ docker compose -f docker-compose.production-edge.yml up -d postgres redis nats
 # 2. migrations (schema control_center): 001_init, 002_current_state, 003_durable_operational_data_plane, 004_operator_actions
 # 3. Authelia (own DB/role, Redis sessions, default deny, operators require 2FA)
 docker compose -f docker-compose.production-edge.yml up -d authelia
-# 4. context, MCP, collector, web, Caddy
-docker compose \
-  -f docker-compose.production-edge.yml \
-  -f docker-compose.warmbly-human-gate.override.yml \
-  up -d context mcp collector web caddy
-# optional additional -f docker-compose.warmbly-collector.override.yml only for
-# the collector's existing read-only observations.
+# 4. context, MCP, collector, web, Caddy. The host collector environment
+# overlay must exist before this command.
+./release-compose.sh up -d --wait context mcp collector web caddy
 ```
 
 After Caddy is up, `ss -lntp` must show nginx on `:80`/`:443` and Caddy on `127.0.0.1:18080` only.

--- a/control-center/deploy/overlays/production-edge/README.md
+++ b/control-center/deploy/overlays/production-edge/README.md
@@ -5,9 +5,18 @@ Canonical compose: `docker-compose.production-edge.yml`.
 - Caddy publishes `127.0.0.1:18080` and optional `127.0.0.1:18443` only.
 - Redis 7, Authelia, unpublished Postgres (`control_center` + `authelia` roles).
 - Datastores on `cc_internal` (`internal: true`). Edge traffic on `cc_edge`.
-- Collector has no datastore/volume access. Its read-only Warmbly network is opt-in via `docker-compose.warmbly-collector.override.yml`.
+- Collector has no datastore/volume access. Production release apply always
+  includes its read-only Warmbly network via
+  `docker-compose.warmbly-collector.override.yml` and requires the host-owned
+  `/etc/confenge/control-center/docker-compose.collector-env.yml`. The wrapper
+  `release-compose.sh` is the single compose entrypoint for release apply and
+  verification, so a recreate cannot silently drop either overlay.
 - The human gate uses the separately reviewed `docker-compose.warmbly-human-gate.override.yml`: only `context` joins Warmbly's application network and receives a file-backed, permission-mask `196` credential. It exposes no send route.
 
 Canonical production apply is `control-center/deploy/PRODUCTION-RUNBOOK.md`. Compose project `confenge-control-center` **is** the production project.
+
+`deploy-release.sh <full-origin-main-sha>` derives every release-stamped service
+from normalized compose, builds and waits for the complete set, verifies the
+same set, and writes mode-0600 rollback/final receipts outside the checkout.
 
 Isolated rehearsal (does not use the production project name): `rehearse-isolated.sh` (`--project-name cc-edge-rehearsal`, host ports 28080/28443).

--- a/control-center/deploy/overlays/production-edge/deploy-release.sh
+++ b/control-center/deploy/overlays/production-edge/deploy-release.sh
@@ -1,61 +1,171 @@
 #!/usr/bin/env bash
-# Roll the Control Center production edge onto an exact repository SHA.
-#
-# This replaces an unversioned host script that rebuilt only context, mcp and
-# web. The collector is built from the same repository and its image tag carries
-# the release SHA too, so leaving it out meant a merged connector change (the
-# Warmbly payload contract lives in connectors/warmbly) stayed unshipped while
-# every health check reported green — and `verify-release.sh collector` would
-# have failed if anyone had thought to run it.
-#
-# Every service whose image tag interpolates CC_RELEASE_SHA must be rebuilt, or
-# compose looks for a tag that was never produced.
-#
-# Usage: deploy-release.sh [sha]     (default: current origin/main)
+# Converge the complete Control Center production release onto an exact main SHA.
+# Usage: deploy-release.sh <full-origin-main-sha>
 set -euo pipefail
 
 REPO_ROOT="${CC_REPO_ROOT:-/opt/confenge-control-center}"
 SECRET_ENV="${CC_SECRET_ENV:-/etc/confenge/control-center/secrets/.env}"
+EVIDENCE_DIR="${CC_RELEASE_EVIDENCE_DIR:-/opt/confenge-control-center-release-evidence}"
+LOCK_FILE="${CC_RELEASE_LOCK_FILE:-/run/lock/confenge-control-center-release.lock}"
+SCRIPT_RELATIVE="control-center/deploy/overlays/production-edge"
+TARGET_SHA="${1:-}"
 
-# Services whose image tag carries the release SHA. Keep in step with
-# docker-compose.production-edge.yml; verify-release.sh checks the same set.
-RELEASE_SERVICES=(context mcp collector web)
-# Started alongside them but not release-stamped.
-EDGE_SERVICES=(caddy)
+if [ "$#" -ne 1 ] || [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "DEPLOY_ERROR: pass exactly one full lowercase 40-character origin/main SHA" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$LOCK_FILE")"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  echo "DEPLOY_ERROR: another Control Center release is already running" >&2
+  exit 1
+fi
 
 cd "$REPO_ROOT"
-git fetch --quiet origin
-TARGET_SHA="${1:-$(git rev-parse origin/main)}"
-[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "DEPLOY_ERROR: full 40-character SHA required" >&2; exit 1; }
-git checkout --quiet -B main "$TARGET_SHA"
 
-# Provenance is only meaningful from a clean checkout. Untracked editor and
-# backup leftovers are enough to make the attestation unprovable, so surface
-# them here instead of at the end, after the images are already built.
+# Refuse dirty source before checkout or any Docker build. Fetching remote refs
+# is safe, but changing the checkout before this gate would obscure provenance.
 if [ -n "$(git status --porcelain=v1 --untracked-files=all)" ]; then
-  echo "DEPLOY_ERROR: checkout is not clean; image provenance would be unprovable:" >&2
+  echo "DEPLOY_ERROR: checkout is not clean; no image was built" >&2
   git status --porcelain=v1 --untracked-files=all >&2
   exit 1
 fi
 
+git fetch --all --prune --quiet
+MAIN_SHA="$(git rev-parse --verify origin/main)"
+if [ "$TARGET_SHA" != "$MAIN_SHA" ]; then
+  echo "DEPLOY_ERROR: requested SHA is not contemporary origin/main ($MAIN_SHA)" >&2
+  echo "DEPLOY_ERROR: rollback uses the recorded image IDs; it is not a release deploy" >&2
+  exit 1
+fi
+if ! git cat-file -e "${TARGET_SHA}^{commit}" 2>/dev/null; then
+  echo "DEPLOY_ERROR: requested SHA is not a repository commit" >&2
+  exit 1
+fi
+
+git checkout --quiet --detach "$TARGET_SHA"
+if [ "$(git rev-parse HEAD)" != "$TARGET_SHA" ]; then
+  echo "DEPLOY_ERROR: checkout did not terminate at the requested SHA" >&2
+  exit 1
+fi
+if [ -n "$(git status --porcelain=v1 --untracked-files=all)" ]; then
+  echo "DEPLOY_ERROR: checkout became dirty; no image was built" >&2
+  exit 1
+fi
+
+if [ ! -r "$SECRET_ENV" ]; then
+  echo "DEPLOY_ERROR: secret environment file is not readable" >&2
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1090
+. "$SECRET_ENV"
+set +a
+# A secret file must never be able to replace the certified release identity.
 export CC_RELEASE_SHA="$TARGET_SHA"
-echo "== deploying Control Center $CC_RELEASE_SHA =="
+CC_SECRET_DIR="$(dirname "$SECRET_ENV")"
+export CC_SECRET_DIR
+unset COMPOSE_FILE COMPOSE_PROJECT_NAME
 
-cd control-center/deploy/overlays/production-edge
-set -a; . "$SECRET_ENV"; set +a
-export CC_SECRET_DIR="$(dirname "$SECRET_ENV")"
+OVERLAY_DIR="$REPO_ROOT/$SCRIPT_RELATIVE"
+COMPOSE="$OVERLAY_DIR/release-compose.sh"
+SERVICE_PARSER="$OVERLAY_DIR/release-services.py"
 
-COMPOSE="docker compose -f docker-compose.production-edge.yml -f docker-compose.warmbly-human-gate.override.yml"
-echo "== building ${RELEASE_SERVICES[*]} =="
+if ! TEMPLATE_SERVICES="$($COMPOSE config --no-interpolate --format json | python3 "$SERVICE_PARSER")"; then
+  echo "DEPLOY_ERROR: release service set could not be derived from compose" >&2
+  exit 1
+fi
+if ! RENDERED_SERVICES="$($COMPOSE config --format json | python3 "$SERVICE_PARSER" --expected "$TARGET_SHA")"; then
+  echo "DEPLOY_ERROR: rendered compose release identity is inconsistent" >&2
+  exit 1
+fi
+if [ "$TEMPLATE_SERVICES" != "$RENDERED_SERVICES" ]; then
+  echo "DEPLOY_ERROR: template and rendered release service sets differ" >&2
+  exit 1
+fi
+mapfile -t RELEASE_SERVICES <<<"$RENDERED_SERVICES"
+
+umask 077
+mkdir -p "$EVIDENCE_DIR"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+ROLLBACK_RECEIPT="$EVIDENCE_DIR/rollback-point-${STAMP}-to-${TARGET_SHA}.log"
+FINAL_RECEIPT="$EVIDENCE_DIR/release-receipt-${STAMP}-${TARGET_SHA}.log"
+FAILURE_RECEIPT="$EVIDENCE_DIR/release-failure-${STAMP}-${TARGET_SHA}.log"
+DEPLOY_STARTED=false
+
+capture_state() {
+  local phase="$1" output="$2" service container image_id
+  {
+    echo "schema_version=control-center.release-state.v1"
+    echo "phase=$phase"
+    echo "captured_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "target_sha=$TARGET_SHA"
+    for service in "${RELEASE_SERVICES[@]}"; do
+      container="$($COMPOSE ps -a -q "$service" 2>/dev/null | head -1)"
+      if [ -z "$container" ]; then
+        echo "service=$service container=missing"
+        continue
+      fi
+      image_id="$(docker inspect "$container" --format '{{.Image}}')"
+      printf 'service=%s running=%s health=%s image_ref=%s image_id=%s revision=%s release_env=%s\n' \
+        "$service" \
+        "$(docker inspect "$container" --format '{{.State.Running}}')" \
+        "$(docker inspect "$container" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}')" \
+        "$(docker inspect "$container" --format '{{.Config.Image}}')" \
+        "$image_id" \
+        "$(docker inspect "$image_id" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || true)" \
+        "$(docker inspect "$container" --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^CC_RELEASE_SHA=//p' | head -1)"
+    done
+  } >"$output"
+}
+
+on_exit() {
+  local status=$?
+  if [ "$status" -ne 0 ] && [ "$DEPLOY_STARTED" = true ]; then
+    set +e
+    capture_state failed "$FAILURE_RECEIPT"
+    echo "DEPLOY_ERROR: partial-state receipt written to $FAILURE_RECEIPT" >&2
+  fi
+  exit "$status"
+}
+trap on_exit EXIT
+
+capture_state rollback_point "$ROLLBACK_RECEIPT"
+echo "== rollback receipt: $ROLLBACK_RECEIPT =="
+echo "== deploying Control Center $TARGET_SHA =="
+echo "== compose-derived release services: ${RELEASE_SERVICES[*]} =="
+
+DEPLOY_STARTED=true
 $COMPOSE build "${RELEASE_SERVICES[@]}"
-echo "== up =="
-$COMPOSE up -d "${RELEASE_SERVICES[@]}" "${EDGE_SERVICES[@]}"
+$COMPOSE up -d --wait --wait-timeout "${CC_RELEASE_WAIT_TIMEOUT:-240}" \
+  "${RELEASE_SERVICES[@]}" caddy
 
-echo "== provenance =="
-cd "$REPO_ROOT"
-./control-center/deploy/overlays/production-edge/verify-release.sh "$CC_RELEASE_SHA" "${RELEASE_SERVICES[@]}"
+assert_http_status() {
+  local expected="$1" label="$2"
+  shift 2
+  local actual
+  actual="$(curl --silent --show-error --max-time 15 -o /dev/null -w '%{http_code}' "$@")"
+  if [ "$actual" != "$expected" ]; then
+    echo "HEALTH_ERROR: $label expected HTTP $expected, got $actual" >&2
+    return 1
+  fi
+  echo "$label=$actual"
+}
 
-echo "== health =="
-curl -sS -H 'Host: ops.confenge.com.br' -o /dev/null -w 'internal:%{http_code}\n' http://127.0.0.1:18080/healthz
-curl -sS -o /dev/null -w 'public:%{http_code} -> %{redirect_url}\n' https://ops.confenge.com.br/
-curl -sS -o /dev/null -w 'authelia:%{http_code}\n' https://auth.ops.confenge.com.br/
+{
+  echo "schema_version=control-center.release-receipt.v1"
+  echo "deployed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "release_sha=$TARGET_SHA"
+  echo "services=${RELEASE_SERVICES[*]}"
+  cd "$REPO_ROOT"
+  "$OVERLAY_DIR/verify-release.sh" "$TARGET_SHA"
+  assert_http_status 200 loopback_health -H 'Host: ops.confenge.com.br' http://127.0.0.1:18080/healthz
+  assert_http_status 302 public_ops https://ops.confenge.com.br/
+  assert_http_status 200 public_auth https://auth.ops.confenge.com.br/
+} | tee "$FINAL_RECEIPT"
+
+DEPLOY_STARTED=false
+trap - EXIT
+echo "GO:CONTROL_CENTER_RELEASE_CONVERGED"
+echo "receipt=$FINAL_RECEIPT"

--- a/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
+++ b/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
@@ -256,6 +256,7 @@ services:
         br.com.confenge.service: "mcp"
     image: confenge-control-center-mcp:${CC_RELEASE_SHA:-local}
     environment:
+      CC_RELEASE_SHA: "${CC_RELEASE_SHA:-local}"
       HOST: 0.0.0.0
       CONFENGE_MCP_HTTP_HOST: 0.0.0.0
       CONFENGE_MCP_HTTP_PORT: "8080"
@@ -294,6 +295,7 @@ services:
         br.com.confenge.service: "collector"
     image: confenge-control-center-collector:${CC_RELEASE_SHA:-local}
     environment:
+      CC_RELEASE_SHA: "${CC_RELEASE_SHA:-local}"
       HOST: 0.0.0.0
       PORT: "8080"
       NODE_ENV: production

--- a/control-center/deploy/overlays/production-edge/release-compose.sh
+++ b/control-center/deploy/overlays/production-edge/release-compose.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Execute Docker Compose with the complete Control Center production topology.
+# The collector environment overlay is host-owned because it references a
+# read-only credential. Its contents must never be copied into the repository.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+COLLECTOR_ENV_COMPOSE="${CC_COLLECTOR_ENV_COMPOSE:-/etc/confenge/control-center/docker-compose.collector-env.yml}"
+WEB_ACTOR_COMPOSE="${CC_WEB_ACTOR_COMPOSE:-/etc/confenge/control-center/docker-compose.web-actor.yml}"
+
+if [ ! -r "$COLLECTOR_ENV_COMPOSE" ]; then
+  echo "COMPOSE_ERROR: required collector environment overlay is not readable: $COLLECTOR_ENV_COMPOSE" >&2
+  exit 1
+fi
+
+COMPOSE=(
+  docker compose
+  --project-name "${CC_COMPOSE_PROJECT:-confenge-control-center}"
+  -f "$SCRIPT_DIR/docker-compose.production-edge.yml"
+  -f "$SCRIPT_DIR/docker-compose.warmbly-collector.override.yml"
+  -f "$SCRIPT_DIR/docker-compose.warmbly-human-gate.override.yml"
+  -f "$COLLECTOR_ENV_COMPOSE"
+)
+
+# Preserve the existing host-only actor overlay when present. Current compose
+# declares the same values, but silently dropping a live overlay during a
+# recreate would make rollback evidence incomplete.
+if [ -r "$WEB_ACTOR_COMPOSE" ]; then
+  COMPOSE+=(-f "$WEB_ACTOR_COMPOSE")
+fi
+
+exec "${COMPOSE[@]}" "$@"

--- a/control-center/deploy/overlays/production-edge/release-services.py
+++ b/control-center/deploy/overlays/production-edge/release-services.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Derive and validate release-stamped services from normalized Compose JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import Any
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+TEMPLATE = "${CC_RELEASE_SHA:-local}"
+
+
+def fail(message: str) -> None:
+    print(f"RELEASE_SERVICES_ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def environment_value(environment: Any, key: str) -> Any:
+    if isinstance(environment, dict):
+        return environment.get(key)
+    if isinstance(environment, list):
+        prefix = f"{key}="
+        for item in environment:
+            if isinstance(item, str) and item.startswith(prefix):
+                return item[len(prefix) :]
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected")
+    parser.add_argument("--format", choices=("names", "tsv"), default="names")
+    args = parser.parse_args()
+
+    if args.expected is not None and not SHA_RE.fullmatch(args.expected):
+        fail("--expected must be a full lowercase 40-character SHA")
+
+    try:
+        document: dict[str, Any] = json.load(sys.stdin)
+    except (json.JSONDecodeError, TypeError) as error:
+        fail(f"compose config is not valid JSON: {error}")
+
+    expected = args.expected or TEMPLATE
+    services = document.get("services")
+    if not isinstance(services, dict):
+        fail("compose config has no services object")
+
+    release_services: list[tuple[str, str]] = []
+    for name, service in services.items():
+        if not isinstance(service, dict):
+            continue
+        image = service.get("image")
+        if not isinstance(image, str) or not image.endswith(f":{expected}"):
+            continue
+
+        build = service.get("build")
+        labels = build.get("labels") if isinstance(build, dict) else None
+        environment = service.get("environment")
+        if not isinstance(labels, dict):
+            fail(f"{name} is release-stamped but has no build labels")
+        if labels.get("org.opencontainers.image.revision") != expected:
+            fail(f"{name} revision label does not match its release image tag")
+        if labels.get("org.opencontainers.image.version") != expected:
+            fail(f"{name} version label does not match its release image tag")
+        if environment_value(environment, "CC_RELEASE_SHA") != expected:
+            fail(f"{name} does not receive the same CC_RELEASE_SHA at runtime")
+        release_services.append((str(name), image))
+
+    if not release_services:
+        fail("compose config contains no release-stamped services")
+
+    for name, image in sorted(release_services):
+        if args.format == "tsv":
+            print(f"{name}\t{image}")
+        else:
+            print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/control-center/deploy/overlays/production-edge/verify-release.sh
+++ b/control-center/deploy/overlays/production-edge/verify-release.sh
@@ -1,34 +1,30 @@
 #!/usr/bin/env bash
-# Reconcile repository SHA -> image digest -> running container for the
-# control-center services. "Health 200" only proves a process answered; it
-# says nothing about which code answered. This script is the acceptance gate.
-#
-# Usage: verify-release.sh <expected-sha> [service...]
+# Reconcile compose -> repository SHA -> image -> container -> runtime health.
+# Usage: verify-release.sh <expected-sha>
 set -euo pipefail
 
-EXPECTED="${1:?usage: verify-release.sh <expected-sha> [service...]}"
-shift || true
+EXPECTED="${1:-}"
 BASELINE="64ece7d38abacd3adeaa02735b4f22af66caab0f"
-if [[ ! "$EXPECTED" =~ ^[0-9a-f]{40}$ ]]; then
-  echo "FAIL release: expected SHA must be the full lowercase 40-character commit identity"
+if [ "$#" -ne 1 ] || [[ ! "$EXPECTED" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "FAIL release: pass exactly one full lowercase 40-character commit identity"
   exit 1
 fi
 if ! git cat-file -e "${EXPECTED}^{commit}" 2>/dev/null; then
   echo "FAIL release: expected SHA is not a commit in this repository"
   exit 1
 fi
-if ! REPOSITORY_HEAD=$(git rev-parse HEAD 2>/dev/null); then
+REPOSITORY_HEAD="$(git rev-parse HEAD 2>/dev/null)" || {
   echo "FAIL release: repository HEAD could not be resolved"
   exit 1
-fi
+}
 if [ "$REPOSITORY_HEAD" != "$EXPECTED" ]; then
   echo "FAIL release: checkout HEAD ${REPOSITORY_HEAD} does not exactly match expected ${EXPECTED}"
   exit 1
 fi
-if ! SOURCE_STATUS=$(git status --porcelain=v1 --untracked-files=all); then
+SOURCE_STATUS="$(git status --porcelain=v1 --untracked-files=all)" || {
   echo "FAIL release: repository source status could not be inspected"
   exit 1
-fi
+}
 if [ -n "$SOURCE_STATUS" ]; then
   echo "FAIL release: checkout contains tracked or untracked changes; image provenance is not reproducible"
   exit 1
@@ -37,25 +33,46 @@ if ! git merge-base --is-ancestor "$BASELINE" "$EXPECTED"; then
   echo "FAIL release: ${EXPECTED} does not descend from required baseline ${BASELINE}"
   exit 1
 fi
-SERVICES=("$@")
-if [ ${#SERVICES[@]} -eq 0 ]; then
-  SERVICES=(web context)
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+OVERLAY_DIR="$REPO_ROOT/control-center/deploy/overlays/production-edge"
+COMPOSE="$OVERLAY_DIR/release-compose.sh"
+SERVICE_PARSER="$OVERLAY_DIR/release-services.py"
+SECRET_ENV="${CC_SECRET_ENV:-/etc/confenge/control-center/secrets/.env}"
+if [ ! -r "$SECRET_ENV" ]; then
+  echo "FAIL release: secret environment file is not readable"
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1090
+. "$SECRET_ENV"
+set +a
+export CC_RELEASE_SHA="$EXPECTED"
+CC_SECRET_DIR="$(dirname "$SECRET_ENV")"
+export CC_SECRET_DIR
+unset COMPOSE_FILE COMPOSE_PROJECT_NAME
+if ! SERVICE_ROWS="$($COMPOSE config --format json | python3 "$SERVICE_PARSER" --expected "$EXPECTED" --format tsv)"; then
+  echo "FAIL release: release service set could not be derived from rendered compose"
+  exit 1
 fi
 
 fail=0
-for svc in "${SERVICES[@]}"; do
-  container="confenge-control-center-${svc}-1"
-  if ! docker inspect "$container" >/dev/null 2>&1; then
-    echo "FAIL ${svc}: container ${container} not found"
+while IFS=$'\t' read -r svc expected_image; do
+  [ -n "$svc" ] || continue
+  container="$($COMPOSE ps -a -q "$svc" 2>/dev/null | head -1)"
+  if [ -z "$container" ] || ! docker inspect "$container" >/dev/null 2>&1; then
+    echo "FAIL ${svc}: compose container not found"
     fail=1
     continue
   fi
 
-  image_ref=$(docker inspect "$container" --format '{{.Config.Image}}')
-  image_id=$(docker inspect "$container" --format '{{.Image}}')
-  label=$(docker inspect "$image_id" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || echo "")
-  envsha=$(docker inspect "$container" --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^CC_RELEASE_SHA=//p' | head -1)
-  running=$(docker inspect "$container" --format '{{.State.Running}}')
+  image_ref="$(docker inspect "$container" --format '{{.Config.Image}}')"
+  image_id="$(docker inspect "$container" --format '{{.Image}}')"
+  label="$(docker inspect "$image_id" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || true)"
+  service_label="$(docker inspect "$image_id" --format '{{index .Config.Labels "br.com.confenge.service"}}' 2>/dev/null || true)"
+  envsha="$(docker inspect "$container" --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^CC_RELEASE_SHA=//p' | head -1)"
+  running="$(docker inspect "$container" --format '{{.State.Running}}')"
+  health="$(docker inspect "$container" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}')"
   runtime_http=""
   case "$svc" in
     context) runtime_endpoint="http://127.0.0.1:8080/v1/runtime-identity" ;;
@@ -63,7 +80,7 @@ for svc in "${SERVICES[@]}"; do
     *) runtime_endpoint="" ;;
   esac
   if [ -n "$runtime_endpoint" ]; then
-    runtime_http=$(docker exec "$container" node -e '
+    runtime_http="$(docker exec "$container" node -e '
       const [endpoint, expectedService, expectedBaseline] = process.argv.slice(1);
       fetch(endpoint, { signal: AbortSignal.timeout(5000) }).then(async (response) => {
         if (!response.ok) throw new Error(`status_${response.status}`);
@@ -76,60 +93,55 @@ for svc in "${SERVICES[@]}"; do
         if (!/^[0-9a-f]{40}$/.test(String(body.release_sha ?? ""))) throw new Error("release_invalid");
         process.stdout.write(String(body.release_sha ?? ""));
       }).catch(() => process.exit(2));
-    ' "$runtime_endpoint" "control-center-${svc}" "$BASELINE" 2>/dev/null || true)
+    ' "$runtime_endpoint" "control-center-${svc}" "$BASELINE" 2>/dev/null || true)"
   fi
 
   echo "--- ${svc}"
-  echo "    container   : ${container} (running=${running})"
   echo "    image ref   : ${image_ref}"
   echo "    image id    : ${image_id}"
   echo "    image label : ${label:-<none>}"
   echo "    runtime env : ${envsha:-<none>}"
-  echo "    runtime HTTP: ${runtime_http:-<none>}"
+  echo "    runtime HTTP: ${runtime_http:-n/a}"
+  echo "    health      : ${health}"
 
-  if [ "$running" != "true" ]; then
-    echo "    -> FAIL: container is not running"
+  if [ "$running" != true ] || [ "$health" != healthy ]; then
+    echo "    -> FAIL: container is not running and healthy"
     fail=1
-    continue
-  fi
-  if [ -z "$label" ] || [ "$label" = "local" ] || [ "$label" = "unknown" ]; then
-    echo "    -> FAIL: image carries no release revision label; it cannot be proven"
+  elif [ "$image_ref" != "$expected_image" ]; then
+    echo "    -> FAIL: image ref does not match rendered compose"
     fail=1
-    continue
-  fi
-  if [ "$label" != "$EXPECTED" ]; then
-    echo "    -> FAIL: image label ${label} does not exactly match expected ${EXPECTED}"
+  elif [ "$service_label" != "$svc" ]; then
+    echo "    -> FAIL: image service label ${service_label:-<none>} does not match ${svc}"
     fail=1
-    continue
+  elif [ "$label" != "$EXPECTED" ]; then
+    echo "    -> FAIL: image label ${label:-<none>} does not exactly match expected ${EXPECTED}"
+    fail=1
+  elif [ "$envsha" != "$EXPECTED" ]; then
+    echo "    -> FAIL: runtime CC_RELEASE_SHA ${envsha:-<none>} does not exactly match expected ${EXPECTED}"
+    fail=1
+  elif [ -n "$runtime_endpoint" ] && [ "$runtime_http" != "$EXPECTED" ]; then
+    echo "    -> FAIL: runtime HTTP identity ${runtime_http:-<none>} does not exactly match expected ${EXPECTED}"
+    fail=1
+  elif [ "$svc" = collector ]; then
+    if ! docker inspect "$container" --format '{{range .Config.Env}}{{println .}}{{end}}' |
+      awk -F= '$1 == "WARMBLY_API_TOKEN" && length($2) > 0 { found=1 } END { exit !found }'; then
+      echo "    -> FAIL: collector lost its read-only Warmbly credential"
+      fail=1
+    elif ! docker inspect "$container" --format '{{json .NetworkSettings.Networks}}' |
+      python3 -c 'import json, os, sys; networks=json.load(sys.stdin); raise SystemExit(0 if os.environ.get("WARMBLY_DOCKER_NETWORK", "warmbly-confenge_default") in networks else 1)'; then
+      echo "    -> FAIL: collector lost its Warmbly network"
+      fail=1
+    else
+      echo "    -> OK: collector release and read-only observation topology converge"
+    fi
+  else
+    echo "    -> OK: repo, compose, image, runtime and health converge"
   fi
-  if [ "$svc" = "context" ] || [ "$svc" = "web" ]; then
-    if [ -z "$envsha" ]; then
-      echo "    -> FAIL: runtime has no CC_RELEASE_SHA"
-      fail=1
-      continue
-    fi
-    if [ "$envsha" != "$EXPECTED" ]; then
-      echo "    -> FAIL: runtime CC_RELEASE_SHA ${envsha} does not exactly match expected ${EXPECTED}"
-      fail=1
-      continue
-    fi
-    if [ -z "$runtime_http" ]; then
-      echo "    -> FAIL: runtime HTTP identity is absent or unpinned"
-      fail=1
-      continue
-    fi
-    if [ "$runtime_http" != "$EXPECTED" ]; then
-      echo "    -> FAIL: runtime HTTP identity ${runtime_http:-<none>} does not exactly match expected ${EXPECTED}"
-      fail=1
-      continue
-    fi
-  fi
-  echo "    -> OK: repo ${EXPECTED} reconciles with image label and runtime"
-done
+done <<<"$SERVICE_ROWS"
 
 if [ "$fail" -ne 0 ]; then
   echo
-  echo "RELEASE VERIFICATION FAILED - do not treat this deploy as done"
+  echo "RELEASE VERIFICATION FAILED - health alone is not release evidence"
   exit 1
 fi
 echo

--- a/control-center/deploy/tests/deploy-release.test.ts
+++ b/control-center/deploy/tests/deploy-release.test.ts
@@ -1,0 +1,2 @@
+// Keep release convergence in the deploy workspace's mandatory test command.
+import "../../tests/convergence/deploy-release.test.ts";

--- a/control-center/deploy/tests/release-attestation.test.ts
+++ b/control-center/deploy/tests/release-attestation.test.ts
@@ -15,51 +15,118 @@ after(() => {
   for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
 });
 
-function fakeRuntimeBin(): string {
+function composeConfig(sha: string): string {
+  const services = Object.fromEntries(
+    ["collector", "context", "mcp", "web"].map((service) => [
+      service,
+      {
+        image: `confenge-control-center-${service}:${sha}`,
+        build: {
+          labels: {
+            "br.com.confenge.service": service,
+            "org.opencontainers.image.revision": sha,
+            "org.opencontainers.image.version": sha,
+          },
+        },
+        environment: { CC_RELEASE_SHA: sha },
+      },
+    ]),
+  );
+  return JSON.stringify({ services });
+}
+
+function fakeRuntime(): { bin: string; secretEnv: string; collectorOverlay: string } {
   const root = mkdtempSync(join(tmpdir(), "cc-release-attestation-"));
   tempDirs.push(root);
+  const secretEnv = join(root, "secrets.env");
+  const collectorOverlay = join(root, "collector-env.yml");
+  writeFileSync(secretEnv, "", "utf8");
+  writeFileSync(collectorOverlay, "services:\n  collector: {}\n", "utf8");
+
   const docker = join(root, "docker");
-  writeFileSync(docker, `#!/bin/sh
-case "$1" in
-  inspect)
-    case "$*" in
-      *org.opencontainers.image.revision*) printf '%s\\n' "$FAKE_RELEASE_SHA" ;;
-      *Config.Env*) printf 'CC_RELEASE_SHA=%s\\n' "$FAKE_RELEASE_SHA" ;;
-      *State.Running*) printf 'true\\n' ;;
-      *Config.Image*) printf 'confenge-control-center:test\\n' ;;
-      *"{{.Image}}"*) printf 'sha256:fixture-image-id\\n' ;;
-      *) exit 0 ;;
-    esac
-    ;;
-  exec) printf '%s' "$FAKE_HTTP_SHA" ;;
-  *) exit 2 ;;
-esac
-`, "utf8");
+  writeFileSync(
+    docker,
+    `#!/bin/sh
+command_name=""
+for argument in "$@"; do
+  case "$argument" in
+    config|ps|build|up) command_name="$argument"; break ;;
+  esac
+done
+if [ "$1" = "compose" ]; then
+  case "$command_name" in
+    config) printf '%s\n' "$FAKE_COMPOSE_JSON"; exit 0 ;;
+    ps)
+      for last_argument in "$@"; do :; done
+      if [ "$last_argument" = "$FAKE_MISSING_SERVICE" ]; then exit 0; fi
+      printf 'container-%s\n' "$last_argument"
+      exit 0
+      ;;
+    *) exit 2 ;;
+  esac
+fi
+if [ "$1" = "inspect" ]; then
+  target="$2"
+  service="$(printf '%s' "$target" | sed -e 's/^container-//' -e 's/^sha256:fixture-//')"
+  service_sha="$FAKE_RELEASE_SHA"
+  if [ "$service" = "$FAKE_DIVERGENT_SERVICE" ]; then service_sha="$FAKE_DIVERGENT_SHA"; fi
+  env_sha="$service_sha"
+  if [ "$service" = "$FAKE_ENV_DIVERGENT_SERVICE" ]; then env_sha="$FAKE_DIVERGENT_SHA"; fi
+  case "$*" in
+    *org.opencontainers.image.revision*) printf '%s\n' "$service_sha" ;;
+    *br.com.confenge.service*) printf '%s\n' "$service" ;;
+    *Config.Env*)
+      printf 'CC_RELEASE_SHA=%s\n' "$env_sha"
+      if [ "$service" = collector ] && [ "$FAKE_COLLECTOR_TOKEN_MISSING" != true ]; then
+        printf 'WARMBLY_API_TOKEN=fixture-read-only\nWARMBLY_BASE_URL=http://backend:8080\n'
+      fi
+      ;;
+    *State.Health*)
+      if [ "$service" = "$FAKE_UNHEALTHY_SERVICE" ]; then printf 'unhealthy\n'; else printf 'healthy\n'; fi
+      ;;
+    *State.Running*) printf 'true\n' ;;
+    *Config.Image*) printf 'confenge-control-center-%s:%s\n' "$service" "$service_sha" ;;
+    *NetworkSettings.Networks*)
+      if [ "$FAKE_COLLECTOR_NETWORK_MISSING" = true ]; then printf '{"confenge-cc-internal":{}}\n';
+      else printf '{"warmbly-confenge_default":{}}\n'; fi
+      ;;
+    *'{{.Image}}'*) printf 'sha256:fixture-%s\n' "$service" ;;
+    *) exit 0 ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "exec" ]; then printf '%s' "$FAKE_HTTP_SHA"; exit 0; fi
+exit 2
+`,
+    "utf8",
+  );
   chmodSync(docker, 0o755);
+
   const git = join(root, "git");
-  writeFileSync(git, `#!/bin/sh
+  writeFileSync(
+    git,
+    `#!/bin/sh
 case "$1" in
   cat-file) exit 0 ;;
   rev-parse)
-    if [ -n "\${FAKE_GIT_HEAD:-}" ]; then printf '%s\\n' "$FAKE_GIT_HEAD"; exit 0; fi
-    exec /usr/bin/git "$@"
+    case "$*" in
+      *--show-toplevel*) printf '%s\n' "$FAKE_REPO_ROOT" ;;
+      *) if [ -n "$FAKE_GIT_HEAD" ]; then printf '%s\n' "$FAKE_GIT_HEAD"; else printf '%s\n' "$FAKE_RELEASE_SHA"; fi ;;
+    esac
     ;;
   status)
-    if [ "\${FAKE_GIT_DIRTY:-false}" = "true" ]; then
-      printf ' M control-center/services/context/src/runtime-identity.ts\\n'
-      exit 0
+    if [ "$FAKE_GIT_DIRTY" = true ]; then
+      printf ' M control-center/deploy/overlays/production-edge/deploy-release.sh\n'
     fi
-    exit 0
     ;;
-  merge-base)
-    if [ "\${FAKE_GIT_ANCESTRY:-valid}" = "valid" ]; then exit 0; fi
-    exit 1
-    ;;
+  merge-base) if [ "$FAKE_GIT_ANCESTRY" = invalid ]; then exit 1; fi ;;
   *) exec /usr/bin/git "$@" ;;
 esac
-`, "utf8");
+`,
+    "utf8",
+  );
   chmodSync(git, 0o755);
-  return root;
+  return { bin: root, secretEnv, collectorOverlay };
 }
 
 function repositoryHead(): string {
@@ -71,96 +138,96 @@ function repositoryHead(): string {
   return result.stdout.trim();
 }
 
-test("release attestation reconciles repository, image, container env and HTTP identity", () => {
-  const sha = repositoryHead();
-  const bin = fakeRuntimeBin();
-  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
+function runVerify(overrides: NodeJS.ProcessEnv = {}, sha = repositoryHead()) {
+  const runtime = fakeRuntime();
+  return spawnSync("bash", [SCRIPT, sha], {
     cwd: REPOSITORY_ROOT,
     env: {
       ...process.env,
-      PATH: `${bin}:${process.env.PATH ?? ""}`,
-      FAKE_RELEASE_SHA: sha,
-      FAKE_HTTP_SHA: sha,
+      PATH: `${runtime.bin}:${process.env.PATH ?? ""}`,
+      CC_SECRET_ENV: runtime.secretEnv,
+      CC_COLLECTOR_ENV_COMPOSE: runtime.collectorOverlay,
+      CC_WEB_ACTOR_COMPOSE: join(runtime.bin, "absent-web-actor.yml"),
+      FAKE_REPO_ROOT: REPOSITORY_ROOT,
+      FAKE_RELEASE_SHA: repositoryHead(),
+      FAKE_HTTP_SHA: repositoryHead(),
+      FAKE_DIVERGENT_SHA: "0000000000000000000000000000000000000000",
+      FAKE_COMPOSE_JSON: composeConfig(repositoryHead()),
+      ...overrides,
     },
     encoding: "utf8",
   });
+}
+
+test("release attestation derives and reconciles every release service", () => {
+  const result = runVerify();
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
-  assert.match(result.stdout, /runtime HTTP:/);
   assert.match(result.stdout, /RELEASE VERIFICATION PASSED/);
-  assert.equal((result.stdout.match(/reconciles with image label and runtime/g) ?? []).length, 2);
+  assert.equal((result.stdout.match(/^--- /gm) ?? []).length, 4);
+  assert.match(result.stdout, /collector release and read-only observation topology converge/);
 });
 
-test("release attestation fails closed when the live HTTP SHA differs", () => {
-  const sha = repositoryHead();
-  const bin = fakeRuntimeBin();
-  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
-    cwd: REPOSITORY_ROOT,
-    env: {
-      ...process.env,
-      PATH: `${bin}:${process.env.PATH ?? ""}`,
-      FAKE_RELEASE_SHA: sha,
-      FAKE_HTTP_SHA: "0000000000000000000000000000000000000000",
-    },
-    encoding: "utf8",
-  });
+test("health green still fails when collector kept a previous release", () => {
+  const result = runVerify({ FAKE_DIVERGENT_SERVICE: "collector" });
   assert.notEqual(result.status, 0);
-  assert.match(result.stdout, /runtime HTTP identity .* does not exactly match expected/);
+  assert.match(result.stdout, /collector[\s\S]*image ref does not match rendered compose/);
   assert.match(result.stdout, /RELEASE VERIFICATION FAILED/);
 });
 
-test("release attestation rejects tags and abbreviated SHAs as mutable identities", () => {
-  const result = spawnSync("bash", [SCRIPT, "64ece7d", "context", "web"], {
-    cwd: REPOSITORY_ROOT,
-    encoding: "utf8",
-  });
+test("restart with current image but stale MCP runtime SHA fails", () => {
+  const result = runVerify({ FAKE_ENV_DIVERGENT_SERVICE: "mcp" });
   assert.notEqual(result.status, 0);
-  assert.match(result.stdout, /full lowercase 40-character commit identity/);
+  assert.match(result.stdout, /mcp[\s\S]*runtime CC_RELEASE_SHA .* does not exactly match expected/);
+});
+
+test("partial deploy with a missing service fails", () => {
+  const result = runVerify({ FAKE_MISSING_SERVICE: "collector" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /FAIL collector: compose container not found/);
+});
+
+test("running but unhealthy service fails", () => {
+  const result = runVerify({ FAKE_UNHEALTHY_SERVICE: "mcp" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /container is not running and healthy/);
+});
+
+test("collector release fails without read-only credential or Warmbly network", () => {
+  const token = runVerify({ FAKE_COLLECTOR_TOKEN_MISSING: "true" });
+  assert.notEqual(token.status, 0);
+  assert.match(token.stdout, /collector lost its read-only Warmbly credential/);
+
+  const network = runVerify({ FAKE_COLLECTOR_NETWORK_MISSING: "true" });
+  assert.notEqual(network.status, 0);
+  assert.match(network.stdout, /collector lost its Warmbly network/);
+});
+
+test("release attestation fails closed when the live HTTP SHA differs", () => {
+  const result = runVerify({ FAKE_HTTP_SHA: "0000000000000000000000000000000000000000" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /runtime HTTP identity .* does not exactly match expected/);
+});
+
+test("release attestation rejects tags and abbreviated SHAs", () => {
+  const result = runVerify({}, "64ece7d");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /exactly one full lowercase 40-character commit identity/);
 });
 
 test("release attestation rejects a full SHA outside the required baseline", () => {
-  const sha = repositoryHead();
-  const bin = fakeRuntimeBin();
-  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
-    cwd: REPOSITORY_ROOT,
-    env: {
-      ...process.env,
-      PATH: `${bin}:${process.env.PATH ?? ""}`,
-      FAKE_GIT_ANCESTRY: "invalid",
-    },
-    encoding: "utf8",
-  });
+  const result = runVerify({ FAKE_GIT_ANCESTRY: "invalid" });
   assert.notEqual(result.status, 0);
   assert.match(result.stdout, /does not descend from required baseline/);
 });
 
-test("release attestation rejects an expected SHA that is not the checked-out HEAD", () => {
-  const sha = repositoryHead();
-  const bin = fakeRuntimeBin();
-  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
-    cwd: REPOSITORY_ROOT,
-    env: {
-      ...process.env,
-      PATH: `${bin}:${process.env.PATH ?? ""}`,
-      FAKE_GIT_HEAD: "0000000000000000000000000000000000000000",
-    },
-    encoding: "utf8",
-  });
+test("rollback to a SHA other than checked-out HEAD fails", () => {
+  const result = runVerify({ FAKE_GIT_HEAD: "0000000000000000000000000000000000000000" });
   assert.notEqual(result.status, 0);
   assert.match(result.stdout, /checkout HEAD .* does not exactly match expected/);
 });
 
 test("release attestation rejects a dirty image source tree", () => {
-  const sha = repositoryHead();
-  const bin = fakeRuntimeBin();
-  const result = spawnSync("bash", [SCRIPT, sha, "context", "web"], {
-    cwd: REPOSITORY_ROOT,
-    env: {
-      ...process.env,
-      PATH: `${bin}:${process.env.PATH ?? ""}`,
-      FAKE_GIT_DIRTY: "true",
-    },
-    encoding: "utf8",
-  });
+  const result = runVerify({ FAKE_GIT_DIRTY: "true" });
   assert.notEqual(result.status, 0);
   assert.match(result.stdout, /checkout contains tracked or untracked changes/);
 });

--- a/control-center/tests/convergence/deploy-release.test.ts
+++ b/control-center/tests/convergence/deploy-release.test.ts
@@ -1,53 +1,289 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import test from "node:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, test } from "node:test";
+import { fileURLToPath } from "node:url";
 
-const OVERLAY = join(import.meta.dirname, "..", "..", "deploy", "overlays", "production-edge");
-const COMPOSE = readFileSync(join(OVERLAY, "docker-compose.production-edge.yml"), "utf8");
-const DEPLOY = readFileSync(join(OVERLAY, "deploy-release.sh"), "utf8");
+const REPOSITORY_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const OVERLAY = join(REPOSITORY_ROOT, "control-center", "deploy", "overlays", "production-edge");
+const DEPLOY_SCRIPT = join(OVERLAY, "deploy-release.sh");
+const SERVICE_PARSER = join(OVERLAY, "release-services.py");
+const DEPLOY_SOURCE = readFileSync(DEPLOY_SCRIPT, "utf8");
+const RELEASE_COMPOSE_SOURCE = readFileSync(join(OVERLAY, "release-compose.sh"), "utf8");
+const PRODUCTION_RUNBOOK = readFileSync(
+  join(REPOSITORY_ROOT, "control-center", "deploy", "PRODUCTION-RUNBOOK.md"),
+  "utf8",
+);
+const tempDirs: string[] = [];
 
-/** Services whose image tag interpolates the release SHA, read from compose itself. */
-function releaseStampedServices(): string[] {
-  const names = new Set<string>();
-  for (const line of COMPOSE.split("\n")) {
-    const match = /^\s*image:\s*confenge-control-center-([a-z0-9-]+):\$\{CC_RELEASE_SHA/.exec(line);
-    if (match) names.add(match[1]);
-  }
-  return [...names].sort();
+after(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+function repositoryHead(): string {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: REPOSITORY_ROOT,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
 }
 
-function declaredReleaseServices(): string[] {
-  const match = /RELEASE_SERVICES=\(([^)]*)\)/.exec(DEPLOY);
-  assert.ok(match, "deploy-release.sh must declare RELEASE_SERVICES");
-  return match[1].trim().split(/\s+/).filter(Boolean).sort();
+function composeConfig(sha: string, includeFuture = true): string {
+  const names = ["collector", "context", "mcp", "web"];
+  if (includeFuture) names.push("future");
+  const services = Object.fromEntries(
+    names.map((service) => [
+      service,
+      {
+        image: `confenge-control-center-${service}:${sha}`,
+        build: {
+          labels: {
+            "br.com.confenge.service": service,
+            "org.opencontainers.image.revision": sha,
+            "org.opencontainers.image.version": sha,
+          },
+        },
+        environment: { CC_RELEASE_SHA: sha },
+      },
+    ]),
+  );
+  return JSON.stringify({ services });
 }
 
-test("every release-stamped service is rebuilt by the rollout", () => {
-  // The previous, unversioned host script rebuilt context, mcp and web only.
-  // The collector is built from this same repository and carries the release SHA
-  // in its tag, so a merged connectors/warmbly change stayed unshipped while
-  // every health check reported green.
-  assert.deepEqual(declaredReleaseServices(), releaseStampedServices());
+type DeployRuntime = {
+  bin: string;
+  collectorOverlay: string;
+  evidenceDir: string;
+  lockFile: string;
+  secretEnv: string;
+  trace: string;
+};
+
+function fakeDeployRuntime(): DeployRuntime {
+  const root = mkdtempSync(join(tmpdir(), "cc-deploy-release-"));
+  tempDirs.push(root);
+  const secretEnv = join(root, "secrets.env");
+  const collectorOverlay = join(root, "collector-env.yml");
+  const evidenceDir = join(root, "evidence");
+  const lockFile = join(root, "release.lock");
+  const trace = join(root, "docker.trace");
+  writeFileSync(secretEnv, "", "utf8");
+  writeFileSync(collectorOverlay, "services:\n  collector: {}\n", "utf8");
+
+  const git = join(root, "git");
+  writeFileSync(
+    git,
+    `#!/bin/sh
+case "$1" in
+  status) if [ "$FAKE_GIT_DIRTY" = true ]; then printf ' M dirty-before-build\n'; fi ;;
+  fetch|checkout|cat-file) exit 0 ;;
+  rev-parse)
+    case "$*" in
+      *--show-toplevel*) printf '%s\n' "$FAKE_REPO_ROOT" ;;
+      *) printf '%s\n' "$FAKE_RELEASE_SHA" ;;
+    esac
+    ;;
+  merge-base) exit 0 ;;
+  *) exit 2 ;;
+esac
+`,
+    "utf8",
+  );
+  chmodSync(git, 0o755);
+
+  const docker = join(root, "docker");
+  writeFileSync(
+    docker,
+    `#!/bin/sh
+command_name=""
+for argument in "$@"; do
+  case "$argument" in
+    config|ps|build|up) command_name="$argument"; break ;;
+  esac
+done
+if [ "$1" = compose ]; then
+  case "$command_name" in
+    config)
+      case "$*" in
+        *--no-interpolate*) printf '%s\n' "$FAKE_TEMPLATE_COMPOSE_JSON" ;;
+        *) printf '%s\n' "$FAKE_RENDERED_COMPOSE_JSON" ;;
+      esac
+      exit 0
+      ;;
+    ps)
+      for last_argument in "$@"; do :; done
+      printf 'container-%s\n' "$last_argument"
+      exit 0
+      ;;
+    build)
+      printf 'build|%s\n' "$*" >> "$FAKE_TRACE"
+      exit 0
+      ;;
+    up)
+      printf 'up|%s\n' "$*" >> "$FAKE_TRACE"
+      if [ "$FAKE_UP_FAIL" = true ]; then exit 17; fi
+      exit 0
+      ;;
+  esac
+fi
+if [ "$1" = inspect ]; then
+  target="$2"
+  service="$(printf '%s' "$target" | sed -e 's/^container-//' -e 's/^sha256:fixture-//')"
+  case "$*" in
+    *org.opencontainers.image.revision*) printf '%s\n' "$FAKE_RELEASE_SHA" ;;
+    *br.com.confenge.service*) printf '%s\n' "$service" ;;
+    *Config.Env*)
+      printf 'CC_RELEASE_SHA=%s\n' "$FAKE_RELEASE_SHA"
+      if [ "$service" = collector ]; then printf 'WARMBLY_API_TOKEN=fixture-read-only\n'; fi
+      ;;
+    *State.Health*) printf 'healthy\n' ;;
+    *State.Running*) printf 'true\n' ;;
+    *Config.Image*) printf 'confenge-control-center-%s:%s\n' "$service" "$FAKE_RELEASE_SHA" ;;
+    *NetworkSettings.Networks*) printf '{"warmbly-confenge_default":{}}\n' ;;
+    *'{{.Image}}'*) printf 'sha256:fixture-%s\n' "$service" ;;
+    *) exit 0 ;;
+  esac
+  exit 0
+fi
+if [ "$1" = exec ]; then printf '%s' "$FAKE_RELEASE_SHA"; exit 0; fi
+exit 2
+`,
+    "utf8",
+  );
+  chmodSync(docker, 0o755);
+
+  const curl = join(root, "curl");
+  writeFileSync(
+    curl,
+    `#!/bin/sh
+case "$*" in
+  *127.0.0.1*) printf '%s' "$FAKE_LOOPBACK_STATUS" ;;
+  *auth.ops.confenge.com.br*) printf '200' ;;
+  *ops.confenge.com.br*) printf '302' ;;
+  *) exit 2 ;;
+esac
+`,
+    "utf8",
+  );
+  chmodSync(curl, 0o755);
+
+  return { bin: root, collectorOverlay, evidenceDir, lockFile, secretEnv, trace };
+}
+
+function runDeploy(overrides: NodeJS.ProcessEnv = {}, sha = repositoryHead()) {
+  const runtime = fakeDeployRuntime();
+  const releaseSha = repositoryHead();
+  const template = composeConfig("${CC_RELEASE_SHA:-local}");
+  const rendered = composeConfig(releaseSha);
+  const result = spawnSync("bash", [DEPLOY_SCRIPT, sha], {
+    cwd: REPOSITORY_ROOT,
+    env: {
+      ...process.env,
+      PATH: `${runtime.bin}:${process.env.PATH ?? ""}`,
+      CC_REPO_ROOT: REPOSITORY_ROOT,
+      CC_SECRET_ENV: runtime.secretEnv,
+      CC_COLLECTOR_ENV_COMPOSE: runtime.collectorOverlay,
+      CC_WEB_ACTOR_COMPOSE: join(runtime.bin, "absent-web-actor.yml"),
+      CC_RELEASE_EVIDENCE_DIR: runtime.evidenceDir,
+      CC_RELEASE_LOCK_FILE: runtime.lockFile,
+      FAKE_REPO_ROOT: REPOSITORY_ROOT,
+      FAKE_RELEASE_SHA: releaseSha,
+      FAKE_TEMPLATE_COMPOSE_JSON: template,
+      FAKE_RENDERED_COMPOSE_JSON: rendered,
+      FAKE_TRACE: runtime.trace,
+      FAKE_LOOPBACK_STATUS: "200",
+      ...overrides,
+    },
+    encoding: "utf8",
+  });
+  return { result, runtime };
+}
+
+test("release service set is derived from compose, including a future service", () => {
+  const sha = repositoryHead();
+  const result = spawnSync("python3", [SERVICE_PARSER, "--expected", sha], {
+    input: composeConfig(sha),
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.stdout.trim().split("\n"), ["collector", "context", "future", "mcp", "web"]);
+  assert.doesNotMatch(DEPLOY_SOURCE, /RELEASE_SERVICES=\(/);
 });
 
-test("the collector is not forgotten", () => {
-  assert.ok(releaseStampedServices().includes("collector"));
-  assert.ok(declaredReleaseServices().includes("collector"));
+test("release parser fails when a stamped service lacks runtime SHA", () => {
+  const sha = repositoryHead();
+  const document = JSON.parse(composeConfig(sha));
+  delete document.services.future.environment.CC_RELEASE_SHA;
+  const result = spawnSync("python3", [SERVICE_PARSER, "--expected", sha], {
+    input: JSON.stringify(document),
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /future does not receive the same CC_RELEASE_SHA/);
 });
 
-test("provenance is checked for every rebuilt service, not a subset", () => {
-  assert.match(DEPLOY, /verify-release\.sh "\$CC_RELEASE_SHA" "\$\{RELEASE_SERVICES\[@\]\}"/);
+test("canonical compose preserves both collector overlays", () => {
+  assert.match(RELEASE_COMPOSE_SOURCE, /docker-compose\.warmbly-collector\.override\.yml/);
+  assert.match(
+    RELEASE_COMPOSE_SOURCE,
+    /\/etc\/confenge\/control-center\/docker-compose\.collector-env\.yml/,
+  );
+  assert.match(RELEASE_COMPOSE_SOURCE, /required collector environment overlay is not readable/);
 });
 
-test("a dirty checkout is refused before anything is built", () => {
-  const dirtyGuard = DEPLOY.indexOf("git status --porcelain");
-  const firstBuild = DEPLOY.indexOf("$COMPOSE build");
-  assert.ok(dirtyGuard > 0, "the rollout must inspect the checkout");
-  assert.ok(dirtyGuard < firstBuild, "the dirty-checkout guard must run before the build");
+test("canonical runbook delegates to deploy-release and contains no partial app rollout", () => {
+  assert.match(PRODUCTION_RUNBOOK, /deploy-release\.sh/);
+  assert.doesNotMatch(PRODUCTION_RUNBOOK, /build context web/);
+  assert.doesNotMatch(PRODUCTION_RUNBOOK, /verify-release\.sh[^\n]*context web/);
 });
 
-test("the rollout pins an exact commit and never a floating branch", () => {
-  assert.match(DEPLOY, /\[\[ "\$TARGET_SHA" =~ \^\[0-9a-f\]\{40\}\$ \]\]/);
-  assert.match(DEPLOY, /git checkout --quiet -B main "\$TARGET_SHA"/);
+test("deploy builds, waits and verifies the complete compose-derived set", () => {
+  const { result, runtime } = runDeploy();
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /compose-derived release services: collector context future mcp web/);
+  assert.match(result.stdout, /GO:CONTROL_CENTER_RELEASE_CONVERGED/);
+  const trace = readFileSync(runtime.trace, "utf8");
+  assert.match(trace, /build\|.* collector context future mcp web/);
+  assert.match(trace, /up\|.*--wait.* collector context future mcp web caddy/);
+  assert.ok(readdirSync(runtime.evidenceDir).some((name) => name.startsWith("rollback-point-")));
+  assert.ok(readdirSync(runtime.evidenceDir).some((name) => name.startsWith("release-receipt-")));
+});
+
+test("dirty checkout fails before any build", () => {
+  const { result, runtime } = runDeploy({ FAKE_GIT_DIRTY: "true" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /checkout is not clean; no image was built/);
+  assert.equal(existsSync(runtime.trace), false);
+});
+
+test("historical full SHA is rejected as rollback, before Docker", () => {
+  const { result, runtime } = runDeploy({}, "0000000000000000000000000000000000000000");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /requested SHA is not contemporary origin\/main/);
+  assert.equal(existsSync(runtime.trace), false);
+});
+
+test("partial compose failure writes a sanitized failure-state receipt", () => {
+  const { result, runtime } = runDeploy({ FAKE_UP_FAIL: "true" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /partial-state receipt written/);
+  assert.ok(readdirSync(runtime.evidenceDir).some((name) => name.startsWith("release-failure-")));
+});
+
+test("HTTP 500 after healthy containers still fails and records state", () => {
+  const { result, runtime } = runDeploy({ FAKE_LOOPBACK_STATUS: "500" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /loopback_health expected HTTP 200, got 500/);
+  assert.ok(readdirSync(runtime.evidenceDir).some((name) => name.startsWith("release-failure-")));
 });


### PR DESCRIPTION
## Outcome

Makes Control Center production release convergence fail closed and restores the collector topology lost by the previous partial compose apply.

## Contract

- derives all release-stamped services from normalized Compose
- requires full contemporary origin/main SHA and a clean checkout before build
- uses one canonical compose wrapper with collector network + host env overlays
- stamps CC_RELEASE_SHA into context, MCP, collector and web
- waits for health and verifies compose image ref, OCI/service labels, runtime SHA and runtime identity
- rejects partial deploy, restart drift, rollback SHA, unhealthy/missing services and health-green SHA divergence
- persists sanitized rollback/final/failure receipts
- makes the canonical runbook delegate to deploy-release.sh

## Live finding

Read-only baseline found collector healthy and SHA-converged but without the Warmbly network or read-only collector env after the last recreate. No secret values were read or logged.

## Verification

- deploy workspace: 42/42 pass
- release adversarial tests: pass
- full Control Center typecheck: pass
- shellcheck + bash syntax + compose config: pass
- full workspace tests: all non-Postgres suites pass locally; embedded-Postgres cases are blocked on this host by missing libpq.so.5 and remain delegated to CI

No SMTP/provider mutation. No web-shell UX, connector mapping, commercial/delivery schema, workflow, package or lockfile changes.