### PR TITLE
feat(commercial): NET_NEW_INBOUND_HANDRAISER 1.0.0-draft.20260904 five-nucleus inbound admission

### DIFF
--- a/commercial/fixtures/net-new-inbound-handraiser/accepted.building_engineering_documentation.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/accepted.building_engineering_documentation.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-accepted-bed-001",
+  "correlation_id": "corr_draft_accepted_bed_001",
+  "receipt_id": "rcpt_draft_accepted_bed_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "building_engineering_documentation",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "DEADLINE",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:bed:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_bed_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_bed_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/accepted.conflict-unknown.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/accepted.conflict-unknown.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-accepted-conflict-unknown-001",
+  "correlation_id": "corr_draft_accepted_conflict_unknown_001",
+  "receipt_id": "rcpt_draft_accepted_conflict_unknown_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "expert_evidence_assistance",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "UNKNOWN",
+    "protected_ref": "conflict:ref:unknown:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_cunk_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_cunk_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/accepted.expert_evidence_assistance.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/accepted.expert_evidence_assistance.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-accepted-eea-001",
+  "correlation_id": "corr_draft_accepted_eea_001",
+  "receipt_id": "rcpt_draft_accepted_eea_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "expert_evidence_assistance",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:eea:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_eea_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_eea_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/accepted.missing-account.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/accepted.missing-account.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-accepted-missing-account-001",
+  "correlation_id": "corr_draft_accepted_missing_account_001",
+  "receipt_id": "rcpt_draft_accepted_missing_account_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "expert_evidence_assistance",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:missing:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_missing_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_missing_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/accepted.occupational_safety.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/accepted.occupational_safety.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-accepted-osaf-001",
+  "correlation_id": "corr_draft_accepted_osaf_001",
+  "receipt_id": "rcpt_draft_accepted_osaf_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "occupational_safety",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "INCIDENT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:osaf:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_osaf_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_osaf_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/accepted.property_valuation.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/accepted.property_valuation.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-accepted-pval-001",
+  "correlation_id": "corr_draft_accepted_pval_001",
+  "receipt_id": "rcpt_draft_accepted_pval_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "property_valuation",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "PROCUREMENT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:pval:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_pval_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_pval_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/accepted.public_works_b2g.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/accepted.public_works_b2g.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-accepted-b2g-001",
+  "correlation_id": "corr_draft_accepted_b2g_001",
+  "receipt_id": "rcpt_draft_accepted_b2g_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "public_works_b2g",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "CAPACITY",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:b2g:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_b2g_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_b2g_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/examples.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/examples.draft-20260904.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "net-new-inbound-handraiser-examples.1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "instruction": "Drive python -m commercial.inbound --fixture <path>. HTTP 2xx is not acceptance.",
+  "examples": {
+    "ACCEPTED": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/accepted.missing-account.draft-20260904.json",
+      "expected_decision": "ACCEPTED",
+      "expected_inbound_only": true,
+      "expected_outbound_eligible": false
+    },
+    "REJECTED_WITH_REASON": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/rejected.consent-refused.draft-20260904.json",
+      "expected_decision": "REJECTED_WITH_REASON",
+      "expected_reason": "CONSENT_REFUSED"
+    },
+    "UNKNOWN": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/unknown.unknown-version.draft-20260904.json",
+      "expected_decision": "UNKNOWN",
+      "expected_reason": "POLICY_VERSION_UNKNOWN"
+    }
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/rejected.consent-refused.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/rejected.consent-refused.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "HUMAN_REVIEW",
+  "idempotency_key": "nihr:web:draft-rejected-consent-001",
+  "correlation_id": "corr_draft_rejected_consent_001",
+  "receipt_id": "rcpt_draft_rejected_consent_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "expert_evidence_assistance",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:eea:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_refused_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": false,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_refused_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/rejected.first-touch-inheritance.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/rejected.first-touch-inheritance.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "CFG-FIRST-TOUCH-ROUTING",
+  "policy_version": "v3",
+  "canonical_name": "CFG-FIRST-TOUCH-ROUTING-v3",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-rejected-first-touch-001",
+  "correlation_id": "corr_draft_rejected_first_touch_001",
+  "receipt_id": "rcpt_draft_rejected_first_touch_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "expert_evidence_assistance",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:eea:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_ft_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_ft_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/rejected.live-intelligence.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/rejected.live-intelligence.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "intel_watch",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:intel:draft-rejected-live-001",
+  "correlation_id": "corr_draft_rejected_live_001",
+  "receipt_id": "rcpt_draft_rejected_live_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "expert_evidence_assistance",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:eea:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_live_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_live_001"
+  },
+  "source": {
+    "system": "extra-cli",
+    "issue_ref": "tjsasakifln/extra-cli#543"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/rejected.outbound-eligible.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/rejected.outbound-eligible.draft-20260904.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-rejected-outbound-001",
+  "correlation_id": "corr_draft_rejected_outbound_001",
+  "receipt_id": "rcpt_draft_rejected_outbound_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "expert_evidence_assistance",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:eea:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_ob_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_ob_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  },
+  "outbound_eligible": true,
+  "auto_send": true
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/rejected.sensitive-content.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/rejected.sensitive-content.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-rejected-sensitive-001",
+  "correlation_id": "corr_draft_rejected_sensitive_001",
+  "receipt_id": "rcpt_draft_rejected_sensitive_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "expert_evidence_assistance",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": true,
+    "class": "LEGAL_PRIVILEGE",
+    "protected_ref": "sens:ref:001"
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:eea:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_sens_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_sens_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/unknown.missing-nucleus.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/unknown.missing-nucleus.draft-20260904.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-unknown-nucleus-001",
+  "correlation_id": "corr_draft_unknown_nucleus_001",
+  "receipt_id": "rcpt_draft_unknown_nucleus_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:eea:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_unkn_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_unkn_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/fixtures/net-new-inbound-handraiser/unknown.unknown-version.draft-20260904.json
+++ b/commercial/fixtures/net-new-inbound-handraiser/unknown.unknown-version.draft-20260904.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "net-new-inbound-handraiser-request.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "not-a-version",
+  "canonical_name": "SOMETHING-ELSE-v9",
+  "origin": "CONFENGE_WEB",
+  "acquisition_lane": "NET_NEW_INBOUND",
+  "intent_kind": "DEEP_DIVE",
+  "idempotency_key": "nihr:web:draft-unknown-version-001",
+  "correlation_id": "corr_draft_unknown_version_001",
+  "receipt_id": "rcpt_draft_unknown_version_001",
+  "subject_ref": null,
+  "account_ref": null,
+  "intake_source": "CONFENGE_WEB",
+  "landing_asset": {
+    "id": "private_project_technical_readiness_v1",
+    "kind": "OFFER"
+  },
+  "nucleus_id": "expert_evidence_assistance",
+  "offer_candidate_id": "private_project_technical_readiness_assessment",
+  "party_kind": "COMPANY",
+  "decision_role": "DECISION_MAKER",
+  "site_location": {
+    "city": "Florianopolis",
+    "uf": "SC",
+    "ibge_municipality_code": "4205407"
+  },
+  "urgency": "THIS_CYCLE",
+  "why_now_class": "AUDIT",
+  "desired_decision_or_deliverable": "ASSESSMENT",
+  "document_availability_class": "COMPLETE",
+  "sensitive_data": {
+    "present": false,
+    "class": "NONE",
+    "protected_ref": null
+  },
+  "conflict_screening": {
+    "status": "CLEAR",
+    "protected_ref": "conflict:ref:eea:001"
+  },
+  "contact_evidence": {
+    "present": true,
+    "channel": "EMAIL",
+    "evidence_ref": "ev_contact_draft_unkv_001",
+    "identity_match_method": "EXPLICIT_CONTACT"
+  },
+  "consent_evidence": {
+    "captured": true,
+    "basis": "EXPLICIT_FORM_SUBMIT",
+    "evidence_ref": "ev_consent_draft_unkv_001"
+  },
+  "source": {
+    "system": "web-cfg",
+    "issue_ref": "tjsasakifln/web-cfg#577"
+  },
+  "freshness": {
+    "as_of": "2026-09-03T11:00:00Z",
+    "max_age_seconds": 86400
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  }
+}

--- a/commercial/inbound/CONSUMER-PIN.1.0.0-draft.20260904.md
+++ b/commercial/inbound/CONSUMER-PIN.1.0.0-draft.20260904.md
@@ -1,0 +1,44 @@
+# Consumer pin — `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904`
+
+Governance is the only admission authority for this version. Pin the
+canonical name and the content hash. Do not copy the schema into web-cfg,
+Warmbly, Meetcfg or extra-cli as a second authority.
+
+## Pin
+
+```
+canonical_name = NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904
+policy_hash    = python -c "from commercial.inbound import load_draft_authority, policy_hash; print(policy_hash(load_draft_authority()))"
+```
+
+`NET_NEW_INBOUND_HANDRAISER-v1` remains an exact-match authority for existing
+Warmbly pins. A v1 string does not activate this version. Missing, old or
+unknown version fail closed.
+
+## Owner planes
+
+| Plane | Owner | Receives |
+|---|---|---|
+| Policy / admit rules | Governance | — |
+| `CONFENGE_WEB` production | web-cfg | submits intake |
+| Persist / act / queue | Warmbly | every closed decision |
+| Accepted context only | Meetcfg | `ACCEPTED` only |
+
+extra-cli `#543` PNCP live is ingestion/telemetry. It is not commercial
+authority and is not this inbound admission.
+
+## Construction
+
+- Net-new is inbound-only. `outbound_eligible=false`, `auto_send=false`.
+- Absence of a prior account is not a discard.
+- Live Intelligence / first-touch / outbound payloads are rejected.
+- Conflict `UNKNOWN` never becomes `CLEAR`.
+- Sensitive class/ref only; no sensitive content in the public envelope.
+- HTTP 2xx is not acceptance; require receipt/readback.
+- Replay is exactly-once logical.
+
+## Coordination IDs
+
+Taxonomy, catalog, web-intake, handraiser-state and Meetcfg context IDs in
+fixtures are test-only. Goal 97 ratifies them. They are not runtime fallbacks.
+Divergent or missing version/hash fail closed.

--- a/commercial/inbound/__init__.py
+++ b/commercial/inbound/__init__.py
@@ -3,10 +3,13 @@
 from .admit import (
     AUTHORITY_PATH,
     CANONICAL_POLICY_NAME,
+    DRAFT_AUTHORITY_PATH,
+    DRAFT_CANONICAL_NAME,
     ModelOnlyHandraiserStore,
     decision_contains_pii,
     evaluate_net_new_inbound_handraiser,
     load_authority,
+    load_draft_authority,
     policy_hash,
 )
 from .conformance import evaluate_owner_readbacks
@@ -14,10 +17,13 @@ from .conformance import evaluate_owner_readbacks
 __all__ = [
     "AUTHORITY_PATH",
     "CANONICAL_POLICY_NAME",
+    "DRAFT_AUTHORITY_PATH",
+    "DRAFT_CANONICAL_NAME",
     "ModelOnlyHandraiserStore",
     "decision_contains_pii",
     "evaluate_net_new_inbound_handraiser",
     "evaluate_owner_readbacks",
     "load_authority",
+    "load_draft_authority",
     "policy_hash",
 ]

--- a/commercial/inbound/admit.py
+++ b/commercial/inbound/admit.py
@@ -18,12 +18,26 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 AUTHORITY_PATH = Path(__file__).resolve().parent / "net-new-inbound-handraiser.v1.json"
+DRAFT_AUTHORITY_PATH = (
+    Path(__file__).resolve().parent / "net-new-inbound-handraiser.1.0.0-draft.20260904.json"
+)
 REQUEST_SCHEMA_VERSION = "net-new-inbound-handraiser-request.v1"
 DECISION_SCHEMA_VERSION = "net-new-inbound-handraiser-admission.v1"
+DRAFT_REQUEST_SCHEMA_VERSION = "net-new-inbound-handraiser-request.1.0.0-draft.20260904"
+DRAFT_DECISION_SCHEMA_VERSION = "net-new-inbound-handraiser-admission.1.0.0-draft.20260904"
 CANONICAL_POLICY_ID = "NET_NEW_INBOUND_HANDRAISER"
 CANONICAL_POLICY_VERSION = "v1"
 CANONICAL_POLICY_NAME = "NET_NEW_INBOUND_HANDRAISER-v1"
+DRAFT_POLICY_VERSION = "1.0.0-draft.20260904"
+DRAFT_CANONICAL_NAME = "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904"
+DRAFT_ACCEPTED_VERSIONS = frozenset({DRAFT_POLICY_VERSION, DRAFT_CANONICAL_NAME})
 OLD_POLICY_VERSIONS = frozenset({"v0", "v2", "v3"})
