### PR TITLE
fix(control-center): show ARMED_FOR_NEXT_BUSINESS_WINDOW instead of GO

### DIFF
--- a/control-center/apps/web-shell/performance-budgets.json
+++ b/control-center/apps/web-shell/performance-budgets.json
@@ -22,14 +22,14 @@
     "cls_p75": 0.1,
     "long_task_max_ms": 350,
     "initial_request_count": 16,
-    "javascript_raw_bytes": 404000,
-    "javascript_gzip_bytes": 123250,
+    "javascript_raw_bytes": 404100,
+    "javascript_gzip_bytes": 123400,
     "css_raw_bytes": 30000,
     "css_gzip_bytes": 6700,
     "bundle_gzip_bytes": 130000
   },
   "budget_change": {
     "previous_bundle_gzip_bytes": 123500,
-    "reason": "The existing founder operating-truth viewport now includes the source-attributed outbound runway, 33 progressive readbacks, fail-closed reconciliation, and first-touch control fallbacks so QUEUED is queued_readback rather than dispatch.queued_approved; the bounded ceiling follows the measured feature delta while mobile LCP and INP targets remain unchanged."
+    "reason": "The existing founder operating-truth viewport now includes the source-attributed outbound runway, fail-closed queued_readback, and ARMED_FOR_NEXT_BUSINESS_WINDOW so dispatch ACTIVE outside the São Paulo window is not shown as GO; the bounded ceiling follows the measured feature delta while mobile LCP and INP targets remain unchanged."
   }
 }

--- a/control-center/apps/web-shell/src/founder-operating-truth.ts
+++ b/control-center/apps/web-shell/src/founder-operating-truth.ts
@@ -34,7 +34,7 @@ export interface MorningException {
   source: MorningSource;
 }
 
