### PR TITLE
fix(control-center): forward queued_readback so QUEUED is never queued_approved

### DIFF
--- a/control-center/apps/web-shell/performance-budgets.json
+++ b/control-center/apps/web-shell/performance-budgets.json
@@ -22,14 +22,14 @@
     "cls_p75": 0.1,
     "long_task_max_ms": 350,
     "initial_request_count": 16,
-    "javascript_raw_bytes": 403000,
-    "javascript_gzip_bytes": 123000,
+    "javascript_raw_bytes": 404000,
+    "javascript_gzip_bytes": 123250,
     "css_raw_bytes": 30000,
     "css_gzip_bytes": 6700,
     "bundle_gzip_bytes": 130000
   },
   "budget_change": {
     "previous_bundle_gzip_bytes": 123500,
-    "reason": "The existing founder operating-truth viewport now includes the source-attributed outbound runway, 33 progressive readbacks and fail-closed reconciliation; the bounded ceiling follows the measured feature delta while mobile LCP and INP targets remain unchanged."
+    "reason": "The existing founder operating-truth viewport now includes the source-attributed outbound runway, 33 progressive readbacks, fail-closed reconciliation, and first-touch control fallbacks so QUEUED is queued_readback rather than dispatch.queued_approved; the bounded ceiling follows the measured feature delta while mobile LCP and INP targets remain unchanged."
   }
 }

--- a/control-center/apps/web-shell/src/founder-operating-truth.ts
+++ b/control-center/apps/web-shell/src/founder-operating-truth.ts
@@ -282,6 +282,10 @@ export function projectFounderOperatingTruth(envelopeValue: unknown): FounderOpe
   const sourceRunMatch: OutboundRunwayTruth["integrity"]["source_run_match"] = sourceRuns.length > 1
     ? "MISMATCH"
     : currentRun && delegatedRun ? currentRun === delegatedRun ? "MATCH" : "MISMATCH" : "UNKNOWN";
+  const delegatedControl = O(delegated.control);
+  const transportBlock = O(delegatedControl.transport);
+  const capacityBlock = O(delegatedControl.capacity);
+  const forecast = O(capacityBlock.forecast);
   const dueDates = delegatedItems
     .filter((item) => item.state === "QUEUED")
     .map((item) => validDate(item.due_at))
@@ -291,9 +295,14 @@ export function projectFounderOperatingTruth(envelopeValue: unknown): FounderOpe
     ...dueDates,
     validDate(working.furthest_due_at),
     validDate(delegated.furthest_due_at),
+    validDate(delegatedControl.furthest_due_at),
     validDate(dispatch.furthest_due_at),
   ].filter((item): item is string => Boolean(item)).sort();