+LIVE_INTELLIGENCE_ORIGINS = frozenset({"intel_watch", "intel_seed", "PNCP_LIVE"})
+FIRST_TOUCH_POLICY_IDS = frozenset({"CFG-FIRST-TOUCH-ROUTING"})
+LOCATION_FORBIDDEN_FIELDS = frozenset(
+    {"street", "address", "cep", "zip", "lat", "lon", "latitude", "longitude", "email"}
+)
+SENSITIVE_CONTENT_KEYS = frozenset({"content", "raw", "text", "payload", "body", "message"})
 ISO_Z_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
 OPAQUE_REF_RE = re.compile(r"^[A-Za-z0-9:._-]{1,128}$")
 PII_KEYS = frozenset(
@@ -63,6 +77,22 @@ def canonical_json(value: Any) -> str:
 def load_authority(path: Path | None = None) -> dict[str, Any]:
     target = path or AUTHORITY_PATH
     return json.loads(target.read_text(encoding="utf-8"))
+
+
+def load_draft_authority(path: Path | None = None) -> dict[str, Any]:
+    target = path or DRAFT_AUTHORITY_PATH
+    return json.loads(target.read_text(encoding="utf-8"))
+
+
+def _claims_draft(payload: Mapping[str, Any]) -> bool:
+    schema = _nonempty_str(payload.get("schema_version"))
+    version = _nonempty_str(payload.get("policy_version"))
+    name = _nonempty_str(payload.get("canonical_name"))
+    return (
+        schema == DRAFT_REQUEST_SCHEMA_VERSION
+        or version in DRAFT_ACCEPTED_VERSIONS
+        or name == DRAFT_CANONICAL_NAME
+    )
 
 
 def policy_hash(authority: Mapping[str, Any] | None = None) -> str:
@@ -255,6 +285,15 @@ def evaluate_net_new_inbound_handraiser(
     evaluated_at: str,
 ) -> dict[str, Any]:
     """Admit a net-new inbound hand-raiser. Returns one closed state only."""
+
+    if isinstance(request, Mapping) and _claims_draft(request):
+        return _evaluate_draft(
+            request,
+            store=store,
+            authority=authority,
+            intake_paused=intake_paused,
+            evaluated_at=evaluated_at,
+        )
 
     unknown_reasons: list[str] = []
     rejected_reasons: list[str] = []
@@ -577,6 +616,658 @@ def evaluate_net_new_inbound_handraiser(
             store.put(key_s, material_hash, decision)
         elif existing["material_hash"] != material_hash:
             # Conflict is not a second logical admission.
+            pass
+
+    return decision
+
+
+def _material_view_draft(request: Mapping[str, Any]) -> dict[str, Any]:
+    material = _material_view(request)
+    landing = request.get("landing_asset") if isinstance(request.get("landing_asset"), Mapping) else None
+    location = request.get("site_location") if isinstance(request.get("site_location"), Mapping) else None
+    sensitive = request.get("sensitive_data") if isinstance(request.get("sensitive_data"), Mapping) else None
+    conflict = request.get("conflict_screening") if isinstance(request.get("conflict_screening"), Mapping) else None
+    material.update(
+        {
+            "intake_source": request.get("intake_source"),
+            "landing_asset": None
+            if landing is None
+            else {"id": landing.get("id"), "kind": landing.get("kind")},
+            "nucleus_id": request.get("nucleus_id"),
+            "offer_candidate_id": request.get("offer_candidate_id"),
+            "party_kind": request.get("party_kind"),
+            "decision_role": request.get("decision_role"),
+            "site_location": None
+            if location is None
+            else {
+                "city": location.get("city"),
+                "uf": location.get("uf"),
+                "ibge_municipality_code": location.get("ibge_municipality_code"),
+            },
+            "urgency": request.get("urgency"),
+            "why_now_class": request.get("why_now_class"),
+            "desired_decision_or_deliverable": request.get("desired_decision_or_deliverable"),
+            "document_availability_class": request.get("document_availability_class"),
+            "sensitive_data": None
+            if sensitive is None
+            else {
+                "present": sensitive.get("present"),
+                "class": sensitive.get("class"),
+                "protected_ref": sensitive.get("protected_ref"),
+            },
+            "conflict_screening": None
+            if conflict is None
+            else {
+                "status": conflict.get("status"),
+                "protected_ref": conflict.get("protected_ref"),
+                "claimed_clear": conflict.get("claimed_clear"),
+            },
+            "partner_required": request.get("partner_required"),
+            "capacity_review_required": request.get("capacity_review_required"),
+            "outbound_eligible": request.get("outbound_eligible"),
+            "auto_send": request.get("auto_send"),
+        }
+    )
+    return material
+
+
+def _derive_qualification(
+    *,
+    nucleus_id: str | None,
+    admitted_nuclei: set[str],
+    conflict_status: str | None,
+    document_class: str | None,
+    partner_required: bool,
+    capacity_review_required: bool,
+    decision_role: str | None,
+    urgency: str | None,
+    why_now: str | None,
+) -> str:
+    if nucleus_id is not None and nucleus_id not in admitted_nuclei:
+        return "OUT_OF_SCOPE"
+    if conflict_status in {"UNKNOWN", "HIT", "NOT_SCREENED"}:
+        return "CONFLICT_CHECK_REQUIRED"
+    if partner_required:
+        return "PARTNER_REQUIRED"
+    if capacity_review_required:
+        return "CAPACITY_REVIEW"
+    if document_class == "GAP":
+        return "DOCUMENT_GAP"
+    if (
+        decision_role == "UNKNOWN"
+        or urgency == "UNKNOWN"
+        or why_now == "UNKNOWN"
+        or document_class == "UNKNOWN"
+    ):
+        return "NEEDS_CONTEXT"
+    if conflict_status == "CLEAR" and document_class == "COMPLETE" and decision_role == "DECISION_MAKER":
+        return "QCO"
+    return "POTENTIAL_FIT"
+
+
+def _evaluate_draft(
+    request: Mapping[str, Any],
+    *,
+    store: ModelOnlyHandraiserStore | None,
+    authority: Mapping[str, Any] | None,
+    intake_paused: bool,
+    evaluated_at: str,
+) -> dict[str, Any]:
+    unknown_reasons: list[str] = []
+    rejected_reasons: list[str] = []
+
+    def unknown(code: str) -> None:
+        if code not in unknown_reasons:
+            unknown_reasons.append(code)
+
+    def reject(code: str) -> None:
+        if code not in rejected_reasons:
+            rejected_reasons.append(code)
+
+    if authority is None:
+        try:
+            authority = load_draft_authority()
+        except (OSError, json.JSONDecodeError):
+            authority = {}
+            unknown("AUTHORITY_UNAVAILABLE")
+    elif not isinstance(authority, Mapping):
+        authority = {}
+        unknown("AUTHORITY_UNAVAILABLE")
+    elif authority.get("canonical_name") == CANONICAL_POLICY_NAME:
+        unknown("AUTHORITY_UNAVAILABLE")
+        authority = {}
+
+    if not isinstance(authority, Mapping) or authority.get("canonical_name") != DRAFT_CANONICAL_NAME:
+        unknown("AUTHORITY_UNAVAILABLE")
+        inputs: Mapping[str, Any] = {}
+        codes: Mapping[str, Any] = {}
+        activation: Mapping[str, Any] = {}
+    else:
+        inputs = authority.get("inputs") if isinstance(authority.get("inputs"), Mapping) else {}
+        codes = authority.get("reason_codes") if isinstance(authority.get("reason_codes"), Mapping) else {}
+        activation = authority.get("activation") if isinstance(authority.get("activation"), Mapping) else {}
+
+    admitted_origins = set(inputs.get("admitted_origins") or ())
+    admitted_lanes = set(inputs.get("admitted_acquisition_lanes") or ())
+    admitted_intents = set(inputs.get("admitted_intent_kinds") or ())
+    admitted_consent = set(inputs.get("admitted_consent_bases") or ())
+    admitted_match = set(inputs.get("admitted_identity_match_methods") or ())
+    forbidden_match = set(inputs.get("forbidden_identity_match_methods") or ())
+    admitted_nuclei = set(inputs.get("admitted_nuclei") or ())
+    admitted_offers = set(inputs.get("admitted_offer_candidates") or ())
+    admitted_intake = set(inputs.get("admitted_intake_sources") or ())
+    admitted_party = set(inputs.get("admitted_party_kinds") or ())
+    admitted_roles = set(inputs.get("admitted_decision_roles") or ())
+    admitted_urgency = set(inputs.get("admitted_urgency") or ())
+    admitted_why = set(inputs.get("admitted_why_now_classes") or ())
+    admitted_deliverable = set(inputs.get("admitted_desired_deliverables") or ())
+    admitted_docs = set(inputs.get("admitted_document_availability_classes") or ())
+    admitted_sensitive = set(inputs.get("admitted_sensitive_classes") or ())
+    admitted_conflict = set(inputs.get("admitted_conflict_statuses") or ())
+    never_emitted = set(codes.get("never_emitted") or ACCOUNT_DISCARD_CODES)
+
+    payload: Mapping[str, Any] = request if isinstance(request, Mapping) else {}
+    if payload.get("schema_version") != DRAFT_REQUEST_SCHEMA_VERSION:
+        unknown("REQUEST_INVALID")
+
+    origin = payload.get("origin")
+    lane = payload.get("acquisition_lane")
+    intent = payload.get("intent_kind")
+    idempotency_key = payload.get("idempotency_key")
+    correlation_id = payload.get("correlation_id")
+    receipt_id = payload.get("receipt_id")
+    subject_raw = payload.get("subject_ref")
+    account_raw = payload.get("account_ref")
+    contact = payload.get("contact_evidence")
+    consent = payload.get("consent_evidence")
+    source = payload.get("source")
+    freshness = payload.get("freshness")
+    intake_source = payload.get("intake_source")
+    landing = payload.get("landing_asset")
+    nucleus_raw = payload.get("nucleus_id")
+    offer_raw = payload.get("offer_candidate_id")
+    party_raw = payload.get("party_kind")
+    role_raw = payload.get("decision_role")
+    location = payload.get("site_location")
+    urgency_raw = payload.get("urgency")
+    why_raw = payload.get("why_now_class")
+    deliverable_raw = payload.get("desired_decision_or_deliverable")
+    docs_raw = payload.get("document_availability_class")
+    sensitive = payload.get("sensitive_data")
+    conflict = payload.get("conflict_screening")
+
+    extra_intents = payload.get("intent_kinds")
+    if isinstance(intent, list) or (extra_intents is not None and extra_intents != intent):
+        unknown("INTENT_KIND_AMBIGUOUS")
+
+    accepted_versions = set(activation.get("accepted_version_strings") or DRAFT_ACCEPTED_VERSIONS)
+    accepted_ids = set(activation.get("accepted_policy_ids") or {CANONICAL_POLICY_ID})
+    claimed_id = _nonempty_str(payload.get("policy_id"))
+    claimed_version = _nonempty_str(payload.get("policy_version"))
+    claimed_name = _nonempty_str(payload.get("canonical_name"))
+    if claimed_version is None:
+        unknown("POLICY_VERSION_MISSING")
+    elif claimed_version in accepted_versions:
+        pass
+    elif claimed_version in {CANONICAL_POLICY_VERSION, CANONICAL_POLICY_NAME} or claimed_version in OLD_POLICY_VERSIONS:
+        reject("POLICY_VERSION_NOT_ADMITTED")
+    else:
+        unknown("POLICY_VERSION_UNKNOWN")
+    if claimed_id is not None and claimed_id not in accepted_ids:
+        if claimed_id in FIRST_TOUCH_POLICY_IDS or claimed_id in {"ACQUISITION_PRESSURE"}:
+            reject("POLICY_VERSION_NOT_ADMITTED")
+            reject("FIRST_TOUCH_INHERITANCE_FORBIDDEN")
+        else:
+            unknown("POLICY_ID_UNKNOWN")
+    if claimed_name is not None and claimed_name not in accepted_versions:
+        if claimed_name.startswith("CFG-FIRST-TOUCH-ROUTING"):
+            reject("FIRST_TOUCH_INHERITANCE_FORBIDDEN")
+            reject("POLICY_VERSION_NOT_ADMITTED")
+        elif claimed_name.startswith("NET_NEW_INBOUND_HANDRAISER") or claimed_name in OLD_POLICY_VERSIONS:
+            reject("POLICY_VERSION_NOT_ADMITTED")
+        else:
+            unknown("POLICY_VERSION_UNKNOWN")
+
+    origin_s, origin_invalid = _safe_token(origin)
+    lane_s, lane_invalid = _safe_token(lane)
+    intent_s, intent_invalid = _safe_token(intent)
+    key_s, key_invalid = _safe_token(idempotency_key)
+    corr_s, corr_invalid = _safe_token(correlation_id)
+    receipt_s, receipt_invalid = _safe_token(receipt_id)
+    intake_s, intake_invalid = _safe_token(intake_source)
+    nucleus_s, nucleus_invalid = _safe_token(nucleus_raw)
+    offer_s, offer_invalid = _safe_token(offer_raw)
+    party_s, party_invalid = _safe_token(party_raw)
+    role_s, role_invalid = _safe_token(role_raw)
+    urgency_s, urgency_invalid = _safe_token(urgency_raw)
+    why_s, why_invalid = _safe_token(why_raw)
+    deliverable_s, deliverable_invalid = _safe_token(deliverable_raw)
+    docs_s, docs_invalid = _safe_token(docs_raw)
+
+    if (
+        origin_invalid
+        or lane_invalid
+        or intent_invalid
+        or key_invalid
+        or corr_invalid
+        or receipt_invalid
+        or intake_invalid
+        or nucleus_invalid
+        or offer_invalid
+        or party_invalid
+        or role_invalid
+        or urgency_invalid
+        or why_invalid
+        or deliverable_invalid
+        or docs_invalid
+    ):
+        unknown("REQUEST_INVALID")
+
+    if origin_s is None and not origin_invalid:
+        unknown("ORIGIN_UNKNOWN")
+    elif origin_s in LIVE_INTELLIGENCE_ORIGINS:
+        reject("LIVE_INTELLIGENCE_NOT_INBOUND")
+        reject("ORIGIN_NOT_ADMITTED")
+    elif origin_s is not None and origin_s not in admitted_origins:
+        reject("ORIGIN_NOT_ADMITTED")
+
+    if lane_s is None and not lane_invalid:
+        unknown("ACQUISITION_LANE_UNKNOWN")
+    elif lane_s is not None and lane_s not in admitted_lanes:
+        reject("ACQUISITION_LANE_NOT_ADMITTED")
+
+    if intent_invalid:
+        pass
+    elif intent_s is None:
+        unknown("INTENT_KIND_UNKNOWN")
+    elif intent_s not in admitted_intents:
+        reject("INTENT_KIND_NOT_ADMITTED")
+
+    if key_s is None and not key_invalid:
+        unknown("IDEMPOTENCY_KEY_MISSING")
+    if corr_s is None and not corr_invalid:
+        unknown("CORRELATION_UNKNOWN")
+    if receipt_s is None and not receipt_invalid:
+        unknown("RECEIPT_UNKNOWN")
+
+    if intake_s is None and not intake_invalid:
+        unknown("SOURCE_UNKNOWN")
+    elif intake_s is not None and intake_s not in admitted_intake:
+        reject("ORIGIN_NOT_ADMITTED")
+
+    if nucleus_raw in {None, ""}:
+        unknown("NUCLEUS_UNKNOWN")
+        nucleus_s = None
+    elif nucleus_s is None:
+        unknown("NUCLEUS_UNKNOWN")
+    elif nucleus_s not in admitted_nuclei:
+        reject("NUCLEUS_NOT_ADMITTED")
+
+    if offer_raw in {None, ""}:
+        unknown("OFFER_CANDIDATE_UNKNOWN")
+        offer_s = None
+    elif offer_s is None:
+        unknown("OFFER_CANDIDATE_UNKNOWN")
+    elif offer_s not in admitted_offers:
+        reject("OFFER_CANDIDATE_NOT_ADMITTED")
+
+    if party_raw in {None, ""} or party_s is None:
+        unknown("PARTY_KIND_UNKNOWN")
+        party_s = None
+    elif party_s not in admitted_party:
+        unknown("PARTY_KIND_UNKNOWN")
+        party_s = None
+
+    if role_s is not None and admitted_roles and role_s not in admitted_roles:
+        unknown("REQUEST_INVALID")
+    if urgency_s is not None and admitted_urgency and urgency_s not in admitted_urgency:
+        unknown("REQUEST_INVALID")
+    if why_s is not None and admitted_why and why_s not in admitted_why:
+        unknown("REQUEST_INVALID")
+    if deliverable_s is not None and admitted_deliverable and deliverable_s not in admitted_deliverable:
+        unknown("REQUEST_INVALID")
+    if docs_s is not None and admitted_docs and docs_s not in admitted_docs:
+        unknown("REQUEST_INVALID")
+
+    landing_out: dict[str, str] | None = None
+    if not isinstance(landing, Mapping):
+        unknown("LANDING_ASSET_UNKNOWN")
+    else:
+        landing_id, landing_id_invalid = _safe_token(landing.get("id"))
+        landing_kind, landing_kind_invalid = _safe_token(landing.get("kind"))
+        if landing_id_invalid or landing_kind_invalid or landing_id is None or landing_kind is None:
+            unknown("LANDING_ASSET_UNKNOWN")
+        else:
+            landing_out = {"id": landing_id, "kind": landing_kind}
+
+    location_out: dict[str, str] | None = None
+    if location is None:
+        unknown("REQUEST_INVALID")
+    elif not isinstance(location, Mapping):
+        unknown("REQUEST_INVALID")
+    else:
+        if any(str(key).lower() in LOCATION_FORBIDDEN_FIELDS for key in location):
+            reject("LOCATION_NOT_MINIMIZED")
+        city = _nonempty_str(location.get("city"))
+        uf = _nonempty_str(location.get("uf"))
+        ibge = _nonempty_str(location.get("ibge_municipality_code"))
+        if city is None or uf is None:
+            unknown("REQUEST_INVALID")
+        else:
+            location_out = {"city": city, "uf": uf}
+            if ibge is not None:
+                location_out["ibge_municipality_code"] = ibge
+
+    sensitive_present = False
+    sensitive_class: str | None = None
+    sensitive_ref: str | None = None
+    if not isinstance(sensitive, Mapping):
+        unknown("SENSITIVE_CLASS_UNKNOWN")
+    else:
+        if any(str(key).lower() in SENSITIVE_CONTENT_KEYS for key in sensitive):
+            reject("SENSITIVE_CONTENT_FORBIDDEN")
+        if any(str(key).lower() in PII_KEYS for key in sensitive):
+            reject("SENSITIVE_CONTENT_FORBIDDEN")
+        sensitive_present = sensitive.get("present") is True
+        sensitive_class = _nonempty_str(sensitive.get("class"))
+        sensitive_ref = _opaque_ref(sensitive.get("protected_ref")) if sensitive.get("protected_ref") not in {None, ""} else None
+        if sensitive_class is None:
+            unknown("SENSITIVE_CLASS_UNKNOWN")
+        elif admitted_sensitive and sensitive_class not in admitted_sensitive:
+            unknown("SENSITIVE_CLASS_UNKNOWN")
+            sensitive_class = None
+        elif sensitive_present and sensitive_class == "NONE":
+            unknown("SENSITIVE_CLASS_UNKNOWN")
+
+    conflict_status: str | None = None
+    conflict_ref: str | None = None
+    if not isinstance(conflict, Mapping):
+        unknown("CONFLICT_STATUS_MISSING")
+    else:
+        conflict_status = _nonempty_str(conflict.get("status"))
+        if conflict_status is None:
+            unknown("CONFLICT_STATUS_MISSING")
+        elif admitted_conflict and conflict_status not in admitted_conflict:
+            unknown("CONFLICT_STATUS_MISSING")
+            conflict_status = None
+        if conflict.get("claimed_clear") is True and conflict_status in {"UNKNOWN", "HIT", "NOT_SCREENED"}:
+            reject("CONFLICT_CLEAR_COERCION_FORBIDDEN")
+        if conflict.get("protected_ref") not in {None, ""}:
+            conflict_ref = _opaque_ref(conflict.get("protected_ref"))
+            if conflict_ref is None:
+                unknown("REQUEST_INVALID")
+
+    if payload.get("outbound_eligible") is True:
+        reject("OUTBOUND_INHERITANCE_FORBIDDEN")
+    if payload.get("auto_send") is True:
+        reject("AUTO_SEND_FORBIDDEN")
+
+    subject_ref: str | None = None
+    if subject_raw not in {None, ""}:
+        subject_ref = _opaque_ref(subject_raw)
+        if subject_ref is None:
+            unknown("SUBJECT_REFERENCE_AMBIGUOUS")
+
+    account_present = account_raw not in {None, ""}
+    account_ref = None
+    if account_present:
+        account_ref = _opaque_ref(account_raw)
+        if account_ref is None:
+            unknown("SUBJECT_REFERENCE_AMBIGUOUS")
+            account_present = False
+        elif subject_ref is not None and account_ref != subject_ref:
+            reject("IDENTITY_CONFLICT")
+
+    match_method = None
+    if not isinstance(contact, Mapping):
+        unknown("CONTACT_EVIDENCE_UNKNOWN")
+    else:
+        match_method = _nonempty_str(contact.get("identity_match_method"))
+        if (
+            contact.get("present") is not True
+            or not _nonempty_str(contact.get("evidence_ref"))
+            or not _nonempty_str(contact.get("channel"))
+            or match_method is None
+        ):
+            unknown("CONTACT_EVIDENCE_UNKNOWN")
+        elif match_method in forbidden_match:
+            reject("FUZZY_IDENTITY_FORBIDDEN")
+        elif match_method not in admitted_match:
+            unknown("CONTACT_EVIDENCE_UNKNOWN")
+        elif match_method == "EXPLICIT_SUBJECT_REF" and subject_ref is None:
+            unknown("SUBJECT_REFERENCE_AMBIGUOUS")
+
+    if not isinstance(consent, Mapping):
+        unknown("CONSENT_EVIDENCE_UNKNOWN")
+    else:
+        captured = consent.get("captured")
+        basis = consent.get("basis")
+        if captured is False:
+            reject("CONSENT_REFUSED")
+        elif captured is not True or not _nonempty_str(consent.get("evidence_ref")):
+            unknown("CONSENT_EVIDENCE_UNKNOWN")
+        elif _nonempty_str(basis) is None:
+            unknown("CONSENT_AMBIGUOUS")
+        elif basis not in admitted_consent:
+            unknown("CONSENT_AMBIGUOUS")
+
+    if "opt_out" in payload and payload.get("opt_out") not in {True, False}:
+        unknown("REQUEST_INVALID")
+    elif payload.get("opt_out") is True:
+        reject("OPT_OUT_PRESENT")
+
+    if source is not None:
+        if not isinstance(source, Mapping) or not _nonempty_str(source.get("system")):
+            unknown("SOURCE_UNKNOWN")
+
+    evaluated = _parse_instant(evaluated_at)
+    if evaluated is None:
+        unknown("FRESHNESS_UNKNOWN")
+    if freshness is not None:
+        if not isinstance(freshness, Mapping):
+            unknown("FRESHNESS_UNKNOWN")
+        else:
+            as_of = _parse_instant(freshness.get("as_of"))
+            max_age = freshness.get("max_age_seconds")
+            if (
+                as_of is None
+                or evaluated is None
+                or not isinstance(max_age, int)
+                or isinstance(max_age, bool)
+                or max_age <= 0
+            ):
+                unknown("FRESHNESS_UNKNOWN")
+            else:
+                age = int((evaluated - as_of).total_seconds())
+                if age < 0:
+                    unknown("FRESHNESS_UNKNOWN")
+                elif age > max_age:
+                    unknown("FRESHNESS_STALE")
+
+    material = _material_view_draft(payload)
+    material_hash = hashlib.sha256(canonical_json(material).encode("utf-8")).hexdigest()
+
+    if store is not None and key_s is not None:
+        existing = store.get(key_s)
+        if existing is not None:
+            if existing["material_hash"] == material_hash:
+                return _replay(existing)
+            reject("IDEMPOTENCY_PAYLOAD_CONFLICT")
+
+    if intake_paused:
+        reject("INTAKE_PAUSED")
+
+    if unknown_reasons:
+        decision_state = "UNKNOWN"
+        reason_codes = unknown_reasons + [code for code in rejected_reasons if code not in unknown_reasons]
+        qualification_state = "NONE"
+    elif rejected_reasons:
+        decision_state = "REJECTED_WITH_REASON"
+        reason_codes = rejected_reasons
+        qualification_state = "NONE"
+    else:
+        decision_state = "ACCEPTED"
+        reason_codes = ["ADMISSION_GATES_SATISFIED"]
+        qualification_state = _derive_qualification(
+            nucleus_id=nucleus_s,
+            admitted_nuclei=admitted_nuclei,
+            conflict_status=conflict_status,
+            document_class=docs_s,
+            partner_required=payload.get("partner_required") is True,
+            capacity_review_required=payload.get("capacity_review_required") is True,
+            decision_role=role_s,
+            urgency=urgency_s,
+            why_now=why_s,
+        )
+
+    reason_codes = [code for code in reason_codes if code not in never_emitted]
+    if not reason_codes:
+        decision_state = "UNKNOWN"
+        reason_codes = ["REQUEST_INVALID"]
+        qualification_state = "NONE"
+
+    if qualification_state == "CONFLICT_CHECK_REQUIRED" and conflict_status == "CLEAR":
+        conflict_status = "UNKNOWN"
+
+    accepted = decision_state == "ACCEPTED"
+    identity_authorization = "INBOUND_ONLY" if accepted else "NONE"
+    logical_basis = {
+        "policy_id": CANONICAL_POLICY_ID,
+        "policy_version": DRAFT_POLICY_VERSION,
+        "idempotency_key": key_s,
+        "material_hash": material_hash,
+    }
+    decision_id = _stable_id("nihr", logical_basis)
+
+    decision = {
+        "schema_version": DRAFT_DECISION_SCHEMA_VERSION,
+        "policy_id": CANONICAL_POLICY_ID,
+        "policy_version": DRAFT_POLICY_VERSION,
+        "canonical_name": DRAFT_CANONICAL_NAME,
+        "decision_id": decision_id,
+        "logical_admission_id": decision_id,
+        "decision": decision_state,
+        "reason_codes": reason_codes,
+        "idempotency_key": key_s,
+        "correlation_id": corr_s,
+        "receipt_id": receipt_s,
+        "replayed": False,
+        "origin": origin_s,
+        "acquisition_lane": lane_s,
+        "intent_kind": intent_s,
+        "intake_source": intake_s,
+        "landing_asset": landing_out,
+        "nucleus_id": nucleus_s,
+        "offer_candidate_id": offer_s,
+        "party_kind": party_s,
+        "decision_role": role_s,
+        "site_location": location_out,
+        "urgency": urgency_s,
+        "why_now_class": why_s,
+        "desired_decision_or_deliverable": deliverable_s,
+        "document_availability_class": docs_s,
+        "sensitive_data": {
+            "present": bool(sensitive_present),
+            "class": sensitive_class,
+            "protected_ref": sensitive_ref,
+        },
+        "conflict_screening": {
+            "status": conflict_status,
+            "protected_ref": conflict_ref,
+        },
+        "qualification_state": qualification_state,
+        "subject_ref": subject_ref,
+        "account_present": bool(account_present),
+        "inbound_only": True if accepted else False,
+        "outbound_eligible": False,
+        "auto_send": False,
+        "smtp_authorized": False,
+        "followup_authorized": False,
+        "account_required_for_acceptance": False,
+        "identity_authorization": identity_authorization,
+        "owner": {
+            "admission": "Governance",
+            "record_queue_outcome": "Warmbly",
+            "accepted_context_consumer": "Meetcfg",
+        },
+        "readback": {
+            "required": True,
+            "http_2xx_is_not_acceptance": True,
+            "receipt_id": receipt_s,
+            "decision_id": decision_id,
+        },
+        "retention": {
+            "purpose": "INBOUND_ADMISSION",
+            "class": "COMMERCIAL_INTAKE",
+        },
+        "downstream_correlation": {
+            "correlation_id": corr_s,
+            "receipt_id": receipt_s,
+            "logical_admission_id": decision_id,
+        },
+        "consumer_authorization": {
+            "create_inbound_only_identity": accepted,
+            "surface_on_commercial_queue": accepted,
+            "outbound_eligible": False,
+            "auto_send": False,
+            "smtp_authorized": False,
+            "followup_authorized": False,
+            "fuzzy_identity_by_name": False,
+        },
+        "metrics": {
+            "decision": decision_state,
+            "reason_codes": list(reason_codes),
+            "replayed": False,
+            "origin": origin_s,
+            "acquisition_lane": lane_s,
+            "intent_kind": intent_s,
+            "nucleus_id": nucleus_s,
+            "qualification_state": qualification_state,
+            "inbound_only": True if accepted else False,
+            "outbound_eligible": False,
+            "auto_send": False,
+            "smtp_authorized": False,
+        },
+        "rollback": {
+            "intake_paused": bool(intake_paused),
+            "receipts_retained": True,
+            "delete_forbidden": True,
+            "outbound_promotion_forbidden": True,
+        },
+        "contains_pii": False,
+        "mutation_mode": "MODEL_ONLY",
+        "evaluated_at": evaluated_at if _parse_instant(evaluated_at) else "1970-01-01T00:00:00Z",
+    }
+
+    if decision_contains_pii(decision, payload) or "@" in canonical_json(decision):
+        decision = _scrub_pii_values(decision, _pii_values(payload))
+        decision["decision"] = "UNKNOWN"
+        reasons = [
+            code
+            for code in list(decision.get("reason_codes") or [])
+            if code not in {"ADMISSION_GATES_SATISFIED"}
+        ]
+        if "REQUEST_INVALID" not in reasons:
+            reasons.insert(0, "REQUEST_INVALID")
+        if not reasons:
+            reasons = ["REQUEST_INVALID"]
+        decision["reason_codes"] = reasons
+        decision["identity_authorization"] = "NONE"
+        decision["inbound_only"] = False
+        decision["qualification_state"] = "NONE"
+        decision["consumer_authorization"]["create_inbound_only_identity"] = False
+        decision["consumer_authorization"]["surface_on_commercial_queue"] = False
+        decision["metrics"]["decision"] = "UNKNOWN"
+        decision["metrics"]["reason_codes"] = list(reasons)
+        decision["metrics"]["inbound_only"] = False
+        decision["metrics"]["qualification_state"] = "NONE"
+        decision["contains_pii"] = False
+
+    if store is not None and key_s is not None:
+        existing = store.get(key_s)
+        if existing is None:
+            store.put(key_s, material_hash, decision)
+        elif existing["material_hash"] != material_hash:
             pass
 
     return decision

--- a/commercial/inbound/authority-table.1.0.0-draft.20260904.json
+++ b/commercial/inbound/authority-table.1.0.0-draft.20260904.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "net-new-inbound-handraiser-authority-table.1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "planes": [
+    {
+      "owner": "Governance",
+      "owns": [
+        "versioned_admission_policy",
+        "admit_evaluator",
+        "closed_states",
+        "reason_codes",
+        "qualification_states",
+        "nucleus_admission_set"
+      ],
+      "must_not": ["crm", "queue", "smtp", "ui", "durable_commercial_datastore", "executor"]
+    },
+    {
+      "owner": "web-cfg",
+      "owns": ["CONFENGE_WEB_intake_production"],
+      "issues": ["tjsasakifln/web-cfg#577", "tjsasakifln/web-cfg#580", "tjsasakifln/web-cfg#585"],
+      "must_not": ["evaluate_admission", "create_crm", "authorize_outbound"]
+    },
+    {
+      "owner": "Warmbly",
+      "owns": ["persist", "act", "commercial_record", "unique_queue", "readback"],
+      "issues": ["tjsasakifln/warmbly#47", "tjsasakifln/warmbly#117", "tjsasakifln/warmbly#260"],
+      "must_not": ["copy_schema_as_second_authority", "mark_outbound_eligible_from_this_policy"]
+    },
+    {
+      "owner": "Meetcfg",
+      "owns": ["accepted_commercial_context_view"],
+      "issues": ["tjsasakifln/MeetCFG#1"],
+      "receives": "accepted_only",
+      "must_not": ["admit", "persist_rejected_as_session", "outbound"]
+    },
+    {
+      "owner": "extra-cli",
+      "owns": ["facts", "identity", "evidence", "PNCP_live_ingestion_telemetry"],
+      "issues": ["tjsasakifln/extra-cli#543"],
+      "must_not": [
+        "site_inbound_admission",
+        "commercial_authority_from_pncp_live",
+        "first_touch_from_this_inbound_policy"
+      ]
+    }
+  ],
+  "invariants": {
+    "outbound_eligible": false,
+    "auto_send": false,
+    "smtp_authorized": false,
+    "live_intelligence_is_not_inbound": true,
+    "pncp_live_is_not_commercial_authority": true,
+    "http_2xx_is_not_acceptance": true
+  }
+}

