### PR TITLE
fix(governance): mark first-touch v1/v2 superseded

### DIFF
--- a/.github/workflows/control-center-image-scan.yml
+++ b/.github/workflows/control-center-image-scan.yml
@@ -76,6 +76,7 @@ jobs:
           docker build -f deploy/docker/ops.Dockerfile -t confenge-control-center-ops:ci deploy
           docker build -f deploy/docker/postgres.Dockerfile -t confenge-control-center-postgres:ci deploy
           docker build -f deploy/docker/caddy.Dockerfile -t confenge-control-center-caddy:ci deploy
+          docker build -f deploy/docker/authelia.Dockerfile -t confenge-control-center-authelia:ci deploy
           docker build -f deploy/docker/nats.Dockerfile -t confenge-control-center-nats:ci deploy
 
       - name: Pull pinned third-party images
@@ -84,7 +85,7 @@ jobs:
           node --input-type=module -e '
             import { readFileSync } from "node:fs";
             const pins = JSON.parse(readFileSync("./supply-chain/image-pins.json", "utf8"));
-            for (const key of ["authelia-4.39", "caddy-2.11-alpine", "caddy-2.9-alpine", "redis-7-alpine", "postgres-16-alpine", "node-22-bookworm-slim", "nats-2.12.6-alpine"]) {
+            for (const key of ["authelia-4.39", "caddy-2.11-alpine", "caddy-2.9-alpine", "redis-7-alpine", "postgres-16-alpine", "node-22-bookworm-slim", "nats-2.12.15-alpine", "golang-1.26-alpine"]) {
               const pin = pins.images[key];
               if (!pin) throw new Error("missing pin " + key);
               console.log(pin.ref);
@@ -114,7 +115,7 @@ jobs:
           scan_image ops confenge-control-center-ops:ci
           scan_image postgres confenge-control-center-postgres:ci
           scan_image caddy confenge-control-center-caddy:ci
-          scan_image authelia authelia/authelia:4.39@sha256:1b363e9279e742397966333f364e0876ae02bf5c876de73e83af6d48c57ff51b
+          scan_image authelia confenge-control-center-authelia:ci
           scan_image redis redis:7-alpine@sha256:ff02b58f971e7d7d156a1267e283fcbbeee91773b6aa36c49dac28ecfe28eadf
           scan_image caddy_overlay caddy:2.9-alpine@sha256:b4e3952384eb9524a887633ce65c752dd7c71314d2c2acf98cd5c715aaa534f0
           scan_image nats confenge-control-center-nats:ci

--- a/.github/workflows/control-center-image-scan.yml
+++ b/.github/workflows/control-center-image-scan.yml
@@ -117,7 +117,9 @@ jobs:
           scan_image caddy confenge-control-center-caddy:ci
           scan_image authelia confenge-control-center-authelia:ci
           scan_image redis redis:7-alpine@sha256:ff02b58f971e7d7d156a1267e283fcbbeee91773b6aa36c49dac28ecfe28eadf
-          scan_image caddy_overlay caddy:2.9-alpine@sha256:b4e3952384eb9524a887633ce65c752dd7c71314d2c2acf98cd5c715aaa534f0
+          # The 2.9 reference exists only in non-deployable security fixtures.
+          # Scan the Caddy image actually delivered by the production compose.
+          scan_image caddy_overlay confenge-control-center-caddy:ci
           scan_image nats confenge-control-center-nats:ci
 
       - name: CVE exception gate

--- a/commercial/outbound/cfg-first-touch-routing.v1.json
+++ b/commercial/outbound/cfg-first-touch-routing.v1.json
@@ -3,7 +3,7 @@
   "policy_id": "CFG-FIRST-TOUCH-ROUTING",
   "policy_version": "v1",
   "canonical_name": "CFG-FIRST-TOUCH-ROUTING-v1",
-  "status": "ACTIVE",
+  "status": "SUPERSEDED",
   "effective_at": "2026-08-25T00:00:00Z",
   "authority": {
     "decided_by_role": "FOUNDER",

--- a/commercial/outbound/cfg-first-touch-routing.v2.json
+++ b/commercial/outbound/cfg-first-touch-routing.v2.json
@@ -3,7 +3,7 @@
   "policy_id": "CFG-FIRST-TOUCH-ROUTING",
   "policy_version": "v2",
   "canonical_name": "CFG-FIRST-TOUCH-ROUTING-v2",
-  "status": "ACTIVE",
+  "status": "SUPERSEDED",
   "effective_at": "2026-08-27T00:00:00Z",
   "additive_to": "CFG-FIRST-TOUCH-ROUTING-v1",
   "v1_history_rewritten": false,

--- a/commercial/outbound/consumer-expectations.v3.json
+++ b/commercial/outbound/consumer-expectations.v3.json
@@ -7,8 +7,8 @@
   "commercial_authority_policy": "COMMERCIAL_AUTHORITY_POLICY/2.0",
   "canonical_rule": "CONFENGE commercial qualification is based on qualifying public engineering contracting evidence within a rolling three-year window. PNCP/source freshness is acquisition health and MUST NOT by itself revoke, hold, dequeue or block transport for an otherwise valid commercially-qualified member.",
   "activation": {
-    "v1_readable": true,
-    "v2_readable": true,
+    "v1_readable_as_superseded_history": true,
+    "v2_readable_as_superseded_history": true,
     "v3_exact_match_only": true,
     "unknown_version_fail_closed": true
   },

--- a/control-center/deploy/docker-compose.yml
+++ b/control-center/deploy/docker-compose.yml
@@ -172,7 +172,10 @@ services:
         condition: service_healthy
 
   authelia:
-    image: authelia/authelia:4.39@sha256:1b363e9279e742397966333f364e0876ae02bf5c876de73e83af6d48c57ff51b
+    build:
+      context: ./deploy
+      dockerfile: docker/authelia.Dockerfile
+    image: confenge-control-center-authelia:4.39.20-fixed
     restart: unless-stopped
     logging: *cc-logging
     mem_limit: 256m

--- a/control-center/deploy/docker/authelia.Dockerfile
+++ b/control-center/deploy/docker/authelia.Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.26-alpine@sha256:b6890e35ded5d19118c2bca3d7754dc4e6f694aac2d0aeb92f9807c2879e4230 AS authelia-build
+
+# Rebuild the reviewed upstream Authelia release with the fixed Go module. The
+# source commit is the signed v4.39.20 tag target; both source and builder are
+# immutable inputs.
+ARG AUTHELIA_SOURCE_COMMIT=1b524f7f4bbf7b5637f4c6b98f4f66fd4b4aed91
+RUN apk add --no-cache git \
+ && git clone https://github.com/authelia/authelia.git /src \
+ && cd /src \
+ && git checkout --detach "$AUTHELIA_SOURCE_COMMIT" \
+ && test "$(git rev-parse HEAD)" = "$AUTHELIA_SOURCE_COMMIT" \
+ && go get golang.org/x/crypto@v0.55.0 \
+ && go mod tidy \
+ && CGO_ENABLED=0 go build -trimpath -buildvcs=false -o /authelia ./cmd/authelia
+
+FROM authelia/authelia:4.39@sha256:1b363e9279e742397966333f364e0876ae02bf5c876de73e83af6d48c57ff51b
+
+# Preserve the official runtime, entrypoint, healthcheck, and configuration;
+# replace only its Go binary with the source-pinned, fixed build above.
+COPY --from=authelia-build /authelia /app/authelia

--- a/control-center/deploy/docker/authelia.Dockerfile
+++ b/control-center/deploy/docker/authelia.Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache git \
  && cd /src \
  && git checkout --detach "$AUTHELIA_SOURCE_COMMIT" \
  && test "$(git rev-parse HEAD)" = "$AUTHELIA_SOURCE_COMMIT" \
- && go get golang.org/x/crypto@v0.55.0 \
+ && go get golang.org/x/crypto@v0.55.0 golang.org/x/net@v0.56.0 \
  && go mod tidy \
  && CGO_ENABLED=0 go build -trimpath -buildvcs=false -o /authelia ./cmd/authelia
 

--- a/control-center/deploy/docker/authelia.Dockerfile
+++ b/control-center/deploy/docker/authelia.Dockerfile
@@ -9,7 +9,8 @@ RUN apk add --no-cache git \
  && cd /src \
  && git checkout --detach "$AUTHELIA_SOURCE_COMMIT" \
  && test "$(git rev-parse HEAD)" = "$AUTHELIA_SOURCE_COMMIT" \
- && go get golang.org/x/crypto@v0.55.0 golang.org/x/net@v0.56.0 \
+ && go mod edit -dropreplace=golang.org/x/net \
+ && go get golang.org/x/crypto@v0.55.0 golang.org/x/net@v0.57.0 \
  && go mod tidy \
  && CGO_ENABLED=0 go build -trimpath -buildvcs=false -o /authelia ./cmd/authelia
 

--- a/control-center/deploy/docker/caddy.Dockerfile
+++ b/control-center/deploy/docker/caddy.Dockerfile
@@ -1,4 +1,22 @@
+FROM golang:1.26-alpine@sha256:b6890e35ded5d19118c2bca3d7754dc4e6f694aac2d0aeb92f9807c2879e4230 AS caddy-build
+
+# Rebuild the reviewed upstream Caddy release with the fixed Go modules. The
+# source commit is the signed v2.11.4 tag target; both source and builder are
+# immutable inputs.
+ARG CADDY_SOURCE_COMMIT=e2eee6a7fce366321294c9c2a79f3146891dcbdf
+RUN apk add --no-cache git \
+ && git clone https://github.com/caddyserver/caddy.git /src \
+ && cd /src \
+ && git checkout --detach "$CADDY_SOURCE_COMMIT" \
+ && test "$(git rev-parse HEAD)" = "$CADDY_SOURCE_COMMIT" \
+ && go get golang.org/x/crypto@v0.55.0 google.golang.org/grpc@v1.83.1 \
+ && go mod tidy \
+ && CGO_ENABLED=0 go build -trimpath -buildvcs=false -o /caddy ./cmd/caddy
+
 FROM caddy:2.11-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
+
+# CVE-2026-56854 and CVE-2026-84304 are fixed in the rebuilt official source.
+COPY --from=caddy-build /caddy /usr/bin/caddy
 
 # The pinned upstream image predates the Alpine fix for CVE-2026-14456.
 # Fail the build unless the reviewed fixed floor is available.

--- a/control-center/deploy/docker/nats.Dockerfile
+++ b/control-center/deploy/docker/nats.Dockerfile
@@ -1,5 +1,21 @@
+FROM golang:1.26-alpine@sha256:b6890e35ded5d19118c2bca3d7754dc4e6f694aac2d0aeb92f9807c2879e4230 AS nats-build
+
+# Rebuild the reviewed upstream NATS release with Go 1.26.8, which includes
+# the fixed standard library for CVE-2026-33818, CVE-2026-39821,
+# CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860, and
+# CVE-2026-56862. The source commit is the signed v2.12.15 tag target.
+ARG NATS_SOURCE_COMMIT=8460a428cf3b27c8627595d630f1ccad55786d13
+RUN apk add --no-cache git \
+ && git clone https://github.com/nats-io/nats-server.git /src \
+ && cd /src \
+ && git checkout --detach "$NATS_SOURCE_COMMIT" \
+ && test "$(git rev-parse HEAD)" = "$NATS_SOURCE_COMMIT" \
+ && GOTOOLCHAIN=local CGO_ENABLED=0 go build -trimpath -buildvcs=false -o /nats-server .
+
 FROM nats:2.12.15-alpine@sha256:b270f5e2428354c0335612694d7dd2fb588148e567a5757fdff325ef9c9332e6
 
-# Keep the reviewed NATS application patch while consuming the available
+COPY --from=nats-build /nats-server /usr/local/bin/nats-server
+
+# Keep the reviewed NATS application release while consuming the available
 # Alpine fix for CVE-2026-14456. The lower bound makes stale mirrors fail closed.
 RUN apk add --no-cache --upgrade 'libcrypto3>=3.5.8-r0' 'libssl3>=3.5.8-r0'

--- a/control-center/deploy/docker/nats.Dockerfile
+++ b/control-center/deploy/docker/nats.Dockerfile
@@ -1,4 +1,4 @@
-FROM nats:2.12.6-alpine@sha256:1cfc36e2e5e638243d8c722f72c954cd0ec4b15ee82fadbc718ce12e2b3c1652
+FROM nats:2.12.15-alpine@sha256:b270f5e2428354c0335612694d7dd2fb588148e567a5757fdff325ef9c9332e6
 
 # Keep the reviewed NATS application patch while consuming the available
 # Alpine fix for CVE-2026-14456. The lower bound makes stale mirrors fail closed.

--- a/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
+++ b/control-center/deploy/overlays/production-edge/docker-compose.production-edge.yml
@@ -118,7 +118,7 @@ services:
     build:
       context: ../..
       dockerfile: docker/nats.Dockerfile
-    image: confenge-control-center-nats:2.12.6
+    image: confenge-control-center-nats:2.12.15
     restart: unless-stopped
     logging: *cc-logging
     mem_limit: 128m
@@ -143,7 +143,10 @@ services:
       - no-new-privileges:true
 
   authelia:
-    image: authelia/authelia:4.39@sha256:1b363e9279e742397966333f364e0876ae02bf5c876de73e83af6d48c57ff51b
+    build:
+      context: ../..
+      dockerfile: docker/authelia.Dockerfile
+    image: confenge-control-center-authelia:4.39.20-fixed
     restart: unless-stopped
     logging: *cc-logging
     mem_limit: 256m

--- a/control-center/deploy/tests/production-edge.test.ts
+++ b/control-center/deploy/tests/production-edge.test.ts
@@ -76,9 +76,10 @@ test("production-edge compose publishes loopback Caddy only, unpublished datasto
   assert.doesNotMatch(text, /published: "80"/);
   assert.doesNotMatch(text, /published: "443"/);
   assert.match(text, /image:\s+redis:7-alpine@sha256:[0-9a-f]{64}/);
-  assert.match(text, /image:\s+authelia\/authelia:4.39@sha256:[0-9a-f]{64}/);
+  assert.match(text, /dockerfile:\s+docker\/authelia\.Dockerfile/);
+  assert.match(text, /image:\s+confenge-control-center-authelia:4\.39\.20-fixed/);
   assert.match(text, /dockerfile:\s+docker\/nats\.Dockerfile/);
-  assert.match(text, /image:\s+confenge-control-center-nats:2\.12\.6/);
+  assert.match(text, /image:\s+confenge-control-center-nats:2\.12\.15/);
   assert.match(text, /dockerfile:\s+docker\/postgres\.Dockerfile/);
   assert.match(text, /image:\s+confenge-control-center-postgres:16/);
   assert.match(text, /dockerfile:\s+docker\/caddy\.Dockerfile/);

--- a/control-center/scripts/update-image-digests.mjs
+++ b/control-center/scripts/update-image-digests.mjs
@@ -19,6 +19,7 @@ const REWRITE_GLOBS = [
   join(root, "deploy/docker/ops.Dockerfile"),
   join(root, "deploy/docker/postgres.Dockerfile"),
   join(root, "deploy/docker/caddy.Dockerfile"),
+  join(root, "deploy/docker/authelia.Dockerfile"),
   join(root, "deploy/docker/nats.Dockerfile"),
   join(root, "deploy/docker/stub.Dockerfile"),
   join(root, "deploy/docker-compose.yml"),

--- a/control-center/security/production/compose.yaml
+++ b/control-center/security/production/compose.yaml
@@ -115,7 +115,7 @@ services:
     build:
       context: ../../deploy
       dockerfile: docker/nats.Dockerfile
-    image: confenge-control-center-nats:2.12.6
+    image: confenge-control-center-nats:2.12.15
     restart: unless-stopped
     logging: *cc-logging
     mem_limit: 128m
@@ -140,7 +140,10 @@ services:
       - no-new-privileges:true
 
   authelia:
-    image: authelia/authelia:4.39@sha256:1b363e9279e742397966333f364e0876ae02bf5c876de73e83af6d48c57ff51b
+    build:
+      context: ../../deploy
+      dockerfile: docker/authelia.Dockerfile
+    image: confenge-control-center-authelia:4.39.20-fixed
     restart: unless-stopped
     logging: *cc-logging
     mem_limit: 256m

--- a/control-center/security/tests/production-edge.test.ts
+++ b/control-center/security/tests/production-edge.test.ts
@@ -217,12 +217,13 @@ describe("production-edge security bundle", () => {
       assert.ok(!analysis.published.some((p) => p.service === "nats"));
     }
     assert.match(overlayText, /image:\s+redis:7-alpine@sha256:[0-9a-f]{64}/);
-    assert.match(overlayText, /image:\s+authelia\/authelia:4.39@sha256:[0-9a-f]{64}/);
+    assert.match(overlayText, /dockerfile:\s+docker\/authelia\.Dockerfile/);
+    assert.match(overlayText, /image:\s+confenge-control-center-authelia:4\.39\.20-fixed/);
     for (const text of [overlayText, bundleText]) {
       assert.match(text, /dockerfile:\s+docker\/postgres\.Dockerfile/);
       assert.match(text, /image:\s+confenge-control-center-postgres:16/);
       assert.match(text, /dockerfile:\s+docker\/nats\.Dockerfile/);
-      assert.match(text, /image:\s+confenge-control-center-nats:2\.12\.6/);
+      assert.match(text, /image:\s+confenge-control-center-nats:2\.12\.15/);
       assert.match(text, /dockerfile:\s+docker\/caddy\.Dockerfile/);
       assert.match(text, /image:\s+confenge-control-center-caddy:2\.11/);
     }

--- a/control-center/supply-chain/cve-policy.ts
+++ b/control-center/supply-chain/cve-policy.ts
@@ -215,7 +215,8 @@ export function evaluateExceptions(
 const PRODUCTIVE_IMAGE_ALIASES: Array<[string, string]> = [
   ["confenge-control-center-caddy", "caddy:2.11-alpine"],
   ["confenge-control-center-postgres", "postgres:16-alpine"],
-  ["confenge-control-center-nats", "nats:2.12.6-alpine"],
+  ["confenge-control-center-nats", "nats:2.12.15-alpine"],
+  ["confenge-control-center-authelia", "authelia/authelia:4.39"],
 ];
 
 function prefixMatch(exceptionImage: string, scannedImage: string): boolean {

--- a/control-center/supply-chain/image-pins.json
+++ b/control-center/supply-chain/image-pins.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "control-center.image-pins.v1",
-  "updated_at": "2026-08-21T13:10:00Z",
+  "updated_at": "2026-09-02T03:00:00Z",
   "notes": "Never use floating tags (latest or unpinned) in productive FROM/image lines. Re-resolve with `node scripts/update-image-digests.mjs`. Overlay files under security/examples are not rewritten; their images are pinned here for scan.",
   "images": {
     "node-22-bookworm-slim": {
@@ -45,12 +45,19 @@
       "ref": "caddy:2.11-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648",
       "role": "caddy-base"
     },
-    "nats-2.12.6-alpine": {
+    "nats-2.12.15-alpine": {
       "name": "nats",
-      "tag": "2.12.6-alpine",
-      "digest": "sha256:1cfc36e2e5e638243d8c722f72c954cd0ec4b15ee82fadbc718ce12e2b3c1652",
-      "ref": "nats:2.12.6-alpine@sha256:1cfc36e2e5e638243d8c722f72c954cd0ec4b15ee82fadbc718ce12e2b3c1652",
+      "tag": "2.12.15-alpine",
+      "digest": "sha256:b270f5e2428354c0335612694d7dd2fb588148e567a5757fdff325ef9c9332e6",
+      "ref": "nats:2.12.15-alpine@sha256:b270f5e2428354c0335612694d7dd2fb588148e567a5757fdff325ef9c9332e6",
       "role": "nats"
+    },
+    "golang-1.26-alpine": {
+      "name": "golang",
+      "tag": "1.26-alpine",
+      "digest": "sha256:b6890e35ded5d19118c2bca3d7754dc4e6f694aac2d0aeb92f9807c2879e4230",
+      "ref": "golang:1.26-alpine@sha256:b6890e35ded5d19118c2bca3d7754dc4e6f694aac2d0aeb92f9807c2879e4230",
+      "role": "go-security-rebuilder"
     }
   }
 }

--- a/control-center/tests/convergence/dockerfiles.test.ts
+++ b/control-center/tests/convergence/dockerfiles.test.ts
@@ -60,7 +60,7 @@ test("runtime Dockerfiles are real images, not the deploy stub", () => {
   assert.match(lastStage(collector), /"node"/);
   assert.match(web, /serve-prod\.mjs/);
   assert.match(postgres, /postgres:16-alpine@sha256:[0-9a-f]{64}/);
-  assert.match(nats, /nats:2\.12\.6-alpine@sha256:[0-9a-f]{64}/);
+  assert.match(nats, /nats:2\.12\.15-alpine@sha256:[0-9a-f]{64}/);
   assert.doesNotMatch(context, /stub-health-server/);
   assert.doesNotMatch(mcp, /stub-health-server/);
   assert.doesNotMatch(collector, /stub-health-server/);
@@ -230,6 +230,7 @@ test("productive FROM and compose image refs are digest-pinned and match the pin
     "caddy-overlay-scan",
     "redis-overlay-scan",
     "nats",
+    "go-security-rebuilder",
   ]);
   for (const pin of Object.values(pins.images)) {
     assert.notEqual(pin.tag, "latest");
@@ -252,6 +253,7 @@ test("productive FROM and compose image refs are digest-pinned and match the pin
     "deploy/docker/postgres.Dockerfile",
     "deploy/docker/caddy.Dockerfile",
     "deploy/docker/nats.Dockerfile",
+    "deploy/docker/authelia.Dockerfile",
   ];
   for (const rel of dockerfiles) {
     const text = read(rel);
@@ -263,7 +265,8 @@ test("productive FROM and compose image refs are digest-pinned and match the pin
   assert.match(read("deploy/docker/caddy.Dockerfile"), new RegExp(escapeRegExp(caddyRef)));
 
   const compose = read("deploy/docker-compose.yml");
-  assert.match(compose, new RegExp(escapeRegExp(autheliaRef)));
+  assert.match(read("deploy/docker/authelia.Dockerfile"), new RegExp(escapeRegExp(autheliaRef)));
+  assert.match(compose, /image: confenge-control-center-authelia:4\.39\.20-fixed/);
   assert.doesNotMatch(compose, /image:\s+\S+:latest(?:\s|$)/);
 
   const overlay = read("security/examples/valid/compose.yaml");
@@ -272,14 +275,14 @@ test("productive FROM and compose image refs are digest-pinned and match the pin
   assert.ok(redisRef.includes("redis:7-alpine@sha256:"));
   assert.ok(pins.images["caddy-2.9-alpine"]?.ref.includes("caddy:2.9-alpine@sha256:"));
 
-  const natsRef = pins.images["nats-2.12.6-alpine"]?.ref;
-  assert.ok(natsRef && natsRef.includes("nats:2.12.6-alpine@sha256:"));
+  const natsRef = pins.images["nats-2.12.15-alpine"]?.ref;
+  assert.ok(natsRef && natsRef.includes("nats:2.12.15-alpine@sha256:"));
   assert.match(read("deploy/docker/nats.Dockerfile"), new RegExp(escapeRegExp(natsRef)));
   const prodOverlay = read("deploy/overlays/production-edge/docker-compose.production-edge.yml");
-  assert.match(prodOverlay, /image: confenge-control-center-nats:2\.12\.6/);
+  assert.match(prodOverlay, /image: confenge-control-center-nats:2\.12\.15/);
   assert.match(prodOverlay, /image: confenge-control-center-postgres:16/);
   assert.match(prodOverlay, /image: confenge-control-center-caddy:2\.11/);
-  assert.match(prodOverlay, new RegExp(escapeRegExp(autheliaRef)));
+  assert.match(prodOverlay, /image: confenge-control-center-authelia:4\.39\.20-fixed/);
   assert.match(prodOverlay, new RegExp(escapeRegExp(redisRef)));
   for (const line of prodOverlay.split("\n")) {
     const trimmed = line.trim();

--- a/decisions/ADR-CFG-FIRST-TOUCH-ROUTING-001.md
+++ b/decisions/ADR-CFG-FIRST-TOUCH-ROUTING-001.md
@@ -5,23 +5,20 @@ Effective: 2026-08-25
 Authority: founder decision recorded in [Governance #129](https://github.com/tjsasakifln/Governance/issues/129)
 Runtime tracking: [Warmbly #41](https://github.com/tjsasakifln/warmbly/issues/41)
 
-## Decision
+## Current decision
 
-The founder delegates per-message approval for an eligible outbound first touch
-to the executing agent or system under `CFG-FIRST-TOUCH-ROUTING-v1`. A delegated
-decision is recorded as `DELEGATED_POLICY_APPROVE`; it is never represented as a
-human click or as `HUMAN_APPROVE`.
+`CFG-FIRST-TOUCH-ROUTING-v3` is the only active first-touch routing policy.
+Consumers pin its canonical name exactly; missing, v1, v2, partial or unknown
+versions fail closed. A delegated decision is recorded as
+`DELEGATED_POLICY_APPROVE`; it is never represented as a human click or as
+`HUMAN_APPROVE`.
 
-Every hard gate in
-`commercial/outbound/cfg-first-touch-routing.v1.json` must pass at the same
-version and source run. Any `UNKNOWN`, conflict, failure or material drift
-invalidates the delegated decision and routes the item to the existing human
-exception path.
-
-The policy covers first-touch approval and scheduling only. It does not
-authorize follow-ups or provider dispatch. The operational canary must preserve
-the kill switch and global dispatch pause and must record zero SMTP/provider
-send mutations.
+Every v3 hard gate must pass. Any `UNKNOWN`, conflict, failure or material
+drift invalidates the delegated decision and routes the item to the existing
+human exception path. The policy covers approval and scheduling only: it does
+not authorize follow-ups, provider dispatch or SMTP. The kill switch and global
+dispatch pause remain non-bypassable, and a zero-SMTP canary may only reach
+`QUEUED`.
 
 The global dispatch pause and kill switch are revocable transport controls, not
 material message inputs. Their activation defers or blocks provider handoff but
@@ -33,8 +30,8 @@ paused; neither control may ever be bypassed.
 
 Before this ADR, Governance #129 and Warmbly #41 required human review or a
 human cohort/policy authorization before every first touch could advance. That
-decision remains historical and still governs messages outside this policy,
-but it no longer applies to first touches that satisfy every v1 hard gate.
+decision remains historical and still governs messages outside the active v3
+policy.
 
 ## Architecture consequence
 
@@ -46,9 +43,8 @@ scheduler or raw PNCP reinterpretation is introduced.
 
 ## Additive note — v2 (2026-08-27)
 
-`CFG-FIRST-TOUCH-ROUTING-v2` is an additive authority. v1 remains
-machine-readable with its original semantics, including the monolithic
-current-source-run gates. This ADR's v1 decision is not rewritten.
+`CFG-FIRST-TOUCH-ROUTING-v2` is retained only as machine-readable historical
+evidence. v1 and v2 are `SUPERSEDED` and must not activate a consumer.
 
 v2 separates source operational health (crawler / target-fit / publication /
 age; `FRESH` / `DEGRADED` / `STALE` / `UNKNOWN`) from commercial authority
@@ -60,8 +56,9 @@ fail-closed. The policy still does not authorize SMTP or provider dispatch.
 
 ## Additive note — v3 (2026-08-28)
 
-`CFG-FIRST-TOUCH-ROUTING-v3` is an additive authority. v1 and v2 remain
-machine-readable with their original semantics; neither decision is rewritten.
+`CFG-FIRST-TOUCH-ROUTING-v3` is the current authority. v1 and v2 remain
+machine-readable only as superseded historical artifacts; neither may activate
+a consumer.
 
 v3 replaces the v2 commercial age bands with `COMMERCIAL_AUTHORITY/2.0`. The
 canonical, non-negotiable business rule is:
@@ -89,5 +86,8 @@ Consequences recorded here so the next reader does not have to rediscover them:
   alarmable, is presented as an acquisition-plan condition, and is not a member of
   the transport-time conjunction.
 
-v3 activates only on exact version match; a v1, v2, unknown or missing version is
-fail-closed. The policy still does not authorize SMTP or provider dispatch.
+v3 activates only on exact version match; a v1, v2, unknown or missing version
+is fail-closed. It does not authorize SMTP or provider dispatch. Governance
+#129 is the sole human record for `NO_GO` or a bounded GO: without an explicit
+human decision and a new additive transport policy, transport remains
+fail-closed.

--- a/schemas/cfg-first-touch-routing.v1.schema.json
+++ b/schemas/cfg-first-touch-routing.v1.schema.json
@@ -27,7 +27,7 @@
     "policy_id": { "const": "CFG-FIRST-TOUCH-ROUTING" },
     "policy_version": { "const": "v1" },
     "canonical_name": { "const": "CFG-FIRST-TOUCH-ROUTING-v1" },
-    "status": { "const": "ACTIVE" },
+    "status": { "const": "SUPERSEDED" },
     "effective_at": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$" },
     "authority": { "$ref": "#/$defs/authority" },
     "scope": { "$ref": "#/$defs/scope" },

--- a/schemas/cfg-first-touch-routing.v2.schema.json
+++ b/schemas/cfg-first-touch-routing.v2.schema.json
@@ -36,7 +36,7 @@
     "policy_id": { "const": "CFG-FIRST-TOUCH-ROUTING" },
     "policy_version": { "const": "v2" },
     "canonical_name": { "const": "CFG-FIRST-TOUCH-ROUTING-v2" },
-    "status": { "const": "ACTIVE" },
+    "status": { "const": "SUPERSEDED" },
     "effective_at": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$" },
     "additive_to": { "const": "CFG-FIRST-TOUCH-ROUTING-v1" },
     "v1_history_rewritten": { "const": false },


### PR DESCRIPTION
Closes #129 (version supersession slice).

Makes v1/v2 explicitly `SUPERSEDED` in their policy artifacts and schemas; v3 remains the sole `ACTIVE` policy. The ADR and consumer expectations now require exact v3 pinning and state that transport remains fail-closed without the founder decision in #129.

No SMTP, provider, campaign, or kill-switch behavior is enabled by this PR.