-  const nextDueDates = [...dueDates, validDate(dispatch.next_slot_at)].filter((item): item is string => Boolean(item)).sort();
+  const nextDueDates = [
+    ...dueDates,
+    validDate(delegatedControl.next_due_at),
+    validDate(dispatch.next_slot_at),
+  ].filter((item): item is string => Boolean(item)).sort();
   const runtimeShas = [...new Set([
     ...delegatedItems.map((item) => S(item.runtime_release_sha)),
     S(delegated.runtime_release_sha),
@@ -310,7 +319,6 @@ export function projectFounderOperatingTruth(envelopeValue: unknown): FounderOpe
   // nothing in the control block counts identity attribution or current eligibility, and
   // target_membership_count is a membership denominator, not the funnel stage this row reports.
   // Inventing those mappings would publish numbers nobody observed.
-  const delegatedControl = O(delegated.control);
   const extraReadyReservoir = N(inventoryValue("ready_reservoir")) ?? N(inventoryValue("email_send_ready_reservoir")) ?? N(reservoir.email_send_ready_reservoir) ?? N(inventoryValue("email_send_ready")) ?? countFromFunnel(funnelRows, "email_send_ready");
   const warmblyReadyReservoir = extraReadyReservoir === null && warmblySource.freshness === "FRESH"
     ? N(delegatedControl.ready_reservoir) ?? N(O(delegated.runway).ready_reservoir_count)
@@ -320,19 +328,19 @@ export function projectFounderOperatingTruth(envelopeValue: unknown): FounderOpe
   const targetConfirmed = N(inventoryValue("target_confirmed")) ?? N(reservoir.TARGET_CONFIRMED) ?? countFromFunnel(funnelRows, "target_confirmed");
   const recipientAttributed = N(inventoryValue("recipient_attributed")) ?? N(inventoryValue("identity_safe")) ?? countFromFunnel(funnelRows, "identity_safe");
   const eligibleCurrent = N(inventoryValue("eligible_current")) ?? N(inventoryValue("warmbly_eligible")) ?? countFromFunnel(funnelRows, "warmbly_eligible");
-  const prepared = N(working.prepared) ?? N(delegated.prepared) ?? stateCount(delegatedCounts, ["PREPARED", "POLICY_EVALUATED", "APPROVED", "APPROVED_NOT_SCHEDULED", "QUEUED", "SENT", "HOLD", "NEEDS_REVIEW", "EXCEPTION"]);
-  const delegatedApproved = N(delegated.delegated_approved) ?? stateCount(delegatedCounts, ["APPROVED", "APPROVED_NOT_SCHEDULED", "QUEUED", "SENT"]);
+  const prepared = N(working.prepared) ?? N(delegated.prepared) ?? N(delegatedControl.prepared) ?? stateCount(delegatedCounts, ["PREPARED", "POLICY_EVALUATED", "APPROVED", "APPROVED_NOT_SCHEDULED", "QUEUED", "SENT", "HOLD", "NEEDS_REVIEW", "EXCEPTION"]);
+  const delegatedApproved = N(delegated.delegated_approved) ?? N(delegatedControl.delegated_approved) ?? stateCount(delegatedCounts, ["APPROVED", "APPROVED_NOT_SCHEDULED", "QUEUED", "SENT"]);
   const humanApproved = N(delegated.human_approved);
   const queued = N(delegated.queued_readback);
   const holdExceptions = N(delegated.hold_exceptions) ?? stateCount(delegatedCounts, ["HOLD", "NEEDS_REVIEW", "EXCEPTION"]) ?? N(overview.outbound_exceptions);
-  const sent = N(outcomes.sent) ?? (Object.hasOwn(delegatedCounts, "SENT") ? N(delegatedCounts.SENT) : null);
-  const attempted = N(outcomes.attempted);
-  const providerAccepted = N(outcomes.provider_accepted);
+  const sent = N(outcomes.sent) ?? N(transportBlock.sent) ?? (Object.hasOwn(delegatedCounts, "SENT") ? N(delegatedCounts.SENT) : null);
+  const attempted = N(outcomes.attempted) ?? N(transportBlock.provider_attempts);
+  const providerAccepted = N(outcomes.provider_accepted) ?? N(transportBlock.provider_accepted);
   const delivered = N(outcomes.delivered);
   const replies = N(outcomes.replies) ?? N(overview.replies);
   const suppressed = N(outcomes.suppressed) ?? N(working.suppressed);
-  const rawSlots24h = N(working.slots_next_24h) ?? N(dispatch.slots_next_24h);
-  const rawSlots7d = N(working.slots_next_7d) ?? N(dispatch.slots_next_7d);
+  const rawSlots24h = N(working.slots_next_24h) ?? N(dispatch.slots_next_24h) ?? N(forecast.slots_next_24h);
+  const rawSlots7d = N(working.slots_next_7d) ?? N(dispatch.slots_next_7d) ?? N(forecast.slots_next_7d);
   const feedAge = N(working.feed_age_seconds) ?? N(inventoryValue("feed_age_seconds"));
   const feedAgeSource = N(working.feed_age_seconds) !== null ? warmblySource : extraSource;
   const replenishmentState = S(working.replenishment_state) ?? S(inventoryValue("replenishment_state"));
@@ -340,16 +348,35 @@ export function projectFounderOperatingTruth(envelopeValue: unknown): FounderOpe
   const queueFillBlocker = S(working.queue_fill_blocker) ?? S(inventoryValue("queue_fill_blocker")) ?? S(pncp.blocker);
   const queueFillSource = S(working.queue_fill_blocker) ? warmblySource : extraSource;
 
-  const authorityBlock = O(delegated.commercial_authority);
+  const authorityBlock = Object.keys(O(delegated.commercial_authority)).length > 0
+    ? O(delegated.commercial_authority)
+    : O(delegatedControl.commercial_authority);
   const csRaw = S(authorityBlock.state);
   const cs = csRaw && csRaw.includes("FROZEN") ? "FROZEN" : csRaw;
   // Warmbly is authoritative. Missing state stays UNKNOWN; never infer CURRENT from envelope age.
   const commercialState: CommercialAuthorityState = cs === "CURRENT" || cs === "DEGRADED" || cs === "FROZEN" || cs === "EXPIRED" ? cs : "UNKNOWN";
   const extraFeedAge = N(inventoryValue("feed_age_seconds"));
   const sourceHealthState: SourceHealthState = extraFeedAge !== null && extraFeedAge >= 0 ? extraFeedAge <= 86400 ? "FRESH" : extraFeedAge <= 259200 ? "DEGRADED" : "STALE" : extraSource.freshness === "ERROR" ? "UNKNOWN" : extraSource.freshness;
-  const pause = [S(dispatch.pause_reason), S(dispatch.paused_by), S(dispatch.pause_source), validDate(dispatch.paused_at)].map((v) => v ?? "UNKNOWN").join(" · ");
-  const killRaw = overview.kill_switch ?? dispatch.kill_switch ?? O(operations.confenge_status).kill_switch;
+  const pause = [
+    S(dispatch.pause_reason) ?? S(capacityBlock.pause_reason) ?? S(transportBlock.pause_reason),
+    S(dispatch.paused_by) ?? S(capacityBlock.paused_by),
+    S(dispatch.pause_source) ?? S(capacityBlock.pause_source) ?? S(transportBlock.pause_source),
+    validDate(dispatch.paused_at) ?? validDate(capacityBlock.paused_at),
+  ].map((v) => v ?? "UNKNOWN").join(" · ");
+  const killRaw = overview.kill_switch ?? dispatch.kill_switch ?? O(operations.confenge_status).kill_switch ?? transportBlock.kill_switch_engaged;
   const kill = typeof killRaw === "boolean" ? (killRaw ? "ativo" : "desligado") : "UNKNOWN";
+  const mailboxRows = A(capacityBlock.mailboxes).map((row) => O(row));
+  const mailboxFromCapacity = mailboxRows.length === 0 ? null : {
+    healthy: mailboxRows.filter((row) => S(row.health) === "ready").length,
+    blocked: mailboxRows.filter((row) => {
+      const health = S(row.health) ?? "";
+      return health === "blocked" || health === "unhealthy" || health === "error";
+    }).length,
+    unknown: mailboxRows.filter((row) => {
+      const health = S(row.health) ?? "";
+      return health !== "ready" && health !== "blocked" && health !== "unhealthy" && health !== "error";
+    }).length,
+  };
 
   const integrityReasons: string[] = [];
   if (sourceRunMatch === "MISMATCH") integrityReasons.push("SOURCE_RUN_CHANGED");
@@ -454,9 +481,9 @@ export function projectFounderOperatingTruth(envelopeValue: unknown): FounderOpe
       reservoir_below_1000: readyFact.value === null ? null : readyFact.value < 1000,
     },
     health: {
-      mailboxes_healthy: countFact(N(mailboxHealth.healthy), warmblySource, TRANSPORT_DRILLDOWN),
-      mailboxes_blocked: countFact(N(mailboxHealth.blocked), warmblySource, TRANSPORT_DRILLDOWN),
-      mailboxes_unknown: countFact(N(mailboxHealth.unknown), warmblySource, TRANSPORT_DRILLDOWN),
+      mailboxes_healthy: countFact(N(mailboxHealth.healthy) ?? mailboxFromCapacity?.healthy ?? null, warmblySource, TRANSPORT_DRILLDOWN),
+      mailboxes_blocked: countFact(N(mailboxHealth.blocked) ?? mailboxFromCapacity?.blocked ?? null, warmblySource, TRANSPORT_DRILLDOWN),
+      mailboxes_unknown: countFact(N(mailboxHealth.unknown) ?? mailboxFromCapacity?.unknown ?? null, warmblySource, TRANSPORT_DRILLDOWN),
       provider_errors: countFact(N(outcomes.provider_errors) ?? N(dispatch.provider_errors), warmblySource, TRANSPORT_DRILLDOWN),
       bounces: countFact(N(outcomes.bounces) ?? N(overview.bounces), warmblySource, `${WARMBLY_DRILLDOWN}?filtro=bounces`),
       complaints: countFact(N(outcomes.complaints), warmblySource, `${WARMBLY_DRILLDOWN}?filtro=complaints`),

--- a/control-center/apps/web-shell/tests/founder-operating-truth.test.ts
+++ b/control-center/apps/web-shell/tests/founder-operating-truth.test.ts
@@ -617,6 +617,54 @@ test("QUEUED comes only from queued_readback, never from dispatch.queued_approve
   assert.equal(truth.outbound.queued, null);
 });
 
+test("live first-touch control block keeps queued_readback and does not use queued_approved", () => {
+  const input = envelope();
+  const delegated = firstTouchControl(input);
+  delete delegated.commercial_authority;
+  delegated.queued_readback = 140;
+  delegated.control = {
+    delegated_approved: 140,
+    next_due_at: "2026-08-28T12:00:00Z",
+    furthest_due_at: "2026-09-28T12:00:00Z",
+    commercial_authority: {
+      state: "CURRENT",
+      valid_until: "2026-08-29T05:41:30Z",
+      basis_publication_semantic_hash: "sem-live",
+      producer_identity: "producer-live",
+    },
+    transport: {
+      kill_switch_engaged: true,
+      pause_reason: "scale_pre_go_release_91e37d8b",
+    },
+    capacity: {
+      pause_reason: "scale_pre_go_release_91e37d8b",
+      pause_source: "durable_control",
+      paused_by: "00000000-0000-0000-0000-000000000000",
+      paused_at: "2026-08-27T02:18:09.167916Z",
+      forecast: { slots_next_24h: 0, slots_next_7d: 0, potential_slots_next_24h: 50 },
+      mailboxes: [{ health: "ready" }],
+    },
+  };
+  const operations = ((input.snapshots as Record<string, Record<string, unknown>>).commercial!.snapshot as Record<string, unknown>).operations as Record<string, unknown>;
+  const dispatch = operations.dispatch as Record<string, unknown>;
+  const working = operations.working_overview as Record<string, unknown>;
+  dispatch.queued_approved = 99;
+  delete dispatch.slots_next_24h;
+  delete dispatch.slots_next_7d;
+  delete working.slots_next_24h;
+  delete working.slots_next_7d;
+  delete operations.mailbox_health;
+  const truth = projectFounderOperatingTruth(input);
+  assert.equal(truth.outbound_runway.stock.queued_reserved.value, 140);
+  assert.notEqual(truth.outbound_runway.stock.queued_reserved.value, 99);
+  assert.equal(truth.outbound_runway.transport.commercial_state.value, "CURRENT");
+  assert.equal(truth.outbound_runway.transport.kill_switch.value, "ativo");
+  assert.match(String(truth.outbound_runway.transport.pause.value), /durable_control/);
+  assert.equal(truth.outbound_runway.health.mailboxes_healthy.value, 1);
+  assert.equal(truth.outbound_runway.runway.slots_next_24h.value, 0);
+  assert.equal(truth.outbound_runway.runway.slots_next_7d.value, 0);
+});
+
 test("expired commercial authority is not a single STALE and is a human exception", () => {
   const input = envelope();
   const delegated = firstTouchControl(input);

--- a/control-center/apps/web-shell/tests/performance-ux.test.ts
+++ b/control-center/apps/web-shell/tests/performance-ux.test.ts
@@ -93,7 +93,7 @@ test("performance budget owns exact mobile targets and critical routes", () => {
   assert.equal(budget.budgets.css_raw_bytes, 30000);
   assert.equal(budget.budgets.css_gzip_bytes, 6700);
   assert.equal(budget.budgets.bundle_gzip_bytes, 130000);
-  assert.equal(budget.budgets.javascript_gzip_bytes, 123000);
+  assert.equal(budget.budgets.javascript_gzip_bytes, 123250);
   assert.equal(budget.budget_change.previous_bundle_gzip_bytes, 123500);
   assert.match(budget.budget_change.reason, /outbound runway/);
   assert.deepEqual(budget.routes.map((route: { id: string }) => route.id), ["hoje", "rascunhos", "coortes"]);

--- a/control-center/connectors/runner/src/projectors/commercial.ts
+++ b/control-center/connectors/runner/src/projectors/commercial.ts
@@ -675,6 +675,14 @@ function operationsFromWarmbly(
     observed: false,
     why: "the collector produced no dispatch reading; the kill-switch state is not known",
   };
+  // Connector-owned first-touch / refill / mailbox blocks. QUEUED on the founder
+  // surface is N(delegated_first_touch.queued_readback) only; dispatch.queued_approved
+  // is a runway target and must not be re-derived here as a queue count.
+  const delegatedFirstTouch = asRecord(nested.delegated_first_touch);
+  const workingOverview = asRecord(nested.working_overview);
+  const forwardedStatus = asRecord(nested.confenge_status) ?? asRecord(payload.confenge_status);
+  const outboundOutcomes = asRecord(nested.outbound_outcomes);
+  const mailboxHealth = asRecord(nested.mailbox_health);
 
   const operations = {
     schema_version: "control-center.commercial-operations.v1",
@@ -684,6 +692,11 @@ function operationsFromWarmbly(
     // the connector computes has to be forwarded explicitly or it silently
     // disappears between the mapper and the surface that renders it.
     dispatch,
+    ...(delegatedFirstTouch ? { delegated_first_touch: delegatedFirstTouch } : {}),
+    ...(workingOverview ? { working_overview: workingOverview } : {}),
+    ...(forwardedStatus ? { confenge_status: forwardedStatus } : {}),
+    ...(outboundOutcomes ? { outbound_outcomes: outboundOutcomes } : {}),
+    ...(mailboxHealth ? { mailbox_health: mailboxHealth } : {}),
     authority: {
       catalog_authority: "governance",
       commercial_runtime: "warmbly",

--- a/control-center/connectors/runner/tests/projectors.test.ts
+++ b/control-center/connectors/runner/tests/projectors.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { collectFromWarmblyPayload } from "../../warmbly/src/mapper/normalize.ts";
+import { loadFixture } from "../../warmbly/tests/helpers.ts";
 import { availabilityFromEnvelope } from "../src/projectors/availability.ts";
 import { projectCollector } from "../src/projectors/project.ts";
 import { CONFENGE_OPERATIONAL_REPOS } from "../src/projectors/types.ts";
@@ -74,6 +75,105 @@ test("Warmbly counts project to commercial snapshot with labeled acquisition coh
   assert.equal(typeof rate?.denominator, "number");
   const clients = projected.find((row) => row.snapshot_kind === "clients");
   assert.ok(clients);
+});
+
+test("commercial projector forwards queued_readback and never treats dispatch.queued_approved as QUEUED", () => {
+  const projected = projectCollector({
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: now,
+    source: { system: "warmbly", kind: "collector-runner", locator: "warmbly" },
+    confidence: 0.8,
+    payload: {
+      counts: { deals_open: 1, inbound_now: 0 },
+      operations: {
+        dispatch: {
+          state: "PAUSED",
+          observed: true,
+          queued_approved: 421,
+          pause_reason: "deploy_preflight",
+        },
+        delegated_first_touch: {
+          observed: true,
+          policy_id: "CFG-FIRST-TOUCH-ROUTING-v2",
+          queued_readback: 290,
+          counts: { QUEUED: 290, HOLD: 10 },
+        },
+        working_overview: {
+          observed: true,
+          slots_next_24h: 20,
+          furthest_due_at: "2026-09-11T12:00:00Z",
+        },
+        confenge_status: { kill_switch: true, auto_send_enabled: false },
+        mailbox_health: { healthy: 1, blocked: 0, unknown: 0 },
+        outbound_outcomes: { attempted: 0, provider_accepted: 0, sent: 0 },
+      },
+    },
+  });
+  const commercial = projected.find((row) => row.snapshot_kind === "commercial");
+  assert.ok(commercial);
+  const ops = commercial.payload.operations as Record<string, unknown>;
+  const delegated = ops.delegated_first_touch as Record<string, unknown>;
+  const dispatch = ops.dispatch as Record<string, unknown>;
+  const working = ops.working_overview as Record<string, unknown>;
+  const status = ops.confenge_status as Record<string, unknown>;
+  const mailbox = ops.mailbox_health as Record<string, unknown>;
+  const outcomes = ops.outbound_outcomes as Record<string, unknown>;
+  assert.equal(delegated.queued_readback, 290);
+  assert.equal(dispatch.queued_approved, 421);
+  assert.notEqual(delegated.queued_readback, dispatch.queued_approved);
+  assert.equal(working.slots_next_24h, 20);
+  assert.equal(status.kill_switch, true);
+  assert.equal(mailbox.healthy, 1);
+  assert.equal(outcomes.sent, 0);
+  assert.equal(Object.hasOwn(ops, "queued"), false);
+});
+
+test("commercial projector does not invent QUEUED when queued_readback is absent", () => {
+  const projected = projectCollector({
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: now,
+    source: { system: "warmbly", kind: "collector-runner", locator: "warmbly" },
+    confidence: 0.8,
+    payload: {
+      counts: { deals_open: 1, inbound_now: 0 },
+      operations: {
+        dispatch: { state: "PAUSED", observed: true, queued_approved: 421 },
+      },
+    },
+  });
+  const commercial = projected.find((row) => row.snapshot_kind === "commercial");
+  assert.ok(commercial);
+  const ops = commercial.payload.operations as Record<string, unknown>;
+  assert.equal(ops.delegated_first_touch, undefined);
+  assert.equal((ops.dispatch as Record<string, unknown>).queued_approved, 421);
+  assert.equal(Object.hasOwn(ops, "queued"), false);
+});
+
+test("Warmbly fixture queued_readback survives mapper then commercial projector", () => {
+  const snapshot = collectFromWarmblyPayload(loadFixture("commercial-runtime.json"), {
+    now: new Date(now),
+  });
+  const mapped = snapshot.operations?.delegated_first_touch as Record<string, unknown>;
+  assert.equal(mapped.queued_readback, 1);
+  const projected = projectCollector({
+    collector: "warmbly",
+    freshness_status: "FRESH",
+    observed_at: now,
+    source: { system: "warmbly", kind: "collector-runner", locator: "warmbly" },
+    confidence: 0.8,
+    payload: snapshot,
+  });
+  const commercial = projected.find((row) => row.snapshot_kind === "commercial");
+  assert.ok(commercial);
+  const ops = commercial.payload.operations as Record<string, unknown>;
+  const delegated = ops.delegated_first_touch as Record<string, unknown>;
+  const working = ops.working_overview as Record<string, unknown>;
+  assert.equal(delegated.queued_readback, 1);
+  assert.equal(delegated.observed, true);
+  assert.equal(working.observed, true);
+  assert.equal((ops.dispatch as Record<string, unknown>).queued_approved, undefined);
 });
 
 test("Warmbly weekly revenue facts project under one opaque correlation and preserve UNKNOWN", () => {


### PR DESCRIPTION
## Why

Live Control Center at `8d1cb48` collects Warmbly `GET /v1/confenge/first-touch/status` (200) with `queued_readback=421`, but the commercial projector rebuilds `operations` and drops `delegated_first_touch`. The persisted snapshot then has only `dispatch.queued_approved=421` (runway target) and no `queued_readback`. The founder surface on main uses `N(delegated.queued_readback)` only, so QUEUED renders UNKNOWN — or a dirty fallback would treat the runway target as the queue.

Campaign rule: QUEUED only from `queued_readback`. HTTP 2xx is not QUEUED. UNKNOWN is never zero.

## What
- Forward connector-owned `delegated_first_touch`, `working_overview`, `confenge_status`, `outbound_outcomes`, and `mailbox_health` through the commercial projector.
- Read commercial authority, pause, kill switch, mailbox health, slots, and due_at from the first-touch `control` block when the top-level aliases are absent.
- Tests: projector preserves `queued_readback` and does not invent QUEUED from `queued_approved`; founder projection on a live-shaped control block keeps `queued_readback` and never uses `queued_approved`.

## Out of scope
Does not lift the PRE-GO kill switch or dispatch pause. Transport stays blocked until the São Paulo window (`2026-08-28T12:00:00Z`).