--- a/commercial/inbound/consumer-conformance.1.0.0-draft.20260904.json
+++ b/commercial/inbound/consumer-conformance.1.0.0-draft.20260904.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "net-new-inbound-handraiser-consumer-conformance.1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "instruction": "Pin canonical_name and policy_hash. Do not copy the schema as a second authority. Goal 97 ratifies coordination draft IDs; missing or divergent version/hash fail closed.",
+  "do_not_copy_schema": true,
+  "coordination_ids_test_only": [
+    "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904",
+    "CONFENGE_OFFER_CATALOG/2.0.0-draft.20260904",
+    "CONFENGE_WEB_INTAKE/2.0.0-draft.20260904",
+    "CONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904",
+    "MEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904"
+  ],
+  "policy_hash": "sha256:984f442690f7c74f309173b31008518631170d63733b5cc04c32abaf88c67e28",
+  "examples": {
+    "ACCEPTED": "commercial/fixtures/net-new-inbound-handraiser/accepted.missing-account.draft-20260904.json",
+    "REJECTED_WITH_REASON": "commercial/fixtures/net-new-inbound-handraiser/rejected.consent-refused.draft-20260904.json",
+    "UNKNOWN": "commercial/fixtures/net-new-inbound-handraiser/unknown.unknown-version.draft-20260904.json"
+  },
+  "fixtures": {
+    "accepted.missing-account": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/accepted.missing-account.draft-20260904.json",
+      "class": "ACCEPTED",
+      "content_hash": "sha256:e972bf8cc921e6c5fa4d5840ebad8136c4aa6d2bbe7cca8795dc24cd096a9ddc"
+    },
+    "accepted.conflict-unknown": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/accepted.conflict-unknown.draft-20260904.json",
+      "class": "ACCEPTED",
+      "content_hash": "sha256:d59492e87b179bf3f42b764816c1154aa4f7e58a0290125dc84dbdaae479866b"
+    },
+    "accepted.expert_evidence_assistance": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/accepted.expert_evidence_assistance.draft-20260904.json",
+      "class": "ACCEPTED",
+      "content_hash": "sha256:31e2cde01a531504cc0b14ca6170d4bd682ad29403d6b901af72e14fbbff30fc"
+    },
+    "accepted.property_valuation": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/accepted.property_valuation.draft-20260904.json",
+      "class": "ACCEPTED",
+      "content_hash": "sha256:e9b6e412fcdec39e91349c7e4f5921d3750641d4359e697e57b471a88b202340"
+    },
+    "accepted.building_engineering_documentation": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/accepted.building_engineering_documentation.draft-20260904.json",
+      "class": "ACCEPTED",
+      "content_hash": "sha256:9fe27549382008f907cde312d0f8943aa8be436db4583b8b1e0cbae0bb5411df"
+    },
+    "accepted.occupational_safety": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/accepted.occupational_safety.draft-20260904.json",
+      "class": "ACCEPTED",
+      "content_hash": "sha256:eb32a7516f9f6e931dc32e9567f805d196b520299b951dbd904609f350d55863"
+    },
+    "accepted.public_works_b2g": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/accepted.public_works_b2g.draft-20260904.json",
+      "class": "ACCEPTED",
+      "content_hash": "sha256:0f2c83a30138c00b805b7d78d217f8ccce350f87f6dcd36b3af35929233b83eb"
+    },
+    "rejected.consent-refused": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/rejected.consent-refused.draft-20260904.json",
+      "class": "REJECTED_WITH_REASON",
+      "content_hash": "sha256:6b1090fb63dab69df311ae8b55a0d4a91259e74b864b40feb32c7da6730da3d7"
+    },
+    "rejected.live-intelligence": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/rejected.live-intelligence.draft-20260904.json",
+      "class": "REJECTED_WITH_REASON",
+      "content_hash": "sha256:53b2f2bf220f2bfa6b7b97ffcfdf6ace90a22971ec0a71deb94999bd9fb264a5"
+    },
+    "rejected.first-touch-inheritance": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/rejected.first-touch-inheritance.draft-20260904.json",
+      "class": "REJECTED_WITH_REASON",
+      "content_hash": "sha256:9e924e5acb9e93134eeab1c94cda73b265ce7559345cd40c51c088edfcdc8021"
+    },
+    "rejected.outbound-eligible": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/rejected.outbound-eligible.draft-20260904.json",
+      "class": "REJECTED_WITH_REASON",
+      "content_hash": "sha256:152367813d6620eb7bd9a1863719a0fbfb6dd67f607d6d4d936a9739b8b1e8b6"
+    },
+    "unknown.unknown-version": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/unknown.unknown-version.draft-20260904.json",
+      "class": "UNKNOWN",
+      "content_hash": "sha256:1b955bfbe19e32f3dcd4109143916510ed7b836df7592fc0cffebde028935135"
+    },
+    "unknown.missing-nucleus": {
+      "path": "commercial/fixtures/net-new-inbound-handraiser/unknown.missing-nucleus.draft-20260904.json",
+      "class": "UNKNOWN",
+      "content_hash": "sha256:82fdcbe8240d9901e33af8264709bc3472181c7bb01fea6e31f651f020023e71"
+    }
+  }
+}

