### PR TITLE
fix(commercial): fail closed on missing policy version and unbound blockers

### DIFF
--- a/commercial/fixtures/net-new-inbound-handraiser/unknown.missing-policy-version-with-id.v1.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/unknown.missing-policy-version-with-id.v1.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.v1",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER-v1",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:missing-policy-version-with-id-001",
+  "correlation_id": "corr_missing_policy_version_with_id_001",
+  "receipt_id": "rcpt_missing_policy_version_with_id_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_missing_policy_version_with_id_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_missing_policy_version_with_id_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#61"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  }
+}

--- a/commercial/inbound/admit.py
+++ b/commercial/inbound/admit.py
@@ -320,26 +320,26 @@ def evaluate_net_new_inbound_handraiser(
     claimed_id = _nonempty_str(payload.get("policy_id"))
     claimed_version = _nonempty_str(payload.get("policy_version"))
     claimed_name = _nonempty_str(payload.get("canonical_name"))
-    if claimed_id is None and claimed_version is None and claimed_name is None:
+    if claimed_version is None:
         unknown("POLICY_VERSION_MISSING")
+    elif claimed_version in accepted_versions:
+        pass
+    elif claimed_version in OLD_POLICY_VERSIONS or (
+        claimed_version.startswith("v") and claimed_version != CANONICAL_POLICY_VERSION
+    ):
+        reject("POLICY_VERSION_NOT_ADMITTED")
     else:
-        if claimed_id is not None and claimed_id not in accepted_ids:
-            if claimed_id in {"CFG-FIRST-TOUCH-ROUTING", "ACQUISITION_PRESSURE"}:
-                reject("POLICY_VERSION_NOT_ADMITTED")
-            else:
-                unknown("POLICY_ID_UNKNOWN")
-        if claimed_name is not None and claimed_name not in accepted_versions:
-            if claimed_name.startswith("NET_NEW_INBOUND_HANDRAISER-") or claimed_name in OLD_POLICY_VERSIONS:
-                reject("POLICY_VERSION_NOT_ADMITTED")
-            else:
-                unknown("POLICY_VERSION_UNKNOWN")
-        if claimed_version is not None:
-            if claimed_version in accepted_versions:
-                pass
-            elif claimed_version in OLD_POLICY_VERSIONS or claimed_version.startswith("v") and claimed_version != CANONICAL_POLICY_VERSION:
-                reject("POLICY_VERSION_NOT_ADMITTED")
-            else:
-                unknown("POLICY_VERSION_UNKNOWN")
+        unknown("POLICY_VERSION_UNKNOWN")
+    if claimed_id is not None and claimed_id not in accepted_ids:
+        if claimed_id in {"CFG-FIRST-TOUCH-ROUTING", "ACQUISITION_PRESSURE"}:
+            reject("POLICY_VERSION_NOT_ADMITTED")
+        else:
+            unknown("POLICY_ID_UNKNOWN")
+    if claimed_name is not None and claimed_name not in accepted_versions:
+        if claimed_name.startswith("NET_NEW_INBOUND_HANDRAISER-") or claimed_name in OLD_POLICY_VERSIONS:
+            reject("POLICY_VERSION_NOT_ADMITTED")
+        else:
+            unknown("POLICY_VERSION_UNKNOWN")
 
     origin_s, origin_invalid = _safe_token(origin)
     lane_s, lane_invalid = _safe_token(lane)

--- a/control-center/apps/web-shell/src/first-touch-readback.ts
+++ b/control-center/apps/web-shell/src/first-touch-readback.ts
@@ -100,21 +100,27 @@ function receiptComplete(input: SchedulingReadbackInput): boolean {
   const runtime = input.runtime_sha || rb?.runtime_sha;
   const readbackAt = input.readback_at || rb?.readback_at;
   const freshness = input.freshness || rb?.freshness;
-  return [
-    executor,
-    authority,
-    policyHash,
-    recipient,
-    content,
-    evidence,
-    source,
-    window,
-    runtime,
-    readbackAt,
-    freshness,
-    input.idempotency_key,
-    rb?.due_at,
-  ].every(nonempty) && freshness !== "stale" && freshness !== "STALE";
+  const blockers = input.blockers !== undefined ? input.blockers : rb?.blockers;
+  return (
+    Array.isArray(blockers) &&
+    [
+      executor,
+      authority,
+      policyHash,
+      recipient,
+      content,
+      evidence,
+      source,
+      window,
+      runtime,
+      readbackAt,
+      freshness,
+      input.idempotency_key,
+      rb?.due_at,
+    ].every(nonempty) &&
+    freshness !== "stale" &&
+    freshness !== "STALE"
+  );
 }
 
 export function classifySchedulingReadback(input: SchedulingReadbackInput): SchedulingReadbackResult {

--- a/control-center/apps/web-shell/tests/first-touch-readback.test.ts
+++ b/control-center/apps/web-shell/tests/first-touch-readback.test.ts
@@ -118,6 +118,22 @@ test("timeout, invalid and stale readback stay unconfirmed on the same key", () 
   assert.equal(replayKeepsIdempotencyKey(timeout, invalid), true);
 });
 
+test("omitted or null blockers is not QUEUED; empty blockers array may confirm", () => {
+  const { blockers: _blockers, ...omitted } = v3Receipt();
+  const omittedRow = classifySchedulingReadback(omitted);
+  assert.equal(omittedRow.queued, false);
+  assert.notEqual(omittedRow.state, "QUEUED");
+
+  const nullRow = classifySchedulingReadback(v3Receipt({ blockers: null }));
+  assert.equal(nullRow.queued, false);
+  assert.notEqual(nullRow.state, "QUEUED");
+
+  const empty = classifySchedulingReadback(v3Receipt({ blockers: [] }));
+  assert.equal(empty.state, "QUEUED");
+  assert.equal(empty.queued, true);
+  assert.equal(empty.provider_mutation, 0);
+});
+
 test("stale freshness on an otherwise complete receipt does not confirm QUEUED", () => {
   const stale = classifySchedulingReadback(v3Receipt({ freshness: "stale" }));
   assert.equal(stale.state, "APPROVAL_PENDING_READBACK");

--- a/tests/test_net_new_inbound_handraiser.py
+++ b/tests/test_net_new_inbound_handraiser.py
@@ -171,6 +171,7 @@ def test_weakened_invariants_fail_closed_on_schema():
         "unknown.missing-contact.v1.json",
         "unknown.stale-freshness.v1.json",
         "unknown.missing-policy-version.v1.json",
+        "unknown.missing-policy-version-with-id.v1.json",
         "unknown.unknown-policy-version.v1.json",
     ],
 )
@@ -441,6 +442,14 @@ def test_missing_old_unknown_policy_version_fail_closed():
     assert unknown["decision"] == "UNKNOWN"
     assert "POLICY_VERSION_UNKNOWN" in unknown["reason_codes"]
     assert unknown["consumer_authorization"]["surface_on_commercial_queue"] is False
+
+    id_without_version = admit(load_fixture("unknown.missing-policy-version-with-id.v1.json"))
+    _assert_closed_and_safe(id_without_version, load_fixture("unknown.missing-policy-version-with-id.v1.json"))
+    assert id_without_version["decision"] == "UNKNOWN"
+    assert "POLICY_VERSION_MISSING" in id_without_version["reason_codes"]
+    assert id_without_version["consumer_authorization"]["create_inbound_only_identity"] is False
+    assert id_without_version["outbound_eligible"] is False
+    assert id_without_version["inbound_only"] is False
 
 
 def test_identity_conflict_is_explicit_and_not_a_second_admission():


### PR DESCRIPTION
Follow-up on merged 29d5bb7.

Admission: `policy_version` is required even when `policy_id` or `canonical_name` is present. Golden fixture `unknown.missing-policy-version-with-id.v1.json` drives the shipped evaluator to `UNKNOWN` / `POLICY_VERSION_MISSING`.

Scheduling readback: `QUEUED` requires `blockers` as an array (empty allowed). Omitted or null blockers stay unconfirmed. HTTP 2xx is still not `QUEUED`. SMTP remains unauthorized.

Issues 65 and 127 stay open on the same residuals (`SCHEMA_MISMATCH_COLLECTION`; `PARTIAL_INCIDENT_GATE` extra-cli 468). This PR does not authorize transport.