### PR TITLE
fix(control-center): reexec checked-out deploy contract

### DIFF
--- a/control-center/deploy/overlays/production-edge/deploy-release.sh
+++ b/control-center/deploy/overlays/production-edge/deploy-release.sh
@@ -9,6 +9,7 @@ EVIDENCE_DIR="${CC_RELEASE_EVIDENCE_DIR:-/opt/confenge-control-center-release-ev
 LOCK_FILE="${CC_RELEASE_LOCK_FILE:-/run/lock/confenge-control-center-release.lock}"
 SCRIPT_RELATIVE="control-center/deploy/overlays/production-edge"
 TARGET_SHA="${1:-}"
+RUNNING_SCRIPT_SHA256="$(sha256sum -- "${BASH_SOURCE[0]}" | awk '{print $1}')"
 
 if [ "$#" -ne 1 ] || [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   echo "DEPLOY_ERROR: pass exactly one full lowercase 40-character origin/main SHA" >&2
@@ -52,6 +53,22 @@ fi
 if [ -n "$(git status --porcelain=v1 --untracked-files=all)" ]; then
   echo "DEPLOY_ERROR: checkout became dirty; no image was built" >&2
   exit 1
+fi
+
+# Bash reads the running script before git checkout changes its file. If the
+# target release updates this deployer, continuing here would execute the old
+# rollout contract against the new checkout. Re-exec the exact checked-out
+# script once, still before secrets, Compose rendering or any image build.
+CHECKED_OUT_SCRIPT="$REPO_ROOT/$SCRIPT_RELATIVE/deploy-release.sh"
+CHECKED_OUT_SCRIPT_SHA256="$(sha256sum -- "$CHECKED_OUT_SCRIPT" | awk '{print $1}')"
+if [ "$RUNNING_SCRIPT_SHA256" != "$CHECKED_OUT_SCRIPT_SHA256" ]; then
+  if [ "${CC_RELEASE_REEXEC_SHA:-}" = "$TARGET_SHA" ]; then
+    echo "DEPLOY_ERROR: checked-out deploy script did not stabilize after re-exec; no image was built" >&2
+    exit 1
+  fi
+  echo "== deploy contract changed at $TARGET_SHA; re-executing checked-out script =="
+  export CC_RELEASE_REEXEC_SHA="$TARGET_SHA"
+  exec "$CHECKED_OUT_SCRIPT" "$TARGET_SHA"
 fi
 
 if [ ! -r "$SECRET_ENV" ]; then

--- a/control-center/tests/convergence/deploy-release.test.ts
+++ b/control-center/tests/convergence/deploy-release.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -87,7 +89,15 @@ function fakeDeployRuntime(): DeployRuntime {
     `#!/bin/sh
 case "$1" in
   status) if [ "$FAKE_GIT_DIRTY" = true ]; then printf ' M dirty-before-build\n'; fi ;;
-  fetch|checkout|cat-file) exit 0 ;;
+  fetch|cat-file) exit 0 ;;
+  checkout)
+    if [ -n "$FAKE_CHECKOUT_DEPLOY_SOURCE" ]; then
+      cp "$FAKE_CHECKOUT_DEPLOY_SOURCE" "$FAKE_CHECKOUT_DEPLOY_TARGET.next"
+      chmod 755 "$FAKE_CHECKOUT_DEPLOY_TARGET.next"
+      mv "$FAKE_CHECKOUT_DEPLOY_TARGET.next" "$FAKE_CHECKOUT_DEPLOY_TARGET"
+    fi
+    exit 0
+    ;;
   rev-parse)
     case "$*" in
       *--show-toplevel*) printf '%s\n' "$FAKE_REPO_ROOT" ;;
@@ -264,6 +274,51 @@ test("dirty checkout fails before any build", () => {
   const { result, runtime } = runDeploy({ FAKE_GIT_DIRTY: "true" });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /checkout is not clean; no image was built/);
+  assert.equal(existsSync(runtime.trace), false);
+});
+
+test("a deployer changed by checkout is re-executed before any build", () => {
+  const runtime = fakeDeployRuntime();
+  const root = mkdtempSync(join(tmpdir(), "cc-deploy-reexec-repo-"));
+  tempDirs.push(root);
+  const copiedOverlay = join(
+    root,
+    "control-center",
+    "deploy",
+    "overlays",
+    "production-edge",
+  );
+  mkdirSync(copiedOverlay, { recursive: true });
+  const copiedDeploy = join(copiedOverlay, "deploy-release.sh");
+  copyFileSync(DEPLOY_SCRIPT, copiedDeploy);
+  chmodSync(copiedDeploy, 0o755);
+  const checkedOutDeploy = join(root, "checked-out-deploy.sh");
+  writeFileSync(
+    checkedOutDeploy,
+    "#!/bin/sh\nprintf 'REEXECUTED_SHA=%s\\n' \"$1\"\n",
+    "utf8",
+  );
+  chmodSync(checkedOutDeploy, 0o755);
+  const sha = repositoryHead();
+
+  const result = spawnSync("bash", [copiedDeploy, sha], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PATH: `${runtime.bin}:${process.env.PATH ?? ""}`,
+      CC_REPO_ROOT: root,
+      CC_RELEASE_LOCK_FILE: runtime.lockFile,
+      FAKE_REPO_ROOT: root,
+      FAKE_RELEASE_SHA: sha,
+      FAKE_CHECKOUT_DEPLOY_SOURCE: checkedOutDeploy,
+      FAKE_CHECKOUT_DEPLOY_TARGET: copiedDeploy,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /deploy contract changed .* re-executing checked-out script/);
+  assert.match(result.stdout, new RegExp(`REEXECUTED_SHA=${sha}`));
   assert.equal(existsSync(runtime.trace), false);
 });
 


### PR DESCRIPTION
## Summary
- fingerprint the running versioned deploy script before checkout
- re-execute the exact script from the certified SHA when checkout changes the contract
- fail closed if the checked-out deployer cannot stabilize, always before secrets, Compose, or build
- add a black-box convergence test that atomically swaps the deployer during checkout

## Verification
- `npm test --workspace @confenge/control-center-deploy` (43/43)
- `npm run typecheck --workspace @confenge/control-center-deploy`
- `bash -n` + `shellcheck` deploy-release.sh
- `git diff --check`