--- a/commercial/inbound/consumer-matrix.1.0.0-draft.20260904.json
+++ b/commercial/inbound/consumer-matrix.1.0.0-draft.20260904.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "net-new-inbound-handraiser-consumer-matrix.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "status": "ACTIVE",
+  "v1_remains_exact_match_authority": true,
+  "policy_hash": "sha256:984f442690f7c74f309173b31008518631170d63733b5cc04c32abaf88c67e28",
+  "exact_version_match_required": true,
+  "missing_old_unknown_fail_closed": true,
+  "do_not_copy_schema": true,
+  "consumers": [
+    {
+      "id": "Warmbly#47",
+      "role": "record_queue_outcome_owner",
+      "compatibility": "pin_version_and_hash",
+      "must_pin": ["canonical_name", "policy_hash"],
+      "may_not": ["outbound_eligible_default", "smtp", "followup", "auto_send", "parallel_crm", "copy_schema"]
+    },
+    {
+      "id": "Warmbly#117",
+      "role": "record_queue_outcome_owner",
+      "compatibility": "pin_version_and_hash",
+      "must_pin": ["canonical_name", "policy_hash"],
+      "may_not": ["outbound_eligible_default", "copy_schema"]
+    },
+    {
+      "id": "Warmbly#260",
+      "role": "record_queue_outcome_owner",
+      "compatibility": "pin_version_and_hash",
+      "must_pin": ["canonical_name", "policy_hash"],
+      "may_not": ["copy_schema"]
+    },
+    {
+      "id": "MeetCFG#1",
+      "role": "view_only_consumer",
+      "compatibility": "accepted_only",
+      "must_pin": ["canonical_name", "policy_hash"],
+      "may_not": ["create_lead", "create_session_from_rejected_or_unknown", "outbound_eligibility", "copy_schema"]
+    },
+    {
+      "id": "web-cfg#577",
+      "role": "intent_producer",
+      "origins": ["CONFENGE_WEB", "confenge_web"],
+      "compatibility": "pin_version_and_hash"
+    },
+    {
+      "id": "web-cfg#580",
+      "role": "intent_producer",
+      "origins": ["CONFENGE_WEB"],
+      "compatibility": "pin_version_and_hash"
+    },
+    {
+      "id": "web-cfg#585",
+      "role": "intent_producer",
+      "origins": ["CONFENGE_WEB"],
+      "compatibility": "pin_version_and_hash"
+    }
+  ],
+  "not_producers": [
+    {
+      "id": "extra-cli#543",
+      "reason": "PNCP live is async ingestion and telemetry. It is not commercial authority and not site inbound."
+    }
+  ],
+  "incompatible": [
+    "missing_policy_version",
+    "v0",
+    "v1_string_on_this_version",
+    "v2",
+    "v3",
+    "unknown_policy_id",
+    "intel_watch",
+    "intel_seed",
+    "CFG-FIRST-TOUCH-ROUTING",
+    "outbound_eligible_true",
+    "auto_send_true"
+  ],
+  "pin_command": "python -c \"from commercial.inbound import load_draft_authority, policy_hash; print(policy_hash(load_draft_authority()))\""
+}

--- a/commercial/inbound/net-new-inbound-handraiser.1.0.0-draft.20260904.json
+++ b/commercial/inbound/net-new-inbound-handraiser.1.0.0-draft.20260904.json
@@ -1,0 +1,418 @@
+{
+  "schema_version": "net-new-inbound-handraiser.1.0.0-draft.20260904",
+  "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+  "policy_version": "1.0.0-draft.20260904",
+  "canonical_name": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "status": "ACTIVE",
+  "effective_at": "2026-09-04T00:00:00Z",
+  "does_not_rewrite_v1": true,
+  "v1_remains_exact_match_authority": true,
+  "coordination_id": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+  "authority": {
+    "decided_by_role": "FOUNDER",
+    "decision_reference": "https://github.com/tjsasakifln/Governance/issues/65",
+    "runtime_reference": "https://github.com/tjsasakifln/warmbly/issues/47",
+    "decision_source": "VERSIONED_GOVERNANCE_POLICY",
+    "human_actor_impersonation_allowed": false,
+    "extra_cli_pncp_live_is_commercial_authority": false,
+    "live_intelligence_is_site_inbound": false
+  },
+  "activation": {
+    "exact_version_match_required": true,
+    "accepted_version_strings": [
+      "1.0.0-draft.20260904",
+      "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904"
+    ],
+    "accepted_policy_ids": ["NET_NEW_INBOUND_HANDRAISER"],
+    "v1_string_does_not_activate_this_version": true,
+    "missing_version_disposition": "FAIL_CLOSED",
+    "unknown_version_disposition": "FAIL_CLOSED",
+    "old_version_disposition": "FAIL_CLOSED"
+  },
+  "boundary": {
+    "admission_owner": "Governance",
+    "producer": "web-cfg",
+    "producer_origin": "CONFENGE_WEB",
+    "producer_issue": "tjsasakifln/web-cfg#577",
+    "producers_by_origin": {
+      "CONFENGE_WEB": "web-cfg",
+      "confenge_web": "web-cfg"
+    },
+    "producer_issues": {
+      "web-cfg": "tjsasakifln/web-cfg#577"
+    },
+    "record_queue_outcome_owner": "Warmbly",
+    "consumer": "Warmbly",
+    "consumer_issue": "tjsasakifln/warmbly#47",
+    "view_only_consumer": "Meetcfg",
+    "view_only_consumer_issue": "tjsasakifln/MeetCFG#1",
+    "policy_governance": "Governance/NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+    "meetcfg_receives": "accepted_commercial_context_only",
+    "not_producers_of_this_authority": [
+      "extra-cli",
+      "intel_watch",
+      "intel_seed",
+      "PNCP_LIVE",
+      "CFG-FIRST-TOUCH-ROUTING"
+    ],
+    "producer_may": [
+      "submit_intake_request",
+      "supply_origin_lane_intent",
+      "supply_idempotency_key",
+      "supply_contact_consent_evidence_refs",
+      "supply_receipt_correlation",
+      "supply_subject_or_account_ref_when_existing",
+      "supply_nucleus_and_offer_candidate",
+      "supply_minimized_location",
+      "supply_sensitive_class_without_content",
+      "supply_conflict_status_and_protected_ref"
+    ],
+    "producer_must_not": [
+      "create_crm_record",
+      "evaluate_outbound_eligibility",
+      "authorize_smtp",
+      "authorize_followup",
+      "authorize_auto_send",
+      "discard_for_missing_account",
+      "fuzzy_match_identity_by_name",
+      "inherit_first_touch",
+      "treat_live_intelligence_as_inbound",
+      "put_sensitive_content_in_public_envelope",
+      "coerce_conflict_unknown_to_clear"
+    ],
+    "consumer_may": [
+      "create_inbound_only_identity_on_accepted",
+      "retain_receipt_and_evidence",
+      "surface_accepted_intent_on_commercial_queue",
+      "return_readback"
+    ],
+    "consumer_must_not": [
+      "mark_outbound_eligible_from_this_authority",
+      "send_smtp",
+      "send_followup",
+      "auto_send",
+      "fuzzy_match_identity_by_name",
+      "discard_for_missing_account",
+      "emit_pii_to_metrics",
+      "copy_schema_as_second_authority"
+    ],
+    "governance_owns": [
+      "versioned_policy",
+      "closed_states",
+      "reason_codes",
+      "idempotency_semantics",
+      "readback_contract",
+      "rollback_contract",
+      "pure_admit_evaluator",
+      "qualification_states",
+      "nucleus_admission_set"
+    ],
+    "governance_must_not": [
+      "crm",
+      "commercial_queue",
+      "ui",
+      "smtp",
+      "web_form",
+      "durable_data_plane",
+      "warmbly_runtime",
+      "meetcfg_runtime"
+    ],
+    "parallel_crm_authorized": false,
+    "parallel_architecture_allowed": false
+  },
+  "inputs": {
+    "required": [
+      "origin",
+      "acquisition_lane",
+      "intent_kind",
+      "idempotency_key",
+      "contact_evidence",
+      "consent_evidence",
+      "receipt_id",
+      "correlation_id",
+      "intake_source",
+      "landing_asset",
+      "nucleus_id",
+      "offer_candidate_id",
+      "party_kind",
+      "decision_role",
+      "site_location",
+      "urgency",
+      "why_now_class",
+      "desired_decision_or_deliverable",
+      "document_availability_class",
+      "sensitive_data",
+      "conflict_screening"
+    ],
+    "optional_when_present": [
+      "subject_ref",
+      "account_ref",
+      "source",
+      "freshness",
+      "policy_id",
+      "policy_version",
+      "canonical_name",
+      "partner_required",
+      "capacity_review_required",
+      "retention"
+    ],
+    "admitted_origins": ["CONFENGE_WEB", "confenge_web"],
+    "admitted_intake_sources": ["CONFENGE_WEB"],
+    "admitted_acquisition_lanes": ["NET_NEW_INBOUND"],
+    "admitted_intent_kinds": [
+      "HUMAN_REVIEW",
+      "DEEP_DIVE",
+      "REQUEST_HUMAN_REVIEW",
+      "REQUEST_DEEP_DIVE"
+    ],
+    "intent_kind_aliases": {
+      "REQUEST_HUMAN_REVIEW": "HUMAN_REVIEW",
+      "REQUEST_DEEP_DIVE": "DEEP_DIVE"
+    },
+    "admitted_nuclei": [
+      "expert_evidence_assistance",
+      "property_valuation",
+      "building_engineering_documentation",
+      "occupational_safety",
+      "public_works_b2g"
+    ],
+    "admitted_offer_candidates": [
+      "private_project_technical_readiness_assessment"
+    ],
+    "admitted_party_kinds": ["PERSON", "COMPANY"],
+    "admitted_decision_roles": ["DECISION_MAKER", "INFLUENCER", "OPERATOR", "UNKNOWN"],
+    "admitted_urgency": ["IMMEDIATE", "THIS_CYCLE", "EXPLORATORY", "UNKNOWN"],
+    "admitted_why_now_classes": [
+      "DEADLINE",
+      "INCIDENT",
+      "AUDIT",
+      "PROCUREMENT",
+      "CAPACITY",
+      "UNKNOWN"
+    ],
+    "admitted_desired_deliverables": [
+      "ASSESSMENT",
+      "OPINION",
+      "DOCUMENT_SET",
+      "SITE_VISIT",
+      "UNKNOWN"
+    ],
+    "admitted_document_availability_classes": [
+      "COMPLETE",
+      "PARTIAL",
+      "GAP",
+      "UNKNOWN"
+    ],
+    "admitted_sensitive_classes": [
+      "NONE",
+      "LGPD_SPECIAL",
+      "LEGAL_PRIVILEGE",
+      "HEALTH",
+      "UNKNOWN"
+    ],
+    "admitted_conflict_statuses": ["CLEAR", "UNKNOWN", "HIT", "NOT_SCREENED"],
+    "forbidden_origins": ["intel_watch", "intel_seed", "PNCP_LIVE", "FIRST_TOUCH"],
+    "admitted_consent_bases": ["EXPLICIT_FORM_SUBMIT", "EXPLICIT_HUMAN_REVIEW_REQUEST"],
+    "admitted_identity_match_methods": ["EXPLICIT_CONTACT", "EXPLICIT_SUBJECT_REF"],
+    "forbidden_identity_match_methods": ["NAME", "DISPLAY_NAME", "FUZZY", "FUZZY_NAME", "FUZZY_IDENTITY"],
+    "location_allowed_fields": ["city", "uf", "ibge_municipality_code"],
+    "location_forbidden_fields": ["street", "address", "cep", "zip", "lat", "lon", "latitude", "longitude", "email"]
+  },
+  "qualification_states": [
+    "NEEDS_CONTEXT",
+    "POTENTIAL_FIT",
+    "CONFLICT_CHECK_REQUIRED",
+    "DOCUMENT_GAP",
+    "CAPACITY_REVIEW",
+    "PARTNER_REQUIRED",
+    "OUT_OF_SCOPE",
+    "QCO"
+  ],
+  "closed_states": ["ACCEPTED", "REJECTED_WITH_REASON", "UNKNOWN"],
+  "reason_codes": {
+    "accepted": ["ADMISSION_GATES_SATISFIED"],
+    "rejected": [
+      "ORIGIN_NOT_ADMITTED",
+      "ACQUISITION_LANE_NOT_ADMITTED",
+      "INTENT_KIND_NOT_ADMITTED",
+      "CONSENT_REFUSED",
+      "OPT_OUT_PRESENT",
+      "FUZZY_IDENTITY_FORBIDDEN",
+      "IDEMPOTENCY_PAYLOAD_CONFLICT",
+      "IDENTITY_CONFLICT",
+      "POLICY_VERSION_NOT_ADMITTED",
+      "INTAKE_PAUSED",
+      "NUCLEUS_NOT_ADMITTED",
+      "OFFER_CANDIDATE_NOT_ADMITTED",
+      "LIVE_INTELLIGENCE_NOT_INBOUND",
+      "FIRST_TOUCH_INHERITANCE_FORBIDDEN",
+      "OUTBOUND_INHERITANCE_FORBIDDEN",
+      "AUTO_SEND_FORBIDDEN",
+      "SENSITIVE_CONTENT_FORBIDDEN",
+      "CONFLICT_CLEAR_COERCION_FORBIDDEN",
+      "LOCATION_NOT_MINIMIZED"
+    ],
+    "unknown": [
+      "REQUEST_INVALID",
+      "AUTHORITY_UNAVAILABLE",
+      "ORIGIN_UNKNOWN",
+      "ACQUISITION_LANE_UNKNOWN",
+      "INTENT_KIND_UNKNOWN",
+      "INTENT_KIND_AMBIGUOUS",
+      "IDEMPOTENCY_KEY_MISSING",
+      "CONTACT_EVIDENCE_UNKNOWN",
+      "CONSENT_EVIDENCE_UNKNOWN",
+      "CONSENT_AMBIGUOUS",
+      "RECEIPT_UNKNOWN",
+      "CORRELATION_UNKNOWN",
+      "SOURCE_UNKNOWN",
+      "FRESHNESS_UNKNOWN",
+      "FRESHNESS_STALE",
+      "SUBJECT_REFERENCE_AMBIGUOUS",
+      "POLICY_VERSION_MISSING",
+      "POLICY_VERSION_UNKNOWN",
+      "POLICY_ID_UNKNOWN",
+      "NUCLEUS_UNKNOWN",
+      "OFFER_CANDIDATE_UNKNOWN",
+      "PARTY_KIND_UNKNOWN",
+      "LANDING_ASSET_UNKNOWN",
+      "SENSITIVE_CLASS_UNKNOWN",
+      "CONFLICT_STATUS_MISSING"
+    ],
+    "never_emitted": [
+      "ACCOUNT_MISSING",
+      "ACCOUNT_REQUIRED",
+      "ACCOUNT_NOT_FOUND",
+      "CONFLICT_UNKNOWN_AS_CLEAR"
+    ]
+  },
+  "evaluation": {
+    "mode": "ALL_REQUIRED_INPUTS_THEN_HARD_GATES",
+    "unknown_result": "UNKNOWN",
+    "absence_or_ambiguity": "UNKNOWN",
+    "fail_closed": true,
+    "replay_semantics": "EXACTLY_ONCE_LOGICAL",
+    "mutation_mode": "MODEL_ONLY",
+    "conflict_unknown_never_becomes_clear": true,
+    "http_2xx_is_not_acceptance": true,
+    "live_intelligence_is_not_inbound": true,
+    "first_touch_inheritance_forbidden": true,
+    "coordination_ids_are_not_runtime_fallbacks": true
+  },
+  "invariants": {
+    "account_required_for_acceptance": false,
+    "missing_account_is_discard_reason": false,
+    "accepted_may_create_inbound_only_identity": true,
+    "inbound_only_on_accepted": true,
+    "inbound_only_equals_outbound_eligible": false,
+    "outbound_eligible_default": false,
+    "auto_send": false,
+    "smtp_authorized": false,
+    "followup_authorized": false,
+    "provider_dispatch_authorized": false,
+    "fuzzy_identity_by_name": false,
+    "pii_in_metrics": false,
+    "pii_in_decision": false,
+    "parallel_crm_authorized": false,
+    "inbound_only_never_promotes_outbound": true,
+    "sensitive_content_in_public_envelope": false,
+    "conflict_unknown_never_becomes_clear": true,
+    "http_2xx_is_not_acceptance": true
+  },
+  "identity": {
+    "accepted_authorization": "INBOUND_ONLY",
+    "rejected_or_unknown_authorization": "NONE",
+    "fuzzy_name_match_allowed": false,
+    "account_ref_optional": true,
+    "subject_ref_optional": true
+  },
+  "idempotency": {
+    "key_required": true,
+    "semantics": "EXACTLY_ONCE_LOGICAL",
+    "same_key_same_material": "REPLAY_ORIGINAL_DECISION",
+    "same_key_different_material": "REJECTED_WITH_REASON",
+    "same_key_different_material_reason": "IDEMPOTENCY_PAYLOAD_CONFLICT",
+    "distinct_keys": "DISTINCT_LOGICAL_ADMISSIONS",
+    "store_mode": "MODEL_ONLY",
+    "production_ledger_authorized": false
+  },
+  "readback": {
+    "required": true,
+    "http_2xx_is_not_acceptance": true,
+    "required_fields": [
+      "schema_version",
+      "policy_id",
+      "policy_version",
+      "canonical_name",
+      "decision_id",
+      "logical_admission_id",
+      "decision",
+      "reason_codes",
+      "idempotency_key",
+      "correlation_id",
+      "receipt_id",
+      "replayed",
+      "origin",
+      "acquisition_lane",
+      "intent_kind",
+      "intake_source",
+      "nucleus_id",
+      "offer_candidate_id",
+      "qualification_state",
+      "inbound_only",
+      "outbound_eligible",
+      "auto_send",
+      "smtp_authorized",
+      "followup_authorized",
+      "account_required_for_acceptance",
+      "identity_authorization",
+      "evaluated_at"
+    ],
+    "pii_fields_forbidden": [
+      "email",
+      "phone",
+      "display_name",
+      "full_name",
+      "name",
+      "cpf",
+      "raw_message",
+      "message_body",
+      "ip_address",
+      "street",
+      "address",
+      "sensitive_content"
+    ]
+  },
+  "rollback": {
+    "pause_intake": true,
+    "retain_receipts": true,
+    "refuse_with_reason_code": true,
+    "refuse_reason_code": "INTAKE_PAUSED",
+    "delete_forbidden": true,
+    "outbound_promotion_forbidden": true,
+    "replay_of_existing_receipt_preserved": true,
+    "freeze_intake": true
+  },
+  "failure": {
+    "absence_decision": "UNKNOWN",
+    "ambiguity_decision": "UNKNOWN",
+    "concrete_reason_codes_required": true,
+    "fail_closed": true
+  },
+  "retention": {
+    "purpose": "INBOUND_ADMISSION",
+    "class": "COMMERCIAL_INTAKE"
+  },
+  "safety": {
+    "smtp_authorized": false,
+    "followup_authorized": false,
+    "auto_send": false,
+    "outbound_eligible_default": false,
+    "crm_parallel_authorized": false,
+    "durable_data_plane_authorized": false,
+    "contains_pii": false,
+    "e2e_claimed": false,
+    "pncp_live_commercial_authority": false,
+    "live_intelligence_as_inbound": false
+  }
+}