-export type TransportDecision = "GO" | "PAUSED" | "NO_GO" | "UNKNOWN";
+export type TransportDecision = "GO" | "PAUSED" | "NO_GO" | "ARMED_FOR_NEXT_BUSINESS_WINDOW" | "UNKNOWN";
 
 export interface MorningFact<T extends string | number> {
   value: T | null;
@@ -272,11 +272,6 @@ export function projectFounderOperatingTruth(envelopeValue: unknown): FounderOpe
   const targetCoverageText = N(target.covered) !== null && N(target.total) !== null ? `${N(target.covered)}/${N(target.total)}` : S(pncp.target_coverage);
 
   const transportRaw = S(dispatch.transport_state) ?? rawDispatchState;
-  const reportedTransportDecision: TransportDecision = transportRaw === "GO" || transportRaw === "NO_GO" || transportRaw === "PAUSED"
-    ? transportRaw
-    : transportRaw === "ACTIVE" ? "GO" : "UNKNOWN";
-  const transportDecision: TransportDecision = warmblySource.freshness === "FRESH" ? reportedTransportDecision : "UNKNOWN";
-  const outboundState: FounderOperatingTruth["outbound"]["state"] = transportDecision === "GO" ? "ACTIVE" : transportDecision === "PAUSED" || transportDecision === "NO_GO" ? "PAUSED" : "UNKNOWN";
   const sourceRuns = [...new Set(delegatedItems.map((item) => S(item.source_run_id)).filter((item): item is string => Boolean(item)))];
   const delegatedRun = sourceRuns.length === 1 ? sourceRuns[0]! : sourceRuns.length === 0 ? S(delegated.source_run_id) : null;
   const sourceRunMatch: OutboundRunwayTruth["integrity"]["source_run_match"] = sourceRuns.length > 1
@@ -286,6 +281,19 @@ export function projectFounderOperatingTruth(envelopeValue: unknown): FounderOpe
   const transportBlock = O(delegatedControl.transport);
   const capacityBlock = O(delegatedControl.capacity);
   const forecast = O(capacityBlock.forecast);
+  const killEngaged = transportBlock.kill_switch_engaged === true || dispatch.kill_switch === true;
+  const durablePaused = transportBlock.dispatch_paused === true || transportRaw === "PAUSED" || transportRaw === "NO_GO";
+  const inSendWindow = capacityBlock.in_send_window;
+  let reportedTransportDecision: TransportDecision;
+  if (transportRaw === "NO_GO") reportedTransportDecision = "NO_GO";
+  else if (killEngaged || durablePaused) reportedTransportDecision = "PAUSED";
+  else if (inSendWindow === false) reportedTransportDecision = "ARMED_FOR_NEXT_BUSINESS_WINDOW";
+  else if (inSendWindow === true && (transportRaw === "ACTIVE" || transportRaw === "GO")) reportedTransportDecision = "GO";
+  else if (transportRaw === "GO" || transportRaw === "PAUSED") reportedTransportDecision = transportRaw;
+  else if (transportRaw === "ACTIVE") reportedTransportDecision = "GO";
+  else reportedTransportDecision = "UNKNOWN";
+  const transportDecision: TransportDecision = warmblySource.freshness === "FRESH" ? reportedTransportDecision : "UNKNOWN";
+  const outboundState: FounderOperatingTruth["outbound"]["state"] = transportDecision === "GO" ? "ACTIVE" : transportDecision === "PAUSED" || transportDecision === "NO_GO" || transportDecision === "ARMED_FOR_NEXT_BUSINESS_WINDOW" ? "PAUSED" : "UNKNOWN";
   const dueDates = delegatedItems
     .filter((item) => item.state === "QUEUED")
     .map((item) => validDate(item.due_at))

--- a/control-center/apps/web-shell/src/ui/hoje.ts
+++ b/control-center/apps/web-shell/src/ui/hoje.ts
@@ -349,7 +349,8 @@ function outboundRunwayBlock(truth: FounderOperatingTruth): string {
   const action = truth.primary_action;
   const transportTone = runway.transport.state.value === "GO" ? "go"
     : runway.transport.state.value === "PAUSED" ? "paused"
-      : runway.transport.state.value === "NO_GO" ? "no-go" : "unknown";
+      : runway.transport.state.value === "NO_GO" ? "no-go"
+        : runway.transport.state.value === "ARMED_FOR_NEXT_BUSINESS_WINDOW" ? "armed" : "unknown";
   const reservoirSignal = runway.runway.reservoir_below_1000 === true
     ? `<span class="pill runway-low">reservoir abaixo de 1 mil</span>`
     : runway.runway.reservoir_below_1000 === false

--- a/control-center/apps/web-shell/tests/founder-operating-truth.test.ts
+++ b/control-center/apps/web-shell/tests/founder-operating-truth.test.ts
@@ -606,6 +606,21 @@ test("capacity v2 stays a read-only projection and exposes deadline blockers in 
   assert.doesNotMatch(html, /REQUESTED_DEADLINE_INFEASIBLE/);
 });
 
+test("dispatch ACTIVE outside the send window is ARMED_FOR_NEXT_BUSINESS_WINDOW not GO", () => {
+  const input = envelope();
+  const delegated = firstTouchControl(input);
+  const operations = ((input.snapshots as Record<string, Record<string, unknown>>).commercial!.snapshot as Record<string, unknown>).operations as Record<string, unknown>;
+  (operations.dispatch as Record<string, unknown>).state = "ACTIVE";
+  delegated.control = {
+    transport: { kill_switch_engaged: false, dispatch_paused: false, sent: 0, provider_attempts: 0 },
+    capacity: { in_send_window: false, timezone: "America/Sao_Paulo", window_start: "09:00", window_end: "18:00" },
+  };
+  const truth = projectFounderOperatingTruth(input);
+  assert.equal(truth.outbound_runway.transport.state.value, "ARMED_FOR_NEXT_BUSINESS_WINDOW");
+  assert.notEqual(truth.outbound_runway.transport.state.value, "GO");
+  assert.equal(truth.outbound.state, "PAUSED");
+});
+
 test("QUEUED comes only from queued_readback, never from dispatch.queued_approved", () => {
   const input = envelope();
   const delegated = firstTouchControl(input);

--- a/control-center/apps/web-shell/tests/performance-ux.test.ts
+++ b/control-center/apps/web-shell/tests/performance-ux.test.ts
@@ -93,7 +93,7 @@ test("performance budget owns exact mobile targets and critical routes", () => {
   assert.equal(budget.budgets.css_raw_bytes, 30000);
   assert.equal(budget.budgets.css_gzip_bytes, 6700);
   assert.equal(budget.budgets.bundle_gzip_bytes, 130000);
-  assert.equal(budget.budgets.javascript_gzip_bytes, 123250);
+  assert.equal(budget.budgets.javascript_gzip_bytes, 123400);
   assert.equal(budget.budget_change.previous_bundle_gzip_bytes, 123500);
   assert.match(budget.budget_change.reason, /outbound runway/);
   assert.deepEqual(budget.routes.map((route: { id: string }) => route.id), ["hoje", "rascunhos", "coortes"]);


### PR DESCRIPTION
## Why

After PRE-GO lift, Warmbly `dispatch.state` is `ACTIVE` while `capacity.in_send_window` is false. Mapping ACTIVE→GO told the founder transport was live outside America/Sao_Paulo 09:00–18:00.

## What
- `TransportDecision` includes `ARMED_FOR_NEXT_BUSINESS_WINDOW`.
- kill_switch_engaged or dispatch_paused → PAUSED
- in_send_window=false (and not paused) → ARMED_FOR_NEXT_BUSINESS_WINDOW
- GO only when the window is open
- QUEUED remains `queued_readback` only