--- a/decisions/ADR-NET-NEW-INBOUND-HANDRAISER-001.md
+++ b/decisions/ADR-NET-NEW-INBOUND-HANDRAISER-001.md
@@ -1,0 +1,49 @@
+# ADR-NET-NEW-INBOUND-HANDRAISER-001
+
+Status: accepted
+Effective: 2026-09-04
+Authority: founder decision recorded in [Governance #65](https://github.com/tjsasakifln/Governance/issues/65)
+Runtime tracking: [Warmbly #47](https://github.com/tjsasakifln/warmbly/issues/47)
+
+## Current decision
+
+`NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904` is the versioned admission
+authority for net-new inbound hand-raisers of the five nuclei, produced on
+`CONFENGE_WEB`. Consumers pin canonical name and content hash. They must not
+copy the schema as a second authority.
+
+`NET_NEW_INBOUND_HANDRAISER-v1` remains an exact-match authority for existing
+pins. This version does not rewrite v1. A v1 string does not activate this
+version. Missing, old or unknown version fail closed.
+
+Closed states are only `ACCEPTED`, `REJECTED_WITH_REASON` and `UNKNOWN`.
+Accepted net-new is inbound-only. `outbound_eligible` is false.
+`auto_send` is false. SMTP, cadence and follow-up are not authorized.
+Absence of a prior account is not a discard. Replay is exactly-once logical.
+HTTP 2xx is not acceptance; receipt/readback is required.
+
+Conflict `UNKNOWN` never becomes `CLEAR`. Sensitive data enters the public
+envelope only as class and protected reference.
+
+## Extra-cli / PNCP live (Governance #1 contemporaneous note)
+
+[extra-cli #543](https://github.com/tjsasakifln/extra-cli/pull/543) canonicalizes
+PNCP live as async ingestion and telemetry. The commercial cycle reads the
+persisted lake. PNCP live is not commercial authority and is not this inbound
+admission. Live Intelligence events (`intel_watch`, `intel_seed`) are not site
+inbound submissions under this version. This note does not rewrite first-touch
+history and is not a substitute ADR for `CFG-FIRST-TOUCH-ROUTING`.
+
+## Architecture consequence
+
+Governance owns the versioned policy and the pure admit evaluator. web-cfg
+produces `CONFENGE_WEB`. Warmbly persists and acts. Meetcfg receives accepted
+context only. No parallel CRM, queue, SMTP client or durable commercial
+datastore is introduced in Governance.
+
+## Additive note — v1 (2026-09-03)
+
+`NET_NEW_INBOUND_HANDRAISER-v1` was published as the first machine-readable
+inbound admission (PR #166 / #167). It remains exact-match ACTIVE for its
+own version strings, including historical `intel_watch` / `intel_seed`
+origins. This draft version does not inherit those origins.

--- a/docs/integration/campaign-20260904/06/acquisition-pressure.intake-freeze.md
+++ b/docs/integration/campaign-20260904/06/acquisition-pressure.intake-freeze.md
@@ -1,0 +1,11 @@
+# Integration fragment — campaign 06 — acquisition-pressure intake freeze
+
+- target_path: `commercial/acquisition/acquisition-pressure.v1.json`
+- operation: none in this campaign; freeze remains `NET_NEW_INBOUND_HANDRAISER-v1`
+- stable_key: `intake_frozen`
+- dependency: campaign 16 may update the issue ledger; it must not alter this admission policy
+- test: `intake_frozen == NET_NEW_INBOUND_HANDRAISER-v1`; `intake_schema_change` remains forbidden
+- rollback: leave the freeze on v1
+
+Campaign 06 publishes a new inbound version beside v1. Goal 97 decides whether
+the freeze should name the draft version.

--- a/docs/integration/campaign-20260904/06/authority-manifest.inbound-draft.md
+++ b/docs/integration/campaign-20260904/06/authority-manifest.inbound-draft.md
@@ -1,0 +1,8 @@
+# Integration fragment — campaign 06 — authority-manifest inbound draft
+
+- target_path: `commercial/authority/authority-manifest.v1.json`
+- operation: optional later listing of `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904` as a distinct inbound authority
+- stable_key: `net_new_inbound_handraiser`
+- dependency: goal 97; do not silently replace the v1 entry
+- test: exact version match; missing/unknown fail closed
+- rollback: manifest continues to omit this draft until ratified

--- a/docs/integration/campaign-20260904/06/consumer-contract.inbound-draft.md
+++ b/docs/integration/campaign-20260904/06/consumer-contract.inbound-draft.md
@@ -1,0 +1,12 @@
+# Integration fragment — campaign 06 — CONSUMER-CONTRACT inbound pin
+
+- target_path: `commercial/CONSUMER-CONTRACT.md`
+- operation: append a section for `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904` without deleting the v1 section
+- stable_key: `inbound_admission_net_new_handraiser`
+- dependency: campaign 06 policy published; goal 97 chooses dual-active vs supersede
+- test: consumers pin `canonical_name` + `policy_hash`; unknown version fail-closed; v1 string does not activate this version
+- rollback: keep the v1 pin; this version remains exact-match only
+
+Do not edit `commercial/CONSUMER-CONTRACT.md` in campaign 06. v1 text currently
+says it is the only active inbound policy; that remains true for v1 pins until
+goal 97 ratifies.

--- a/docs/integration/campaign-20260904/06/consumer-handoff.inbound-draft.md
+++ b/docs/integration/campaign-20260904/06/consumer-handoff.inbound-draft.md
@@ -1,0 +1,10 @@
+# Integration fragment — campaign 06 — CONSUMER-HANDOFF inbound pin
+
+- target_path: `commercial/CONSUMER-HANDOFF.md`
+- operation: add pin instructions for `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904` and the inbound consumer pin file
+- stable_key: `inbound_admission_consumer_handoff`
+- dependency: `commercial/inbound/CONSUMER-PIN.1.0.0-draft.20260904.md`
+- test: pin command `python -c "from commercial.inbound import load_draft_authority, policy_hash; print(policy_hash(load_draft_authority()))"`
+- rollback: consumers keep the v1 pin command
+
+Do not copy the schema. Do not treat extra-cli PNCP live as this inbound source.

--- a/schemas/net-new-inbound-handraiser-admission.1.0.0-draft.20260904.schema.json
+++ b/schemas/net-new-inbound-handraiser-admission.1.0.0-draft.20260904.schema.json
@@ -1,0 +1,350 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/schemas/net-new-inbound-handraiser-admission.1.0.0-draft.20260904.schema.json",
+  "title": "NET_NEW_INBOUND_HANDRAISER admission decision 1.0.0-draft.20260904",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "policy_id",
+    "policy_version",
+    "canonical_name",
+    "decision_id",
+    "logical_admission_id",
+    "decision",
+    "reason_codes",
+    "idempotency_key",
+    "correlation_id",
+    "receipt_id",
+    "replayed",
+    "origin",
+    "acquisition_lane",
+    "intent_kind",
+    "intake_source",
+    "landing_asset",
+    "nucleus_id",
+    "offer_candidate_id",
+    "party_kind",
+    "decision_role",
+    "site_location",
+    "urgency",
+    "why_now_class",
+    "desired_decision_or_deliverable",
+    "document_availability_class",
+    "sensitive_data",
+    "conflict_screening",
+    "qualification_state",
+    "subject_ref",
+    "account_present",
+    "inbound_only",
+    "outbound_eligible",
+    "auto_send",
+    "smtp_authorized",
+    "followup_authorized",
+    "account_required_for_acceptance",
+    "identity_authorization",
+    "owner",
+    "readback",
+    "retention",
+    "downstream_correlation",
+    "consumer_authorization",
+    "metrics",
+    "rollback",
+    "contains_pii",
+    "mutation_mode",
+    "evaluated_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "net-new-inbound-handraiser-admission.1.0.0-draft.20260904" },
+    "policy_id": { "const": "NET_NEW_INBOUND_HANDRAISER" },
+    "policy_version": { "const": "1.0.0-draft.20260904" },
+    "canonical_name": { "const": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904" },
+    "decision_id": { "type": "string", "pattern": "^nihr_[0-9a-f]{32}$" },
+    "logical_admission_id": { "type": "string", "pattern": "^nihr_[0-9a-f]{32}$" },
+    "decision": { "enum": ["ACCEPTED", "REJECTED_WITH_REASON", "UNKNOWN"] },
+    "reason_codes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/reason_code" }
+    },
+    "idempotency_key": { "type": ["string", "null"] },
+    "correlation_id": { "type": ["string", "null"] },
+    "receipt_id": { "type": ["string", "null"] },
+    "replayed": { "type": "boolean" },
+    "origin": { "type": ["string", "null"] },
+    "acquisition_lane": { "type": ["string", "null"] },
+    "intent_kind": { "type": ["string", "null"] },
+    "intake_source": { "type": ["string", "null"] },
+    "landing_asset": { "type": ["object", "null"] },
+    "nucleus_id": { "type": ["string", "null"] },
+    "offer_candidate_id": { "type": ["string", "null"] },
+    "party_kind": { "type": ["string", "null"] },
+    "decision_role": { "type": ["string", "null"] },
+    "site_location": { "type": ["object", "null"] },
+    "urgency": { "type": ["string", "null"] },
+    "why_now_class": { "type": ["string", "null"] },
+    "desired_decision_or_deliverable": { "type": ["string", "null"] },
+    "document_availability_class": { "type": ["string", "null"] },
+    "sensitive_data": { "$ref": "#/$defs/sensitive_data" },
+    "conflict_screening": { "$ref": "#/$defs/conflict_screening" },
+    "qualification_state": {
+      "enum": [
+        "NEEDS_CONTEXT",
+        "POTENTIAL_FIT",
+        "CONFLICT_CHECK_REQUIRED",
+        "DOCUMENT_GAP",
+        "CAPACITY_REVIEW",
+        "PARTNER_REQUIRED",
+        "OUT_OF_SCOPE",
+        "QCO",
+        "NONE"
+      ]
+    },
+    "subject_ref": { "type": ["string", "null"] },
+    "account_present": { "type": "boolean" },
+    "inbound_only": { "type": "boolean" },
+    "outbound_eligible": { "const": false },
+    "auto_send": { "const": false },
+    "smtp_authorized": { "const": false },
+    "followup_authorized": { "const": false },
+    "account_required_for_acceptance": { "const": false },
+    "identity_authorization": { "enum": ["INBOUND_ONLY", "NONE"] },
+    "owner": { "$ref": "#/$defs/owner" },
+    "readback": { "$ref": "#/$defs/readback" },
+    "retention": { "$ref": "#/$defs/retention" },
+    "downstream_correlation": { "$ref": "#/$defs/downstream_correlation" },
+    "consumer_authorization": { "$ref": "#/$defs/consumer_authorization" },
+    "metrics": { "$ref": "#/$defs/metrics" },
+    "rollback": { "$ref": "#/$defs/rollback" },
+    "contains_pii": { "const": false },
+    "mutation_mode": { "const": "MODEL_ONLY" },
+    "evaluated_at": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "decision": { "const": "ACCEPTED" } },
+        "required": ["decision"]
+      },
+      "then": {
+        "properties": {
+          "inbound_only": { "const": true },
+          "identity_authorization": { "const": "INBOUND_ONLY" },
+          "outbound_eligible": { "const": false },
+          "auto_send": { "const": false }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "decision": { "enum": ["REJECTED_WITH_REASON", "UNKNOWN"] } },
+        "required": ["decision"]
+      },
+      "then": {
+        "properties": {
+          "inbound_only": { "const": false },
+          "identity_authorization": { "const": "NONE" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "reason_code": {
+      "enum": [
+        "ADMISSION_GATES_SATISFIED",
+        "ORIGIN_NOT_ADMITTED",
+        "ACQUISITION_LANE_NOT_ADMITTED",
+        "INTENT_KIND_NOT_ADMITTED",
+        "CONSENT_REFUSED",
+        "OPT_OUT_PRESENT",
+        "FUZZY_IDENTITY_FORBIDDEN",
+        "IDEMPOTENCY_PAYLOAD_CONFLICT",
+        "INTAKE_PAUSED",
+        "REQUEST_INVALID",
+        "AUTHORITY_UNAVAILABLE",
+        "ORIGIN_UNKNOWN",
+        "ACQUISITION_LANE_UNKNOWN",
+        "INTENT_KIND_UNKNOWN",
+        "INTENT_KIND_AMBIGUOUS",
+        "IDEMPOTENCY_KEY_MISSING",
+        "CONTACT_EVIDENCE_UNKNOWN",
+        "CONSENT_EVIDENCE_UNKNOWN",
+        "CONSENT_AMBIGUOUS",
+        "RECEIPT_UNKNOWN",
+        "CORRELATION_UNKNOWN",
+        "SOURCE_UNKNOWN",
+        "FRESHNESS_UNKNOWN",
+        "FRESHNESS_STALE",
+        "SUBJECT_REFERENCE_AMBIGUOUS",
+        "IDENTITY_CONFLICT",
+        "POLICY_VERSION_NOT_ADMITTED",
+        "POLICY_VERSION_MISSING",
+        "POLICY_VERSION_UNKNOWN",
+        "POLICY_ID_UNKNOWN",
+        "NUCLEUS_NOT_ADMITTED",
+        "OFFER_CANDIDATE_NOT_ADMITTED",
+        "LIVE_INTELLIGENCE_NOT_INBOUND",
+        "FIRST_TOUCH_INHERITANCE_FORBIDDEN",
+        "OUTBOUND_INHERITANCE_FORBIDDEN",
+        "AUTO_SEND_FORBIDDEN",
+        "SENSITIVE_CONTENT_FORBIDDEN",
+        "CONFLICT_CLEAR_COERCION_FORBIDDEN",
+        "LOCATION_NOT_MINIMIZED",
+        "NUCLEUS_UNKNOWN",
+        "OFFER_CANDIDATE_UNKNOWN",
+        "PARTY_KIND_UNKNOWN",
+        "LANDING_ASSET_UNKNOWN",
+        "SENSITIVE_CLASS_UNKNOWN",
+        "CONFLICT_STATUS_MISSING"
+      ]
+    },
+    "sensitive_data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["present", "class", "protected_ref"],
+      "properties": {
+        "present": { "type": "boolean" },
+        "class": { "type": ["string", "null"] },
+        "protected_ref": { "type": ["string", "null"] }
+      }
+    },
+    "conflict_screening": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "protected_ref"],
+      "properties": {
+        "status": { "type": ["string", "null"] },
+        "protected_ref": { "type": ["string", "null"] }
+      }
+    },
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["admission", "record_queue_outcome", "accepted_context_consumer"],
+      "properties": {
+        "admission": { "const": "Governance" },
+        "record_queue_outcome": { "const": "Warmbly" },
+        "accepted_context_consumer": { "const": "Meetcfg" }
+      }
+    },
+    "readback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "http_2xx_is_not_acceptance", "receipt_id", "decision_id"],
+      "properties": {
+        "required": { "const": true },
+        "http_2xx_is_not_acceptance": { "const": true },
+        "receipt_id": { "type": ["string", "null"] },
+        "decision_id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "retention": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["purpose", "class"],
+      "properties": {
+        "purpose": { "const": "INBOUND_ADMISSION" },
+        "class": { "const": "COMMERCIAL_INTAKE" }
+      }
+    },
+    "downstream_correlation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlation_id", "receipt_id", "logical_admission_id"],
+      "properties": {
+        "correlation_id": { "type": ["string", "null"] },
+        "receipt_id": { "type": ["string", "null"] },
+        "logical_admission_id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "consumer_authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "create_inbound_only_identity",
+        "surface_on_commercial_queue",
+        "outbound_eligible",
+        "auto_send",
+        "smtp_authorized",
+        "followup_authorized",
+        "fuzzy_identity_by_name"
+      ],
+      "properties": {
+        "create_inbound_only_identity": { "type": "boolean" },
+        "surface_on_commercial_queue": { "type": "boolean" },
+        "outbound_eligible": { "const": false },
+        "auto_send": { "const": false },
+        "smtp_authorized": { "const": false },
+        "followup_authorized": { "const": false },
+        "fuzzy_identity_by_name": { "const": false }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision",
+        "reason_codes",
+        "replayed",
+        "origin",
+        "acquisition_lane",
+        "intent_kind",
+        "nucleus_id",
+        "qualification_state",
+        "inbound_only",
+        "outbound_eligible",
+        "auto_send",
+        "smtp_authorized"
+      ],
+      "properties": {
+        "decision": { "enum": ["ACCEPTED", "REJECTED_WITH_REASON", "UNKNOWN"] },
+        "reason_codes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/reason_code" }
+        },
+        "replayed": { "type": "boolean" },
+        "origin": { "type": ["string", "null"] },
+        "acquisition_lane": { "type": ["string", "null"] },
+        "intent_kind": { "type": ["string", "null"] },
+        "nucleus_id": { "type": ["string", "null"] },
+        "qualification_state": {
+          "enum": [
+            "NEEDS_CONTEXT",
+            "POTENTIAL_FIT",
+            "CONFLICT_CHECK_REQUIRED",
+            "DOCUMENT_GAP",
+            "CAPACITY_REVIEW",
+            "PARTNER_REQUIRED",
+            "OUT_OF_SCOPE",
+            "QCO",
+            "NONE"
+          ]
+        },
+        "inbound_only": { "type": "boolean" },
+        "outbound_eligible": { "const": false },
+        "auto_send": { "const": false },
+        "smtp_authorized": { "const": false }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "intake_paused",
+        "receipts_retained",
+        "delete_forbidden",
+        "outbound_promotion_forbidden"
+      ],
+      "properties": {
+        "intake_paused": { "type": "boolean" },
+        "receipts_retained": { "const": true },
+        "delete_forbidden": { "const": true },
+        "outbound_promotion_forbidden": { "const": true }
+      }
+    }
+  }
+}

--- a/schemas/net-new-inbound-handraiser-request.1.0.0-draft.20260904.schema.json
+++ b/schemas/net-new-inbound-handraiser-request.1.0.0-draft.20260904.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/schemas/net-new-inbound-handraiser-request.1.0.0-draft.20260904.schema.json",
+  "title": "NET_NEW_INBOUND_HANDRAISER request 1.0.0-draft.20260904",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "origin",
+    "acquisition_lane",
+    "intent_kind",
+    "idempotency_key",
+    "correlation_id",
+    "receipt_id",
+    "contact_evidence",
+    "consent_evidence",
+    "intake_source",
+    "landing_asset",
+    "nucleus_id",
+    "offer_candidate_id",
+    "party_kind",
+    "decision_role",
+    "site_location",
+    "urgency",
+    "why_now_class",
+    "desired_decision_or_deliverable",
+    "document_availability_class",
+    "sensitive_data",
+    "conflict_screening"
+  ],
+  "properties": {
+    "schema_version": { "const": "net-new-inbound-handraiser-request.1.0.0-draft.20260904" },
+    "origin": { "type": "string", "minLength": 1 },
+    "acquisition_lane": { "type": "string", "minLength": 1 },
+    "intent_kind": { "type": "string", "minLength": 1 },
+    "idempotency_key": { "type": "string", "minLength": 1 },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "receipt_id": { "type": "string", "minLength": 1 },
+    "subject_ref": { "type": ["string", "null"] },
+    "account_ref": { "type": ["string", "null"] },
+    "opt_out": { "type": "boolean" },
+    "outbound_eligible": { "type": "boolean" },
+    "auto_send": { "type": "boolean" },
+    "partner_required": { "type": "boolean" },
+    "capacity_review_required": { "type": "boolean" },
+    "contact_evidence": { "$ref": "#/$defs/contact_evidence" },
+    "consent_evidence": { "$ref": "#/$defs/consent_evidence" },
+    "source": { "$ref": "#/$defs/source" },
+    "freshness": { "$ref": "#/$defs/freshness" },
+    "policy_id": { "type": "string", "minLength": 1 },
+    "policy_version": { "type": "string", "minLength": 1 },
+    "canonical_name": { "type": "string", "minLength": 1 },
+    "intake_source": { "type": "string", "minLength": 1 },
+    "landing_asset": { "$ref": "#/$defs/landing_asset" },
+    "nucleus_id": { "type": "string", "minLength": 1 },
+    "offer_candidate_id": { "type": "string", "minLength": 1 },
+    "party_kind": { "type": "string", "minLength": 1 },
+    "decision_role": { "type": "string", "minLength": 1 },
+    "site_location": { "$ref": "#/$defs/site_location" },
+    "urgency": { "type": "string", "minLength": 1 },
+    "why_now_class": { "type": "string", "minLength": 1 },
+    "desired_decision_or_deliverable": { "type": "string", "minLength": 1 },
+    "document_availability_class": { "type": "string", "minLength": 1 },
+    "sensitive_data": { "$ref": "#/$defs/sensitive_data" },
+    "conflict_screening": { "$ref": "#/$defs/conflict_screening" },
+    "retention": { "$ref": "#/$defs/retention" }
+  },
+  "$defs": {
+    "contact_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["present", "channel", "evidence_ref", "identity_match_method"],
+      "properties": {
+        "present": { "type": "boolean" },
+        "channel": { "type": "string", "minLength": 1 },
+        "evidence_ref": { "type": "string", "minLength": 1 },
+        "identity_match_method": { "type": "string", "minLength": 1 }
+      }
+    },
+    "consent_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["captured", "basis", "evidence_ref"],
+      "properties": {
+        "captured": { "type": "boolean" },
+        "basis": { "type": "string", "minLength": 1 },
+        "evidence_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system"],
+      "properties": {
+        "system": { "type": "string", "minLength": 1 },
+        "issue_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["as_of", "max_age_seconds"],
+      "properties": {
+        "as_of": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+        },
+        "max_age_seconds": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "landing_asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "minLength": 1 }
+      }
+    },
+    "site_location": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["city", "uf"],
+      "properties": {
+        "city": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "uf": { "type": "string", "pattern": "^[A-Z]{2}$" },
+        "ibge_municipality_code": { "type": "string", "pattern": "^[0-9]{7}$" }
+      }
+    },
+    "sensitive_data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["present", "class"],
+      "properties": {
+        "present": { "type": "boolean" },
+        "class": { "type": "string", "minLength": 1 },
+        "protected_ref": { "type": ["string", "null"] }
+      }
+    },
+    "conflict_screening": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "type": "string", "minLength": 1 },
+        "protected_ref": { "type": ["string", "null"] },
+        "claimed_clear": { "type": "boolean" }
+      }
+    },
+    "retention": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["purpose", "class"],
+      "properties": {
+        "purpose": { "type": "string", "minLength": 1 },
+        "class": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/schemas/net-new-inbound-handraiser.1.0.0-draft.20260904.schema.json
+++ b/schemas/net-new-inbound-handraiser.1.0.0-draft.20260904.schema.json
@@ -1,0 +1,508 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tjsasakifln/Governance/schemas/net-new-inbound-handraiser.1.0.0-draft.20260904.schema.json",
+  "title": "CONFENGE NET_NEW_INBOUND_HANDRAISER authority 1.0.0-draft.20260904",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "policy_id",
+    "policy_version",
+    "canonical_name",
+    "status",
+    "effective_at",
+    "does_not_rewrite_v1",
+    "v1_remains_exact_match_authority",
+    "coordination_id",
+    "authority",
+    "activation",
+    "boundary",
+    "inputs",
+    "qualification_states",
+    "closed_states",
+    "reason_codes",
+    "evaluation",
+    "invariants",
+    "identity",
+    "idempotency",
+    "readback",
+    "rollback",
+    "failure",
+    "retention",
+    "safety"
+  ],
+  "properties": {
+    "schema_version": { "const": "net-new-inbound-handraiser.1.0.0-draft.20260904" },
+    "policy_id": { "const": "NET_NEW_INBOUND_HANDRAISER" },
+    "policy_version": { "const": "1.0.0-draft.20260904" },
+    "canonical_name": { "const": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904" },
+    "status": { "const": "ACTIVE" },
+    "effective_at": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$" },
+    "does_not_rewrite_v1": { "const": true },
+    "v1_remains_exact_match_authority": { "const": true },
+    "coordination_id": { "const": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904" },
+    "authority": { "$ref": "#/$defs/authority" },
+    "activation": { "$ref": "#/$defs/activation" },
+    "boundary": { "$ref": "#/$defs/boundary" },
+    "inputs": { "$ref": "#/$defs/inputs" },
+    "qualification_states": {
+      "const": [
+        "NEEDS_CONTEXT",
+        "POTENTIAL_FIT",
+        "CONFLICT_CHECK_REQUIRED",
+        "DOCUMENT_GAP",
+        "CAPACITY_REVIEW",
+        "PARTNER_REQUIRED",
+        "OUT_OF_SCOPE",
+        "QCO"
+      ]
+    },
+    "closed_states": {
+      "const": ["ACCEPTED", "REJECTED_WITH_REASON", "UNKNOWN"]
+    },
+    "reason_codes": { "$ref": "#/$defs/reason_codes" },
+    "evaluation": { "$ref": "#/$defs/evaluation" },
+    "invariants": { "$ref": "#/$defs/invariants" },
+    "identity": { "$ref": "#/$defs/identity" },
+    "idempotency": { "$ref": "#/$defs/idempotency" },
+    "readback": { "$ref": "#/$defs/readback" },
+    "rollback": { "$ref": "#/$defs/rollback" },
+    "failure": { "$ref": "#/$defs/failure" },
+    "retention": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["purpose", "class"],
+      "properties": {
+        "purpose": { "const": "INBOUND_ADMISSION" },
+        "class": { "const": "COMMERCIAL_INTAKE" }
+      }
+    },
+    "safety": { "$ref": "#/$defs/safety" }
+  },
+  "$defs": {
+    "string_array": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decided_by_role",
+        "decision_reference",
+        "runtime_reference",
+        "decision_source",
+        "human_actor_impersonation_allowed",
+        "extra_cli_pncp_live_is_commercial_authority",
+        "live_intelligence_is_site_inbound"
+      ],
+      "properties": {
+        "decided_by_role": { "const": "FOUNDER" },
+        "decision_reference": { "const": "https://github.com/tjsasakifln/Governance/issues/65" },
+        "runtime_reference": { "const": "https://github.com/tjsasakifln/warmbly/issues/47" },
+        "decision_source": { "const": "VERSIONED_GOVERNANCE_POLICY" },
+        "human_actor_impersonation_allowed": { "const": false },
+        "extra_cli_pncp_live_is_commercial_authority": { "const": false },
+        "live_intelligence_is_site_inbound": { "const": false }
+      }
+    },
+    "activation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exact_version_match_required",
+        "accepted_version_strings",
+        "accepted_policy_ids",
+        "v1_string_does_not_activate_this_version",
+        "missing_version_disposition",
+        "unknown_version_disposition",
+        "old_version_disposition"
+      ],
+      "properties": {
+        "exact_version_match_required": { "const": true },
+        "accepted_version_strings": {
+          "const": [
+            "1.0.0-draft.20260904",
+            "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904"
+          ]
+        },
+        "accepted_policy_ids": { "const": ["NET_NEW_INBOUND_HANDRAISER"] },
+        "v1_string_does_not_activate_this_version": { "const": true },
+        "missing_version_disposition": { "const": "FAIL_CLOSED" },
+        "unknown_version_disposition": { "const": "FAIL_CLOSED" },
+        "old_version_disposition": { "const": "FAIL_CLOSED" }
+      }
+    },
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "admission_owner",
+        "producer",
+        "producer_origin",
+        "producer_issue",
+        "producers_by_origin",
+        "producer_issues",
+        "record_queue_outcome_owner",
+        "consumer",
+        "consumer_issue",
+        "view_only_consumer",
+        "view_only_consumer_issue",
+        "policy_governance",
+        "meetcfg_receives",
+        "not_producers_of_this_authority",
+        "producer_may",
+        "producer_must_not",
+        "consumer_may",
+        "consumer_must_not",
+        "governance_owns",
+        "governance_must_not",
+        "parallel_crm_authorized",
+        "parallel_architecture_allowed"
+      ],
+      "properties": {
+        "admission_owner": { "const": "Governance" },
+        "producer": { "const": "web-cfg" },
+        "producer_origin": { "const": "CONFENGE_WEB" },
+        "producer_issue": { "const": "tjsasakifln/web-cfg#577" },
+        "producers_by_origin": {
+          "const": {
+            "CONFENGE_WEB": "web-cfg",
+            "confenge_web": "web-cfg"
+          }
+        },
+        "producer_issues": {
+          "const": {
+            "web-cfg": "tjsasakifln/web-cfg#577"
+          }
+        },
+        "record_queue_outcome_owner": { "const": "Warmbly" },
+        "consumer": { "const": "Warmbly" },
+        "consumer_issue": { "const": "tjsasakifln/warmbly#47" },
+        "view_only_consumer": { "const": "Meetcfg" },
+        "view_only_consumer_issue": { "const": "tjsasakifln/MeetCFG#1" },
+        "policy_governance": { "const": "Governance/NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904" },
+        "meetcfg_receives": { "const": "accepted_commercial_context_only" },
+        "not_producers_of_this_authority": { "$ref": "#/$defs/string_array" },
+        "producer_may": { "$ref": "#/$defs/string_array" },
+        "producer_must_not": { "$ref": "#/$defs/string_array" },
+        "consumer_may": { "$ref": "#/$defs/string_array" },
+        "consumer_must_not": { "$ref": "#/$defs/string_array" },
+        "governance_owns": { "$ref": "#/$defs/string_array" },
+        "governance_must_not": { "$ref": "#/$defs/string_array" },
+        "parallel_crm_authorized": { "const": false },
+        "parallel_architecture_allowed": { "const": false }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "optional_when_present",
+        "admitted_origins",
+        "admitted_intake_sources",
+        "admitted_acquisition_lanes",
+        "admitted_intent_kinds",
+        "intent_kind_aliases",
+        "admitted_nuclei",
+        "admitted_offer_candidates",
+        "admitted_party_kinds",
+        "admitted_decision_roles",
+        "admitted_urgency",
+        "admitted_why_now_classes",
+        "admitted_desired_deliverables",
+        "admitted_document_availability_classes",
+        "admitted_sensitive_classes",
+        "admitted_conflict_statuses",
+        "forbidden_origins",
+        "admitted_consent_bases",
+        "admitted_identity_match_methods",
+        "forbidden_identity_match_methods",
+        "location_allowed_fields",
+        "location_forbidden_fields"
+      ],
+      "properties": {
+        "required": { "$ref": "#/$defs/string_array" },
+        "optional_when_present": { "$ref": "#/$defs/string_array" },
+        "admitted_origins": { "const": ["CONFENGE_WEB", "confenge_web"] },
+        "admitted_intake_sources": { "const": ["CONFENGE_WEB"] },
+        "admitted_acquisition_lanes": { "const": ["NET_NEW_INBOUND"] },
+        "admitted_intent_kinds": {
+          "const": [
+            "HUMAN_REVIEW",
+            "DEEP_DIVE",
+            "REQUEST_HUMAN_REVIEW",
+            "REQUEST_DEEP_DIVE"
+          ]
+        },
+        "intent_kind_aliases": {
+          "const": {
+            "REQUEST_HUMAN_REVIEW": "HUMAN_REVIEW",
+            "REQUEST_DEEP_DIVE": "DEEP_DIVE"
+          }
+        },
+        "admitted_nuclei": {
+          "const": [
+            "expert_evidence_assistance",
+            "property_valuation",
+            "building_engineering_documentation",
+            "occupational_safety",
+            "public_works_b2g"
+          ]
+        },
+        "admitted_offer_candidates": {
+          "const": ["private_project_technical_readiness_assessment"]
+        },
+        "admitted_party_kinds": { "const": ["PERSON", "COMPANY"] },
+        "admitted_decision_roles": {
+          "const": ["DECISION_MAKER", "INFLUENCER", "OPERATOR", "UNKNOWN"]
+        },
+        "admitted_urgency": {
+          "const": ["IMMEDIATE", "THIS_CYCLE", "EXPLORATORY", "UNKNOWN"]
+        },
+        "admitted_why_now_classes": {
+          "const": ["DEADLINE", "INCIDENT", "AUDIT", "PROCUREMENT", "CAPACITY", "UNKNOWN"]
+        },
+        "admitted_desired_deliverables": {
+          "const": ["ASSESSMENT", "OPINION", "DOCUMENT_SET", "SITE_VISIT", "UNKNOWN"]
+        },
+        "admitted_document_availability_classes": {
+          "const": ["COMPLETE", "PARTIAL", "GAP", "UNKNOWN"]
+        },
+        "admitted_sensitive_classes": {
+          "const": ["NONE", "LGPD_SPECIAL", "LEGAL_PRIVILEGE", "HEALTH", "UNKNOWN"]
+        },
+        "admitted_conflict_statuses": {
+          "const": ["CLEAR", "UNKNOWN", "HIT", "NOT_SCREENED"]
+        },
+        "forbidden_origins": {
+          "const": ["intel_watch", "intel_seed", "PNCP_LIVE", "FIRST_TOUCH"]
+        },
+        "admitted_consent_bases": {
+          "const": ["EXPLICIT_FORM_SUBMIT", "EXPLICIT_HUMAN_REVIEW_REQUEST"]
+        },
+        "admitted_identity_match_methods": {
+          "const": ["EXPLICIT_CONTACT", "EXPLICIT_SUBJECT_REF"]
+        },
+        "forbidden_identity_match_methods": {
+          "const": ["NAME", "DISPLAY_NAME", "FUZZY", "FUZZY_NAME", "FUZZY_IDENTITY"]
+        },
+        "location_allowed_fields": { "const": ["city", "uf", "ibge_municipality_code"] },
+        "location_forbidden_fields": {
+          "const": ["street", "address", "cep", "zip", "lat", "lon", "latitude", "longitude", "email"]
+        }
+      }
+    },
+    "reason_codes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["accepted", "rejected", "unknown", "never_emitted"],
+      "properties": {
+        "accepted": { "const": ["ADMISSION_GATES_SATISFIED"] },
+        "rejected": { "$ref": "#/$defs/string_array" },
+        "unknown": { "$ref": "#/$defs/string_array" },
+        "never_emitted": {
+          "const": [
+            "ACCOUNT_MISSING",
+            "ACCOUNT_REQUIRED",
+            "ACCOUNT_NOT_FOUND",
+            "CONFLICT_UNKNOWN_AS_CLEAR"
+          ]
+        }
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "unknown_result",
+        "absence_or_ambiguity",
+        "fail_closed",
+        "replay_semantics",
+        "mutation_mode",
+        "conflict_unknown_never_becomes_clear",
+        "http_2xx_is_not_acceptance",
+        "live_intelligence_is_not_inbound",
+        "first_touch_inheritance_forbidden",
+        "coordination_ids_are_not_runtime_fallbacks"
+      ],
+      "properties": {
+        "mode": { "const": "ALL_REQUIRED_INPUTS_THEN_HARD_GATES" },
+        "unknown_result": { "const": "UNKNOWN" },
+        "absence_or_ambiguity": { "const": "UNKNOWN" },
+        "fail_closed": { "const": true },
+        "replay_semantics": { "const": "EXACTLY_ONCE_LOGICAL" },
+        "mutation_mode": { "const": "MODEL_ONLY" },
+        "conflict_unknown_never_becomes_clear": { "const": true },
+        "http_2xx_is_not_acceptance": { "const": true },
+        "live_intelligence_is_not_inbound": { "const": true },
+        "first_touch_inheritance_forbidden": { "const": true },
+        "coordination_ids_are_not_runtime_fallbacks": { "const": true }
+      }
+    },
+    "invariants": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "account_required_for_acceptance",
+        "missing_account_is_discard_reason",
+        "accepted_may_create_inbound_only_identity",
+        "inbound_only_on_accepted",
+        "inbound_only_equals_outbound_eligible",
+        "outbound_eligible_default",
+        "auto_send",
+        "smtp_authorized",
+        "followup_authorized",
+        "provider_dispatch_authorized",
+        "fuzzy_identity_by_name",
+        "pii_in_metrics",
+        "pii_in_decision",
+        "parallel_crm_authorized",
+        "inbound_only_never_promotes_outbound",
+        "sensitive_content_in_public_envelope",
+        "conflict_unknown_never_becomes_clear",
+        "http_2xx_is_not_acceptance"
+      ],
+      "properties": {
+        "account_required_for_acceptance": { "const": false },
+        "missing_account_is_discard_reason": { "const": false },
+        "accepted_may_create_inbound_only_identity": { "const": true },
+        "inbound_only_on_accepted": { "const": true },
+        "inbound_only_equals_outbound_eligible": { "const": false },
+        "outbound_eligible_default": { "const": false },
+        "auto_send": { "const": false },
+        "smtp_authorized": { "const": false },
+        "followup_authorized": { "const": false },
+        "provider_dispatch_authorized": { "const": false },
+        "fuzzy_identity_by_name": { "const": false },
+        "pii_in_metrics": { "const": false },
+        "pii_in_decision": { "const": false },
+        "parallel_crm_authorized": { "const": false },
+        "inbound_only_never_promotes_outbound": { "const": true },
+        "sensitive_content_in_public_envelope": { "const": false },
+        "conflict_unknown_never_becomes_clear": { "const": true },
+        "http_2xx_is_not_acceptance": { "const": true }
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "accepted_authorization",
+        "rejected_or_unknown_authorization",
+        "fuzzy_name_match_allowed",
+        "account_ref_optional",
+        "subject_ref_optional"
+      ],
+      "properties": {
+        "accepted_authorization": { "const": "INBOUND_ONLY" },
+        "rejected_or_unknown_authorization": { "const": "NONE" },
+        "fuzzy_name_match_allowed": { "const": false },
+        "account_ref_optional": { "const": true },
+        "subject_ref_optional": { "const": true }
+      }
+    },
+    "idempotency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key_required",
+        "semantics",
+        "same_key_same_material",
+        "same_key_different_material",
+        "same_key_different_material_reason",
+        "distinct_keys",
+        "store_mode",
+        "production_ledger_authorized"
+      ],
+      "properties": {
+        "key_required": { "const": true },
+        "semantics": { "const": "EXACTLY_ONCE_LOGICAL" },
+        "same_key_same_material": { "const": "REPLAY_ORIGINAL_DECISION" },
+        "same_key_different_material": { "const": "REJECTED_WITH_REASON" },
+        "same_key_different_material_reason": { "const": "IDEMPOTENCY_PAYLOAD_CONFLICT" },
+        "distinct_keys": { "const": "DISTINCT_LOGICAL_ADMISSIONS" },
+        "store_mode": { "const": "MODEL_ONLY" },
+        "production_ledger_authorized": { "const": false }
+      }
+    },
+    "readback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "http_2xx_is_not_acceptance", "required_fields", "pii_fields_forbidden"],
+      "properties": {
+        "required": { "const": true },
+        "http_2xx_is_not_acceptance": { "const": true },
+        "required_fields": { "$ref": "#/$defs/string_array" },
+        "pii_fields_forbidden": { "$ref": "#/$defs/string_array" }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pause_intake",
+        "retain_receipts",
+        "refuse_with_reason_code",
+        "refuse_reason_code",
+        "delete_forbidden",
+        "outbound_promotion_forbidden",
+        "replay_of_existing_receipt_preserved",
+        "freeze_intake"
+      ],
+      "properties": {
+        "pause_intake": { "const": true },
+        "retain_receipts": { "const": true },
+        "refuse_with_reason_code": { "const": true },
+        "refuse_reason_code": { "const": "INTAKE_PAUSED" },
+        "delete_forbidden": { "const": true },
+        "outbound_promotion_forbidden": { "const": true },
+        "replay_of_existing_receipt_preserved": { "const": true },
+        "freeze_intake": { "const": true }
+      }
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "absence_decision",
+        "ambiguity_decision",
+        "concrete_reason_codes_required",
+        "fail_closed"
+      ],
+      "properties": {
+        "absence_decision": { "const": "UNKNOWN" },
+        "ambiguity_decision": { "const": "UNKNOWN" },
+        "concrete_reason_codes_required": { "const": true },
+        "fail_closed": { "const": true }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "smtp_authorized",
+        "followup_authorized",
+        "auto_send",
+        "outbound_eligible_default",
+        "crm_parallel_authorized",
+        "durable_data_plane_authorized",
+        "contains_pii",
+        "e2e_claimed",
+        "pncp_live_commercial_authority",
+        "live_intelligence_as_inbound"
+      ],
+      "properties": {
+        "smtp_authorized": { "const": false },
+        "followup_authorized": { "const": false },
+        "auto_send": { "const": false },
+        "outbound_eligible_default": { "const": false },
+        "crm_parallel_authorized": { "const": false },
+        "durable_data_plane_authorized": { "const": false },
+        "contains_pii": { "const": false },
+        "e2e_claimed": { "const": false },
+        "pncp_live_commercial_authority": { "const": false },
+        "live_intelligence_as_inbound": { "const": false }
+      }
+    }
+  }
+}

--- a/tests/test_net_new_inbound_handraiser.py
+++ b/tests/test_net_new_inbound_handraiser.py
@@ -10,11 +10,14 @@ import pytest
 
 from commercial.inbound import (
     AUTHORITY_PATH,
+    DRAFT_AUTHORITY_PATH,
+    DRAFT_CANONICAL_NAME,
     ModelOnlyHandraiserStore,
     decision_contains_pii,
     evaluate_net_new_inbound_handraiser,
     evaluate_owner_readbacks,
     load_authority,
+    load_draft_authority,
     policy_hash,
 )
 from scripts.validate_commercial_authority import ValidationError, load_json, schema_validate
@@ -24,6 +27,26 @@ FIXTURES = ROOT / "commercial" / "fixtures" / "net-new-inbound-handraiser"
 POLICY_SCHEMA = ROOT / "schemas" / "net-new-inbound-handraiser.v1.schema.json"
 REQUEST_SCHEMA = ROOT / "schemas" / "net-new-inbound-handraiser-request.v1.schema.json"
 ADMISSION_SCHEMA = ROOT / "schemas" / "net-new-inbound-handraiser-admission.v1.schema.json"
+DRAFT_POLICY_SCHEMA = ROOT / "schemas" / "net-new-inbound-handraiser.1.0.0-draft.20260904.schema.json"
+DRAFT_REQUEST_SCHEMA = ROOT / "schemas" / "net-new-inbound-handraiser-request.1.0.0-draft.20260904.schema.json"
+DRAFT_ADMISSION_SCHEMA = ROOT / "schemas" / "net-new-inbound-handraiser-admission.1.0.0-draft.20260904.schema.json"
+NUCLEI = (
+    "expert_evidence_assistance",
+    "property_valuation",
+    "building_engineering_documentation",
+    "occupational_safety",
+    "public_works_b2g",
+)
+QUALIFICATION_STATES = (
+    "NEEDS_CONTEXT",
+    "POTENTIAL_FIT",
+    "CONFLICT_CHECK_REQUIRED",
+    "DOCUMENT_GAP",
+    "CAPACITY_REVIEW",
+    "PARTNER_REQUIRED",
+    "OUT_OF_SCOPE",
+    "QCO",
+)
 EVALUATED_AT = "2026-09-03T12:00:00Z"
 CLOSED_STATES = ("ACCEPTED", "REJECTED_WITH_REASON", "UNKNOWN")
 ACCOUNT_DISCARD_CODES = ("ACCOUNT_MISSING", "ACCOUNT_REQUIRED", "ACCOUNT_NOT_FOUND")
@@ -513,3 +536,347 @@ def test_ci_workflow_runs_this_module():
     pytest_line = next(line.strip() for line in workflow.splitlines() if "python -m pytest" in line)
     assert "tests/test_net_new_inbound_handraiser.py" in pytest_line
     assert "tests/test_first_touch_routing_policy.py" in pytest_line
+
+
+def draft_policy():
+    return load_draft_authority()
+
+
+def validate_draft_policy(value):
+    schema_validate(value, load_json(DRAFT_POLICY_SCHEMA))
+
+
+def validate_draft_decision(value):
+    schema_validate(value, load_json(DRAFT_ADMISSION_SCHEMA))
+
+
+def _assert_draft_closed_and_safe(decision, request):
+    validate_draft_decision(decision)
+    assert decision["decision"] in CLOSED_STATES
+    assert decision["canonical_name"] == DRAFT_CANONICAL_NAME
+    assert decision["policy_version"] == "1.0.0-draft.20260904"
+    assert decision["outbound_eligible"] is False
+    assert decision["auto_send"] is False
+    assert decision["smtp_authorized"] is False
+    assert decision["followup_authorized"] is False
+    assert decision["account_required_for_acceptance"] is False
+    assert decision["contains_pii"] is False
+    assert decision["mutation_mode"] == "MODEL_ONLY"
+    assert decision["consumer_authorization"]["outbound_eligible"] is False
+    assert decision["consumer_authorization"]["auto_send"] is False
+    assert decision["consumer_authorization"]["smtp_authorized"] is False
+    assert decision["metrics"]["smtp_authorized"] is False
+    assert decision["metrics"]["outbound_eligible"] is False
+    assert decision["metrics"]["auto_send"] is False
+    assert decision["readback"]["required"] is True
+    assert decision["readback"]["http_2xx_is_not_acceptance"] is True
+    assert decision["readback"]["decision_id"] == decision["decision_id"]
+    assert "http_status" not in decision
+    assert not any(code in decision["reason_codes"] for code in ACCOUNT_DISCARD_CODES)
+    assert "CONFLICT_UNKNOWN_AS_CLEAR" not in decision["reason_codes"]
+    assert decision["conflict_screening"]["status"] != "CLEAR" or decision["qualification_state"] != "CONFLICT_CHECK_REQUIRED"
+    if decision["conflict_screening"]["status"] == "UNKNOWN":
+        assert decision["qualification_state"] in {"CONFLICT_CHECK_REQUIRED", "NONE"}
+    assert "content" not in (decision.get("sensitive_data") or {})
+    assert decision_contains_pii(decision, request) is False
+    blob = json.dumps(decision)
+    assert not any(sample in blob for sample in PII_SAMPLES)
+    assert "sensitive-secret" not in blob
+
+
+def test_draft_authority_is_versioned_fail_closed_and_does_not_rewrite_v1():
+    value = draft_policy()
+    validate_draft_policy(value)
+    assert value["canonical_name"] == DRAFT_CANONICAL_NAME
+    assert value["policy_version"] == "1.0.0-draft.20260904"
+    assert value["does_not_rewrite_v1"] is True
+    assert value["v1_remains_exact_match_authority"] is True
+    assert value["activation"]["v1_string_does_not_activate_this_version"] is True
+    assert value["activation"]["missing_version_disposition"] == "FAIL_CLOSED"
+    assert value["qualification_states"] == list(QUALIFICATION_STATES)
+    assert value["inputs"]["admitted_nuclei"] == list(NUCLEI)
+    assert value["invariants"]["outbound_eligible_default"] is False
+    assert value["invariants"]["auto_send"] is False
+    assert value["invariants"]["conflict_unknown_never_becomes_clear"] is True
+    assert value["safety"]["pncp_live_commercial_authority"] is False
+    assert value["safety"]["live_intelligence_as_inbound"] is False
+    assert "intel_watch" not in value["inputs"]["admitted_origins"]
+    assert "crm" in value["boundary"]["governance_must_not"]
+    assert "durable_data_plane" in value["boundary"]["governance_must_not"]
+    assert DRAFT_AUTHORITY_PATH.is_file()
+    v1 = policy()
+    assert v1["canonical_name"] == "NET_NEW_INBOUND_HANDRAISER-v1"
+    assert v1["canonical_name"] != value["canonical_name"]
+
+    weakened = deepcopy(value)
+    weakened["invariants"]["auto_send"] = True
+    with pytest.raises(ValidationError, match="expected const"):
+        validate_draft_policy(weakened)
+
+
+@pytest.mark.parametrize("nucleus", NUCLEI)
+def test_draft_five_nuclei_are_admitted_inbound_only(nucleus: str):
+    request = load_fixture(f"accepted.{nucleus}.draft-20260904.json")
+    schema_validate(request, load_json(DRAFT_REQUEST_SCHEMA))
+    decision = admit(request)
+    _assert_draft_closed_and_safe(decision, request)
+    assert decision["decision"] == "ACCEPTED"
+    assert decision["nucleus_id"] == nucleus
+    assert decision["offer_candidate_id"] == "private_project_technical_readiness_assessment"
+    assert decision["intake_source"] == "CONFENGE_WEB"
+    assert decision["inbound_only"] is True
+    assert decision["outbound_eligible"] is False
+    assert decision["auto_send"] is False
+    assert decision["qualification_state"] in QUALIFICATION_STATES
+    assert decision["identity_authorization"] == "INBOUND_ONLY"
+
+
+def test_draft_missing_account_is_not_discarded():
+    request = load_fixture("accepted.missing-account.draft-20260904.json")
+    schema_validate(request, load_json(DRAFT_REQUEST_SCHEMA))
+    request_with_pii = deepcopy(request)
+    request_with_pii["email"] = "visitor@example.com"
+    request_with_pii["display_name"] = "Visitante Exemplo"
+    decision = admit(request_with_pii)
+    _assert_draft_closed_and_safe(decision, request_with_pii)
+    assert decision["decision"] == "ACCEPTED"
+    assert decision["account_present"] is False
+    assert decision["inbound_only"] is True
+    assert "ACCOUNT_MISSING" not in decision["reason_codes"]
+
+
+def test_draft_conflict_unknown_never_becomes_clear():
+    request = load_fixture("accepted.conflict-unknown.draft-20260904.json")
+    schema_validate(request, load_json(DRAFT_REQUEST_SCHEMA))
+    decision = admit(request)
+    _assert_draft_closed_and_safe(decision, request)
+    assert decision["decision"] == "ACCEPTED"
+    assert decision["conflict_screening"]["status"] == "UNKNOWN"
+    assert decision["qualification_state"] == "CONFLICT_CHECK_REQUIRED"
+    coerced = deepcopy(request)
+    coerced["conflict_screening"]["claimed_clear"] = True
+    coerced_decision = admit(coerced)
+    _assert_draft_closed_and_safe(coerced_decision, coerced)
+    assert coerced_decision["decision"] == "REJECTED_WITH_REASON"
+    assert "CONFLICT_CLEAR_COERCION_FORBIDDEN" in coerced_decision["reason_codes"]
+    assert coerced_decision["conflict_screening"]["status"] != "CLEAR"
+
+
+def test_draft_sensitive_content_never_enters_public_envelope():
+    request = load_fixture("rejected.sensitive-content.draft-20260904.json")
+    schema_validate(request, load_json(DRAFT_REQUEST_SCHEMA))
+    poisoned = deepcopy(request)
+    poisoned["sensitive_data"]["content"] = "sensitive-secret privilege notes"
+    decision = admit(poisoned)
+    _assert_draft_closed_and_safe(decision, poisoned)
+    assert decision["decision"] == "REJECTED_WITH_REASON"
+    assert "SENSITIVE_CONTENT_FORBIDDEN" in decision["reason_codes"]
+    assert "content" not in decision["sensitive_data"]
+    assert "sensitive-secret" not in json.dumps(decision)
+
+
+def test_draft_live_intelligence_is_not_inbound():
+    request = load_fixture("rejected.live-intelligence.draft-20260904.json")
+    schema_validate(request, load_json(DRAFT_REQUEST_SCHEMA))
+    decision = admit(request)
+    _assert_draft_closed_and_safe(decision, request)
+    assert decision["decision"] == "REJECTED_WITH_REASON"
+    assert "LIVE_INTELLIGENCE_NOT_INBOUND" in decision["reason_codes"]
+    assert decision["inbound_only"] is False
+    assert decision["consumer_authorization"]["create_inbound_only_identity"] is False
+
+
+def test_draft_first_touch_and_outbound_inheritance_are_rejected():
+    first_touch = load_fixture("rejected.first-touch-inheritance.draft-20260904.json")
+    schema_validate(first_touch, load_json(DRAFT_REQUEST_SCHEMA))
+    first_touch_decision = admit(first_touch)
+    _assert_draft_closed_and_safe(first_touch_decision, first_touch)
+    assert first_touch_decision["decision"] == "REJECTED_WITH_REASON"
+    assert "FIRST_TOUCH_INHERITANCE_FORBIDDEN" in first_touch_decision["reason_codes"]
+    assert first_touch_decision["outbound_eligible"] is False
+    assert first_touch_decision["auto_send"] is False
+
+    outbound = load_fixture("rejected.outbound-eligible.draft-20260904.json")
+    schema_validate(outbound, load_json(DRAFT_REQUEST_SCHEMA))
+    outbound_decision = admit(outbound)
+    _assert_draft_closed_and_safe(outbound_decision, outbound)
+    assert outbound_decision["decision"] == "REJECTED_WITH_REASON"
+    assert "OUTBOUND_INHERITANCE_FORBIDDEN" in outbound_decision["reason_codes"]
+    assert "AUTO_SEND_FORBIDDEN" in outbound_decision["reason_codes"]
+    assert outbound_decision["outbound_eligible"] is False
+    assert outbound_decision["auto_send"] is False
+
+
+def test_draft_missing_and_unknown_version_fail_closed():
+    missing = load_fixture("accepted.missing-account.draft-20260904.json")
+    missing.pop("policy_version")
+    missing_decision = admit(missing)
+    _assert_draft_closed_and_safe(missing_decision, missing)
+    assert missing_decision["decision"] == "UNKNOWN"
+    assert "POLICY_VERSION_MISSING" in missing_decision["reason_codes"]
+    assert missing_decision["consumer_authorization"]["create_inbound_only_identity"] is False
+
+    unknown = load_fixture("unknown.unknown-version.draft-20260904.json")
+    unknown_decision = admit(unknown)
+    _assert_draft_closed_and_safe(unknown_decision, unknown)
+    assert unknown_decision["decision"] == "UNKNOWN"
+    assert "POLICY_VERSION_UNKNOWN" in unknown_decision["reason_codes"]
+
+    v1_claim = load_fixture("accepted.missing-account.draft-20260904.json")
+    v1_claim["policy_version"] = "v1"
+    v1_claim["canonical_name"] = "NET_NEW_INBOUND_HANDRAISER-v1"
+    v1_decision = admit(v1_claim)
+    _assert_draft_closed_and_safe(v1_decision, v1_claim)
+    assert v1_decision["decision"] == "REJECTED_WITH_REASON"
+    assert "POLICY_VERSION_NOT_ADMITTED" in v1_decision["reason_codes"]
+
+
+def test_draft_missing_nucleus_is_unknown_and_retains_receipt():
+    request = load_fixture("unknown.missing-nucleus.draft-20260904.json")
+    decision = admit(request)
+    _assert_draft_closed_and_safe(decision, request)
+    assert decision["decision"] == "UNKNOWN"
+    assert "NUCLEUS_UNKNOWN" in decision["reason_codes"]
+    assert decision["receipt_id"] == request["receipt_id"]
+    assert decision["rollback"]["receipts_retained"] is True
+    assert decision["readback"]["receipt_id"] == request["receipt_id"]
+
+
+def test_draft_consent_refused_retains_minimal_evidence():
+    request = load_fixture("rejected.consent-refused.draft-20260904.json")
+    schema_validate(request, load_json(DRAFT_REQUEST_SCHEMA))
+    decision = admit(request)
+    _assert_draft_closed_and_safe(decision, request)
+    assert decision["decision"] == "REJECTED_WITH_REASON"
+    assert "CONSENT_REFUSED" in decision["reason_codes"]
+    assert decision["receipt_id"] == request["receipt_id"]
+    assert decision["idempotency_key"] == request["idempotency_key"]
+    assert decision["rollback"]["delete_forbidden"] is True
+
+
+def test_draft_qualification_states_are_closed():
+    request = load_fixture("accepted.expert_evidence_assistance.draft-20260904.json")
+    qco = admit(request)
+    assert qco["qualification_state"] == "QCO"
+
+    gap = deepcopy(request)
+    gap["idempotency_key"] = "nihr:web:draft-gap-001"
+    gap["receipt_id"] = "rcpt_draft_gap_001"
+    gap["document_availability_class"] = "GAP"
+    gap_decision = admit(gap)
+    assert gap_decision["decision"] == "ACCEPTED"
+    assert gap_decision["qualification_state"] == "DOCUMENT_GAP"
+
+    partner = deepcopy(request)
+    partner["idempotency_key"] = "nihr:web:draft-partner-001"
+    partner["receipt_id"] = "rcpt_draft_partner_001"
+    partner["partner_required"] = True
+    partner_decision = admit(partner)
+    assert partner_decision["qualification_state"] == "PARTNER_REQUIRED"
+
+    capacity = deepcopy(request)
+    capacity["idempotency_key"] = "nihr:web:draft-capacity-001"
+    capacity["receipt_id"] = "rcpt_draft_capacity_001"
+    capacity["capacity_review_required"] = True
+    capacity_decision = admit(capacity)
+    assert capacity_decision["qualification_state"] == "CAPACITY_REVIEW"
+
+    needs = deepcopy(request)
+    needs["idempotency_key"] = "nihr:web:draft-needs-001"
+    needs["receipt_id"] = "rcpt_draft_needs_001"
+    needs["decision_role"] = "UNKNOWN"
+    needs_decision = admit(needs)
+    assert needs_decision["qualification_state"] == "NEEDS_CONTEXT"
+
+    fit = deepcopy(request)
+    fit["idempotency_key"] = "nihr:web:draft-fit-001"
+    fit["receipt_id"] = "rcpt_draft_fit_001"
+    fit["decision_role"] = "INFLUENCER"
+    fit_decision = admit(fit)
+    assert fit_decision["qualification_state"] == "POTENTIAL_FIT"
+
+    out = deepcopy(request)
+    out["idempotency_key"] = "nihr:web:draft-oos-001"
+    out["receipt_id"] = "rcpt_draft_oos_001"
+    out["nucleus_id"] = "not_a_nucleus"
+    out_decision = admit(out)
+    assert out_decision["decision"] == "REJECTED_WITH_REASON"
+    assert "NUCLEUS_NOT_ADMITTED" in out_decision["reason_codes"]
+    assert out_decision["qualification_state"] == "NONE"
+
+    for row in (qco, gap_decision, partner_decision, capacity_decision, needs_decision, fit_decision):
+        _assert_draft_closed_and_safe(row, request)
+        assert row["qualification_state"] in QUALIFICATION_STATES
+
+
+def test_draft_100_same_key_replays_collapse_to_one_logical_admission():
+    store = ModelOnlyHandraiserStore()
+    request = load_fixture("accepted.missing-account.draft-20260904.json")
+    first = admit(request, store=store)
+    replays = [admit(request, store=store) for _ in range(99)]
+    assert first["decision"] == "ACCEPTED"
+    assert first["replayed"] is False
+    assert len(store) == 1
+    assert store.accepted_logical_count() == 1
+    assert {row["decision"] for row in replays} == {"ACCEPTED"}
+    assert all(row["replayed"] is True for row in replays)
+    assert {row["logical_admission_id"] for row in [first, *replays]} == {first["logical_admission_id"]}
+    assert {row["decision_id"] for row in [first, *replays]} == {first["decision_id"]}
+    assert all(row["outbound_eligible"] is False and row["auto_send"] is False for row in [first, *replays])
+
+
+def test_draft_100_distinct_keys_remain_distinct():
+    store = ModelOnlyHandraiserStore()
+    base = load_fixture("accepted.missing-account.draft-20260904.json")
+    decisions = []
+    for index in range(100):
+        request = deepcopy(base)
+        request["idempotency_key"] = f"nihr:web:draft-distinct-{index:03d}"
+        request["correlation_id"] = f"corr_draft_distinct_{index:03d}"
+        request["receipt_id"] = f"rcpt_draft_distinct_{index:03d}"
+        decisions.append(admit(request, store=store))
+    assert len(store) == 100
+    assert store.accepted_logical_count() == 100
+    assert all(row["decision"] == "ACCEPTED" for row in decisions)
+    assert len({row["logical_admission_id"] for row in decisions}) == 100
+    assert all(row["inbound_only"] is True and row["outbound_eligible"] is False for row in decisions)
+
+
+def test_draft_v1_intel_watch_fixture_still_uses_v1_path():
+    request = load_fixture("accepted.extra-cli-intel-watch.v1.json")
+    decision = admit(request)
+    _assert_closed_and_safe(decision, request)
+    assert decision["canonical_name"] == "NET_NEW_INBOUND_HANDRAISER-v1"
+    assert decision["decision"] == "ACCEPTED"
+    assert decision["origin"] == "intel_watch"
+
+
+def test_draft_consumer_pin_matches_live_hash_and_does_not_copy_schema():
+    digest = policy_hash(draft_policy())
+    assert digest.startswith("sha256:")
+    assert len(digest) == 71
+    matrix = json.loads(
+        (ROOT / "commercial" / "inbound" / "consumer-matrix.1.0.0-draft.20260904.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert matrix["canonical_name"] == DRAFT_CANONICAL_NAME
+    assert matrix["policy_hash"] == digest
+    assert matrix["do_not_copy_schema"] is True
+    pin = (ROOT / "commercial" / "inbound" / "CONSUMER-PIN.1.0.0-draft.20260904.md").read_text(
+        encoding="utf-8"
+    )
+    assert DRAFT_CANONICAL_NAME in pin
+    assert "Do not copy the schema" in pin
+    conformance = json.loads(
+        (ROOT / "commercial" / "inbound" / "consumer-conformance.1.0.0-draft.20260904.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert conformance["policy_hash"] == digest
+    for _name, row in conformance["fixtures"].items():
+        payload = json.loads((ROOT / row["path"]).read_text(encoding="utf-8"))
+        computed = "sha256:" + __import__("hashlib").sha256(
+            json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        assert row["content_hash"] == computed


### PR DESCRIPTION
CAMPAIGN_ID=06
BRANCH=`feat/campaign-20260904-net-new-multivertical-intake-policy-v3`
WORKTREE=`/home/tjsasakifln/code/confenge/.worktrees/Governance/c20260904-06-governance-intake`
BASE_SHA=`230d73a22a321112abe09b34a0d5fe743790b857`
INITIAL_MAIN_SHA=`230d73a22a321112abe09b34a0d5fe743790b857`
CURRENT_MAIN_SHA=`230d73a22a321112abe09b34a0d5fe743790b857`
HEAD_SHA=`e3fe7a4f5175e9152f19f4f9414e0141570bf130`

## Issue owner and decision state

Governance remains the exclusive owner of inbound admission policy and schema. This PR publishes `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904` beside existing `NET_NEW_INBOUND_HANDRAISER-v1` (exact-match ACTIVE for its own pins). It does not rewrite v1, does not create a commercial queue/CRM/executor, and does not close issue 65 or issue 1. E2E to Warmbly queue is still required before issue 65 can close.

Visitor job / business outcome: a net-new hand-raiser from `CONFENGE_WEB` for any of the five nuclei can be admitted inbound-only without a prior account, without outbound eligibility, and without first-touch/SMTP/auto-send inheritance.

## WRITE_SET (declared before first edit)

- `commercial/inbound/admit.py`
- `commercial/inbound/__init__.py`
- `commercial/inbound/net-new-inbound-handraiser.1.0.0-draft.20260904.json`
- `commercial/inbound/authority-table.1.0.0-draft.20260904.json`
- `commercial/inbound/consumer-matrix.1.0.0-draft.20260904.json`
- `commercial/inbound/consumer-conformance.1.0.0-draft.20260904.json`
- `commercial/inbound/CONSUMER-PIN.1.0.0-draft.20260904.md`
- `schemas/net-new-inbound-handraiser.1.0.0-draft.20260904.schema.json`
- `schemas/net-new-inbound-handraiser-request.1.0.0-draft.20260904.schema.json`
- `schemas/net-new-inbound-handraiser-admission.1.0.0-draft.20260904.schema.json`
- `commercial/fixtures/net-new-inbound-handraiser/*.draft-20260904.json`
- `tests/test_net_new_inbound_handraiser.py`
- `decisions/ADR-NET-NEW-INBOUND-HANDRAISER-001.md`
- `docs/integration/campaign-20260904/06/*`

Committed delta vs BASE_SHA is a subset of that set (31 files). Untouched: `.github/**`, lockfiles, `commercial/acquisition/**`, `commercial/outbound/**`, `commercial/offers/**`, `commercial/authority/**`, `commercial/CONSUMER-CONTRACT.md`, `commercial/CONSUMER-HANDOFF.md`, v1 contract/schemas.

## Contracts / versions produced

- `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904`
- policy hash `sha256:984f442690f7c74f309173b31008518631170d63733b5cc04c32abaf88c67e28`
- v1 remains `NET_NEW_INBOUND_HANDRAISER-v1` hash `sha256:5f8c03b6a11af3527b202d08c74de1d59d420f181807f094e62b337f055ec4ac`
- Source/lane `CONFENGE_WEB` / `NET_NEW_INBOUND`
- Nuclei: `expert_evidence_assistance`, `property_valuation`, `building_engineering_documentation`, `occupational_safety`, `public_works_b2g`
- Invariants: `outbound_eligible=false`, `auto_send=false`
- Coordination IDs appear in fixtures/fragments only; they are not runtime fallbacks. Goal 97 ratifies.

Pin (do not copy the schema):

```
python -c "from commercial.inbound import load_draft_authority, policy_hash; print(policy_hash(load_draft_authority()))"
```

## Tests at HEAD `e3fe7a4f5175e9152f19f4f9414e0141570bf130`

- `python3 -m pytest tests/test_net_new_inbound_handraiser.py -q` → 62 passed
- commercial-authority pytest set from `.github/workflows/commercial-authority.yml` → 349 passed
- `python3 scripts/validate_commercial_authority.py` → pass (catalog verdict unchanged)
- `python3 -m commercial.inbound --fixture <golden>` twice per class:
  - ACCEPTED (`accepted.missing-account.draft-20260904.json`) identical both runs; receipt/readback present; `outbound_eligible=false`
  - REJECTED_WITH_REASON (`rejected.consent-refused.draft-20260904.json`) reason `CONSENT_REFUSED`; receipt retained
  - UNKNOWN (`unknown.unknown-version.draft-20260904.json`) reason `POLICY_VERSION_UNKNOWN`

Local pytest is supporting evidence. GitHub check-run on this PR is the CI oracle.

## 100-repetition

- 100 identical draft submits collapse to one logical admission (`replayed=true` after the first).
- 100 distinct keys remain 100 accepted inbound-only admissions.

## Data / analytics / privacy

Public envelope carries class and protected refs only. Sensitive content, email, phone, name, street and similar keys are forbidden. Metrics are PII-free. Conflict `UNKNOWN` never becomes `CLEAR`.

## ADR / issues

- New `decisions/ADR-NET-NEW-INBOUND-HANDRAISER-001.md` (does not rewrite first-touch history).
- extra-cli PR 543: PNCP live is ingestion/telemetry, not commercial authority, not this inbound admission.
- Live Intelligence (`intel_watch` / `intel_seed`) is rejected on this version; v1 path is unchanged.
- Issue 65 stays open (E2E residual `SCHEMA_MISMATCH_COLLECTION` on Warmbly). This PR does not close it.
- Issue 1 stays open as residual commercial-authority record. This PR does not close it.

## Fragments (shared-owner files not edited)

- `docs/integration/campaign-20260904/06/consumer-contract.inbound-draft.md`
- `docs/integration/campaign-20260904/06/consumer-handoff.inbound-draft.md`
- `docs/integration/campaign-20260904/06/acquisition-pressure.intake-freeze.md` (freeze remains v1)
- `docs/integration/campaign-20260904/06/authority-manifest.inbound-draft.md`

## Rollback

Pause intake (`INTAKE_PAUSED`), retain receipts, refuse with reason code, do not delete intent, do not promote inbound to outbound. Consumers keep the v1 pin if this draft is not adopted.

NO_MERGE=CONFIRMED
NO_DEPLOY=CONFIRMED
NO_SMTP=CONFIRMED